### PR TITLE
feat(core): add S3 upload backend and presigned download flow

### DIFF
--- a/modules/core/domain/entities/upload/upload_storage.go
+++ b/modules/core/domain/entities/upload/upload_storage.go
@@ -2,10 +2,13 @@ package upload
 
 import (
 	"context"
+	"time"
 )
 
 type Storage interface {
 	Open(ctx context.Context, fileName string) ([]byte, error)
 	Save(ctx context.Context, fileName string, bytes []byte) error
 	Rename(ctx context.Context, oldPath, newPath string) error
+	Delete(ctx context.Context, fileName string) error
+	PresignGetURL(ctx context.Context, fileName string, ttl time.Duration) (string, error)
 }

--- a/modules/core/infrastructure/persistence/upload_fs_storage.go
+++ b/modules/core/infrastructure/persistence/upload_fs_storage.go
@@ -3,8 +3,12 @@ package persistence
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/iota-uz/iota-sdk/pkg/configuration"
 )
@@ -33,9 +37,38 @@ func (s *FSStorage) Open(ctx context.Context, fileName string) ([]byte, error) {
 }
 
 func (s *FSStorage) Save(ctx context.Context, fileName string, bytes []byte) error {
+	_ = ctx
+	if err := os.MkdirAll(filepath.Dir(fileName), 0777); err != nil {
+		return err
+	}
 	return os.WriteFile(fileName, bytes, 0644)
 }
 
 func (s *FSStorage) Rename(ctx context.Context, oldPath, newPath string) error {
+	_ = ctx
+	if err := os.MkdirAll(filepath.Dir(newPath), 0777); err != nil {
+		return err
+	}
 	return os.Rename(oldPath, newPath)
+}
+
+func (s *FSStorage) Delete(ctx context.Context, fileName string) error {
+	_ = ctx
+	if err := os.Remove(fileName); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func (s *FSStorage) PresignGetURL(ctx context.Context, fileName string, ttl time.Duration) (string, error) {
+	_ = ctx
+	_ = ttl
+
+	cleaned := strings.TrimSpace(fileName)
+	cleaned = strings.TrimPrefix(cleaned, "/")
+	cleaned = path.Clean("/" + cleaned)
+	if cleaned == "/" {
+		return "", fmt.Errorf("invalid file path")
+	}
+	return cleaned, nil
 }

--- a/modules/core/infrastructure/persistence/upload_fs_storage.go
+++ b/modules/core/infrastructure/persistence/upload_fs_storage.go
@@ -4,6 +4,7 @@ package persistence
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -11,19 +12,22 @@ import (
 	"time"
 
 	"github.com/iota-uz/iota-sdk/pkg/configuration"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
 )
 
 type FSStorage struct{}
 
 func NewFSStorage() (*FSStorage, error) {
+	const op serrors.Op = "persistence.NewFSStorage"
+
 	conf := configuration.Use()
 	workDir, err := os.Getwd()
 	if err != nil {
-		return nil, err
+		return nil, serrors.E(op, err)
 	}
 	fullPath := filepath.Join(workDir, conf.UploadsPath)
-	if err := os.MkdirAll(fullPath, 0777); err != nil {
-		return nil, err
+	if err := os.MkdirAll(fullPath, 0o755); err != nil {
+		return nil, serrors.E(op, err)
 	}
 	return &FSStorage{}, nil
 }
@@ -37,38 +41,55 @@ func (s *FSStorage) Open(ctx context.Context, fileName string) ([]byte, error) {
 }
 
 func (s *FSStorage) Save(ctx context.Context, fileName string, bytes []byte) error {
+	const op serrors.Op = "persistence.FSStorage.Save"
 	_ = ctx
-	if err := os.MkdirAll(filepath.Dir(fileName), 0777); err != nil {
-		return err
+	if err := os.MkdirAll(filepath.Dir(fileName), 0o755); err != nil {
+		return serrors.E(op, err)
 	}
-	return os.WriteFile(fileName, bytes, 0644)
+	if err := os.WriteFile(fileName, bytes, 0o644); err != nil {
+		return serrors.E(op, err)
+	}
+	return nil
 }
 
 func (s *FSStorage) Rename(ctx context.Context, oldPath, newPath string) error {
+	const op serrors.Op = "persistence.FSStorage.Rename"
 	_ = ctx
-	if err := os.MkdirAll(filepath.Dir(newPath), 0777); err != nil {
-		return err
+	if err := os.MkdirAll(filepath.Dir(newPath), 0o755); err != nil {
+		return serrors.E(op, err)
 	}
-	return os.Rename(oldPath, newPath)
+	if err := os.Rename(oldPath, newPath); err != nil {
+		return serrors.E(op, err)
+	}
+	return nil
 }
 
 func (s *FSStorage) Delete(ctx context.Context, fileName string) error {
+	const op serrors.Op = "persistence.FSStorage.Delete"
 	_ = ctx
 	if err := os.Remove(fileName); err != nil && !os.IsNotExist(err) {
-		return err
+		return serrors.E(op, err)
 	}
 	return nil
 }
 
 func (s *FSStorage) PresignGetURL(ctx context.Context, fileName string, ttl time.Duration) (string, error) {
+	const op serrors.Op = "persistence.FSStorage.PresignGetURL"
+
 	_ = ctx
 	_ = ttl
 
+	conf := configuration.Use()
 	cleaned := strings.TrimSpace(fileName)
 	cleaned = strings.TrimPrefix(cleaned, "/")
 	cleaned = path.Clean("/" + cleaned)
 	if cleaned == "/" {
-		return "", fmt.Errorf("invalid file path")
+		return "", serrors.E(op, serrors.Invalid, fmt.Errorf("invalid file path"))
 	}
-	return cleaned, nil
+
+	return (&url.URL{
+		Scheme: conf.Scheme(),
+		Host:   conf.Domain,
+		Path:   cleaned,
+	}).String(), nil
 }

--- a/modules/core/infrastructure/persistence/upload_s3_storage.go
+++ b/modules/core/infrastructure/persistence/upload_s3_storage.go
@@ -1,0 +1,160 @@
+package persistence
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/signer/v4"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/iota-uz/iota-sdk/pkg/configuration"
+)
+
+type s3Client interface {
+	PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	CopyObject(ctx context.Context, params *s3.CopyObjectInput, optFns ...func(*s3.Options)) (*s3.CopyObjectOutput, error)
+	DeleteObject(ctx context.Context, params *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+}
+
+type s3PresignClient interface {
+	PresignGetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.PresignOptions)) (*v4.PresignedHTTPRequest, error)
+}
+
+type S3Storage struct {
+	bucket  string
+	client  s3Client
+	presign s3PresignClient
+}
+
+func NewS3Storage() (*S3Storage, error) {
+	conf := configuration.Use()
+
+	bucket := strings.TrimSpace(conf.UploadS3Bucket)
+	region := strings.TrimSpace(conf.UploadS3Region)
+	endpoint := normalizeS3Endpoint(strings.TrimSpace(conf.UploadS3Endpoint), conf.UploadS3Secure)
+	accessKey := strings.TrimSpace(conf.UploadS3AccessKey)
+	secretKey := strings.TrimSpace(conf.UploadS3SecretKey)
+
+	if bucket == "" {
+		return nil, fmt.Errorf("UPLOAD_S3_BUCKET is required")
+	}
+	if region == "" {
+		region = "us-east-1"
+	}
+	if accessKey == "" || secretKey == "" {
+		return nil, fmt.Errorf("UPLOAD_S3_ACCESS_KEY and UPLOAD_S3_SECRET_KEY are required")
+	}
+
+	awsCfg, err := awsconfig.LoadDefaultConfig(
+		context.Background(),
+		awsconfig.WithRegion(region),
+		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("load aws config: %w", err)
+	}
+
+	client := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+		o.UsePathStyle = conf.UploadS3ForcePathStyle
+		if endpoint != "" {
+			o.BaseEndpoint = aws.String(endpoint)
+		}
+	})
+
+	return &S3Storage{
+		bucket:  bucket,
+		client:  client,
+		presign: s3.NewPresignClient(client),
+	}, nil
+}
+
+func (s *S3Storage) Open(ctx context.Context, fileName string) ([]byte, error) {
+	key := normalizeS3Key(fileName)
+	res, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	return io.ReadAll(res.Body)
+}
+
+func (s *S3Storage) Save(ctx context.Context, fileName string, b []byte) error {
+	key := normalizeS3Key(fileName)
+	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+		Body:   bytes.NewReader(b),
+	})
+	return err
+}
+
+func (s *S3Storage) Rename(ctx context.Context, oldPath, newPath string) error {
+	sourceKey := normalizeS3Key(oldPath)
+	targetKey := normalizeS3Key(newPath)
+
+	_, err := s.client.CopyObject(ctx, &s3.CopyObjectInput{
+		Bucket:     aws.String(s.bucket),
+		CopySource: aws.String(s.bucket + "/" + sourceKey),
+		Key:        aws.String(targetKey),
+	})
+	if err != nil {
+		return err
+	}
+	return s.Delete(ctx, sourceKey)
+}
+
+func (s *S3Storage) Delete(ctx context.Context, fileName string) error {
+	key := normalizeS3Key(fileName)
+	_, err := s.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	return err
+}
+
+func (s *S3Storage) PresignGetURL(ctx context.Context, fileName string, ttl time.Duration) (string, error) {
+	key := normalizeS3Key(fileName)
+	req, err := s.presign.PresignGetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	}, func(po *s3.PresignOptions) {
+		po.Expires = ttl
+	})
+	if err != nil {
+		return "", err
+	}
+	return req.URL, nil
+}
+
+func normalizeS3Key(fileName string) string {
+	cleaned := strings.TrimSpace(fileName)
+	cleaned = strings.TrimPrefix(cleaned, "/")
+	cleaned = path.Clean("/" + cleaned)
+	return strings.TrimPrefix(cleaned, "/")
+}
+
+func normalizeS3Endpoint(endpoint string, secure bool) string {
+	if endpoint == "" {
+		return ""
+	}
+	if strings.HasPrefix(endpoint, "http://") || strings.HasPrefix(endpoint, "https://") {
+		return endpoint
+	}
+	scheme := "http://"
+	if secure {
+		scheme = "https://"
+	}
+	return scheme + endpoint
+}

