### PR TITLE
feat: add debt aggregate view for counterparty debt summary

### DIFF
--- a/modules/finance/domain/aggregates/debt/debt.go
+++ b/modules/finance/domain/aggregates/debt/debt.go
@@ -59,3 +59,22 @@ type Debt interface {
 	CreatedAt() time.Time
 	UpdatedAt() time.Time
 }
+
+// CounterpartyAggregate represents aggregated debt data for a counterparty
+type CounterpartyAggregate interface {
+	CounterpartyID() uuid.UUID
+	TotalReceivable() float64
+	TotalPayable() float64
+	TotalOutstandingReceivable() float64
+	TotalOutstandingPayable() float64
+	DebtCount() int
+	CurrencyCode() string
+	NetAmount() float64
+	UpdateCounterpartyID(id uuid.UUID) CounterpartyAggregate
+	UpdateTotalReceivable(amount float64) CounterpartyAggregate
+	UpdateTotalPayable(amount float64) CounterpartyAggregate
+	UpdateTotalOutstandingReceivable(amount float64) CounterpartyAggregate
+	UpdateTotalOutstandingPayable(amount float64) CounterpartyAggregate
+	UpdateDebtCount(count int) CounterpartyAggregate
+	UpdateCurrencyCode(code string) CounterpartyAggregate
+}

