### PR TITLE
ci: make test workflow PR-centric with path-aware checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -385,7 +385,7 @@ jobs:
       (github.event_name != 'pull_request' || !github.event.pull_request.draft) &&
       (github.event_name == 'workflow_dispatch' || github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.e2e == 'true')
     concurrency:
-      group: e2e-tests-${{ github.event.pull_request.number || github.ref }}
+      group: e2e-tests-${{ github.event.pull_request.number || github.ref }}-${{ matrix.shardIndex }}
       cancel-in-progress: true
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 20


### PR DESCRIPTION
## Summary\n- Add PR/push/workflow_dispatch triggers on staging and main\n- Add backend/e2e/docs path filtering using dorny/paths-filter\n- Gate security, lint, unit-integration, e2e and docs jobs by changed paths and PR draft state\n- Switch to per-job PR-aware concurrency groups\n\n## Motivation\nAlign CI quality gates with recent eai behavior to reduce unnecessary runs and speed PR feedback.\n