--- a/modules/core/infrastructure/persistence/upload_s3_storage.go
+++ b/modules/core/infrastructure/persistence/upload_s3_storage.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/iota-uz/iota-sdk/pkg/configuration"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
 )
 
 type s3Client interface {
@@ -35,6 +36,8 @@ type S3Storage struct {
 }
 
 func NewS3Storage() (*S3Storage, error) {
+	const op serrors.Op = "persistence.NewS3Storage"
+
 	conf := configuration.Use()
 
 	bucket := strings.TrimSpace(conf.UploadS3Bucket)
@@ -44,13 +47,13 @@ func NewS3Storage() (*S3Storage, error) {
 	secretKey := strings.TrimSpace(conf.UploadS3SecretKey)
 
 	if bucket == "" {
-		return nil, fmt.Errorf("UPLOAD_S3_BUCKET is required")
+		return nil, serrors.E(op, serrors.Invalid, "UPLOAD_S3_BUCKET is required")
 	}
 	if region == "" {
 		region = "us-east-1"
 	}
 	if accessKey == "" || secretKey == "" {
-		return nil, fmt.Errorf("UPLOAD_S3_ACCESS_KEY and UPLOAD_S3_SECRET_KEY are required")
+		return nil, serrors.E(op, serrors.Invalid, "UPLOAD_S3_ACCESS_KEY and UPLOAD_S3_SECRET_KEY are required")
 	}
 
 	awsCfg, err := awsconfig.LoadDefaultConfig(
@@ -59,7 +62,7 @@ func NewS3Storage() (*S3Storage, error) {
 		awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(accessKey, secretKey, "")),
 	)
 	if err != nil {
-		return nil, fmt.Errorf("load aws config: %w", err)
+		return nil, serrors.E(op, fmt.Errorf("load aws config: %w", err))
 	}
 
 	client := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
@@ -77,55 +80,91 @@ func NewS3Storage() (*S3Storage, error) {
 }
 
 func (s *S3Storage) Open(ctx context.Context, fileName string) ([]byte, error) {
-	key := normalizeS3Key(fileName)
+	const op serrors.Op = "persistence.S3Storage.Open"
+	key, err := normalizeS3Key(fileName)
+	if err != nil {
+		return nil, serrors.E(op, err)
+	}
 	res, err := s.client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(key),
 	})
 	if err != nil {
-		return nil, err
+		return nil, serrors.E(op, err)
 	}
 	defer func() { _ = res.Body.Close() }()
 
-	return io.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, serrors.E(op, err)
+	}
+	return body, nil
 }
 
 func (s *S3Storage) Save(ctx context.Context, fileName string, b []byte) error {
-	key := normalizeS3Key(fileName)
-	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+	const op serrors.Op = "persistence.S3Storage.Save"
+	key, err := normalizeS3Key(fileName)
+	if err != nil {
+		return serrors.E(op, err)
+	}
+	_, err = s.client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(key),
 		Body:   bytes.NewReader(b),
 	})