--- a/modules/finance/domain/aggregates/debt/debt_impl.go
+++ b/modules/finance/domain/aggregates/debt/debt_impl.go
@@ -225,3 +225,153 @@ func (d *debt) CreatedAt() time.Time {
 func (d *debt) UpdatedAt() time.Time {
 	return d.updatedAt
 }
+
+// CounterpartyAggregate functional options
+type CounterpartyAggregateOption func(ca *counterpartyAggregate)
+
+func WithAggCounterpartyID(id uuid.UUID) CounterpartyAggregateOption {
+	return func(ca *counterpartyAggregate) {
+		ca.counterpartyID = id
+	}
+}
+
+func WithAggTotalReceivable(amount float64) CounterpartyAggregateOption {
+	return func(ca *counterpartyAggregate) {
+		ca.totalReceivable = amount
+	}
+}
+
+func WithAggTotalPayable(amount float64) CounterpartyAggregateOption {
+	return func(ca *counterpartyAggregate) {
+		ca.totalPayable = amount
+	}
+}
+
+func WithAggTotalOutstandingReceivable(amount float64) CounterpartyAggregateOption {
+	return func(ca *counterpartyAggregate) {
+		ca.totalOutstandingReceivable = amount
+	}
+}
+
+func WithAggTotalOutstandingPayable(amount float64) CounterpartyAggregateOption {
+	return func(ca *counterpartyAggregate) {
+		ca.totalOutstandingPayable = amount
+	}
+}
+
+func WithAggDebtCount(count int) CounterpartyAggregateOption {
+	return func(ca *counterpartyAggregate) {
+		ca.debtCount = count
+	}
+}
+
+func WithAggCurrencyCode(code string) CounterpartyAggregateOption {
+	return func(ca *counterpartyAggregate) {
+		ca.currencyCode = code
+	}
+}
+
+// NewCounterpartyAggregate creates a new CounterpartyAggregate with functional options
+func NewCounterpartyAggregate(
+	counterpartyID uuid.UUID,
+	opts ...CounterpartyAggregateOption,
+) CounterpartyAggregate {
+	ca := &counterpartyAggregate{
+		counterpartyID:             counterpartyID,
+		totalReceivable:            0,
+		totalPayable:               0,
+		totalOutstandingReceivable: 0,
+		totalOutstandingPayable:    0,
+		debtCount:                  0,
+		currencyCode:               "",
+	}
+	for _, opt := range opts {
+		opt(ca)
+	}
+	return ca
+}
+
+// counterpartyAggregate private implementation
+type counterpartyAggregate struct {
+	counterpartyID             uuid.UUID
+	totalReceivable            float64
+	totalPayable               float64
+	totalOutstandingReceivable float64
+	totalOutstandingPayable    float64
+	debtCount                  int
+	currencyCode               string
+}
+
+func (ca *counterpartyAggregate) CounterpartyID() uuid.UUID {
+	return ca.counterpartyID
+}
+
+func (ca *counterpartyAggregate) TotalReceivable() float64 {
+	return ca.totalReceivable
+}
+
+func (ca *counterpartyAggregate) TotalPayable() float64 {
+	return ca.totalPayable
+}
+
+func (ca *counterpartyAggregate) TotalOutstandingReceivable() float64 {
+	return ca.totalOutstandingReceivable
+}
+
+func (ca *counterpartyAggregate) TotalOutstandingPayable() float64 {
+	return ca.totalOutstandingPayable
+}
+
+func (ca *counterpartyAggregate) DebtCount() int {
+	return ca.debtCount
+}
+
+func (ca *counterpartyAggregate) CurrencyCode() string {
+	return ca.currencyCode
+}
+
+func (ca *counterpartyAggregate) NetAmount() float64 {
+	return ca.totalReceivable - ca.totalPayable
+}
+
+func (ca *counterpartyAggregate) UpdateCounterpartyID(id uuid.UUID) CounterpartyAggregate {
+	result := *ca
+	result.counterpartyID = id
+	return &result
+}
+
+func (ca *counterpartyAggregate) UpdateTotalReceivable(amount float64) CounterpartyAggregate {
+	result := *ca
+	result.totalReceivable = amount
+	return &result
+}
+
+func (ca *counterpartyAggregate) UpdateTotalPayable(amount float64) CounterpartyAggregate {
+	result := *ca
+	result.totalPayable = amount
+	return &result
+}
+
+func (ca *counterpartyAggregate) UpdateTotalOutstandingReceivable(amount float64) CounterpartyAggregate {
+	result := *ca
+	result.totalOutstandingReceivable = amount
+	return &result
+}
+
+func (ca *counterpartyAggregate) UpdateTotalOutstandingPayable(amount float64) CounterpartyAggregate {
+	result := *ca
+	result.totalOutstandingPayable = amount
+	return &result
+}
+
+func (ca *counterpartyAggregate) UpdateDebtCount(count int) CounterpartyAggregate {
+	result := *ca
+	result.debtCount = count
+	return &result
+}
+
+func (ca *counterpartyAggregate) UpdateCurrencyCode(code string) CounterpartyAggregate {
+	result := *ca
+	result.currencyCode = code
+	return &result
+}

--- a/modules/finance/domain/aggregates/debt/debt_repository.go
+++ b/modules/finance/domain/aggregates/debt/debt_repository.go
@@ -23,12 +23,23 @@ type FindParams struct {
 	Status         *DebtStatus
 }
 
+type CounterpartyAggregate struct {
+	CounterpartyID                uuid.UUID
+	TotalReceivable               float64
+	TotalPayable                  float64
+	TotalOutstandingReceivable    float64
+	TotalOutstandingPayable       float64
+	DebtCount                     int
+	CurrencyCode                  string
+}
+
 type Repository interface {
 	Count(ctx context.Context) (int64, error)
 	GetAll(ctx context.Context) ([]Debt, error)
 	GetPaginated(ctx context.Context, params *FindParams) ([]Debt, error)
 	GetByID(ctx context.Context, id uuid.UUID) (Debt, error)
 	GetByCounterpartyID(ctx context.Context, counterpartyID uuid.UUID) ([]Debt, error)
+	GetCounterpartyAggregates(ctx context.Context) ([]CounterpartyAggregate, error)
 	Create(ctx context.Context, debt Debt) (Debt, error)
 	Update(ctx context.Context, debt Debt) (Debt, error)
 	Delete(ctx context.Context, id uuid.UUID) error

--- a/modules/finance/domain/aggregates/debt/debt_repository.go
+++ b/modules/finance/domain/aggregates/debt/debt_repository.go
@@ -23,15 +23,6 @@ type FindParams struct {
 	Status         *DebtStatus
 }
 
-type CounterpartyAggregate struct {
-	CounterpartyID                uuid.UUID
-	TotalReceivable               float64
-	TotalPayable                  float64
-	TotalOutstandingReceivable    float64
-	TotalOutstandingPayable       float64
-	DebtCount                     int
-	CurrencyCode                  string
-}
 
 type Repository interface {
 	Count(ctx context.Context) (int64, error)

--- a/modules/finance/infrastructure/persistence/debt_repository.go
+++ b/modules/finance/infrastructure/persistence/debt_repository.go
@@ -178,18 +178,32 @@ func (g *GormDebtRepository) GetCounterpartyAggregates(ctx context.Context) ([]d
 
 	aggregates := make([]debt.CounterpartyAggregate, 0)
 	for rows.Next() {
-		var agg debt.CounterpartyAggregate
+		var counterpartyID uuid.UUID
+		var totalReceivable, totalPayable, totalOutstandingReceivable, totalOutstandingPayable float64
+		var debtCount int
+		var currencyCode string
+
 		if err := rows.Scan(
-			&agg.CounterpartyID,
-			&agg.TotalReceivable,
-			&agg.TotalPayable,
-			&agg.TotalOutstandingReceivable,
-			&agg.TotalOutstandingPayable,
-			&agg.DebtCount,
-			&agg.CurrencyCode,
+			&counterpartyID,
+			&totalReceivable,
+			&totalPayable,
+			&totalOutstandingReceivable,
+			&totalOutstandingPayable,
+			&debtCount,
+			&currencyCode,
 		); err != nil {
 			return nil, err
 		}
+
+		agg := debt.NewCounterpartyAggregate(
+			counterpartyID,
+			debt.WithAggTotalReceivable(totalReceivable),
+			debt.WithAggTotalPayable(totalPayable),
+			debt.WithAggTotalOutstandingReceivable(totalOutstandingReceivable),
+			debt.WithAggTotalOutstandingPayable(totalOutstandingPayable),
+			debt.WithAggDebtCount(debtCount),
+			debt.WithAggCurrencyCode(currencyCode),
+		)
 		aggregates = append(aggregates, agg)
 	}
 	return aggregates, nil

--- a/modules/finance/links.go
+++ b/modules/finance/links.go
@@ -60,6 +60,12 @@ var (
 		Permissions: nil,
 		Children:    nil,
 	}
+	DebtAggregatesItem = types.NavigationItem{
+		Name:        "NavigationLinks.DebtAggregates",
+		Href:        "/finance/debt-aggregates",
+		Permissions: nil,
+		Children:    nil,
+	}
 	EnumsItem = types.NavigationItem{
 		Name:        "NavigationLinks.Finance.Enums",
 		Href:        "/finance/enums",
@@ -99,6 +105,7 @@ var FinanceItem = types.NavigationItem{
 		PaymentsItem,
 		ExpensesItem,
 		DebtsItem,
+		DebtAggregatesItem,
 		AccountsItem,
 		CounterpartiesItem,
 		InventoryItem,

--- a/modules/finance/module.go
+++ b/modules/finance/module.go
@@ -80,6 +80,7 @@ func (m *Module) Register(app application.Application) error {
 		controllers.NewCounterpartiesController(app),
 		controllers.NewInventoryController(app),
 		controllers.NewDebtsController(app),
+		controllers.NewDebtAggregateController(app),
 		controllers.NewFinancialReportController(app),
 		controllers.NewCashflowController(app),
 	)

--- a/modules/finance/presentation/controllers/debt_aggregate_controller.go
+++ b/modules/finance/presentation/controllers/debt_aggregate_controller.go
@@ -99,7 +99,7 @@ func (c *DebtAggregateController) List(w http.ResponseWriter, r *http.Request) {
 	rows := make([]table.TableRow, 0, len(aggregates))
 
 	for _, agg := range aggregates {
-		counterparty, err := c.counterpartyService.GetByID(ctx, agg.CounterpartyID)
+		counterparty, err := c.counterpartyService.GetByID(ctx, agg.CounterpartyID())
 		if err != nil {
 			http.Error(w, "Error retrieving counterparty", http.StatusInternalServerError)
 			return

--- a/modules/finance/presentation/controllers/debt_aggregate_controller.go
+++ b/modules/finance/presentation/controllers/debt_aggregate_controller.go
@@ -1,0 +1,195 @@
+package controllers
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/a-h/templ"
+	"github.com/gorilla/mux"
+	"github.com/iota-uz/iota-sdk/components/scaffold/table"
+	"github.com/iota-uz/iota-sdk/modules/finance/domain/aggregates/debt"
+	"github.com/iota-uz/iota-sdk/modules/finance/presentation/mappers"
+	"github.com/iota-uz/iota-sdk/modules/finance/presentation/viewmodels"
+	"github.com/iota-uz/iota-sdk/modules/finance/services"
+	"github.com/iota-uz/iota-sdk/pkg/application"
+	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"github.com/iota-uz/iota-sdk/pkg/htmx"
+	"github.com/iota-uz/iota-sdk/pkg/mapping"
+	"github.com/iota-uz/iota-sdk/pkg/middleware"
+	"github.com/iota-uz/iota-sdk/pkg/shared"
+)
+
+type DebtAggregateController struct {
+	app                 application.Application
+	debtService         *services.DebtService
+	counterpartyService *services.CounterpartyService
+	basePath            string
+	tableDefinition     table.TableDefinition
+}
+
+func NewDebtAggregateController(app application.Application) application.Controller {
+	basePath := "/finance/debt-aggregates"
+
+	tableDefinition := table.NewTableDefinition("", basePath).
+		WithInfiniteScroll(false).
+		Build()
+
+	return &DebtAggregateController{
+		app:                 app,
+		debtService:         app.Service(services.DebtService{}).(*services.DebtService),
+		counterpartyService: app.Service(services.CounterpartyService{}).(*services.CounterpartyService),
+		basePath:            basePath,
+		tableDefinition:     tableDefinition,
+	}
+}
+
+func (c *DebtAggregateController) Key() string {
+	return c.basePath
+}
+
+func (c *DebtAggregateController) Register(r *mux.Router) {
+	commonMiddleware := []mux.MiddlewareFunc{
+		middleware.Authorize(),
+		middleware.RedirectNotAuthenticated(),
+		middleware.ProvideUser(),
+		middleware.ProvideDynamicLogo(c.app),
+		middleware.Tabs(),
+		middleware.ProvideLocalizer(c.app.Bundle()),
+		middleware.NavItems(),
+		middleware.WithPageContext(),
+	}
+
+	router := r.PathPrefix(c.basePath).Subrouter()
+	router.Use(commonMiddleware...)
+	router.HandleFunc("", c.List).Methods(http.MethodGet)
+	router.HandleFunc("/{counterparty_id:[0-9a-fA-F-]+}/drawer", c.GetCounterpartyDrawer).Methods(http.MethodGet)
+}
+
+func (c *DebtAggregateController) List(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	pageCtx := composables.UsePageCtx(ctx)
+
+	aggregates, err := c.debtService.GetCounterpartyAggregates(ctx)
+	if err != nil {
+		http.Error(w, "Error retrieving debt aggregates", http.StatusInternalServerError)
+		return
+	}
+
+	var definition table.TableDefinition
+	if !htmx.IsHxRequest(r) {
+		definition = table.NewTableDefinition(
+			pageCtx.T("DebtAggregates.Meta.List.Title"),
+			c.basePath,
+		).
+			WithColumns(
+				table.Column("counterparty", pageCtx.T("DebtAggregates.List.Counterparty")),
+				table.Column("total_receivable", pageCtx.T("DebtAggregates.List.TotalReceivable")),
+				table.Column("total_payable", pageCtx.T("DebtAggregates.List.TotalPayable")),
+				table.Column("outstanding_receivable", pageCtx.T("DebtAggregates.List.OutstandingReceivable")),
+				table.Column("outstanding_payable", pageCtx.T("DebtAggregates.List.OutstandingPayable")),
+				table.Column("net_amount", pageCtx.T("DebtAggregates.List.NetAmount")),
+				table.Column("debt_count", pageCtx.T("DebtAggregates.List.DebtCount")),
+			).
+			WithInfiniteScroll(false).
+			Build()
+	} else {
+		definition = c.tableDefinition
+	}
+
+	rows := make([]table.TableRow, 0, len(aggregates))
+
+	for _, agg := range aggregates {
+		counterparty, err := c.counterpartyService.GetByID(ctx, agg.CounterpartyID)
+		if err != nil {
+			http.Error(w, "Error retrieving counterparty", http.StatusInternalServerError)
+			return
+		}
+
+		aggVM := mappers.DebtCounterpartyAggregateToViewModel(agg, counterparty.Name())
+
+		cells := []templ.Component{
+			templ.Raw(aggVM.CounterpartyName),
+			templ.Raw(aggVM.TotalReceivable),
+			templ.Raw(aggVM.TotalPayable),
+			templ.Raw(aggVM.TotalOutstandingReceivable),
+			templ.Raw(aggVM.TotalOutstandingPayable),
+			templ.Raw(aggVM.NetAmount),
+			templ.Raw(fmt.Sprintf("%d", aggVM.DebtCount)),
+		}
+
+		row := table.Row(cells...).ApplyOpts(
+			table.WithDrawer(fmt.Sprintf("%s/%s/drawer", c.basePath, aggVM.CounterpartyID)),
+		)
+		rows = append(rows, row)
+	}
+
+	tableData := table.NewTableData().
+		WithRows(rows...).
+		WithQueryParams(r.URL.Query())
+
+	renderer := table.NewTableRenderer(definition, tableData)
+
+	if htmx.IsHxRequest(r) {
+		templ.Handler(renderer.RenderRows(), templ.WithStreaming()).ServeHTTP(w, r)
+	} else {
+		templ.Handler(renderer.RenderFull(), templ.WithStreaming()).ServeHTTP(w, r)
+	}
+}
+
+func (c *DebtAggregateController) GetCounterpartyDrawer(w http.ResponseWriter, r *http.Request) {
+	counterpartyID, err := shared.ParseUUID(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	ctx := r.Context()
+	pageCtx := composables.UsePageCtx(ctx)
+
+	debts, err := c.debtService.GetByCounterpartyID(ctx, counterpartyID)
+	if err != nil {
+		http.Error(w, "Error retrieving debts", http.StatusInternalServerError)
+		return
+	}
+
+	counterparty, err := c.counterpartyService.GetByID(ctx, counterpartyID)
+	if err != nil {
+		http.Error(w, "Error retrieving counterparty", http.StatusInternalServerError)
+		return
+	}
+
+	debtVMs := mapping.MapViewModels(debts, func(d debt.Debt) *viewmodels.Debt {
+		return mappers.DebtToViewModel(d, counterparty.Name())
+	})
+
+	// Create simple table for drawer content
+	definition := table.NewTableDefinition(
+		fmt.Sprintf("%s - %s", pageCtx.T("DebtAggregates.Drawer.Title"), counterparty.Name()),
+		"",
+	).
+		WithColumns(
+			table.Column("type", pageCtx.T("Debts.List.Type")),
+			table.Column("original_amount", pageCtx.T("Debts.List.OriginalAmount")),
+			table.Column("outstanding_amount", pageCtx.T("Debts.List.OutstandingAmount")),
+			table.Column("status", pageCtx.T("Debts.List.Status")),
+			table.Column("description", pageCtx.T("Debts.List.Description")),
+		).
+		Build()
+
+	rows := make([]table.TableRow, 0, len(debtVMs))
+	for _, debtVM := range debtVMs {
+		cells := []templ.Component{
+			templ.Raw(pageCtx.T(fmt.Sprintf("Debts.Types.%s", debtVM.Type))),
+			templ.Raw(debtVM.OriginalAmountWithCurrency),
+			templ.Raw(debtVM.OutstandingAmountWithCurrency),
+			templ.Raw(pageCtx.T(fmt.Sprintf("Debts.Statuses.%s", debtVM.Status))),
+			templ.Raw(debtVM.Description),
+		}
+		rows = append(rows, table.Row(cells...))
+	}
+
+	tableData := table.NewTableData().WithRows(rows...)
+	renderer := table.NewTableRenderer(definition, tableData)
+
+	templ.Handler(renderer.RenderFull(), templ.WithStreaming()).ServeHTTP(w, r)
+}

--- a/modules/finance/presentation/locales/en.json
+++ b/modules/finance/presentation/locales/en.json
@@ -9,6 +9,7 @@
     "PaymentCategories": "Payment categories",
     "Counterparties": "Counterparties",
     "Debts": "Debts",
+    "DebtAggregates": "Debt Summary",
     "Inventory": "Inventory",
     "Reports": "Reports",
     "IncomeStatement": "Income Statement",
@@ -507,6 +508,25 @@
       "Deleted": "Debt deleted successfully",
       "Settled": "Debt settled successfully",
       "WrittenOff": "Debt written off successfully"
+    }
+  },
+  "DebtAggregates": {
+    "Meta": {
+      "List": {
+        "Title": "Debt Summary by Counterparty"
+      }
+    },
+    "List": {
+      "Counterparty": "Counterparty",
+      "TotalReceivable": "Total Receivable",
+      "TotalPayable": "Total Payable",
+      "OutstandingReceivable": "Outstanding Receivable",
+      "OutstandingPayable": "Outstanding Payable",
+      "NetAmount": "Net Amount",
+      "DebtCount": "Total Debts"
+    },
+    "Drawer": {
+      "Title": "Debt Details"
     }
   }
 }

--- a/modules/finance/presentation/locales/ru.json
+++ b/modules/finance/presentation/locales/ru.json
@@ -9,6 +9,7 @@
     "Finances": "Финансы",
     "Counterparties": "Контрагенты",
     "Debts": "Долги",
+    "DebtAggregates": "Сводка по долгам",
     "Inventory": "Склад",
     "Reports": "Отчёты",
     "IncomeStatement": "Отчёт о прибылях и убытках",
@@ -507,6 +508,25 @@
       "Deleted": "Долг успешно удалён",
       "Settled": "Долг успешно погашен",
       "WrittenOff": "Долг успешно списан"
+    }
+  },
+  "DebtAggregates": {
+    "Meta": {
+      "List": {
+        "Title": "Сводка долгов по контрагентам"
+      }
+    },
+    "List": {
+      "Counterparty": "Контрагент",
+      "TotalReceivable": "Всего к получению",
+      "TotalPayable": "Всего к оплате",
+      "OutstandingReceivable": "К получению остаток",
+      "OutstandingPayable": "К оплате остаток",
+      "NetAmount": "Чистая сумма",
+      "DebtCount": "Всего долгов"
+    },
+    "Drawer": {
+      "Title": "Детали долгов"
     }
   }
 }

--- a/modules/finance/presentation/locales/uz.json
+++ b/modules/finance/presentation/locales/uz.json
@@ -9,6 +9,7 @@
     "Finances": "Moliya",
     "Counterparties": "Kontragentlar",
     "Debts": "Qarzlar",
+    "DebtAggregates": "Qarzlar xulosasi",
     "Inventory": "Ombor",
     "Reports": "Hisobotlar",
     "IncomeStatement": "Daromad va zarar hisoboti",
@@ -507,6 +508,25 @@
       "Deleted": "Qarz muvaffaqiyatli o'chirildi",
       "Settled": "Qarz muvaffaqiyatli to'landi",
       "WrittenOff": "Qarz muvaffaqiyatli hisobdan chiqarildi"
+    }
+  },
+  "DebtAggregates": {
+    "Meta": {
+      "List": {
+        "Title": "Kontragentlar bo'yicha qarzlar xulosasi"
+      }
+    },
+    "List": {
+      "Counterparty": "Kontragent",
+      "TotalReceivable": "Jami olinadigan",
+      "TotalPayable": "Jami to'lanadigan",
+      "OutstandingReceivable": "Olinadigan qoldiq",
+      "OutstandingPayable": "To'lanadigan qoldiq",
+      "NetAmount": "Aniq summa",
+      "DebtCount": "Jami qarzlar"
+    },
+    "Drawer": {
+      "Title": "Qarz tafsilotlari"
     }
   }
 }

