### PR TITLE
feat: replace UpdatedAt with CreatedAt in clients table

### DIFF
--- a/modules/crm/presentation/templates/pages/clients/clients.templ
+++ b/modules/crm/presentation/templates/pages/clients/clients.templ
@@ -71,7 +71,7 @@ templ ClientRow(client *viewmodels.Client, rowProps *base.TableRowProps) {
 		}
 		@base.TableCell(base.TableCellProps{}) {
 			<div x-data="relativeformat">
-				<span x-text={ fmt.Sprintf("format('%s')", client.UpdatedAt) }></span>
+				<span x-text={ fmt.Sprintf("format('%s')", client.CreatedAt) }></span>
 			</div>
 		}
 	}
@@ -113,7 +113,7 @@ templ ClientsTable(props *IndexPageProps) {
 		Columns: []*base.TableColumn{
 			{Label: pageCtx.T("Clients.List.FullName"), Key: "fullName"},
 			{Label: pageCtx.T("Clients.List.Phone"), Key: "phone"},
-			{Label: pageCtx.T("UpdatedAt"), Key: "updatedAt"},
+			{Label: pageCtx.T("CreatedAt"), Key: "createdAt"},
 		},
 		TBodyAttrs: templ.Attributes{
 			"id": "clients-table-body",


### PR DESCRIPTION
Replace UpdatedAt column with CreatedAt in clients table display

- Remove UpdatedAt column from clients table display
- Add CreatedAt column to show client creation date instead
- Update table header and row display to use CreatedAt

Resolves #292

Generated with [Claude Code](https://claude.ai/code)