### PR TITLE
fix: z-index on `DetailsDropdown` component call-sites

### DIFF
--- a/components/base/dropdown.templ
+++ b/components/base/dropdown.templ
@@ -18,10 +18,24 @@ templ DropdownItem(props DropdownItemProps) {
 	</li>
 }
 
-templ DetailsDropdown(summary templ.Component, rootClass string) {
-	<div class={rootClass}>
+type DetailsDropdownProps struct {
+	Summary templ.Component
+	Classes templ.CSSClasses
+}
+
+func newDetailsDropdown(props *DetailsDropdownProps) *DetailsDropdownProps {
+	if props.Classes == nil {
+		props.Classes = templ.CSSClasses{}
+	}
+	return props
+}
+
+templ (p *DetailsDropdownProps) render() {
+	<div class={p.Classes.String()}>
 		<details class="relative z-10 peer" name="details-dropdown">
-			@summary
+			if p.Summary != nil {
+				@p.Summary
+			}
 			<ul class="flex flex-col gap-1 mt-1 absolute bg-surface-300 right-0 text-sm rounded-md w-44 overflow-hidden shadow-sm border border-secondary p-1">
 				{ children... }
 			</ul>
@@ -31,4 +45,10 @@ templ DetailsDropdown(summary templ.Component, rootClass string) {
 			<summary class="fixed w-full h-full left-0 top-0"></summary>
 		</details>
 	</div>
+}
+
+templ DetailsDropdown(props *DetailsDropdownProps) {
+	@newDetailsDropdown(props).render() {
+		{ children... }
+	}
 }

--- a/components/base/dropdown.templ
+++ b/components/base/dropdown.templ
@@ -18,8 +18,8 @@ templ DropdownItem(props DropdownItemProps) {
 	</li>
 }
 
-templ DetailsDropdown(summary templ.Component) {
-	<div>
+templ DetailsDropdown(summary templ.Component, rootClass string) {
+	<div class={rootClass}>
 		<details class="relative z-10 peer" name="details-dropdown">
 			@summary
 			<ul class="flex flex-col gap-1 mt-1 absolute bg-surface-300 right-0 text-sm rounded-md w-44 overflow-hidden shadow-sm border border-secondary p-1">

--- a/components/base/dropdown_templ.go
+++ b/components/base/dropdown_templ.go
@@ -81,7 +81,19 @@ func DropdownItem(props DropdownItemProps) templ.Component {
 	})
 }
 
-func DetailsDropdown(summary templ.Component, rootClass string) templ.Component {
+type DetailsDropdownProps struct {
+	Summary templ.Component
+	Classes templ.CSSClasses
+}
+
+func newDetailsDropdown(props *DetailsDropdownProps) *DetailsDropdownProps {
+	if props.Classes == nil {
+		props.Classes = templ.CSSClasses{}
+	}
+	return props
+}
+
+func (p *DetailsDropdownProps) render() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -102,7 +114,7 @@ func DetailsDropdown(summary templ.Component, rootClass string) templ.Component 
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		var templ_7745c5c3_Var4 = []any{rootClass}
+		var templ_7745c5c3_Var4 = []any{p.Classes.String()}
 		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var4...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -124,9 +136,11 @@ func DetailsDropdown(summary templ.Component, rootClass string) templ.Component 
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = summary.Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
+		if p.Summary != nil {
+			templ_7745c5c3_Err = p.Summary.Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<ul class=\"flex flex-col gap-1 mt-1 absolute bg-surface-300 right-0 text-sm rounded-md w-44 overflow-hidden shadow-sm border border-secondary p-1\">")
 		if templ_7745c5c3_Err != nil {
@@ -137,6 +151,53 @@ func DetailsDropdown(summary templ.Component, rootClass string) templ.Component 
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</ul></details><details class=\"hidden peer-open:block\" name=\"details-dropdown\"><summary class=\"fixed w-full h-full left-0 top-0\"></summary></details></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func DetailsDropdown(props *DetailsDropdownProps) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Var7 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templ_7745c5c3_Var6.Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = newDetailsDropdown(props).render().Render(templ.WithChildren(ctx, templ_7745c5c3_Var7), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/components/base/dropdown_templ.go
+++ b/components/base/dropdown_templ.go
@@ -81,7 +81,7 @@ func DropdownItem(props DropdownItemProps) templ.Component {
 	})
 }
 
-func DetailsDropdown(summary templ.Component) templ.Component {
+func DetailsDropdown(summary templ.Component, rootClass string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -102,7 +102,25 @@ func DetailsDropdown(summary templ.Component) templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div><details class=\"relative z-10 peer\" name=\"details-dropdown\">")
+		var templ_7745c5c3_Var4 = []any{rootClass}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var4...)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div class=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var5 string
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var4).String())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/dropdown.templ`, Line: 1, Col: 0}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\"><details class=\"relative z-10 peer\" name=\"details-dropdown\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -110,7 +128,7 @@ func DetailsDropdown(summary templ.Component) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<ul class=\"flex flex-col gap-1 mt-1 absolute bg-surface-300 right-0 text-sm rounded-md w-44 overflow-hidden shadow-sm border border-secondary p-1\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<ul class=\"flex flex-col gap-1 mt-1 absolute bg-surface-300 right-0 text-sm rounded-md w-44 overflow-hidden shadow-sm border border-secondary p-1\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -118,7 +136,7 @@ func DetailsDropdown(summary templ.Component) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</ul></details><details class=\"hidden peer-open:block\" name=\"details-dropdown\"><summary class=\"fixed w-full h-full left-0 top-0\"></summary></details></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</ul></details><details class=\"hidden peer-open:block\" name=\"details-dropdown\"><summary class=\"fixed w-full h-full left-0 top-0\"></summary></details></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/docs/COMPONENTS.MD
+++ b/docs/COMPONENTS.MD
@@ -326,7 +326,7 @@ templ summary() {
 }
 
 templ DropdownDemo(summary()) {
-  @base.DetailsDropdown(summary()) {
+  @base.DetailsDropdown(&base.DetailsDropdownProps{Summary: summary()}) {
     @base.DropdownItem(base.DropdownItemProps{Href: "/account"}) {
       Account
     }
@@ -338,9 +338,16 @@ templ DropdownDemo(summary()) {
     }
   }
 }
-
 ```
