### PR TITLE
Reduce Loki stream cardinality in collect_logs defaults

### DIFF
--- a/pkg/commands/collect_logs.go
+++ b/pkg/commands/collect_logs.go
@@ -55,16 +55,10 @@ func CollectLogs(ctx context.Context, options ...func(*LogCollector)) error {
 
 	defaultLabels := []string{
 		"level",
-		"request-id",
-		"path",
-		"method",
-		"host",
-		"ip",
+		// Keep only low-cardinality labels to avoid stream explosion in Loki.
+		// High-cardinality fields (request-id, path, host, ip, user-agent, trace ids, etc.)
+		// remain in the log payload and can still be queried with |= in LogQL.
 		"completed",
-		"user-agent",
-		"trace-id",
-		"span-id",
-		"status-code",
 		"status-class",
 	}
 


### PR DESCRIPTION
## Summary
- remove high-cardinality fields from default Loki stream labels in collect_logs
- keep only low-cardinality defaults: level, completed, status-class
- leave high-cardinality fields in log payload so they remain searchable with LogQL text filters

## Why
This prevents Loki active-stream explosion (429) and reduces chunk/file churn under heavy request-id/path variance.

## Validation
- go test ./pkg/commands/...
