### PR TITLE
fix: expense creation silent failing because of absent returning id

### DIFF
--- a/modules/finance/infrastructure/persistence/expense_repository.go
+++ b/modules/finance/infrastructure/persistence/expense_repository.go
@@ -4,14 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/iota-uz/iota-sdk/modules/finance/infrastructure/persistence/models"
-	"github.com/iota-uz/iota-sdk/pkg/repo"
 	"strings"
 
 	"github.com/iota-uz/iota-sdk/modules/finance/domain/aggregates/expense"
 	category "github.com/iota-uz/iota-sdk/modules/finance/domain/aggregates/expense_category"
 	"github.com/iota-uz/iota-sdk/modules/finance/domain/entities/transaction"
+	"github.com/iota-uz/iota-sdk/modules/finance/infrastructure/persistence/models"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"github.com/iota-uz/iota-sdk/pkg/repo"
 )
 
 var (
@@ -148,6 +148,7 @@ func (g *GormExpenseRepository) Create(ctx context.Context, data *expense.Expens
 	if err := tx.QueryRow(ctx, `
 		INSERT INTO expenses (transaction_id, category_id)
 		VALUES ($1, $2)
+		RETURNING id
 	`, transactionRow.ID, expenseRow.CategoryID).Scan(&data.ID); err != nil {
 		return err
 	}

--- a/modules/finance/presentation/controllers/expense_controller.go
+++ b/modules/finance/presentation/controllers/expense_controller.go
@@ -1,24 +1,25 @@
 package controllers
 
 import (
+	"net/http"
+
+	"github.com/iota-uz/iota-sdk/components/base/pagination"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/currency"
+	"github.com/iota-uz/iota-sdk/modules/finance/domain/aggregates/expense"
 	category "github.com/iota-uz/iota-sdk/modules/finance/domain/aggregates/expense_category"
 	"github.com/iota-uz/iota-sdk/modules/finance/presentation/mappers"
 	expenses2 "github.com/iota-uz/iota-sdk/modules/finance/presentation/templates/pages/expenses"
 	"github.com/iota-uz/iota-sdk/modules/finance/presentation/viewmodels"
-	"github.com/iota-uz/iota-sdk/pkg/middleware"
-	"net/http"
-
-	"github.com/a-h/templ"
-	"github.com/go-faster/errors"
-	"github.com/gorilla/mux"
-	"github.com/iota-uz/iota-sdk/components/base/pagination"
-	"github.com/iota-uz/iota-sdk/modules/finance/domain/aggregates/expense"
 	"github.com/iota-uz/iota-sdk/modules/finance/services"
 	"github.com/iota-uz/iota-sdk/pkg/application"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
 	"github.com/iota-uz/iota-sdk/pkg/mapping"
+	"github.com/iota-uz/iota-sdk/pkg/middleware"
 	"github.com/iota-uz/iota-sdk/pkg/shared"
+
+	"github.com/a-h/templ"
+	"github.com/go-faster/errors"
+	"github.com/gorilla/mux"
 )
 
 type ExpenseController struct {


### PR DESCRIPTION
Closes: #187

The user was able to create expense, it just fell with 500 because of lack of `RETURNING id` even though the creation was successful.