-	return err
+	if err != nil {
+		return serrors.E(op, err)
+	}
+	return nil
 }
 
 func (s *S3Storage) Rename(ctx context.Context, oldPath, newPath string) error {
-	sourceKey := normalizeS3Key(oldPath)
-	targetKey := normalizeS3Key(newPath)
+	const op serrors.Op = "persistence.S3Storage.Rename"
+	sourceKey, err := normalizeS3Key(oldPath)
+	if err != nil {
+		return serrors.E(op, err)
+	}
+	targetKey, err := normalizeS3Key(newPath)
+	if err != nil {
+		return serrors.E(op, err)
+	}
 
-	_, err := s.client.CopyObject(ctx, &s3.CopyObjectInput{
+	_, err = s.client.CopyObject(ctx, &s3.CopyObjectInput{
 		Bucket:     aws.String(s.bucket),
 		CopySource: aws.String(s.bucket + "/" + sourceKey),
 		Key:        aws.String(targetKey),
 	})
 	if err != nil {
-		return err
+		return serrors.E(op, err)
 	}
-	return s.Delete(ctx, sourceKey)
+	if err := s.Delete(ctx, sourceKey); err != nil {
+		return serrors.E(op, err)
+	}
+	return nil
 }
 
 func (s *S3Storage) Delete(ctx context.Context, fileName string) error {
-	key := normalizeS3Key(fileName)
-	_, err := s.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+	const op serrors.Op = "persistence.S3Storage.Delete"
+	key, err := normalizeS3Key(fileName)
+	if err != nil {
+		return serrors.E(op, err)
+	}
+	_, err = s.client.DeleteObject(ctx, &s3.DeleteObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(key),
 	})
-	return err
+	if err != nil {
+		return serrors.E(op, err)
+	}
+	return nil
 }
 
 func (s *S3Storage) PresignGetURL(ctx context.Context, fileName string, ttl time.Duration) (string, error) {
-	key := normalizeS3Key(fileName)
+	const op serrors.Op = "persistence.S3Storage.PresignGetURL"
+	key, err := normalizeS3Key(fileName)
+	if err != nil {
+		return "", serrors.E(op, err)
+	}
 	req, err := s.presign.PresignGetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(s.bucket),
 		Key:    aws.String(key),
@@ -133,16 +172,20 @@ func (s *S3Storage) PresignGetURL(ctx context.Context, fileName string, ttl time
 		po.Expires = ttl
 	})
 	if err != nil {
-		return "", err
+		return "", serrors.E(op, err)
 	}
 	return req.URL, nil
 }
 