--- a/modules/finance/presentation/mappers/mappers.go
+++ b/modules/finance/presentation/mappers/mappers.go
@@ -932,22 +932,22 @@ func DebtToViewModel(entity debt.Debt, counterpartyName string) *viewmodels.Debt
 }
 
 func DebtCounterpartyAggregateToViewModel(agg debt.CounterpartyAggregate, counterpartyName string) *viewmodels.DebtCounterpartyAggregate {
-	receivableMoney := money.NewFromFloat(agg.TotalReceivable, agg.CurrencyCode)
-	payableMoney := money.NewFromFloat(agg.TotalPayable, agg.CurrencyCode)
-	outstandingReceivableMoney := money.NewFromFloat(agg.TotalOutstandingReceivable, agg.CurrencyCode)
-	outstandingPayableMoney := money.NewFromFloat(agg.TotalOutstandingPayable, agg.CurrencyCode)
+	receivableMoney := money.NewFromFloat(agg.TotalReceivable(), agg.CurrencyCode())
+	payableMoney := money.NewFromFloat(agg.TotalPayable(), agg.CurrencyCode())
+	outstandingReceivableMoney := money.NewFromFloat(agg.TotalOutstandingReceivable(), agg.CurrencyCode())
+	outstandingPayableMoney := money.NewFromFloat(agg.TotalOutstandingPayable(), agg.CurrencyCode())
 	
 	netAmount, _ := outstandingReceivableMoney.Subtract(outstandingPayableMoney)
 
 	return &viewmodels.DebtCounterpartyAggregate{
-		CounterpartyID:             agg.CounterpartyID.String(),
+		CounterpartyID:             agg.CounterpartyID().String(),
 		CounterpartyName:           counterpartyName,
 		TotalReceivable:            receivableMoney.Display(),
 		TotalPayable:               payableMoney.Display(),
 		TotalOutstandingReceivable: outstandingReceivableMoney.Display(),
 		TotalOutstandingPayable:    outstandingPayableMoney.Display(),
 		NetAmount:                  netAmount.Display(),
-		DebtCount:                  agg.DebtCount,
-		CurrencyCode:               agg.CurrencyCode,
+		DebtCount:                  agg.DebtCount(),
+		CurrencyCode:               agg.CurrencyCode(),
 	}
 }

