### PR TITLE
add: sensible defaults to e2e db config and document it

### DIFF
--- a/docs/CONTRIBUTING.MD
+++ b/docs/CONTRIBUTING.MD
@@ -111,7 +111,7 @@ Before starting, ensure the following tools are installed on your system:
 
 9. **Access the web app**:
 
-   Open your browser and navigate to:  
+   Open your browser and navigate to:
    [http://localhost:8080](http://localhost:8080)
 
    Use the following credentials to log in:
@@ -125,9 +125,26 @@ Before starting, ensure the following tools are installed on your system:
    TestPass123!
    ```
 
-10. **Access the GraphQL Schema**:  
-    Open Postman and connect to:  
+10. **Access the GraphQL Schema**:
+    Open Postman and connect to:
     [http://localhost:3200/query](http://localhost:3200/query)
+
+### Running tests
+
+To run end-to-end Cypress tests you need to have a working, migrated and seeded database and a running back-end on the background. Tests require these environment variables to be able to truncate the database before each test suite:
+
+- `DB_USER`
+- `DB_PASSWORD`
+- `DB_HOST`
+- `DB_PORT`
+- `DB_NAME`
+
+If they are not provided the tests will assume sensible defaults for a local database. To run the tests:
+
+```bash
+cd e2e/
+pnpm cypress run --headed
+```
 
 ### Troubleshooting Windows Setup
 
@@ -156,6 +173,6 @@ Before starting, ensure the following tools are installed on your system:
 
 ### Communication rules
 
-1. The contributer should close the conversation if he considers it's done. It can be reopened by the reviewer if needed. 
+1. The contributer should close the conversation if he considers it's done. It can be reopened by the reviewer if needed.
 
 For additional help, please check our [FAQ](./FAQ.md) or open an issue on GitHub.

--- a/e2e/cypress.config.js
+++ b/e2e/cypress.config.js
@@ -5,8 +5,15 @@ const { Pool } = require("pg");
 
 const exec = util.promisify(cp.exec);
 const { env } = process;
+const [DB_USER, DB_PASSWORD, DB_HOST, DB_PORT, DB_NAME] = [
+	env.DB_USER ?? "postgres",
+	env.DB_PASSWORD ?? "postgres",
+	env.DB_HOST ?? "localhost",
+	env.DB_PORT ?? 5432,
+	env.DB_NAME ?? "iota_erp",
+];
 const pool = new Pool({
-	connectionString: `postgres://${env.DB_USER}:${env.DB_PASSWORD}@${env.DB_HOST}:${env.DB_PORT}/${env.DB_NAME}`,
+	connectionString: `postgres://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}`,
 });
 
 async function resetDatabase() {


### PR DESCRIPTION
Setting up variables for testing for each new shell session gets tiring. Introduce sensible defaults just like the server has:

https://github.com/iota-uz/iota-sdk/blob/b933e583ceb31f07d63a8d0047cd5a103b8d32e7/pkg/configuration/environment.go#L54-L58