### PR TITLE
feat: add NameField to group repository for exact name filtering

### DIFF
--- a/modules/core/domain/aggregates/group/group_repository.go
+++ b/modules/core/domain/aggregates/group/group_repository.go
@@ -13,6 +13,7 @@ const (
 	CreatedAtField Field = iota
 	UpdatedAtField
 	TenantIDField
+	NameField
 )
 
 type SortBy = repo.SortBy[Field]

--- a/modules/core/infrastructure/persistence/group_repository.go
+++ b/modules/core/infrastructure/persistence/group_repository.go
@@ -53,6 +53,7 @@ func NewGroupRepository(userRepo user.Repository, roleRepo role.Repository) grou
 			group.CreatedAtField: "g.created_at",
 			group.UpdatedAtField: "g.updated_at",
 			group.TenantIDField:  "g.tenant_id",
+			group.NameField:      "g.name",
 		},
 	}
 }


### PR DESCRIPTION
Add NameField to group repository to enable exact name-based filtering in group queries. This improves query precision and performance.

## Changes Made:

### Domain Layer:
- Added `NameField` constant to group repository interface
- Enables filtering groups by exact name matches

### Infrastructure Layer:
- Added `NameField` mapping to SQL column "g.name" in fieldMap
- Allows proper SQL query generation for name-based filters

## Usage:
```go
params := &group.FindParams{
    Filters: []group.Filter{
        {Column: group.NameField, Filter: repo.Eq("Dispatchers")},
    },
}
```

## Impact:
- Enables precise group lookups by name instead of search-based matching
- Improves performance by using indexed WHERE clauses vs ILIKE searches
- Required for tenant-specific dispatcher group implementation