### PR TITLE
enhance: restrict Claude code review to non-draft PRs only

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,10 +2,11 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, ready_for_review]
 
 jobs:
   code-review:
+    if: github.event.pull_request.draft == false
     runs-on: blacksmith-8vcpu-ubuntu-2204
     permissions:
       contents: read


### PR DESCRIPTION
- Add ready_for_review trigger to run when PR transitions from draft
- Add condition to skip workflow execution on draft PRs