-func normalizeS3Key(fileName string) string {
+func normalizeS3Key(fileName string) (string, error) {
 	cleaned := strings.TrimSpace(fileName)
 	cleaned = strings.TrimPrefix(cleaned, "/")
 	cleaned = path.Clean("/" + cleaned)
-	return strings.TrimPrefix(cleaned, "/")
+	cleaned = strings.TrimPrefix(cleaned, "/")
+	if cleaned == "" || cleaned == "." {
+		return "", fmt.Errorf("invalid s3 object key for %q", fileName)
+	}
+	return cleaned, nil
 }
 
 func normalizeS3Endpoint(endpoint string, secure bool) string {

--- a/modules/core/module.go
+++ b/modules/core/module.go
@@ -4,11 +4,14 @@ package core
 import (
 	"embed"
 	"errors"
+	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/permission"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/upload"
 	"github.com/iota-uz/iota-sdk/modules/core/validators"
 	"github.com/iota-uz/iota-sdk/pkg/configuration"
 	"github.com/iota-uz/iota-sdk/pkg/rbac"
@@ -65,7 +68,7 @@ func (m *Module) Register(app application.Application) error {
 
 	_ = MigrationFiles
 	app.RegisterLocaleFiles(&LocaleFiles)
-	fsStorage, err := persistence.NewFSStorage()
+	uploadStorage, err := m.newUploadStorage()
 	if err != nil {
 		return serrors.E(op, err)
 	}
@@ -90,7 +93,7 @@ func (m *Module) Register(app application.Application) error {
 
 	// Create services
 	tenantService := services.NewTenantService(tenantRepo)
-	uploadService := services.NewUploadService(uploadRepo, fsStorage, app.EventPublisher())
+	uploadService := services.NewUploadService(uploadRepo, uploadStorage, app.EventPublisher())
 	sessionService := services.NewSessionService(persistence.NewSessionRepository(), app.EventPublisher())
 
 	app.RegisterServices(
@@ -270,4 +273,16 @@ func uploadAPIControllerOpts(opts *ModuleOptions) []controllers.UploadAPIControl
 		result = append(result, controllers.WithDefaultTenantID(opts.DefaultTenantID))
 	}
 	return result
+}
+
+func (m *Module) newUploadStorage() (upload.Storage, error) {
+	conf := configuration.Use()
+	switch strings.ToLower(strings.TrimSpace(conf.UploadStorageBackend)) {
+	case "", "fs":
+		return persistence.NewFSStorage()
+	case "s3":
+		return persistence.NewS3Storage()
+	default:
+		return nil, fmt.Errorf("unsupported upload storage backend: %s", conf.UploadStorageBackend)
+	}
 }

--- a/modules/core/presentation/controllers/upload_api_controller.go
+++ b/modules/core/presentation/controllers/upload_api_controller.go
@@ -186,9 +186,15 @@ func (c *UploadAPIController) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Build response
+	downloadURL, err := uploadService.GetDownloadURL(r.Context(), uploadEntity)
+	if err != nil {
+		c.writeJSONError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+
 	response := UploadAPIResponse{
 		ID:   uploadEntity.ID(),
-		URL:  uploadEntity.URL().String(),
+		URL:  downloadURL,
 		Hash: uploadEntity.Hash(),
 		Path: uploadEntity.Path(),
 		Name: uploadEntity.Name(),

--- a/modules/core/presentation/controllers/upload_api_controller.go
+++ b/modules/core/presentation/controllers/upload_api_controller.go
@@ -4,6 +4,7 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"strconv"
 
@@ -188,8 +189,8 @@ func (c *UploadAPIController) Create(w http.ResponseWriter, r *http.Request) {
 	// Build response
 	downloadURL, err := uploadService.GetDownloadURL(r.Context(), uploadEntity)
 	if err != nil {
-		c.writeJSONError(w, http.StatusInternalServerError, err.Error())
-		return
+		log.Printf("upload created but failed to build download URL: upload_id=%d error=%v", uploadEntity.ID(), err)
+		downloadURL = uploadEntity.URL().String()
 	}
 
 	response := UploadAPIResponse{

--- a/modules/core/presentation/controllers/upload_controller.go
+++ b/modules/core/presentation/controllers/upload_controller.go
@@ -146,18 +146,44 @@ func (c *UploadController) Create(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *UploadController) ServeUploadByPath(w http.ResponseWriter, r *http.Request) {
+	conf := configuration.Use()
+	prefix := path.Join("/", conf.UploadsPath, "/")
+
 	if strings.HasSuffix(r.URL.Path, "/") {
 		http.NotFound(w, r)
 		return
 	}
 
-	pathOnly := strings.TrimPrefix(r.URL.Path, "/")
-	if strings.TrimSpace(pathOnly) == "" {
+	if !strings.HasPrefix(r.URL.Path, prefix) {
 		http.NotFound(w, r)
 		return
 	}
 
-	downloadURL, err := c.uploadService.GetDownloadURLByPath(r.Context(), pathOnly)
+	trimmed := strings.TrimPrefix(r.URL.Path, prefix)
+	if strings.TrimSpace(trimmed) == "" {
+		http.NotFound(w, r)
+		return
+	}
+	if strings.Contains(trimmed, "..") {
+		http.NotFound(w, r)
+		return
+	}
+
+	normalized := path.Clean("/" + trimmed)
+	normalized = strings.TrimPrefix(normalized, "/")
+	if normalized == "" || strings.Contains(normalized, "..") {
+		http.NotFound(w, r)
+		return
+	}
+
+	basePath := strings.Trim(path.Clean("/"+conf.UploadsPath), "/")
+	storagePath := path.Join(basePath, normalized)
+	if !strings.HasPrefix(storagePath, basePath+"/") {
+		http.NotFound(w, r)
+		return
+	}
+
+	downloadURL, err := c.uploadService.GetDownloadURLByPath(r.Context(), storagePath)
 	if err != nil {
 		http.NotFound(w, r)
 		return

--- a/modules/core/presentation/controllers/upload_controller.go
+++ b/modules/core/presentation/controllers/upload_controller.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/a-h/templ"
 	"github.com/gorilla/mux"
@@ -50,12 +51,17 @@ func (c *UploadController) Register(r *mux.Router) {
 	router.Use(middleware.ProvideLocalizer(c.app))
 	router.HandleFunc("", c.Create).Methods(http.MethodPost)
 
+	prefix := path.Join("/", conf.UploadsPath, "/")
+	if strings.EqualFold(strings.TrimSpace(conf.UploadStorageBackend), "s3") {
+		r.PathPrefix(prefix).Handler(http.HandlerFunc(c.ServeUploadByPath))
+		return
+	}
+
 	workDir, err := os.Getwd()
 	if err != nil {
 		panic(err)
 	}
 	fullPath := filepath.Join(workDir, conf.UploadsPath)
-	prefix := path.Join("/", conf.UploadsPath, "/")
 	neuteredFS := multifs.NewNeuteredFileSystem(http.Dir(fullPath))
 	r.PathPrefix(prefix).Handler(http.StripPrefix(prefix, http.FileServer(neuteredFS)))
 }
@@ -137,4 +143,24 @@ func (c *UploadController) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	templ.Handler(components.UploadTarget(props), templ.WithStreaming()).ServeHTTP(w, r)
+}
+
+func (c *UploadController) ServeUploadByPath(w http.ResponseWriter, r *http.Request) {
+	if strings.HasSuffix(r.URL.Path, "/") {
+		http.NotFound(w, r)
+		return
+	}
+
+	pathOnly := strings.TrimPrefix(r.URL.Path, "/")
+	if strings.TrimSpace(pathOnly) == "" {
+		http.NotFound(w, r)
+		return
+	}
+
+	downloadURL, err := c.uploadService.GetDownloadURLByPath(r.Context(), pathOnly)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	http.Redirect(w, r, downloadURL, http.StatusSeeOther)
 }

--- a/modules/core/presentation/controllers/upload_controller_test.go
+++ b/modules/core/presentation/controllers/upload_controller_test.go
@@ -2,6 +2,7 @@ package controllers_test
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/iota-uz/iota-sdk/modules/core"
 	"github.com/iota-uz/iota-sdk/modules/core/presentation/controllers"
+	"github.com/iota-uz/iota-sdk/pkg/configuration"
 	"github.com/iota-uz/iota-sdk/pkg/defaults"
 	"github.com/iota-uz/iota-sdk/pkg/itf"
 	"github.com/stretchr/testify/require"
@@ -169,4 +171,20 @@ func TestUploadController_NonExistentFile_Returns404(t *testing.T) {
 	// Test that non-existent file returns 404
 	urlPath := "/" + uploadsPath + "/" + testSubDir + "/nonexistent.txt"
 	suite.GET(urlPath).Expect(t).Status(http.StatusNotFound)
+}
+
+func TestUploadController_S3Route_TraversalPath_Returns404(t *testing.T) {
+	conf := configuration.Use()
+	prevUploadsPath := conf.UploadsPath
+	conf.UploadsPath = "test-uploads"
+	t.Cleanup(func() {
+		conf.UploadsPath = prevUploadsPath
+	})
+
+	controller := &controllers.UploadController{}
+	req := httptest.NewRequest(http.MethodGet, "/test-uploads/../secrets.txt", nil)
+	rec := httptest.NewRecorder()
+
+	controller.ServeUploadByPath(rec, req)
+	require.Equal(t, http.StatusNotFound, rec.Code)
 }

--- a/modules/core/services/excel_export_service_test.go
+++ b/modules/core/services/excel_export_service_test.go
@@ -2,15 +2,9 @@ package services_test
 
 import (
 	"context"
-	"testing"
-
-	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
-
 	"fmt"
 	"net/url"
+	"testing"
 	"time"
 
 	"github.com/gabriel-vasile/mimetype"
@@ -22,6 +16,10 @@ import (
 	"github.com/iota-uz/iota-sdk/modules/core/services"
 	"github.com/iota-uz/iota-sdk/pkg/eventbus"
 	"github.com/iota-uz/iota-sdk/pkg/excel"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // Mock dependencies
@@ -129,6 +127,11 @@ func (m *MockUploadStorage) Open(ctx context.Context, path string) ([]byte, erro
 		return nil, args.Error(1)
 	}
 	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (m *MockUploadStorage) PresignGetURL(ctx context.Context, path string, ttl time.Duration) (string, error) {
+	args := m.Called(ctx, path, ttl)
+	return args.String(0), args.Error(1)
 }
 
 type MockUpload struct {

--- a/modules/core/services/upload_service.go
+++ b/modules/core/services/upload_service.go
@@ -4,9 +4,11 @@ package services
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/upload"
 	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence"
+	"github.com/iota-uz/iota-sdk/pkg/configuration"
 	"github.com/iota-uz/iota-sdk/pkg/eventbus"
 )
 
@@ -141,12 +143,31 @@ func (s *UploadService) CreateMany(ctx context.Context, data []*upload.CreateDTO
 	return entities, nil
 }
 
+func (s *UploadService) GetDownloadURL(ctx context.Context, entity upload.Upload) (string, error) {
+	if entity == nil {
+		return "", errors.New("upload is nil")
+	}
+	return s.GetDownloadURLByPath(ctx, entity.Path())
+}
+
+func (s *UploadService) GetDownloadURLByPath(ctx context.Context, storagePath string) (string, error) {
+	conf := configuration.Use()
+	ttlSeconds := conf.UploadS3PresignTTL
+	if ttlSeconds <= 0 {
+		ttlSeconds = 300
+	}
+	return s.storage.PresignGetURL(ctx, storagePath, time.Duration(ttlSeconds)*time.Second)
+}
+
 func (s *UploadService) Delete(ctx context.Context, id uint) (upload.Upload, error) {
 	entity, err := s.repo.GetByID(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 	if err := s.repo.Delete(ctx, id); err != nil {
+		return nil, err
+	}
+	if err := s.storage.Delete(ctx, entity.Path()); err != nil {
 		return nil, err
 	}
 	deletedEvent, err := upload.NewDeletedEvent(ctx, entity)

--- a/modules/core/services/upload_service.go
+++ b/modules/core/services/upload_service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence"
 	"github.com/iota-uz/iota-sdk/pkg/configuration"
 	"github.com/iota-uz/iota-sdk/pkg/eventbus"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
 )
 
 type UploadService struct {
@@ -144,19 +145,31 @@ func (s *UploadService) CreateMany(ctx context.Context, data []*upload.CreateDTO
 }
 
 func (s *UploadService) GetDownloadURL(ctx context.Context, entity upload.Upload) (string, error) {
+	const op serrors.Op = "services.UploadService.GetDownloadURL"
+
 	if entity == nil {
-		return "", errors.New("upload is nil")
+		return "", serrors.E(op, serrors.Invalid, errors.New("upload is nil"))
 	}
-	return s.GetDownloadURLByPath(ctx, entity.Path())
+	downloadURL, err := s.GetDownloadURLByPath(ctx, entity.Path())
+	if err != nil {
+		return "", serrors.E(op, err)
+	}
+	return downloadURL, nil
 }
 
 func (s *UploadService) GetDownloadURLByPath(ctx context.Context, storagePath string) (string, error) {
+	const op serrors.Op = "services.UploadService.GetDownloadURLByPath"
+
 	conf := configuration.Use()
 	ttlSeconds := conf.UploadS3PresignTTL
 	if ttlSeconds <= 0 {
 		ttlSeconds = 300
 	}
-	return s.storage.PresignGetURL(ctx, storagePath, time.Duration(ttlSeconds)*time.Second)
+	downloadURL, err := s.storage.PresignGetURL(ctx, storagePath, time.Duration(ttlSeconds)*time.Second)
+	if err != nil {
+		return "", serrors.E(op, err)
+	}
+	return downloadURL, nil
 }
 
 func (s *UploadService) Delete(ctx context.Context, id uint) (upload.Upload, error) {
@@ -164,10 +177,10 @@ func (s *UploadService) Delete(ctx context.Context, id uint) (upload.Upload, err
 	if err != nil {
 		return nil, err
 	}
-	if err := s.repo.Delete(ctx, id); err != nil {
+	if err := s.storage.Delete(ctx, entity.Path()); err != nil {
 		return nil, err
 	}
-	if err := s.storage.Delete(ctx, entity.Path()); err != nil {
+	if err := s.repo.Delete(ctx, id); err != nil {
 		return nil, err
 	}
 	deletedEvent, err := upload.NewDeletedEvent(ctx, entity)

--- a/modules/core/services/upload_service_test.go
+++ b/modules/core/services/upload_service_test.go
@@ -1,0 +1,176 @@
+package services_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/upload"
+	"github.com/iota-uz/iota-sdk/modules/core/services"
+	"github.com/iota-uz/iota-sdk/pkg/eventbus"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type uploadRepoMock struct {
+	mock.Mock
+}
+
+func (m *uploadRepoMock) GetByID(ctx context.Context, id uint) (upload.Upload, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(upload.Upload), args.Error(1)
+}
+
+func (m *uploadRepoMock) GetByIDs(ctx context.Context, ids []uint) ([]upload.Upload, error) {
+	args := m.Called(ctx, ids)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]upload.Upload), args.Error(1)
+}
+
+func (m *uploadRepoMock) GetByHash(ctx context.Context, hash string) (upload.Upload, error) {
+	args := m.Called(ctx, hash)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(upload.Upload), args.Error(1)
+}
+
+func (m *uploadRepoMock) GetBySlug(ctx context.Context, slug string) (upload.Upload, error) {
+	args := m.Called(ctx, slug)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(upload.Upload), args.Error(1)
+}
+
+func (m *uploadRepoMock) GetAll(ctx context.Context) ([]upload.Upload, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]upload.Upload), args.Error(1)
+}
+
+func (m *uploadRepoMock) GetPaginated(ctx context.Context, params *upload.FindParams) ([]upload.Upload, error) {
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]upload.Upload), args.Error(1)
+}
+
+func (m *uploadRepoMock) Create(ctx context.Context, entity upload.Upload) (upload.Upload, error) {
+	args := m.Called(ctx, entity)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(upload.Upload), args.Error(1)
+}
+
+func (m *uploadRepoMock) Update(ctx context.Context, entity upload.Upload) error {
+	args := m.Called(ctx, entity)
+	return args.Error(0)
+}
+
+func (m *uploadRepoMock) Delete(ctx context.Context, id uint) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *uploadRepoMock) Count(ctx context.Context) (int64, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *uploadRepoMock) Exists(ctx context.Context, id uint) (bool, error) {
+	args := m.Called(ctx, id)
+	return args.Bool(0), args.Error(1)
+}
+
+type uploadStorageMock struct {
+	mock.Mock
+}
+
+func (m *uploadStorageMock) Open(ctx context.Context, fileName string) ([]byte, error) {
+	args := m.Called(ctx, fileName)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (m *uploadStorageMock) Save(ctx context.Context, fileName string, bytes []byte) error {
+	args := m.Called(ctx, fileName, bytes)
+	return args.Error(0)
+}
+
+func (m *uploadStorageMock) Rename(ctx context.Context, oldPath, newPath string) error {
+	args := m.Called(ctx, oldPath, newPath)
+	return args.Error(0)
+}
+
+func (m *uploadStorageMock) Delete(ctx context.Context, fileName string) error {
+	args := m.Called(ctx, fileName)
+	return args.Error(0)
+}
+
+func (m *uploadStorageMock) PresignGetURL(ctx context.Context, fileName string, ttl time.Duration) (string, error) {
+	args := m.Called(ctx, fileName, ttl)
+	return args.String(0), args.Error(1)
+}
+
+func TestUploadService_GetDownloadURLByPath(t *testing.T) {
+	t.Parallel()
+
+	repo := &uploadRepoMock{}
+	storage := &uploadStorageMock{}
+	svc := services.NewUploadService(repo, storage, eventbus.NewEventPublisher(logrus.New()))
+
+	storage.On("PresignGetURL", mock.Anything, "uploads/a.txt", mock.MatchedBy(func(ttl time.Duration) bool {
+		return ttl > 0
+	})).Return("https://example.test/presigned", nil).Once()
+
+	got, err := svc.GetDownloadURLByPath(context.Background(), "uploads/a.txt")
+	require.NoError(t, err)
+	require.Equal(t, "https://example.test/presigned", got)
+	storage.AssertExpectations(t)
+}
+
+func TestUploadService_Delete_RemovesStorageObject(t *testing.T) {
+	t.Parallel()
+
+	repo := &uploadRepoMock{}
+	storage := &uploadStorageMock{}
+	svc := services.NewUploadService(repo, storage, eventbus.NewEventPublisher(logrus.New()))
+
+	entity := upload.NewWithID(
+		12,
+		uuid.Nil,
+		"hash",
+		"uploads/doc.pdf",
+		"doc.pdf",
+		"slug",
+		42,
+		nil,
+		upload.UploadTypeDocument,
+		time.Now(),
+		time.Now(),
+	)
+
+	repo.On("GetByID", mock.Anything, uint(12)).Return(entity, nil).Once()
+	repo.On("Delete", mock.Anything, uint(12)).Return(nil).Once()
+	storage.On("Delete", mock.Anything, "uploads/doc.pdf").Return(nil).Once()
+
+	deleted, err := svc.Delete(context.Background(), 12)
+	require.NoError(t, err)
+	require.Equal(t, uint(12), deleted.ID())
+	repo.AssertExpectations(t)
+	storage.AssertExpectations(t)
+}

--- a/modules/core/services/upload_service_test.go
+++ b/modules/core/services/upload_service_test.go
@@ -2,6 +2,7 @@ package services_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/iota-uz/iota-sdk/modules/core/services"
 	"github.com/iota-uz/iota-sdk/pkg/eventbus"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -126,29 +128,62 @@ func (m *uploadStorageMock) PresignGetURL(ctx context.Context, fileName string, 
 	return args.String(0), args.Error(1)
 }
 
-func TestUploadService_GetDownloadURLByPath(t *testing.T) {
+func TestUploadService_GetDownloadURLByPath_Scenarios(t *testing.T) {
 	t.Parallel()
 
-	repo := &uploadRepoMock{}
-	storage := &uploadStorageMock{}
-	svc := services.NewUploadService(repo, storage, eventbus.NewEventPublisher(logrus.New()))
+	tests := []struct {
+		name          string
+		path          string
+		setup         func(storage *uploadStorageMock)
+		expectedURL   string
+		expectedError bool
+	}{
+		{
+			name: "success",
+			path: "uploads/a.txt",
+			setup: func(storage *uploadStorageMock) {
+				storage.On("PresignGetURL", mock.Anything, "uploads/a.txt", mock.MatchedBy(func(ttl time.Duration) bool {
+					return ttl > 0
+				})).Return("https://example.test/presigned", nil).Once()
+			},
+			expectedURL: "https://example.test/presigned",
+		},
+		{
+			name: "storage_error",
+			path: "uploads/a.txt",
+			setup: func(storage *uploadStorageMock) {
+				storage.On("PresignGetURL", mock.Anything, "uploads/a.txt", mock.Anything).Return("", errors.New("presign failed")).Once()
+			},
+			expectedError: true,
+		},
+	}
 
-	storage.On("PresignGetURL", mock.Anything, "uploads/a.txt", mock.MatchedBy(func(ttl time.Duration) bool {
-		return ttl > 0
-	})).Return("https://example.test/presigned", nil).Once()
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	got, err := svc.GetDownloadURLByPath(context.Background(), "uploads/a.txt")
-	require.NoError(t, err)
-	require.Equal(t, "https://example.test/presigned", got)
-	storage.AssertExpectations(t)
+			repo := &uploadRepoMock{}
+			storage := &uploadStorageMock{}
+			svc := services.NewUploadService(repo, storage, eventbus.NewEventPublisher(logrus.New()))
+			tc.setup(storage)
+
+			got, err := svc.GetDownloadURLByPath(context.Background(), tc.path)
+			if tc.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tc.expectedURL, got)
+			}
+
+			repo.AssertExpectations(t)
+			storage.AssertExpectations(t)
+		})
+	}
 }
 
-func TestUploadService_Delete_RemovesStorageObject(t *testing.T) {
+func TestUploadService_Delete_Scenarios(t *testing.T) {
 	t.Parallel()
-
-	repo := &uploadRepoMock{}
-	storage := &uploadStorageMock{}
-	svc := services.NewUploadService(repo, storage, eventbus.NewEventPublisher(logrus.New()))
 
 	entity := upload.NewWithID(
 		12,
@@ -164,13 +199,59 @@ func TestUploadService_Delete_RemovesStorageObject(t *testing.T) {
 		time.Now(),
 	)
 
-	repo.On("GetByID", mock.Anything, uint(12)).Return(entity, nil).Once()
-	repo.On("Delete", mock.Anything, uint(12)).Return(nil).Once()
-	storage.On("Delete", mock.Anything, "uploads/doc.pdf").Return(nil).Once()
+	tests := []struct {
+		name          string
+		setup         func(repo *uploadRepoMock, storage *uploadStorageMock)
+		expectedID    uint
+		expectedError bool
+	}{
+		{
+			name: "success",
+			setup: func(repo *uploadRepoMock, storage *uploadStorageMock) {
+				repo.On("GetByID", mock.Anything, uint(12)).Return(entity, nil).Once()
+				storage.On("Delete", mock.Anything, "uploads/doc.pdf").Return(nil).Once()
+				repo.On("Delete", mock.Anything, uint(12)).Return(nil).Once()
+			},
+			expectedID: 12,
+		},
+		{
+			name: "repo_get_error",
+			setup: func(repo *uploadRepoMock, storage *uploadStorageMock) {
+				repo.On("GetByID", mock.Anything, uint(12)).Return(nil, errors.New("not found")).Once()
+			},
+			expectedError: true,
+		},
+		{
+			name: "storage_error",
+			setup: func(repo *uploadRepoMock, storage *uploadStorageMock) {
+				repo.On("GetByID", mock.Anything, uint(12)).Return(entity, nil).Once()
+				storage.On("Delete", mock.Anything, "uploads/doc.pdf").Return(errors.New("storage failed")).Once()
+			},
+			expectedError: true,
+		},
+	}
 
-	deleted, err := svc.Delete(context.Background(), 12)
-	require.NoError(t, err)
-	require.Equal(t, uint(12), deleted.ID())
-	repo.AssertExpectations(t)
-	storage.AssertExpectations(t)
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := &uploadRepoMock{}
+			storage := &uploadStorageMock{}
+			svc := services.NewUploadService(repo, storage, eventbus.NewEventPublisher(logrus.New()))
+			tc.setup(repo, storage)
+
+			deleted, err := svc.Delete(context.Background(), 12)
+			if tc.expectedError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, deleted)
+				assert.Equal(t, tc.expectedID, deleted.ID())
+			}
+
+			repo.AssertExpectations(t)
+			storage.AssertExpectations(t)
+		})
+	}
 }

--- a/pkg/configuration/environment.go
+++ b/pkg/configuration/environment.go
@@ -245,6 +245,15 @@ type Configuration struct {
 	SocketAddress           string        `env:"-"`
 	OpenAIKey               string        `env:"OPENAI_KEY"`
 	UploadsPath             string        `env:"UPLOADS_PATH" envDefault:"static"`
+	UploadStorageBackend    string        `env:"UPLOAD_STORAGE_BACKEND" envDefault:"fs"`
+	UploadS3Bucket          string        `env:"UPLOAD_S3_BUCKET"`
+	UploadS3Region          string        `env:"UPLOAD_S3_REGION" envDefault:"us-east-1"`
+	UploadS3Endpoint        string        `env:"UPLOAD_S3_ENDPOINT"`
+	UploadS3AccessKey       string        `env:"UPLOAD_S3_ACCESS_KEY"`
+	UploadS3SecretKey       string        `env:"UPLOAD_S3_SECRET_KEY"`
+	UploadS3Secure          bool          `env:"UPLOAD_S3_SECURE" envDefault:"false"`
+	UploadS3ForcePathStyle  bool          `env:"UPLOAD_S3_FORCE_PATH_STYLE" envDefault:"true"`
+	UploadS3PresignTTL      int           `env:"UPLOAD_S3_PRESIGN_TTL_SECONDS" envDefault:"300"`
 	Domain                  string        `env:"DOMAIN" envDefault:"localhost"`
 	Origin                  string        `env:"ORIGIN" envDefault:"http://localhost:3200"`
 	BiChatKnowledgeDir      string        `env:"BICHAT_KNOWLEDGE_DIR"`


### PR DESCRIPTION
## Summary
- extend upload storage contract with delete and presigned-get URL support
- add S3 storage backend implementation with MinIO-compatible endpoint/path-style config
- wire runtime backend selection via `UPLOAD_STORAGE_BACKEND=fs|s3`
- make upload download serving backend-aware while preserving existing URL path compatibility
- update upload API response URL generation and delete semantics to use storage backend
- add service tests for presigned URL + physical delete behavior

## Config
- `UPLOAD_STORAGE_BACKEND`
- `UPLOAD_S3_BUCKET`, `UPLOAD_S3_REGION`, `UPLOAD_S3_ENDPOINT`
- `UPLOAD_S3_ACCESS_KEY`, `UPLOAD_S3_SECRET_KEY`
- `UPLOAD_S3_SECURE`, `UPLOAD_S3_FORCE_PATH_STYLE`
- `UPLOAD_S3_PRESIGN_TTL_SECONDS`

## Validation
- `go test ./modules/core/infrastructure/persistence ./modules/core/services ./modules/core/presentation/controllers -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added S3 storage backend option for uploads (filesystem remains default)
  * Implemented presigned URL generation for secure, time-limited download links
  * Added file deletion capability for uploaded content
  * Enhanced upload API responses with direct download URLs

* **Configuration**
  * New S3 settings available: storage backend selection, bucket, region, credentials, endpoint, and presigned link TTL

<!-- end of auto-generated comment: release notes by coderabbit.ai -->