### PR TITLE
feat(css): complete Tailwind v4 generation flow alignment (fixes #648)

### DIFF
--- a/.github/actions/setup-tailwind/action.yml
+++ b/.github/actions/setup-tailwind/action.yml
@@ -1,5 +1,5 @@
 name: Setup TailwindCSS
-description: Install TailwindCSS via pnpm (Tailwind v4)
+description: Install TailwindCSS via pnpm (Tailwind v4 + @tailwindcss/cli)
 
 runs:
   using: composite

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ static
 uploads
 *_templ.txt
 modules/core/presentation/assets/css/main.min.css
+styles/tailwind/main.generated.css
 modules/bichat/presentation/assets/dist/
 /tailwind/
 /assets/

--- a/Justfile
+++ b/Justfile
@@ -4,10 +4,6 @@ set dotenv-load
 DEV_COMPOSE_FILE := "compose.dev.yml"
 TESTING_COMPOSE_FILE := "compose.testing.yml"
 
-TAILWIND_INPUT := "styles/tailwind/input.css"
-TAILWIND_GENERATED_INPUT := "styles/tailwind/main.generated.css"
-TAILWIND_OUTPUT := "modules/core/presentation/assets/css/main.min.css"
-
 GO_TEST_TAG := "dev"
 
 [default]
@@ -227,13 +223,12 @@ coverage-report:
 [group("assets")]
 [doc("Build Tailwind CSS. Extra arguments are passed to `tailwindcss`")]
 css *args="":
-  node scripts/build-tailwind-css.mjs
-  pnpm exec tailwindcss --input {{TAILWIND_GENERATED_INPUT}} --output {{TAILWIND_OUTPUT}} --minify {{args}}
+  node scripts/build-tailwind-css.mjs --minify {{args}}
 
 [group("assets")]
 [doc("Remove generated CSS file")]
 css-clean:
-  rm -rf {{TAILWIND_OUTPUT}}
+  node scripts/build-tailwind-css.mjs --clean
 
 [group("e2e")]
 [doc("E2E commands (test|reset|seed|migrate|status|run|ci|dev|clean)")]

--- a/Justfile
+++ b/Justfile
@@ -5,6 +5,7 @@ DEV_COMPOSE_FILE := "compose.dev.yml"
 TESTING_COMPOSE_FILE := "compose.testing.yml"
 
 TAILWIND_INPUT := "styles/tailwind/input.css"
+TAILWIND_GENERATED_INPUT := "styles/tailwind/main.generated.css"
 TAILWIND_OUTPUT := "modules/core/presentation/assets/css/main.min.css"
 
 GO_TEST_TAG := "dev"
@@ -224,9 +225,10 @@ coverage-report:
   go tool cover -html=./coverage/coverage.out -o ./coverage/cover.html
 
 [group("assets")]
-[doc("Build Tailwind CSS. Extra arguments are passed to `tailwindcss` (uses npx, no root package.json required)")]
+[doc("Build Tailwind CSS. Extra arguments are passed to `tailwindcss`")]
 css *args="":
-  npx @tailwindcss/cli@4.1.18 --input {{TAILWIND_INPUT}} --output {{TAILWIND_OUTPUT}} --minify {{args}}
+  node scripts/build-tailwind-css.mjs
+  pnpm exec tailwindcss --input {{TAILWIND_GENERATED_INPUT}} --output {{TAILWIND_OUTPUT}} --minify {{args}}
 
 [group("assets")]
 [doc("Remove generated CSS file")]

--- a/docs/postcss.config.mjs
+++ b/docs/postcss.config.mjs
@@ -1,6 +1,3 @@
-const config = {
-  plugins: {
-    "@tailwindcss/postcss": {},
-  },
-};
-export default config;
+import { createTailwindPostcssConfig } from "../styles/tailwind/postcss.shared.mjs";
+
+export default createTailwindPostcssConfig({ autoprefixer: false });

--- a/modules/bichat/presentation/web/package.json
+++ b/modules/bichat/presentation/web/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "@tailwindcss/cli": "4.1.18",
+    "@tailwindcss/postcss": "4.1.18",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",

--- a/modules/bichat/presentation/web/package.json
+++ b/modules/bichat/presentation/web/package.json
@@ -45,5 +45,12 @@
     "tailwindcss": "4.1.18",
     "typescript": "^5.5.3",
     "vite": "^5.4.2"
+  },
+  "pnpm": {
+    "overrides": {
+      "@tailwindcss/cli": "4.1.18",
+      "@tailwindcss/postcss": "4.1.18",
+      "tailwindcss": "4.1.18"
+    }
   }
 }

