### PR TITLE
refactor: new make targets and updated Dockerfile w/base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,31 @@ RUN go mod download
 COPY . .
 RUN make generate && go vet ./...
 RUN make css
+RUN make release
 
-FROM install-stage AS production
-RUN go build -o run_server cmd/server/main.go
-CMD go run cmd/migrate/main.go up && /build/run_server
+# Default final base image to Alpine Linux
+FROM alpine:3.21 AS production
+
+# Ensure we have latest packages applied
+RUN apk update \
+    && apk upgrade
+
+# Create a non-root user
+RUN addgroup -g 10001 -S iota-user \
+    && adduser --disabled-password --gecos '' -u 10000 --home /home/iota-user iota-user -G iota-user \
+    && chown -R iota-user:iota-user /home/iota-user
+
+WORKDIR /home/iota-user
+COPY --from=install-stage /build/run_server ./run_server
+COPY --from=install-stage /build/.env.example ./.env
+
+ENV PATH=/home/iota-user:$PATH
+
+USER iota-user
+ENTRYPOINT run_server
 
 FROM install-stage AS staging
-RUN go build -o run_server cmd/server/main.go && go build -o seed_db cmd/seed/main.go
+RUN make build && go build -o seed_db cmd/seed/main.go
 CMD go run cmd/migrate/main.go up && /build/seed_db && /build/run_server
 
 FROM install-stage AS testing-ci

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,14 @@ css:
 lint:
 	golangci-lint run ./...
 
+# Release - assume Alpine Linux as target
+release:
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o /build/run_server cmd/server/main.go
+
+# Release - assume local OS as target
+release-local:
+	go build -ldflags="-s -w" -o run_server cmd/server/main.go
+
 # Clean build artifacts
 clean:
 	rm -rf $(TAILWIND_OUTPUT)
@@ -69,4 +77,4 @@ clean:
 # Full setup
 setup: deps localdb migrate-up css lint
 
-.PHONY: default deps test test-watch localdb migrate-up migrate-down dev css-watch css lint clean setup
+.PHONY: default deps test test-watch localdb migrate-up migrate-down dev css-watch css lint release release-local clean setup


### PR DESCRIPTION
This PR addresses: #62 

1. Added new make targets (release and release-local)
2. Updated production stage to leverage new make target
3. Implement Alpine Linux for base image

Follows best practice guidance at [https://github.com/dnaprawa/dockerfile-best-practices](https://github.com/dnaprawa/dockerfile-best-practices). 

### Docker build output
```
❯ docker build . --target production -t iota-sdk:latest
[+] Building 44.8s (23/23) FINISHED                                                                                        docker:desktop-linux
 => [internal] load .dockerignore                                                                                                          0.0s
 => => transferring context: 209B                                                                                                          0.0s
 => [internal] load build definition from Dockerfile                                                                                       0.0s
 => => transferring dockerfile: 1.75kB                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/alpine:3.21                                                                             0.8s
 => [internal] load metadata for docker.io/library/golang:1.23.2                                                                           0.8s
 => [install-stage  1/11] FROM docker.io/library/golang:1.23.2@sha256:ad5c126b5cf501a8caef751a243bb717ec204ab1aa56dc41dc11be089fafcb4f     0.0s
 => [internal] load build context                                                                                                          0.1s
 => => transferring context: 618.27kB                                                                                                      0.0s
 => [production 1/6] FROM docker.io/library/alpine:3.21@sha256:56fa17d2a7e7f168a043a2712e63aed1f8543aeafdcee47c58dcffe38ed51099            0.0s
 => CACHED [install-stage  2/11] WORKDIR /build                                                                                            0.0s
 => CACHED [install-stage  3/11] RUN case "$(uname -m)" in       "x86_64") ARCH="x64" ;;       "aarch64") ARCH="arm64" ;;       *) echo "  0.0s
 => CACHED [install-stage  4/11] RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b   0.0s
 => CACHED [install-stage  5/11] RUN go install github.com/a-h/templ/cmd/templ@v0.2.793 && go install github.com/mitranim/gow@latest       0.0s
 => CACHED [install-stage  6/11] COPY go.mod go.sum ./                                                                                     0.0s
 => CACHED [install-stage  7/11] RUN go mod download                                                                                       0.0s
 => [install-stage  8/11] COPY . .                                                                                                         0.1s
 => [install-stage  9/11] RUN make generate && go vet ./...                                                                               31.8s
 => [install-stage 10/11] RUN make css                                                                                                     1.2s
 => [install-stage 11/11] RUN make release                                                                                                10.7s
 => CACHED [production 2/6] RUN apk update     && apk upgrade                                                                              0.0s
 => CACHED [production 3/6] RUN addgroup -g 10001 -S iota-user     && adduser --disabled-password --gecos '' -u 10000 --home /home/iota-u  0.0s
 => CACHED [production 4/6] WORKDIR /home/iota-user                                                                                        0.0s
 => CACHED [production 5/6] COPY --from=install-stage /build/run_server ./run_server                                                       0.0s
 => CACHED [production 6/6] COPY --from=install-stage /build/.env.example ./.env                                                           0.0s
 => exporting to image                                                                                                                     0.0s
 => => exporting layers                                                                                                                    0.0s
 => => writing image sha256:1bed8b53792d96732569a70a1b7cc4feed149636ee3c9e4466f8dd81e24c08a7                                               0.0s
 => => naming to docker.io/library/iota-sdk:latest                                                                                         0.0s

What's Next?
  View a summary of image vulnerabilities and recommendations → docker scout quickview

iota-sdk on  main [!] via  v23.5.0 took 47s
❯
```
### Docker run
```
❯ docker run -it iota-sdk:latest
2025/01/11 04:57:28 connect to http://localhost:3200/playground for GraphQL playground
```

