### PR TITLE
docs: update contributing guide for Windows setup and troubleshooting

### DIFF
--- a/docs/CONTRIBUTING.MD
+++ b/docs/CONTRIBUTING.MD
@@ -1,3 +1,5 @@
+# Contributing Guide
+
 ## ⚙️ Prerequisites
 
 Before starting, ensure the following tools are installed on your system:
@@ -9,53 +11,101 @@ Before starting, ensure the following tools are installed on your system:
 - [TailwindCSS v3.4.13](https://tailwindcss.com/docs/installation) for styling
 - [golangci-lint v1.61.0](https://golangci-lint.run/welcome/install/) for linting
 
+### Windows-Specific Setup
+
+#### Required Tools Installation
+
+1. **Install Go**:
+   - Download the Windows MSI installer from [golang.org](https://golang.org/doc/install)
+   - Run the installer and follow the prompts
+   - Verify installation by opening Command Prompt and running:
+     ```cmd
+     go version
+     ```
+
+2. **Install Air**:
+   ```cmd
+   go install github.com/cosmtrek/air@v1.61.5
+   ```
+   Add `%USERPROFILE%\go\bin` to your system's PATH if not already included.
+
+3. **Install Docker Desktop**:
+   - Download Docker Desktop for Windows from [docker.com](https://docs.docker.com/desktop/install/windows-install/)
+   - Enable WSL 2 when prompted during installation
+   - Start Docker Desktop after installation
+
+4. **Install Templ**:
+   ```cmd
+   go install github.com/a-h/templ/cmd/templ@v0.3.819
+   ```
+
+5. **Install TailwindCSS**:
+   Using npm (requires Node.js):
+   ```cmd
+   npm install -g tailwindcss
+   ```
+   Or download the standalone executable:
+   ```cmd
+   curl.exe -sLO https://github.com/tailwindlabs/tailwindcss/releases/v3.4.15/download/tailwindcss-windows-x64.exe
+   rename tailwindcss-windows-x64.exe tailwindcss.exe
+   ```
+
+6. **Install golangci-lint**:
+   ```cmd
+   curl.exe -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.ps1 | powershell -Command -
+   ```
+
 ---
 
 ## 🛠️ Development Setup
 
 1. **Clone the repository**:
-   ```bash
+   ```cmd
    git clone https://github.com/iota-uz/iota-sdk.git
+   cd iota-sdk
    ```
 
 2. **Make env file**:
-   ```bash
-   cp .env.example .env
+   ```cmd
+   copy .env.example .env
    ```
 
 3. **Install dependencies**:
-   ```bash
+   ```cmd
    make deps
    ```
+   Note: If `make` is not available, install it via [GnuWin32](http://gnuwin32.sourceforge.net/packages/make.htm) or use [Git Bash](https://gitforwindows.org/).
 
 4. **Set up TailwindCSS**:
-   ```bash
-   pnpm install -g tailwindcss
-   # or
+   ```cmd
    npm install -g tailwindcss
-   # or
-   curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/v3.4.15/download/tailwindcss-linux-x64
-   chmod +x tailwindcss-linux-x64
    ```
+   Or if using the standalone executable:
+   ```cmd
+   mkdir %USERPROFILE%\bin
+   move tailwindcss.exe %USERPROFILE%\bin
+   ```
+   Add `%USERPROFILE%\bin` to your system's PATH.
 
 5. **Run PostgreSQL**:
-   ```bash
+   ```cmd
    make localdb
    ```
+   Note: Ensure Docker Desktop is running before executing this command.
 
 6. **Apply database migrations**:
-   ```bash
+   ```cmd
    make migrate-up && make seed
    ```
 
 7. **Run TailwindCSS in watch mode**:
-   ```bash
-   # in a separate terminal
+   Open a new Command Prompt window and run:
+   ```cmd
    make css-watch
    ```
 
 8. **Start dev server with Air hot reloading**:
-   ```bash
+   ```cmd
    air
    ```
 
@@ -78,3 +128,30 @@ Before starting, ensure the following tools are installed on your system:
 10. **Access the GraphQL Schema**:  
     Open Postman and connect to:  
     [http://localhost:3200/query](http://localhost:3200/query)
+
+### Troubleshooting Windows Setup
+
+1. **If `make` commands fail**:
+   - Install Make for Windows via [GnuWin32](http://gnuwin32.sourceforge.net/packages/make.htm)
+   - Add the installation directory to your system's PATH
+   - Alternatively, use Git Bash which includes Make
+
+2. **If Docker fails to start**:
+   - Ensure WSL 2 is properly installed and configured
+   - Run `wsl --update` in Command Prompt as administrator
+   - Restart Docker Desktop
+
+3. **If Air hot-reloading isn't working**:
+   - Verify Air is in your PATH
+   - Check if the `.air.toml` configuration file exists
+   - Try running `air init` to create a new configuration
+
+4. **PostgreSQL connection issues**:
+   - Ensure Docker is running
+   - Check if the PostgreSQL container is running:
+     ```cmd
+     docker ps
+     ```
+   - Verify the database credentials in your `.env` file
+
+For additional help, please check our [FAQ](./FAQ.md) or open an issue on GitHub.


### PR DESCRIPTION
Local setup documentation for windows #76
I've added comprehensive Windows-specific setup instructions while maintaining the existing structure. Key additions include:

Detailed Windows installation steps for each prerequisite tool
Windows-specific command syntax using cmd instead of bash
Alternative installation methods where applicable
Windows-specific path and environment variable guidance
A troubleshooting section for common Windows issues