--- a/modules/bichat/presentation/web/pnpm-lock.yaml
+++ b/modules/bichat/presentation/web/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@tailwindcss/cli': 4.1.18
+  '@tailwindcss/postcss': 4.1.18
+  tailwindcss: 4.1.18
+
 importers:
 
   .:

--- a/modules/bichat/presentation/web/pnpm-lock.yaml
+++ b/modules/bichat/presentation/web/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@tailwindcss/cli':
         specifier: 4.1.18
         version: 4.1.18
+      '@tailwindcss/postcss':
+        specifier: 4.1.18
+        version: 4.1.18
       '@types/react':
         specifier: ^18.3.3
         version: 18.3.27
@@ -80,6 +83,10 @@ importers:
         version: 5.4.21(@types/node@25.2.0)(lightningcss@1.30.2)
 
 packages:
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -731,6 +738,9 @@ packages:
   '@tailwindcss/oxide@4.1.18':
     resolution: {integrity: sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==}
     engines: {node: '>= 10'}
+
+  '@tailwindcss/postcss@4.1.18':
+    resolution: {integrity: sha512-Ce0GFnzAOuPyfV5SxjXGn0CubwGcuDB0zcdaPuCSzAa/2vII24JTkH+I6jcbXLb1ctjZMZZI6OjDaLPJQL1S0g==}
 
   '@tanstack/react-virtual@3.13.18':
     resolution: {integrity: sha512-dZkhyfahpvlaV0rIKnvQiVoWPyURppl6w4m9IwMDpuIjcJ1sD9YGWrt0wISvgU7ewACXx2Ct46WPgI6qAD4v6A==}
@@ -1716,6 +1726,8 @@ packages:
 
 snapshots:
 
+  '@alloc/quick-lru@5.2.0': {}
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -2259,6 +2271,14 @@ snapshots:
       '@tailwindcss/oxide-wasm32-wasi': 4.1.18
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
+
+  '@tailwindcss/postcss@4.1.18':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.1.18
+      '@tailwindcss/oxide': 4.1.18
+      postcss: 8.5.6
+      tailwindcss: 4.1.18
 
   '@tanstack/react-virtual@3.13.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:

--- a/modules/bichat/presentation/web/postcss.config.js
+++ b/modules/bichat/presentation/web/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    tailwindcss: {},
+    "@tailwindcss/postcss": {},
     autoprefixer: {},
   },
 }

--- a/modules/bichat/presentation/web/postcss.config.js
+++ b/modules/bichat/presentation/web/postcss.config.js
@@ -1,6 +1,3 @@
-export default {
-  plugins: {
-    "@tailwindcss/postcss": {},
-    autoprefixer: {},
-  },
-}
+import { createTailwindPostcssConfig } from "../../../../styles/tailwind/postcss.shared.mjs"
+
+export default createTailwindPostcssConfig()

