### PR TITLE
ci(test): fix workflow YAML parse regression in test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,10 +87,10 @@ jobs:
       - name: Install gosec
         run: go install github.com/securego/gosec/v2/cmd/gosec@v2.22.2
 
-        - name: Install just
-          uses: extractions/setup-just@v3
-          with:
-            just-version: "1.46.0"
+      - name: Install just
+        uses: extractions/setup-just@v3
+        with:
+          just-version: "1.46.0"
 
       - name: Run gosec (production entrypoints)
         run: just gosec
@@ -151,10 +151,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pgformatter
 
-        - name: Install just
-          uses: extractions/setup-just@v3
-          with:
-            just-version: "1.46.0"
+      - name: Install just
+        uses: extractions/setup-just@v3
+        with:
+          just-version: "1.46.0"
 
       - name: Download Go dependencies
         run: go mod download
@@ -294,10 +294,10 @@ jobs:
         with:
           go-version: "1.24.13"
 
-        - name: Install just
-          uses: extractions/setup-just@v3
-          with:
-            just-version: "1.46.0"
+      - name: Install just
+        uses: extractions/setup-just@v3
+        with:
+          just-version: "1.46.0"
 
       - name: Install tools
         run: |


### PR DESCRIPTION
## Summary
- fix invalid indentation for three `Install just` steps in `.github/workflows/test.yml`
- restore valid step-level YAML so GitHub Actions can instantiate jobs again
- keep behavior unchanged (only indentation corrected)

## Root Cause
A recent change nested `- name: Install just` under preceding `run:` blocks, producing invalid YAML and causing Actions to fail before job creation.

## Verification
- local YAML parse passes: `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/test.yml'); puts 'YAML valid'"`
- previously failing run symptom: 0s failure with "This run likely failed because of a workflow file issue" ([run 22545356518](https://github.com/iota-uz/iota-sdk/actions/runs/22545356518))
