### PR TITLE
fix: account update changing the password

### DIFF
--- a/modules/core/domain/aggregates/user/user.go
+++ b/modules/core/domain/aggregates/user/user.go
@@ -1,10 +1,11 @@
 package user
 
 import (
-	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/permission"
-	"github.com/iota-uz/utils/sequence"
 	"strings"
 	"time"
+
+	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/permission"
+	"github.com/iota-uz/utils/sequence"
 
 	"golang.org/x/crypto/bcrypt"
 
@@ -40,6 +41,7 @@ type User interface {
 	SetAvatarID(id uint) User
 	SetLastIP(ip string) User
 	SetPassword(password string) (User, error)
+	SetPasswordUnsafe(password string) User
 	SetEmail(email string) User
 }
 
@@ -357,4 +359,24 @@ func (u *user) SetPassword(password string) (User, error) {
 		createdAt:  u.createdAt,
 		updatedAt:  time.Now(),
 	}, nil
+}
+
+func (u *user) SetPasswordUnsafe(newPassword string) User {
+	return &user{
+		id:         u.id,
+		firstName:  u.firstName,
+		lastName:   u.lastName,
+		middleName: u.middleName,
+		password:   newPassword,
+		email:      u.email,
+		avatarID:   u.avatarID,
+		avatar:     u.avatar,
+		lastIP:     u.lastIP,
+		uiLanguage: u.uiLanguage,
+		roles:      u.roles,
+		lastLogin:  u.lastLogin,
+		lastAction: u.lastAction,
+		createdAt:  u.createdAt,
+		updatedAt:  time.Now(),
+	}
 }

--- a/modules/core/presentation/controllers/account_controller.go
+++ b/modules/core/presentation/controllers/account_controller.go
@@ -1,11 +1,12 @@
 package controllers
 
 import (
+	"net/http"
+
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/tab"
 	"github.com/iota-uz/iota-sdk/modules/core/presentation/controllers/dtos"
 	"github.com/iota-uz/iota-sdk/modules/core/services"
 	"github.com/iota-uz/iota-sdk/pkg/middleware"
-	"net/http"
 
 	"github.com/a-h/templ"
 	"github.com/gorilla/mux"
@@ -86,17 +87,12 @@ func (c *AccountController) Get(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *AccountController) Update(w http.ResponseWriter, r *http.Request) {
-	if err := r.ParseForm(); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	dto := dtos.SaveAccountDTO{}
-	if err := shared.Decoder.Decode(&dto, r.Form); err != nil {
+	dto, err := composables.UseForm(&dtos.SaveAccountDTO{}, r)
+	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	errors, ok := dto.Ok(r.Context())
-	if !ok {
+	if errors, ok := dto.Ok(r.Context()); !ok {
 		props, err := c.defaultProps(r, errors)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/modules/core/presentation/controllers/dtos/account_dto.go
+++ b/modules/core/presentation/controllers/dtos/account_dto.go
@@ -3,6 +3,7 @@ package dtos
 import (
 	"context"
 	"fmt"
+
 	"github.com/go-playground/validator/v10"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/user"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
@@ -50,6 +51,9 @@ func (d *SaveAccountDTO) Apply(u user.User) (user.User, error) {
 	updated := u.
 		SetName(d.FirstName, d.LastName, d.MiddleName).
 		SetAvatarID(d.AvatarID).
-		SetUILanguage(lang)
+		SetUILanguage(lang).
+		// set to empty without hashing because an account cannot change its password and empty
+		// password is ignored by UserService.Update
+		SetPasswordUnsafe("")
 	return updated, nil
 }


### PR DESCRIPTION
The issue was with `composables.UseUser` which returned the user with it's password. Naturally, the returned password was hashed and not empty. This lead to UserService.Update to re-hash the already hashed password:

https://github.com/iota-uz/iota-sdk/blob/cc2f2d097d4049a8582f9e734b03698cc0a0cbdb/modules/core/services/user_service.go#L72-L77

So, this was working with user update and not account update because in user update if the password wasn't changed it would be empty and work properly. In case of account this was not the case.

My solution changed the interface of user to be able to set the password without hashing. I named the function `SetPasswordUnsafe` because it sets the password to raw, unhashed string value. In the case of account, setting the password to empty string makes it work correctly.