--- a/package.json
+++ b/package.json
@@ -10,11 +10,20 @@
   },
   "scripts": {
     "build": "echo \"Canonical @iota-uz/sdk package is maintained in ../applets\"",
+    "build:css": "node scripts/build-tailwind-css.mjs --minify",
+    "build:css:watch": "node scripts/build-tailwind-css.mjs --watch",
     "lint": "echo \"no lint\""
   },
   "devDependencies": {
     "@tailwindcss/cli": "4.1.18",
     "@tailwindcss/postcss": "4.1.18",
     "tailwindcss": "4.1.18"
+  },
+  "pnpm": {
+    "overrides": {
+      "@tailwindcss/cli": "4.1.18",
+      "@tailwindcss/postcss": "4.1.18",
+      "tailwindcss": "4.1.18"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "lint": "echo \"no lint\""
   },
   "devDependencies": {
+    "@tailwindcss/cli": "4.1.18",
+    "@tailwindcss/postcss": "4.1.18",
     "tailwindcss": "4.1.18"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@tailwindcss/cli': 4.1.18
+  '@tailwindcss/postcss': 4.1.18
+  tailwindcss: 4.1.18
+
 importers:
 
   .:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,592 @@ importers:
 
   .:
     devDependencies:
+      '@tailwindcss/cli':
+        specifier: 4.1.18
+        version: 4.1.18
+      '@tailwindcss/postcss':
+        specifier: 4.1.18
+        version: 4.1.18
       tailwindcss:
         specifier: 4.1.18
         version: 4.1.18
 
 packages:
 
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@parcel/watcher-android-arm64@2.5.6':
+    resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    resolution: {integrity: sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    resolution: {integrity: sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    resolution: {integrity: sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    resolution: {integrity: sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    resolution: {integrity: sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    resolution: {integrity: sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@parcel/watcher@2.5.6':
+    resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
+    engines: {node: '>= 10.0.0'}
+
+  '@tailwindcss/cli@4.1.18':
+    resolution: {integrity: sha512-sMZ+lZbDyxwjD2E0L7oRUjJ01Ffjtme5OtjvvnC+cV4CEDcbqzbp25TCpxHj6kWLU9+DlqJOiNgSOgctC2aZmg==}
+    hasBin: true
+
+  '@tailwindcss/node@4.1.18':
+    resolution: {integrity: sha512-DoR7U1P7iYhw16qJ49fgXUlry1t4CpXeErJHnQ44JgTSKMaZUdf17cfn5mHchfJ4KRBZRFA/Coo+MUF5+gOaCQ==}
+
+  '@tailwindcss/oxide-android-arm64@4.1.18':
+    resolution: {integrity: sha512-dJHz7+Ugr9U/diKJA0W6N/6/cjI+ZTAoxPf9Iz9BFRF2GzEX8IvXxFIi/dZBloVJX/MZGvRuFA9rqwdiIEZQ0Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.1.18':
+    resolution: {integrity: sha512-Gc2q4Qhs660bhjyBSKgq6BYvwDz4G+BuyJ5H1xfhmDR3D8HnHCmT/BSkvSL0vQLy/nkMLY20PQ2OoYMO15Jd0A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.1.18':
+    resolution: {integrity: sha512-FL5oxr2xQsFrc3X9o1fjHKBYBMD1QZNyc1Xzw/h5Qu4XnEBi3dZn96HcHm41c/euGV+GRiXFfh2hUCyKi/e+yw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.1.18':
+    resolution: {integrity: sha512-Fj+RHgu5bDodmV1dM9yAxlfJwkkWvLiRjbhuO2LEtwtlYlBgiAT4x/j5wQr1tC3SANAgD+0YcmWVrj8R9trVMA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18':
+    resolution: {integrity: sha512-Fp+Wzk/Ws4dZn+LV2Nqx3IilnhH51YZoRaYHQsVq3RQvEl+71VGKFpkfHrLM/Li+kt5c0DJe/bHXK1eHgDmdiA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.18':
+    resolution: {integrity: sha512-S0n3jboLysNbh55Vrt7pk9wgpyTTPD0fdQeh7wQfMqLPM/Hrxi+dVsLsPrycQjGKEQk85Kgbx+6+QnYNiHalnw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
+    resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
+    resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.1.18':
+    resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.1.18':
+    resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.18':
+    resolution: {integrity: sha512-HjSA7mr9HmC8fu6bdsZvZ+dhjyGCLdotjVOgLA2vEqxEBZaQo9YTX4kwgEvPCpRh8o4uWc4J/wEoFzhEmjvPbA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.18':
+    resolution: {integrity: sha512-bJWbyYpUlqamC8dpR7pfjA0I7vdF6t5VpUGMWRkXVE3AXgIZjYUYAK7II1GNaxR8J1SSrSrppRar8G++JekE3Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.1.18':
+    resolution: {integrity: sha512-EgCR5tTS5bUSKQgzeMClT6iCY3ToqE1y+ZB0AKldj809QXk1Y+3jB0upOYZrn9aGIzPtUsP7sX4QQ4XtjBB95A==}
+    engines: {node: '>= 10'}
+
+  '@tailwindcss/postcss@4.1.18':
+    resolution: {integrity: sha512-Ce0GFnzAOuPyfV5SxjXGn0CubwGcuDB0zcdaPuCSzAa/2vII24JTkH+I6jcbXLb1ctjZMZZI6OjDaLPJQL1S0g==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  enhanced-resolve@5.20.0:
+    resolution: {integrity: sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==}
+    engines: {node: '>=10.13.0'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  lightningcss-android-arm64@1.30.2:
+    resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.30.2:
+    resolution: {integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.30.2:
+    resolution: {integrity: sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.30.2:
+    resolution: {integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.30.2:
+    resolution: {integrity: sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.30.2:
+    resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.30.2:
+    resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.30.2:
+    resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.30.2:
+    resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.30.2:
+    resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.30.2:
+    resolution: {integrity: sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.30.2:
+    resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   tailwindcss@4.1.18:
     resolution: {integrity: sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==}
 
+  tapable@2.3.0:
+    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+    engines: {node: '>=6'}
+
 snapshots:
 
+  '@alloc/quick-lru@5.2.0': {}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@parcel/watcher-android-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher@2.5.6':
+    dependencies:
+      detect-libc: 2.1.2
+      is-glob: 4.0.3
+      node-addon-api: 7.1.1
+      picomatch: 4.0.3
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.5.6
+      '@parcel/watcher-darwin-arm64': 2.5.6
+      '@parcel/watcher-darwin-x64': 2.5.6
+      '@parcel/watcher-freebsd-x64': 2.5.6
+      '@parcel/watcher-linux-arm-glibc': 2.5.6
+      '@parcel/watcher-linux-arm-musl': 2.5.6
+      '@parcel/watcher-linux-arm64-glibc': 2.5.6
+      '@parcel/watcher-linux-arm64-musl': 2.5.6
+      '@parcel/watcher-linux-x64-glibc': 2.5.6
+      '@parcel/watcher-linux-x64-musl': 2.5.6
+      '@parcel/watcher-win32-arm64': 2.5.6
+      '@parcel/watcher-win32-ia32': 2.5.6
+      '@parcel/watcher-win32-x64': 2.5.6
+
+  '@tailwindcss/cli@4.1.18':
+    dependencies:
+      '@parcel/watcher': 2.5.6
+      '@tailwindcss/node': 4.1.18
+      '@tailwindcss/oxide': 4.1.18
+      enhanced-resolve: 5.20.0
+      mri: 1.2.0
+      picocolors: 1.1.1
+      tailwindcss: 4.1.18
+
+  '@tailwindcss/node@4.1.18':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.20.0
+      jiti: 2.6.1
+      lightningcss: 1.30.2
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.1.18
+
+  '@tailwindcss/oxide-android-arm64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.1.18':
+    optional: true
+
+  '@tailwindcss/oxide@4.1.18':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.1.18
+      '@tailwindcss/oxide-darwin-arm64': 4.1.18
+      '@tailwindcss/oxide-darwin-x64': 4.1.18
+      '@tailwindcss/oxide-freebsd-x64': 4.1.18
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.1.18
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.1.18
+      '@tailwindcss/oxide-linux-arm64-musl': 4.1.18
+      '@tailwindcss/oxide-linux-x64-gnu': 4.1.18
+      '@tailwindcss/oxide-linux-x64-musl': 4.1.18
+      '@tailwindcss/oxide-wasm32-wasi': 4.1.18
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
+      '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
+
+  '@tailwindcss/postcss@4.1.18':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.1.18
+      '@tailwindcss/oxide': 4.1.18
+      postcss: 8.5.6
+      tailwindcss: 4.1.18
+
+  detect-libc@2.1.2: {}
+
+  enhanced-resolve@5.20.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.0
+
+  graceful-fs@4.2.11: {}
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  jiti@2.6.1: {}
+
+  lightningcss-android-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-arm64@1.30.2:
+    optional: true
+
+  lightningcss-darwin-x64@1.30.2:
+    optional: true
+
+  lightningcss-freebsd-x64@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.30.2:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.30.2:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.30.2:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.30.2:
+    optional: true
+
+  lightningcss@1.30.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.30.2
+      lightningcss-darwin-arm64: 1.30.2
+      lightningcss-darwin-x64: 1.30.2
+      lightningcss-freebsd-x64: 1.30.2
+      lightningcss-linux-arm-gnueabihf: 1.30.2
+      lightningcss-linux-arm64-gnu: 1.30.2
+      lightningcss-linux-arm64-musl: 1.30.2
+      lightningcss-linux-x64-gnu: 1.30.2
+      lightningcss-linux-x64-musl: 1.30.2
+      lightningcss-win32-arm64-msvc: 1.30.2
+      lightningcss-win32-x64-msvc: 1.30.2
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mri@1.2.0: {}
+
+  nanoid@3.3.11: {}
+
+  node-addon-api@7.1.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  source-map-js@1.2.1: {}
+
   tailwindcss@4.1.18: {}
+
+  tapable@2.3.0: {}

--- a/scripts/build-tailwind-css.mjs
+++ b/scripts/build-tailwind-css.mjs
@@ -1,0 +1,46 @@
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+const inputPath = path.join(repoRoot, "styles/tailwind/input.css");
+const generatedPath = path.join(repoRoot, "styles/tailwind/main.generated.css");
+
+const sourceGlobs = [
+  "../../cmd/**/*.{go,templ,html,js,ts,tsx}",
+  "../../components/**/*.{go,templ,html,js,ts,tsx}",
+  "../../modules/**/*.{go,templ,html,js,ts,tsx}",
+  "../../pkg/**/*.{go,templ,html,js,ts,tsx}",
+];
+
+function buildSourceBlock() {
+  const lines = sourceGlobs
+    .map((glob) => `@source "${glob}";`)
+    .join("\n");
+
+  return [
+    "/* AUTO-GENERATED SOURCES START */",
+    lines,
+    "/* AUTO-GENERATED SOURCES END */",
+  ].join("\n");
+}
+
+async function run() {
+  const input = await readFile(inputPath, "utf8");
+  const sourceBlock = buildSourceBlock();
+
+  const withoutGeneratedBlock = input
+    .replace(/\/\* AUTO-GENERATED SOURCES START \*\/[\s\S]*?\/\* AUTO-GENERATED SOURCES END \*\/\n?/g, "")
+    .trimEnd();
+
+  const output = `${withoutGeneratedBlock}\n\n${sourceBlock}\n`;
+  await writeFile(generatedPath, output, "utf8");
+}
+
+run().catch((error) => {
+  console.error("Failed to generate Tailwind input:", error);
+  process.exitCode = 1;
+});

--- a/scripts/build-tailwind-css.mjs
+++ b/scripts/build-tailwind-css.mjs
@@ -1,4 +1,5 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -6,19 +7,50 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..");
 
-const inputPath = path.join(repoRoot, "styles/tailwind/input.css");
-const generatedPath = path.join(repoRoot, "styles/tailwind/main.generated.css");
+const argv = process.argv.slice(2);
+const options = {
+  clean: false,
+  configPath: "styles/tailwind/pipeline.config.json",
+  generateOnly: false,
+  minify: false,
+  tailwindArgs: [],
+};
 
-const sourceGlobs = [
-  "../../cmd/**/*.{go,templ,html,js,ts,tsx}",
-  "../../components/**/*.{go,templ,html,js,ts,tsx}",
-  "../../modules/**/*.{go,templ,html,js,ts,tsx}",
-  "../../pkg/**/*.{go,templ,html,js,ts,tsx}",
-];
+for (let i = 0; i < argv.length; i += 1) {
+  const arg = argv[i];
 
-function buildSourceBlock() {
-  const lines = sourceGlobs
-    .map((glob) => `@source "${glob}";`)
+  if (arg === "--clean") {
+    options.clean = true;
+    continue;
+  }
+
+  if (arg === "--generate-only") {
+    options.generateOnly = true;
+    continue;
+  }
+
+  if (arg === "--minify") {
+    options.minify = true;
+    continue;
+  }
+
+  if (arg === "--config") {
+    const configPath = argv[i + 1];
+    if (!configPath) {
+      throw new Error("Missing value for --config");
+    }
+    options.configPath = configPath;
+    i += 1;
+    continue;
+  }
+
+  options.tailwindArgs.push(arg);
+}
+
+function createSourceBlock(sources) {
+  const stableSources = [...new Set(sources)].sort();
+  const lines = stableSources
+    .map((source) => `@source "${source}";`)
     .join("\n");
 
   return [
@@ -28,19 +60,92 @@ function buildSourceBlock() {
   ].join("\n");
 }
 
+function removeGeneratedSourceBlock(css) {
+  return css.replace(
+    /\/\* AUTO-GENERATED SOURCES START \*\/[\s\S]*?\/\* AUTO-GENERATED SOURCES END \*\/\n?/g,
+    "",
+  );
+}
+
+async function loadPipelineConfig(configPath) {
+  const resolvedPath = path.resolve(repoRoot, configPath);
+  const content = await readFile(resolvedPath, "utf8");
+  const config = JSON.parse(content);
+
+  return {
+    generated: path.resolve(repoRoot, config.generated),
+    input: path.resolve(repoRoot, config.input),
+    output: path.resolve(repoRoot, config.output),
+    sources: Array.isArray(config.sources) ? config.sources : [],
+  };
+}
+
+async function generateInputFile(config) {
+  const baseInput = await readFile(config.input, "utf8");
+  const sourceBlock = createSourceBlock(config.sources);
+  const normalizedInput = removeGeneratedSourceBlock(baseInput).trimEnd();
+  const output = `${normalizedInput}\n\n${sourceBlock}\n`;
+
+  await writeFile(config.generated, output, "utf8");
+}
+
+function runTailwind(config) {
+  return new Promise((resolve, reject) => {
+    const args = [
+      "exec",
+      "tailwindcss",
+      "--input",
+      path.relative(repoRoot, config.generated),
+      "--output",
+      path.relative(repoRoot, config.output),
+      ...options.tailwindArgs,
+    ];
+
+    if (options.minify) {
+      args.push("--minify");
+    }
+
+    const child = spawn("pnpm", args, {
+      cwd: repoRoot,
+      stdio: "inherit",
+    });
+
+    child.on("close", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      reject(new Error(`tailwindcss exited with code ${code}`));
+    });
+  });
+}
+
+async function cleanFiles(config) {
+  await Promise.all([
+    rm(config.generated, { force: true }),
+    rm(config.output, { force: true }),
+  ]);
+}
+
 async function run() {
-  const input = await readFile(inputPath, "utf8");
-  const sourceBlock = buildSourceBlock();
+  const config = await loadPipelineConfig(options.configPath);
 
-  const withoutGeneratedBlock = input
-    .replace(/\/\* AUTO-GENERATED SOURCES START \*\/[\s\S]*?\/\* AUTO-GENERATED SOURCES END \*\/\n?/g, "")
-    .trimEnd();
+  if (options.clean) {
+    await cleanFiles(config);
+    return;
+  }
 
-  const output = `${withoutGeneratedBlock}\n\n${sourceBlock}\n`;
-  await writeFile(generatedPath, output, "utf8");
+  await generateInputFile(config);
+
+  if (options.generateOnly) {
+    return;
+  }
+
+  await runTailwind(config);
 }
 
 run().catch((error) => {
-  console.error("Failed to generate Tailwind input:", error);
+  console.error("Failed to build Tailwind CSS:", error);
   process.exitCode = 1;
 });

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,4 +24,4 @@ fi
 cd "$REPO_ROOT"
 pnpm install --frozen-lockfile
 pnpm exec tailwindcss --help >/dev/null
-echo "TailwindCSS installed (Tailwind v4 via pnpm)."
+echo "TailwindCSS installed (Tailwind v4 with @tailwindcss/cli via pnpm)."

--- a/styles/tailwind/pipeline.config.json
+++ b/styles/tailwind/pipeline.config.json
@@ -1,0 +1,13 @@
+{
+  "input": "styles/tailwind/input.css",
+  "generated": "styles/tailwind/main.generated.css",
+  "output": "modules/core/presentation/assets/css/main.min.css",
+  "sources": [
+    "../../cmd/**/*.{go,templ,html,js,ts,tsx}",
+    "../../components/**/*.{go,templ,html,js,ts,tsx}",
+    "../../internal/**/*.{go,templ,html,js,ts,tsx}",
+    "../../modules/**/*.{go,templ,html,js,ts,tsx}",
+    "../../pkg/**/*.{go,templ,html,js,ts,tsx}",
+    "../../ui/src/**/*.{js,ts,jsx,tsx}"
+  ]
+}

--- a/styles/tailwind/postcss.shared.mjs
+++ b/styles/tailwind/postcss.shared.mjs
@@ -1,0 +1,14 @@
+export function createTailwindPostcssConfig(options = {}) {
+  const { autoprefixer = true } = options;
+  const plugins = {
+    "@tailwindcss/postcss": {},
+  };
+
+  if (autoprefixer) {
+    plugins.autoprefixer = {};
+  }
+
+  return { plugins };
+}
+
+export default createTailwindPostcssConfig();

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,10 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   darkMode: "class",
-  content: [
-    "./modules/**/templates/**/*.{html,js,templ}",
-    "./components/**/*.{html,js,templ,go}",
-  ],
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
## Summary
This PR completes Tailwind v4 generation-flow alignment in `iota-sdk` and also introduces a canonical shared setup to reduce future drift.

Fixes #648

## What Changed
### 1) Canonical root pipeline
- Added a single pipeline config file: `styles/tailwind/pipeline.config.json`.
  - Defines input, generated intermediate, output artifact, and source globs in one place.
- Refactored `scripts/build-tailwind-css.mjs` to be the canonical pipeline entrypoint.
  - Supports `--generate-only`, `--minify`, `--clean`, and passthrough tailwind flags.
  - Reads source globs/config from `pipeline.config.json`.
  - Generates deterministic `@source` directives in `styles/tailwind/main.generated.css`.
  - Runs Tailwind CLI compile from generated input when not in `--generate-only` mode.
- Updated `Justfile` to call only this script:
  - `just css` -> `node scripts/build-tailwind-css.mjs --minify ...`
  - `just css-clean` -> `node scripts/build-tailwind-css.mjs --clean`

### 2) Shared PostCSS config wiring
- Added `styles/tailwind/postcss.shared.mjs` with `createTailwindPostcssConfig()` helper.
- Updated `modules/bichat/presentation/web/postcss.config.js` to consume shared helper.
- Updated `docs/postcss.config.mjs` to consume shared helper (with `autoprefixer: false`), so plugin wiring stays consistent across targets.

### 3) Tailwind dependency/version drift controls
- Root and BiChat web package manifests now pin:
  - `tailwindcss@4.1.18`
  - `@tailwindcss/cli@4.1.18`
  - `@tailwindcss/postcss@4.1.18`
- Added `pnpm.overrides` in both root and BiChat web `package.json` to enforce those versions.
- Updated corresponding lockfiles.

### 4) Previous migration deltas retained
- `tailwind.config.js` keeps v4 model (removed v3 `content` block for root flow).
- `styles/tailwind/main.generated.css` remains generated-only (gitignored).
- Setup/install messaging updated for explicit v4 CLI usage.

## Verification
- `node scripts/build-tailwind-css.mjs --generate-only` ✅
- `just css` ✅
- `pnpm run build:css` (root canonical command path) ✅
- `pnpm -C modules/bichat/presentation/web run build` ✅
- `rg -n "@tailwind base|@tailwind components|@tailwind utilities" styles modules .github` (no matches) ✅

### Environment-limited check
- `go vet ./...` ⛔ blocked locally by macOS/Xcode license prompt:
  - `You have not agreed to the Xcode license agreements...`

## Risk / Rollback
- Runtime CSS artifact paths are unchanged.
- Rollback path is straightforward by reverting this PR.

## Notes
- A separate PR in `../applets` was not necessary for this change because config-sharing and pipeline centralization are fully contained in `iota-sdk`.