--- a/modules/finance/presentation/mappers/mappers.go
+++ b/modules/finance/presentation/mappers/mappers.go
@@ -930,3 +930,24 @@ func DebtToViewModel(entity debt.Debt, counterpartyName string) *viewmodels.Debt
 
 	return vm
 }
+
+func DebtCounterpartyAggregateToViewModel(agg debt.CounterpartyAggregate, counterpartyName string) *viewmodels.DebtCounterpartyAggregate {
+	receivableMoney := money.NewFromFloat(agg.TotalReceivable, agg.CurrencyCode)
+	payableMoney := money.NewFromFloat(agg.TotalPayable, agg.CurrencyCode)
+	outstandingReceivableMoney := money.NewFromFloat(agg.TotalOutstandingReceivable, agg.CurrencyCode)
+	outstandingPayableMoney := money.NewFromFloat(agg.TotalOutstandingPayable, agg.CurrencyCode)
+	
+	netAmount, _ := outstandingReceivableMoney.Subtract(outstandingPayableMoney)
+
+	return &viewmodels.DebtCounterpartyAggregate{
+		CounterpartyID:             agg.CounterpartyID.String(),
+		CounterpartyName:           counterpartyName,
+		TotalReceivable:            receivableMoney.Display(),
+		TotalPayable:               payableMoney.Display(),
+		TotalOutstandingReceivable: outstandingReceivableMoney.Display(),
+		TotalOutstandingPayable:    outstandingPayableMoney.Display(),
+		NetAmount:                  netAmount.Display(),
+		DebtCount:                  agg.DebtCount,
+		CurrencyCode:               agg.CurrencyCode,
+	}
+}

