### PR TITLE
Fix DI concurrent map writes by making provider resolution thread-safe

### DIFF
--- a/pkg/di/router.go
+++ b/pkg/di/router.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
+	"sync"
 )
 
 // Invoke creates a generic DI function that can be used for any function type
@@ -22,37 +23,55 @@ func H(handler interface{}, customProviders ...Provider) http.HandlerFunc {
 // DIContext holds context for dependency injection
 type DIContext struct {
 	customProviders  []Provider
+	allProviders     []Provider
 	matchedProviders map[reflect.Type]Provider
+	mu               sync.RWMutex
 }
 
 // NewDIContext creates a new DIContext with custom providers
 func NewDIContext(customProviders ...Provider) *DIContext {
+	allProviders := append([]Provider{}, customProviders...)
+	allProviders = append(allProviders, BuiltinProviders()...)
+
 	return &DIContext{
 		customProviders:  customProviders,
+		allProviders:     allProviders,
 		matchedProviders: make(map[reflect.Type]Provider),
 	}
 }
 
-// provideValue resolves a single dependency value for a given type
-func (d *DIContext) provideValue(argType reflect.Type, ctx context.Context) (reflect.Value, error) {
-	// Check if we have already matched this type
+func (d *DIContext) resolveProvider(argType reflect.Type) (Provider, error) {
+	d.mu.RLock()
 	provider, ok := d.matchedProviders[argType]
-	if !ok {
-		// Find a provider for this type
-		allProviders := append(d.customProviders, BuiltinProviders()...)
-		for _, p := range allProviders {
-			if p.Ok(argType) {
-				provider = p
-				d.matchedProviders[argType] = p
-				break
-			}
-		}
+	d.mu.RUnlock()
+	if ok {
+		return provider, nil
+	}
 
-		if provider == nil {
-			return reflect.Value{}, fmt.Errorf("no provider found for type: %v", argType)
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// Re-check after upgrading to write lock.
+	if provider, ok = d.matchedProviders[argType]; ok {
+		return provider, nil
+	}
+
+	for _, p := range d.allProviders {
+		if p.Ok(argType) {
+			d.matchedProviders[argType] = p
+			return p, nil
 		}
 	}
 
+	return nil, fmt.Errorf("no provider found for type: %v", argType)
+}
+
+// provideValue resolves a single dependency value for a given type
+func (d *DIContext) provideValue(argType reflect.Type, ctx context.Context) (reflect.Value, error) {
+	provider, err := d.resolveProvider(argType)
+	if err != nil {
+		return reflect.Value{}, err
+	}
 	return provider.Provide(argType, ctx)
 }
 
@@ -96,6 +115,7 @@ func createHandlerFunc(diContext *DIContext, handler interface{}) http.HandlerFu
 	hasHttpRequestArg := make([]bool, numArgs)
 	hasHttpWriterArg := make([]bool, numArgs)
 	writerInterface := reflect.TypeOf((*http.ResponseWriter)(nil)).Elem()
+	resolvedProviders := make([]Provider, numArgs)
 
 	for i, argType := range argTypes {
 		// Check for direct *http.Request injection
@@ -110,23 +130,15 @@ func createHandlerFunc(diContext *DIContext, handler interface{}) http.HandlerFu
 			continue
 		}
 
-		// For other types, check if we have a provider
-		allProviders := append(diContext.customProviders, BuiltinProviders()...)
-		found := false
-		for _, provider := range allProviders {
-			if provider.Ok(argType) {
-				found = true
-				break
-			}
-		}
-
-		if !found {
+		provider, err := diContext.resolveProvider(argType)
+		if err != nil {
 			// Return a handler that will return an error for this specific type
-			errorMsg := fmt.Sprintf("No provider found for type: %v", argType)
+			errorMsg := err.Error()
 			return func(w http.ResponseWriter, r *http.Request) {
 				http.Error(w, errorMsg, http.StatusInternalServerError)
 			}
 		}
+		resolvedProviders[i] = provider
 	}
 
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -148,10 +160,7 @@ func createHandlerFunc(diContext *DIContext, handler interface{}) http.HandlerFu
 		// For remaining args, use diContext to resolve them
 		for i := 0; i < numArgs; i++ {
 			if !hasHttpRequestArg[i] && !hasHttpWriterArg[i] {
-				argType := argTypes[i]
-
-				// For other types, use provider system
-				value, err := diContext.provideValue(argType, r.Context())
+				value, err := resolvedProviders[i].Provide(argTypes[i], r.Context())
 				if err != nil {
 					http.Error(w, err.Error(), http.StatusInternalServerError)
 					return

--- a/pkg/di/router_test.go
+++ b/pkg/di/router_test.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/iota-uz/go-i18n/v2/i18n"
@@ -137,5 +140,46 @@ func BenchmarkNonDIRouter(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		rr := httptest.NewRecorder()
 		NonDIHandler(rr, req)
+	}
+}
+
+func TestDIHandlerConcurrentRequests_NoDataRace(t *testing.T) {
+	handler := H(func(w http.ResponseWriter, r *http.Request, u user.User) {
+		_, _ = fmt.Fprintf(w, "Path: %s\n", r.URL.Path)
+		_, _ = fmt.Fprintf(w, "Fullname: %s %s\n", u.FirstName(), u.LastName())
+	})
+
+	const goroutines = 64
+	const requestsPerGoroutine = 50
+
+	var failed atomic.Int32
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for g := 0; g < goroutines; g++ {
+		go func(group int) {
+			defer wg.Done()
+			for i := 0; i < requestsPerGoroutine; i++ {
+				ctx := setupTestContext()
+				req := httptest.NewRequest(http.MethodGet, "/health", nil).WithContext(ctx)
+				rr := httptest.NewRecorder()
+				handler(rr, req)
+
+				if rr.Code != http.StatusOK {
+					failed.Add(1)
+					continue
+				}
+
+				body := rr.Body.String()
+				if !strings.Contains(body, "Fullname: John Doe") || !strings.Contains(body, "Path: /health") {
+					failed.Add(1)
+				}
+			}
+		}(g)
+	}
+
+	wg.Wait()
+	if got := failed.Load(); got != 0 {
+		t.Fatalf("expected 0 failed responses, got %d", got)
 	}
 }


### PR DESCRIPTION
## Summary\n- make DI provider cache access thread-safe with RWMutex\n- pre-resolve providers at handler construction time so request path does not mutate shared state\n- add high-concurrency regression test for DI handlers\n\n## Validation\n- go test ./pkg/di -count=1\n- go test -race ./pkg/di -count=1