### PR TITLE
chore: Migrate to Go 1.24

### DIFF
--- a/.claude/tools/go.mod
+++ b/.claude/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/iota-uz/iota-sdk/sdk-tools
 
-go 1.23.2
+go 1.24.10
 
 require (
 	github.com/fatih/color v1.18.0

--- a/.github/actions/setup-backend/action.yml
+++ b/.github/actions/setup-backend/action.yml
@@ -5,7 +5,7 @@ inputs:
   go-version:
     description: Go version to install
     required: false
-    default: '1.23.2'
+    default: '1.24.10'
   install-templ:
     description: Whether to install templ tool
     required: false

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,7 +17,7 @@ Multi-tenant business management platform built on the IOTA SDK framework. Provi
 
 ## Technology Stack
 
-- **Backend**: Go 1.23.2, IOTA SDK framework, GraphQL
+- **Backend**: Go 1.24.10, IOTA SDK framework, GraphQL
 - **Database**: PostgreSQL 13+ (multi-tenant with organization_id)
 - **Frontend**: HTMX + Alpine.js + Templ + Tailwind CSS
 - **Auth**: Cookie-based sessions with RBAC

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.23.2"
+          go-version: "1.24.10"
 
       - name: Install golangci-lint
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: useblacksmith/setup-go@v6
         with:
-          go-version: "1.23.2"
+          go-version: "1.24.10"
 
       - name: Install golangci-lint
         run: |
@@ -175,7 +175,7 @@ jobs:
       - name: Set up Go
         uses: useblacksmith/setup-go@v6
         with:
-          go-version: "1.23.2"
+          go-version: "1.24.10"
 
       - name: Install just
         run: |
@@ -299,7 +299,7 @@ jobs:
       - name: Set up Go
         uses: useblacksmith/setup-go@v6
         with:
-          go-version: "1.23.2"
+          go-version: "1.24.10"
 
       - name: Install just
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ modules/{module}/
 
 ## Technology Stack
 
-- **Backend**: Go 1.23.2, IOTA SDK framework, GraphQL
+- **Backend**: Go 1.24.10, IOTA SDK framework, GraphQL
 - **Database**: PostgreSQL 13+ (multi-tenant with organization_id)
 - **Frontend**: HTMX + Alpine.js + Templ + Tailwind CSS
 - **Auth**: Cookie-based sessions with RBAC
@@ -146,7 +146,7 @@ cd e2e && npx playwright test tests/module/specific.spec.ts  # Single test
 
 ## Code Style Guidelines
 - Use `go fmt` for formatting. Do not indent code manually.
-- Use Go v1.23.2 and follow standard Go idioms
+- Use Go v1.24.10 and follow standard Go idioms
 - File organization: group related functionality in modules/ or pkg/ directories
 - Naming: use camelCase for variables, PascalCase for exported functions/types
 - Testing: table-driven tests with descriptive names (TestFunctionName_Scenario), use the `require` and `assert` packages from `github.com/stretchr/testify`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ cd e2e && npx playwright test tests/module/specific.spec.ts:LINE  # Single test 
 
 ## Technology Stack
 
-- **Backend**: Go 1.23.2, IOTA SDK framework, GraphQL
+- **Backend**: Go 1.24.10, IOTA SDK framework, GraphQL
 - **Database**: PostgreSQL 13+ (multi-tenant with tenant_id)
 - **Frontend**: HTMX + Alpine.js + Templ + Tailwind CSS
 - **Auth**: Cookie-based sessions with RBAC

--- a/Dockerfile.superadmin
+++ b/Dockerfile.superadmin
@@ -1,4 +1,4 @@
-FROM golang:1.23.2-alpine AS base
+FROM golang:1.24.10-alpine AS base
 
 ARG JUST_VERSION=1.46.0
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.23.2
+FROM golang:1.24.10
 
 WORKDIR /build
 

--- a/docs/content/architecture/index.mdx
+++ b/docs/content/architecture/index.mdx
@@ -144,7 +144,7 @@ graph LR
 
 | Component | Technology | Purpose |
 |-----------|-----------|---------|
-| Language | Go 1.23+ | Type-safe, performant |
+| Language | Go 1.24+ | Type-safe, performant |
 | Router | gorilla/mux | HTTP routing |
 | Database | PostgreSQL 13+ | ACID, JSON support |
 | ORM | sqlx | Structured queries |

--- a/docs/content/development/module-development.mdx
+++ b/docs/content/development/module-development.mdx
@@ -23,7 +23,7 @@ By the end of this guide, you'll have a fully functional Product Catalog module 
 
 Before starting, ensure you have:
 - Understanding of [IOTA SDK Architecture](/architecture
-- Go 1.23+ installed
+- Go 1.24+ installed
 - PostgreSQL database set up
 - IOTA SDK project cloned and running
 

--- a/docs/content/getting-started/index.mdx
+++ b/docs/content/getting-started/index.mdx
@@ -20,7 +20,7 @@ By following this guide, you will:
 
 Before you begin, ensure you have:
 
-- **Go 1.23 or later** - The SDK is built with Go
+- **Go 1.24 or later** - The SDK is built with Go
 - **PostgreSQL 13 or later** - For data persistence with multi-tenancy
 - **Node.js 18 or later** - For frontend asset building
 - **Git** - For version control

--- a/docs/content/getting-started/installation.mdx
+++ b/docs/content/getting-started/installation.mdx
@@ -11,7 +11,7 @@ This guide walks you through setting up the IOTA SDK development environment.
 
 ### Required Software
 
-- **Go 1.23+** ([Download](https://go.dev/dl/): %v", err)
+- **Go 1.24+** ([Download](https://go.dev/dl/): %v", err)
 - **PostgreSQL 13+** ([Download](https://www.postgresql.org/download/): %v", err)
 - **Node.js 18+** ([Download](https://nodejs.org/): %v", err)
 - **Git** ([Download](https://git-scm.com/downloads): %v", err)
@@ -20,7 +20,7 @@ This guide walks you through setting up the IOTA SDK development environment.
 ### Verify Installations
 
 ```bash
-go version          # Should show 1.23 or later
+go version          # Should show 1.24 or later
 psql --version      # Should show 13.x or later
 node --version      # Should show 18.x or later
 git --version       # Any recent version


### PR DESCRIPTION
## Summary
Migrates the project to Go 1.24 as requested in #130.

## Changes
- **CI**: GitHub Actions (`test.yml`, `release.yml`) and `setup-backend` action default now use Go 1.24.10
- **Docker**: `Dockerfile.test` and `Dockerfile.superadmin` base images updated to `golang:1.24.10` / `golang:1.24.10-alpine`
- **Docs**: Getting started, installation, module development, and architecture docs updated to require Go 1.24+
- **Config**: `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md`, and `.claude/tools/go.mod` updated to 1.24.10

Root `go.mod` and main `Dockerfile` were already on 1.24.10; this PR aligns all remaining references.

Closes #130

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go language toolchain from 1.23.2 to 1.24.10 across all build configurations, CI/CD pipelines, Docker containers, and development prerequisites.
  * Updated project documentation to reflect Go 1.24+ as the new requirement for building and contributing to the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->