--- a/modules/finance/presentation/viewmodels/debt_viewmodel.go
+++ b/modules/finance/presentation/viewmodels/debt_viewmodel.go
@@ -16,3 +16,15 @@ type Debt struct {
 	CreatedAt                     string
 	UpdatedAt                     string
 }
+
+type DebtCounterpartyAggregate struct {
+	CounterpartyID                string
+	CounterpartyName              string
+	TotalReceivable               string
+	TotalPayable                  string
+	TotalOutstandingReceivable    string
+	TotalOutstandingPayable       string
+	NetAmount                     string
+	DebtCount                     int
+	CurrencyCode                  string
+}

--- a/modules/finance/services/debt_service.go
+++ b/modules/finance/services/debt_service.go
@@ -57,6 +57,13 @@ func (s *DebtService) GetByCounterpartyID(ctx context.Context, counterpartyID uu
 	return s.repo.GetByCounterpartyID(ctx, counterpartyID)
 }
 
+func (s *DebtService) GetCounterpartyAggregates(ctx context.Context) ([]debt.CounterpartyAggregate, error) {
+	if err := composables.CanUser(ctx, permissions.DebtRead); err != nil {
+		return nil, err
+	}
+	return s.repo.GetCounterpartyAggregates(ctx)
+}
+
 func (s *DebtService) Create(ctx context.Context, entity debt.Debt) (debt.Debt, error) {
 	if err := composables.CanUser(ctx, permissions.DebtCreate); err != nil {
 		return nil, err


### PR DESCRIPTION
Implements debt aggregate page showing total receivable/payable amounts per counterparty with detail drawer displaying individual debt operations.

**Features:**
- Aggregate table showing total receivable/payable amounts per counterparty
- Detail drawer showing all debt operations for selected counterparty
- Net amount calculation (receivable - payable)
- Follows existing HTMX/table scaffold patterns
- Complete localization for en/ru/uz

**Closes #396**

Generated with [Claude Code](https://claude.ai/code)