### PR TITLE
Fix iota-1482: trigger title generation on stream error

### DIFF
--- a/modules/bichat/presentation/web/package.json
+++ b/modules/bichat/presentation/web/package.json
@@ -4,7 +4,9 @@
   "version": "1.0.0",
   "type": "module",
   "packageManager": "pnpm@9.15.0",
-  "engines": { "node": ">=18" },
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "dev": "pnpm run dev:standalone",
     "build:css": "tailwindcss -i ./src/index.css -o ./dist/style.css --minify",
@@ -17,28 +19,28 @@
     "codegen": "echo \"codegen removed (RPC-only)\""
   },
   "dependencies": {
-    "@iota-uz/sdk": "0.4.11",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-router-dom": "^6.26.0",
+    "@headlessui/react": "^2.2.0",
+    "@iota-uz/sdk": "0.4.16",
+    "@phosphor-icons/react": "^2.1.10",
     "date-fns": "^3.6.0",
     "framer-motion": "^11.0.0",
     "fuse.js": "^7.0.0",
-    "@headlessui/react": "^2.2.0",
-    "@phosphor-icons/react": "^2.1.10",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "react-markdown": "^9.0.1",
+    "react-router-dom": "^6.26.0",
     "react-syntax-highlighter": "^15.5.0"
   },
   "devDependencies": {
+    "@tailwindcss/cli": "4.1.18",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
-    "typescript": "^5.5.3",
-    "vite": "^5.4.2",
-    "@tailwindcss/cli": "4.1.18",
-    "tailwindcss": "4.1.18",
     "autoprefixer": "^10.4.20",
+    "chokidar-cli": "^3.0.0",
     "postcss": "^8.4.41",
-    "chokidar-cli": "^3.0.0"
+    "tailwindcss": "4.1.18",
+    "typescript": "^5.5.3",
+    "vite": "^5.4.2"
   }
 }

