### PR TITLE
fix(eventbus): log warning when no matching subscribers for an event

### DIFF
--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"os"
+	"runtime/debug"
 	"time"
 
 	"github.com/iota-uz/iota-sdk/modules"
@@ -14,21 +16,27 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/composables"
 	"github.com/iota-uz/iota-sdk/pkg/configuration"
 	"github.com/iota-uz/iota-sdk/pkg/eventbus"
-	"github.com/iota-uz/iota-sdk/pkg/logging"
 
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/sirupsen/logrus"
 )
 
 func main() {
+	defer func() {
+		if r := recover(); r != nil {
+			configuration.Use().Unload()
+			debug.PrintStack()
+			os.Exit(1)
+		}
+	}()
+
 	conf := configuration.Use()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-	pool, err := pgxpool.New(ctx, conf.DBOpts)
+	pool, err := pgxpool.New(ctx, conf.Database.Opts)
 	if err != nil {
 		panic(err)
 	}
-	app := application.New(pool, eventbus.NewEventPublisher(logging.ConsoleLogger(logrus.WarnLevel)))
+	app := application.New(pool, eventbus.NewEventPublisher(conf.Logger()))
 	if err := modules.Load(app, modules.BuiltInModules...); err != nil {
 		panic(err)
 	}

--- a/cmd/seed/main.go
+++ b/cmd/seed/main.go
@@ -14,8 +14,10 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/composables"
 	"github.com/iota-uz/iota-sdk/pkg/configuration"
 	"github.com/iota-uz/iota-sdk/pkg/eventbus"
+	"github.com/iota-uz/iota-sdk/pkg/logging"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {
@@ -26,7 +28,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	app := application.New(pool, eventbus.NewEventPublisher())
+	app := application.New(pool, eventbus.NewEventPublisher(logging.ConsoleLogger(logrus.WarnLevel)))
 	if err := modules.Load(app, modules.BuiltInModules...); err != nil {
 		panic(err)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"runtime/debug"
 	"time"
 
 	internalassets "github.com/iota-uz/iota-sdk/internal/assets"
@@ -23,10 +24,17 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/lib/pq"
-	"github.com/sirupsen/logrus"
 )
 
 func main() {
+	defer func() {
+		if r := recover(); r != nil {
+			configuration.Use().Unload()
+			debug.PrintStack()
+			os.Exit(1)
+		}
+	}()
+
 	conf := configuration.Use()
 	logFile, logger, err := logging.FileLogger(conf.LogrusLogLevel())
 	if err != nil {
@@ -40,11 +48,11 @@ func main() {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-	pool, err := pgxpool.New(ctx, conf.DBOpts)
+	pool, err := pgxpool.New(ctx, conf.Database.Opts)
 	if err != nil {
 		panic(err)
 	}
-	app := application.New(pool, eventbus.NewEventPublisher(logging.ConsoleLogger(logrus.WarnLevel)))
+	app := application.New(pool, eventbus.NewEventPublisher(conf.Logger()))
 	if err := modules.Load(app, modules.BuiltInModules...); err != nil {
 		log.Fatalf("failed to load modules: %v", err)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/lib/pq"
+	"github.com/sirupsen/logrus"
 )
 
 func main() {
@@ -43,7 +44,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	app := application.New(pool, eventbus.NewEventPublisher())
+	app := application.New(pool, eventbus.NewEventPublisher(logging.ConsoleLogger(logrus.WarnLevel)))
 	if err := modules.Load(app, modules.BuiltInModules...); err != nil {
 		log.Fatalf("failed to load modules: %v", err)
 	}

--- a/modules/core/services/auth_service.go
+++ b/modules/core/services/auth_service.go
@@ -82,7 +82,7 @@ func (s *AuthService) CookieGoogleAuthenticate(ctx context.Context, code string)
 		Expires:  sess.ExpiresAt,
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
-		Secure:   conf.GoAppEnvironment == "production",
+		Secure:   conf.GoAppEnvironment == configuration.Production,
 		Domain:   conf.Domain,
 		Path:     "/",
 	}
@@ -171,7 +171,7 @@ func (s *AuthService) CookieAuthenticateWithUserID(ctx context.Context, id uint,
 		Expires:  sess.ExpiresAt,
 		HttpOnly: false,
 		SameSite: http.SameSiteLaxMode,
-		Secure:   conf.GoAppEnvironment == "production",
+		Secure:   conf.GoAppEnvironment == configuration.Production,
 		Domain:   conf.Domain,
 	}
 	return cookie, nil
@@ -204,7 +204,7 @@ func (s *AuthService) CookieAuthenticate(ctx context.Context, email, password st
 		Expires:  sess.ExpiresAt,
 		HttpOnly: false,
 		SameSite: http.SameSiteLaxMode,
-		Secure:   conf.GoAppEnvironment == "production",
+		Secure:   conf.GoAppEnvironment == configuration.Production,
 		Domain:   conf.Domain,
 	}
 	return cookie, nil
@@ -224,7 +224,7 @@ func generateStateOauthCookie() (*http.Cookie, error) {
 		Expires:  time.Now().Add(time.Minute * 5),
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
-		Secure:   conf.GoAppEnvironment == "production",
+		Secure:   conf.GoAppEnvironment == configuration.Production,
 		Domain:   conf.Domain,
 	}
 	return cookie, nil

--- a/modules/core/services/auth_service.go
+++ b/modules/core/services/auth_service.go
@@ -30,9 +30,9 @@ func NewAuthService(app application.Application) *AuthService {
 	return &AuthService{
 		app: app,
 		oAuthConfig: &oauth2.Config{
-			RedirectURL:  conf.GoogleRedirectURL,
-			ClientID:     conf.GoogleClientID,
-			ClientSecret: conf.GoogleClientSecret,
+			RedirectURL:  conf.Google.RedirectURL,
+			ClientID:     conf.Google.ClientID,
+			ClientSecret: conf.Google.ClientSecret,
 			Scopes: []string{
 				"https://www.googleapis.com/auth/userinfo.email",
 				"https://www.googleapis.com/auth/userinfo.profile",

--- a/modules/crm/module.go
+++ b/modules/crm/module.go
@@ -31,10 +31,10 @@ func (m *Module) Register(app application.Application) error {
 	conf := configuration.Use()
 	twilioProvider := cpassproviders.NewTwilioProvider(
 		twilio.ClientParams{
-			Username: conf.TwilioAccountSID,
-			Password: conf.TwilioAuthToken,
+			Username: conf.Twilio.AccountSID,
+			Password: conf.Twilio.AuthToken,
 		},
-		conf.TwilioWebhookURL,
+		conf.Twilio.WebhookURL,
 	)
 	chatRepo := persistence.NewChatRepository()
 	clientRepo := persistence.NewClientRepository()

--- a/modules/crm/services/chat_service.go
+++ b/modules/crm/services/chat_service.go
@@ -197,7 +197,7 @@ func (s *ChatService) SendMessage(ctx context.Context, dto SendMessageDTO) (chat
 		return nil, err
 	}
 	if err := s.cpassProvider.SendMessage(ctx, cpassproviders.SendMessageDTO{
-		From:    configuration.Use().TwilioPhoneNumber,
+		From:    configuration.Use().Twilio.PhoneNumber,
 		To:      clientEntity.Phone().Value(),
 		Message: dto.Message,
 	}); err != nil {

--- a/modules/finance/services/payment_service_test.go
+++ b/modules/finance/services/payment_service_test.go
@@ -2,6 +2,9 @@ package services_test
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/iota-uz/iota-sdk/modules"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/country"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/permission"
@@ -9,10 +12,8 @@ import (
 	"github.com/iota-uz/iota-sdk/modules/finance/domain/entities/counterparty"
 	"github.com/iota-uz/iota-sdk/pkg/application"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"github.com/iota-uz/iota-sdk/pkg/logging"
 	"github.com/iota-uz/iota-sdk/pkg/shared"
-	"github.com/jackc/pgx/v5/pgxpool"
-	"testing"
-	"time"
 
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/currency"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/session"
@@ -24,6 +25,9 @@ import (
 	"github.com/iota-uz/iota-sdk/modules/finance/services"
 	"github.com/iota-uz/iota-sdk/pkg/eventbus"
 	"github.com/iota-uz/iota-sdk/pkg/testutils"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sirupsen/logrus"
 )
 
 // testFixtures contains common test dependencies
@@ -58,7 +62,7 @@ func setupTest(t *testing.T, permissions ...*permission.Permission) *testFixture
 	ctx = composables.WithTx(ctx, tx)
 	ctx = composables.WithSession(ctx, &session.Session{})
 
-	publisher := eventbus.NewEventPublisher()
+	publisher := eventbus.NewEventPublisher(logging.ConsoleLogger(logrus.WarnLevel))
 	app := setupApplication(t, pool, publisher)
 
 	return &testFixtures{

--- a/pkg/commands/migrate_command.go
+++ b/pkg/commands/migrate_command.go
@@ -5,16 +5,15 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"time"
 
 	"github.com/iota-uz/iota-sdk/modules"
 	"github.com/iota-uz/iota-sdk/pkg/application"
 	"github.com/iota-uz/iota-sdk/pkg/configuration"
 	"github.com/iota-uz/iota-sdk/pkg/eventbus"
-	"github.com/iota-uz/iota-sdk/pkg/logging"
 
 	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -22,6 +21,14 @@ var (
 )
 
 func Migrate(mods ...application.Module) error {
+	defer func() {
+		if r := recover(); r != nil {
+			configuration.Use().Unload()
+			debug.PrintStack()
+			os.Exit(1)
+		}
+	}()
+
 	if len(os.Args) < 2 {
 		return ErrNoCommand
 	}
@@ -30,11 +37,11 @@ func Migrate(mods ...application.Module) error {
 	conf := configuration.Use()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-	pool, err := pgxpool.New(ctx, conf.DBOpts)
+	pool, err := pgxpool.New(ctx, conf.Database.Opts)
 	if err != nil {
 		panic(err)
 	}
-	app := application.New(pool, eventbus.NewEventPublisher(logging.ConsoleLogger(logrus.WarnLevel)))
+	app := application.New(pool, eventbus.NewEventPublisher(conf.Logger()))
 	if err := modules.Load(app, mods...); err != nil {
 		return err
 	}

--- a/pkg/commands/migrate_command.go
+++ b/pkg/commands/migrate_command.go
@@ -11,7 +11,10 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/application"
 	"github.com/iota-uz/iota-sdk/pkg/configuration"
 	"github.com/iota-uz/iota-sdk/pkg/eventbus"
+	"github.com/iota-uz/iota-sdk/pkg/logging"
+
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -31,7 +34,7 @@ func Migrate(mods ...application.Module) error {
 	if err != nil {
 		panic(err)
 	}
-	app := application.New(pool, eventbus.NewEventPublisher())
+	app := application.New(pool, eventbus.NewEventPublisher(logging.ConsoleLogger(logrus.WarnLevel)))
 	if err := modules.Load(app, mods...); err != nil {
 		return err
 	}

--- a/pkg/configuration/environment.go
+++ b/pkg/configuration/environment.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/iota-uz/iota-sdk/pkg/logging"
+
 	"github.com/caarlos0/env/v11"
 	"github.com/iota-uz/utils/fs"
 	"github.com/joho/godotenv"
@@ -17,6 +19,7 @@ import (
 var singleton = sync.OnceValue(func() *Configuration {
 	c := &Configuration{}
 	if err := c.load([]string{".env", ".env.local"}); err != nil {
+		c.Unload()
 		panic(err)
 	}
 	return c
@@ -44,37 +47,63 @@ func LoadEnv(envFiles []string) (int, error) {
 	return len(existingFiles), godotenv.Load(existingFiles...)
 }
 
+type DatabaseOptions struct {
+	Opts     string `env:"-"`
+	Name     string `env:"DB_NAME" envDefault:"iota_erp"`
+	Host     string `env:"DB_HOST" envDefault:"localhost"`
+	Port     string `env:"DB_PORT" envDefault:"5432"`
+	User     string `env:"DB_USER" envDefault:"postgres"`
+	Password string `env:"DB_PASSWORD" envDefault:"postgres"`
+}
+
+func (d *DatabaseOptions) ConnectionString() string {
+	return fmt.Sprintf(
+		"host=%s port=%s user=%s dbname=%s password=%s sslmode=disable",
+		d.Host, d.Port, d.User, d.Name, d.Password,
+	)
+}
+
+type GoogleOptions struct {
+	RedirectURL  string `env:"GOOGLE_REDIRECT_URL"`
+	ClientID     string `env:"GOOGLE_CLIENT_ID"`
+	ClientSecret string `env:"GOOGLE_CLIENT_SECRET"`
+}
+
+type TwilioOptions struct {
+	WebhookURL  string `env:"TWILIO_WEBHOOK_URL"`
+	AccountSID  string `env:"TWILIO_ACCOUNT_SID"`
+	AuthToken   string `env:"TWILIO_AUTH_TOKEN"`
+	PhoneNumber string `env:"TWILIO_PHONE_NUMBER"`
+}
+
 type Configuration struct {
-	DBOpts             string        `env:"-"`
-	DBName             string        `env:"DB_NAME" envDefault:"iota_erp"`
-	DBHost             string        `env:"DB_HOST" envDefault:"localhost"`
-	DBPort             string        `env:"DB_PORT" envDefault:"5432"`
-	DBUser             string        `env:"DB_USER" envDefault:"postgres"`
-	DBPassword         string        `env:"DB_PASSWORD" envDefault:"postgres"`
-	GoogleRedirectURL  string        `env:"GOOGLE_REDIRECT_URL"`
-	GoogleClientID     string        `env:"GOOGLE_CLIENT_ID"`
-	GoogleClientSecret string        `env:"GOOGLE_CLIENT_SECRET"`
-	ServerPort         int           `env:"PORT" envDefault:"3200"`
-	SessionDuration    time.Duration `env:"SESSION_DURATION" envDefault:"720h"`
-	GoAppEnvironment   string        `env:"GO_APP_ENV" envDefault:"development"`
-	SocketAddress      string        `env:"-"`
-	OpenAIKey          string        `env:"OPENAI_KEY"`
-	UploadsPath        string        `env:"UPLOADS_PATH" envDefault:"static"`
-	Domain             string        `env:"DOMAIN" envDefault:"localhost"`
-	Origin             string        `env:"ORIGIN" envDefault:"http://localhost:3200"`
-	PageSize           int           `env:"PAGE_SIZE" envDefault:"25"`
-	MaxPageSize        int           `env:"MAX_PAGE_SIZE" envDefault:"100"`
-	LogLevel           string        `env:"LOG_LEVEL" envDefault:"error"`
+	Database DatabaseOptions
+	Google   GoogleOptions
+	Twilio   TwilioOptions
+
+	ServerPort       int           `env:"PORT" envDefault:"3200"`
+	SessionDuration  time.Duration `env:"SESSION_DURATION" envDefault:"720h"`
+	GoAppEnvironment string        `env:"GO_APP_ENV" envDefault:"development"`
+	SocketAddress    string        `env:"-"`
+	OpenAIKey        string        `env:"OPENAI_KEY"`
+	UploadsPath      string        `env:"UPLOADS_PATH" envDefault:"static"`
+	Domain           string        `env:"DOMAIN" envDefault:"localhost"`
+	Origin           string        `env:"ORIGIN" envDefault:"http://localhost:3200"`
+	PageSize         int           `env:"PAGE_SIZE" envDefault:"25"`
+	MaxPageSize      int           `env:"MAX_PAGE_SIZE" envDefault:"100"`
+	LogLevel         string        `env:"LOG_LEVEL" envDefault:"error"`
 	// Session ID cookie key
 	SidCookieKey        string `env:"SID_COOKIE_KEY" envDefault:"sid"`
 	OauthStateCookieKey string `env:"OAUTH_STATE_COOKIE_KEY" envDefault:"oauthState"`
 
-	TwilioWebhookURL  string `env:"TWILIO_WEBHOOK_URL"`
-	TwilioAccountSID  string `env:"TWILIO_ACCOUNT_SID"`
-	TwilioAuthToken   string `env:"TWILIO_AUTH_TOKEN"`
-	TwilioPhoneNumber string `env:"TWILIO_PHONE_NUMBER"`
-
 	TelegramBotToken string `env:"TELEGRAM_BOT_TOKEN"`
+
+	logFile *os.File
+	logger  *logrus.Logger
+}
+
+func (c *Configuration) Logger() *logrus.Logger {
+	return c.logger
 }
 
 func (c *Configuration) LogrusLogLevel() logrus.Level {
@@ -97,6 +126,13 @@ func Use() *Configuration {
 }
 
 func (c *Configuration) load(envFiles []string) error {
+	f, logger, err := logging.FileLogger(c.LogrusLogLevel())
+	if err != nil {
+		return err
+	}
+	c.logFile = f
+	c.logger = logger
+
 	n, err := LoadEnv(envFiles)
 	if err != nil {
 		return err
@@ -111,14 +147,18 @@ func (c *Configuration) load(envFiles []string) error {
 	if err := env.Parse(c); err != nil {
 		return err
 	}
-	c.DBOpts = fmt.Sprintf(
-		"host=%s port=%s user=%s dbname=%s password=%s sslmode=disable",
-		c.DBHost, c.DBPort, c.DBUser, c.DBName, c.DBPassword,
-	)
+	c.Database.Opts = c.Database.ConnectionString()
 	if c.GoAppEnvironment == "production" {
 		c.SocketAddress = fmt.Sprintf(":%d", c.ServerPort)
 	} else {
 		c.SocketAddress = fmt.Sprintf("localhost:%d", c.ServerPort)
 	}
 	return nil
+}
+
+// unload handles a graceful shutdown.
+func (c *Configuration) Unload() {
+	if c.logFile != nil {
+		c.logFile.Close()
+	}
 }

--- a/pkg/testutils/utils.go
+++ b/pkg/testutils/utils.go
@@ -4,13 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/jackc/pgx/v5"
 	"strings"
 	"time"
-
-	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/jackc/pgx/v5/stdlib"
-	_ "github.com/lib/pq"
 
 	"github.com/iota-uz/iota-sdk/modules"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/role"
@@ -21,6 +16,13 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/composables"
 	"github.com/iota-uz/iota-sdk/pkg/configuration"
 	"github.com/iota-uz/iota-sdk/pkg/eventbus"
+	"github.com/iota-uz/iota-sdk/pkg/logging"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/jackc/pgx/v5/stdlib"
+	_ "github.com/lib/pq"
+	"github.com/sirupsen/logrus"
 )
 
 type TestFixtures struct {
@@ -126,7 +128,7 @@ func DbOpts(name string) string {
 }
 
 func SetupApplication(pool *pgxpool.Pool, mods ...application.Module) (application.Application, error) {
-	app := application.New(pool, eventbus.NewEventPublisher())
+	app := application.New(pool, eventbus.NewEventPublisher(logging.ConsoleLogger(logrus.WarnLevel)))
 	if err := modules.Load(app, mods...); err != nil {
 		return nil, err
 	}
@@ -139,7 +141,7 @@ func SetupApplication(pool *pgxpool.Pool, mods ...application.Module) (applicati
 func GetTestContext() *TestFixtures {
 	conf := configuration.Use()
 	pool := NewPool(conf.DBOpts)
-	app := application.New(pool, eventbus.NewEventPublisher())
+	app := application.New(pool, eventbus.NewEventPublisher(logging.ConsoleLogger(logrus.WarnLevel)))
 	if err := modules.Load(app, modules.BuiltInModules...); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
> [!NOTE]
> - Used existing `logging` (which uses `logrus` under the hood) module. Not sure though. Happy to comply and rewrite to use just the `logrus` itself.
> - Added tests too. Seemed kinda redundant, but I think it is worth it just to at least play around with the isolated module itself instead of starting the whole app.

Example logs:

```json
{"level":"warning","msg":"eventbus.Publish: no matching subscribers for event with args: [\u003c*moneyaccount.CreatedEvent Value\u003e]","time":"2025-02-18T13:30:50+05:00"}
```