+
 ### API
+
+### Detalis Dropdown
+
+| Name    | Type               | Description                  |
+| ------- | ------------------ | ---------------------------- |
+| Summary | `templ.Component`  | Summary component            |
+| Classes | `templ.CSSClasses` | CSS classes to apply to root |
 
 summary - `templ.Component`
 

--- a/modules/core/presentation/templates/layouts/authenticated.templ
+++ b/modules/core/presentation/templates/layouts/authenticated.templ
@@ -147,7 +147,10 @@ templ Navbar(pageCtx *types.PageContext) {
 				@spotlight.Spotlight()
 			</div>
 			@ThemeSwitcher()
-			@base.DetailsDropdown(Avatar(), "z-10") {
+			@base.DetailsDropdown(&base.DetailsDropdownProps{
+				Summary: Avatar(),
+				Classes: templ.CSSClasses{"z-10"},
+			}) {
 				@base.DropdownItem(base.DropdownItemProps{Href: "/account"}) {
 					{ pageCtx.T("NavigationLinks.Navbar.Profile") }
 				}

--- a/modules/core/presentation/templates/layouts/authenticated.templ
+++ b/modules/core/presentation/templates/layouts/authenticated.templ
@@ -147,7 +147,7 @@ templ Navbar(pageCtx *types.PageContext) {
 				@spotlight.Spotlight()
 			</div>
 			@ThemeSwitcher()
-			@base.DetailsDropdown(Avatar()) {
+			@base.DetailsDropdown(Avatar(), "z-10") {
 				@base.DropdownItem(base.DropdownItemProps{Href: "/account"}) {
 					{ pageCtx.T("NavigationLinks.Navbar.Profile") }
 				}

--- a/modules/core/presentation/templates/layouts/authenticated_templ.go
+++ b/modules/core/presentation/templates/layouts/authenticated_templ.go
@@ -340,7 +340,7 @@ func Navbar(pageCtx *types.PageContext) templ.Component {
 				var templ_7745c5c3_Var14 string
 				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.Profile"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 152, Col: 50}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 155, Col: 50}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 				if templ_7745c5c3_Err != nil {
@@ -371,7 +371,7 @@ func Navbar(pageCtx *types.PageContext) templ.Component {
 				var templ_7745c5c3_Var16 string
 				templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.Settings"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 155, Col: 51}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 158, Col: 51}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 				if templ_7745c5c3_Err != nil {
@@ -402,7 +402,7 @@ func Navbar(pageCtx *types.PageContext) templ.Component {
 				var templ_7745c5c3_Var18 string
 				templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.Logout"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 158, Col: 49}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 161, Col: 49}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 				if templ_7745c5c3_Err != nil {
@@ -416,7 +416,10 @@ func Navbar(pageCtx *types.PageContext) templ.Component {
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = base.DetailsDropdown(Avatar(), "z-10").Render(templ.WithChildren(ctx, templ_7745c5c3_Var12), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = base.DetailsDropdown(&base.DetailsDropdownProps{
+			Summary: Avatar(),
+			Classes: templ.CSSClasses{"z-10"},
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var12), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -478,7 +481,7 @@ func SidebarFooter(pageCtx *types.PageContext) templ.Component {
 			var templ_7745c5c3_Var21 string
 			templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("SignOut"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 175, Col: 24}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 178, Col: 24}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 			if templ_7745c5c3_Err != nil {

--- a/modules/core/presentation/templates/layouts/authenticated_templ.go
+++ b/modules/core/presentation/templates/layouts/authenticated_templ.go
@@ -416,7 +416,7 @@ func Navbar(pageCtx *types.PageContext) templ.Component {
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = base.DetailsDropdown(Avatar()).Render(templ.WithChildren(ctx, templ_7745c5c3_Var12), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = base.DetailsDropdown(Avatar(), "z-10").Render(templ.WithChildren(ctx, templ_7745c5c3_Var12), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/modules/warehouse/presentation/templates/pages/orders/index.templ
+++ b/modules/warehouse/presentation/templates/pages/orders/index.templ
@@ -126,7 +126,7 @@ templ OrdersContent(props *IndexPageProps) {
 				@filters.PageSize()
 				@filters.CreatedAt()
 				<div class="flex-grow"></div>
-				@base.DetailsDropdown(newOrderButton()) {
+				@base.DetailsDropdown(newOrderButton(), "z-0") {
 					@base.DropdownItem(base.DropdownItemProps{Href: "/warehouse/orders/in/new"}) {
 						{ pageCtx.T("WarehouseOrders.List.NewIn") }
 					}

--- a/modules/warehouse/presentation/templates/pages/orders/index.templ
+++ b/modules/warehouse/presentation/templates/pages/orders/index.templ
@@ -126,7 +126,10 @@ templ OrdersContent(props *IndexPageProps) {
 				@filters.PageSize()
 				@filters.CreatedAt()
 				<div class="flex-grow"></div>
-				@base.DetailsDropdown(newOrderButton(), "z-0") {
+				@base.DetailsDropdown(&base.DetailsDropdownProps{
+					Summary: newOrderButton(),
+					Classes: templ.CSSClasses{"z-0"},
+				}) {
 					@base.DropdownItem(base.DropdownItemProps{Href: "/warehouse/orders/in/new"}) {
 						{ pageCtx.T("WarehouseOrders.List.NewIn") }
 					}

--- a/modules/warehouse/presentation/templates/pages/orders/index_templ.go
+++ b/modules/warehouse/presentation/templates/pages/orders/index_templ.go
@@ -604,7 +604,7 @@ func OrdersContent(props *IndexPageProps) templ.Component {
 				var templ_7745c5c3_Var32 string
 				templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("WarehouseOrders.List.NewIn"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/warehouse/presentation/templates/pages/orders/index.templ`, Line: 131, Col: 47}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/warehouse/presentation/templates/pages/orders/index.templ`, Line: 134, Col: 47}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
 				if templ_7745c5c3_Err != nil {
@@ -635,7 +635,7 @@ func OrdersContent(props *IndexPageProps) templ.Component {
 				var templ_7745c5c3_Var34 string
 				templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("WarehouseOrders.List.NewOut"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/warehouse/presentation/templates/pages/orders/index.templ`, Line: 134, Col: 48}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/warehouse/presentation/templates/pages/orders/index.templ`, Line: 137, Col: 48}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 				if templ_7745c5c3_Err != nil {
@@ -649,7 +649,10 @@ func OrdersContent(props *IndexPageProps) templ.Component {
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = base.DetailsDropdown(newOrderButton(), "z-0").Render(templ.WithChildren(ctx, templ_7745c5c3_Var30), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = base.DetailsDropdown(&base.DetailsDropdownProps{
+			Summary: newOrderButton(),
+			Classes: templ.CSSClasses{"z-0"},
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var30), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/modules/warehouse/presentation/templates/pages/orders/index_templ.go
+++ b/modules/warehouse/presentation/templates/pages/orders/index_templ.go
@@ -649,7 +649,7 @@ func OrdersContent(props *IndexPageProps) templ.Component {
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = base.DetailsDropdown(newOrderButton()).Render(templ.WithChildren(ctx, templ_7745c5c3_Var30), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = base.DetailsDropdown(newOrderButton(), "z-0").Render(templ.WithChildren(ctx, templ_7745c5c3_Var30), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
Fixes the issue: https://github.com/iota-uz/iota-sdk/issues/78

The main issue was the stacking context of the parent. Because both dropdowns used the same component (`DetailsDropdown`) there wasn't really a way to control the z-index from the call-site and browser's defaults kicked-in.

Tested on Safari and Firefox.

Aftermath of changes:

<img width="198" alt="Screenshot 2025-02-04 at 20 10 29" src="https://github.com/user-attachments/assets/1debcfa7-8388-47dd-a690-c2c4545bf1fa" />