--- a/modules/bichat/presentation/web/pnpm-lock.yaml
+++ b/modules/bichat/presentation/web/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@iota-uz/sdk':
-        specifier: 0.4.11
-        version: 0.4.11(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 0.4.16
+        version: 0.4.16(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -328,8 +328,8 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
-  '@iota-uz/sdk@0.4.11':
-    resolution: {integrity: sha512-f1b11/SGUhxF6aFHwoD/O1TKDBM3KRFa9L5U4mlQP9d7TjkTBq0FTqmd7hHVnSMz+oErYLcWVOeYWaElmjRvwA==}
+  '@iota-uz/sdk@0.4.16':
+    resolution: {integrity: sha512-ADbSXevflF9cfv4aoV4yWhAeRUSq9arxUoHt/o0v2aUtad8UnzHe2lMaNvzmfkJ/JOEGXfGBWIkBF2MhRAj0TA==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
@@ -1674,6 +1674,9 @@ packages:
   yargs@13.3.2:
     resolution: {integrity: sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -1897,7 +1900,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       use-sync-external-store: 1.6.0(react@18.3.1)
 
-  '@iota-uz/sdk@0.4.11(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@iota-uz/sdk@0.4.16(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@headlessui/react': 2.2.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@phosphor-icons/react': 2.1.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1911,6 +1914,7 @@ snapshots:
       react-syntax-highlighter: 15.6.6(react@18.3.1)
       rehype-sanitize: 6.0.0
       remark-gfm: 4.0.1
+      zod: 3.25.76
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
       - '@types/react'
@@ -3429,5 +3433,7 @@ snapshots:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 13.1.2
+
+  zod@3.25.76: {}
 
   zwitch@2.0.4: {}

--- a/modules/bichat/services/chat_service_impl.go
+++ b/modules/bichat/services/chat_service_impl.go
@@ -618,13 +618,13 @@ func (s *chatServiceImpl) SendMessageStream(ctx context.Context, req bichatservi
 		return err
 	}
 
-	if streamErr != nil {
-		return serrors.E(op, streamErr)
-	}
-
 	// Generate title if not interrupted
 	if interrupt == nil {
 		s.maybeGenerateTitleAsync(ctx, req.SessionID)
+	}
+
+	if streamErr != nil {
+		return serrors.E(op, streamErr)
 	}
 
 	return nil

--- a/modules/bichat/services/chat_service_impl_test.go
+++ b/modules/bichat/services/chat_service_impl_test.go
@@ -323,6 +323,53 @@ func TestChatService_ResumeWithAnswer_InterruptPersistsPendingState(t *testing.T
 	assert.Len(t, messages, 2)
 }
 
+func TestChatService_SendMessageStream_StreamErrorStillTriggersTitleGeneration(t *testing.T) {
+	t.Parallel()
+
+	chatRepo := newMockChatRepository()
+	session := domain.NewSession(
+		domain.WithTenantID(uuid.New()),
+		domain.WithUserID(1),
+		domain.WithTitle("Generating..."),
+	)
+	require.NoError(t, chatRepo.CreateSession(t.Context(), session))
+
+	titleService := &captureTitleContextService{
+		called: make(chan context.Context, 1),
+	}
+	agentSvc := &stubAgentService{
+		processEvents: []bichatservices.Event{
+			{
+				Type:    bichatservices.EventTypeContent,
+				Content: "partial assistant response",
+			},
+		},
+		processStreamErr: assert.AnError,
+	}
+
+	svc := NewChatService(chatRepo, agentSvc, nil, titleService)
+	err := svc.SendMessageStream(t.Context(), bichatservices.SendMessageRequest{
+		SessionID: session.ID(),
+		Content:   "first user message",
+	}, func(_ bichatservices.StreamChunk) {})
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, assert.AnError.Error())
+
+	messages, msgErr := chatRepo.GetSessionMessages(t.Context(), session.ID(), domain.ListOptions{})
+	require.NoError(t, msgErr)
+	require.Len(t, messages, 2)
+	assert.Equal(t, types.RoleUser, messages[0].Role())
+	assert.Equal(t, types.RoleAssistant, messages[1].Role())
+	assert.Equal(t, "partial assistant response", messages[1].Content())
+
+	select {
+	case <-titleService.called:
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected async title generation to be invoked")
+	}
+}
+
 type captureTitleContextService struct {
 	called chan context.Context
 }
@@ -330,11 +377,30 @@ type captureTitleContextService struct {
 type stubRepoTx struct{}
 
 type stubAgentService struct {
-	resumeEvents []bichatservices.Event
+	processEvents    []bichatservices.Event
+	processErr       error
+	processStreamErr error
+	resumeEvents     []bichatservices.Event
 }
 
 func (s *stubAgentService) ProcessMessage(ctx context.Context, sessionID uuid.UUID, content string, attachments []domain.Attachment) (types.Generator[bichatservices.Event], error) {
-	return nil, assert.AnError
+	if s.processErr != nil {
+		return nil, s.processErr
+	}
+	if len(s.processEvents) == 0 && s.processStreamErr == nil {
+		return nil, assert.AnError
+	}
+
+	events := append([]bichatservices.Event{}, s.processEvents...)
+	streamErr := s.processStreamErr
+	return types.NewGenerator(ctx, func(ctx context.Context, yield func(bichatservices.Event) bool) error {
+		for _, ev := range events {
+			if !yield(ev) {
+				return nil
+			}
+		}
+		return streamErr
+	}), nil
 }
 
 func (s *stubAgentService) ResumeWithAnswer(ctx context.Context, sessionID uuid.UUID, checkpointID string, answers map[string]types.Answer) (types.Generator[bichatservices.Event], error) {


### PR DESCRIPTION
## Summary
- Move async title generation in SendMessageStream to run even when stream returns error after persistence
- Add regression test for title generation on stream-error path
- Bump iota-sdk bichat web package to SDK 0.4.16

Resolves iota-uz/eai#1482.