### PR TITLE
fix: auto-correct permission UUIDs via upsert + ON UPDATE CASCADE

### DIFF
--- a/migrations/changes-1777600000.sql
+++ b/migrations/changes-1777600000.sql
@@ -1,0 +1,33 @@
+-- Migration: Add ON UPDATE CASCADE to permission FK constraints
+-- Date: 2026-03-02
+-- Purpose: When permission UUIDs are corrected via upsert (SET id = EXCLUDED.id),
+--   ON UPDATE CASCADE automatically propagates the new UUID to role_permissions
+--   and user_permissions, preventing orphaned or mismatched foreign keys.
+
+-- +migrate Up
+ALTER TABLE role_permissions
+    DROP CONSTRAINT role_permissions_permission_id_fkey,
+    ADD CONSTRAINT role_permissions_permission_id_fkey
+        FOREIGN KEY (permission_id) REFERENCES permissions (id)
+        ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE user_permissions
+    DROP CONSTRAINT user_permissions_permission_id_fkey,
+    ADD CONSTRAINT user_permissions_permission_id_fkey
+        FOREIGN KEY (permission_id) REFERENCES permissions (id)
+        ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- +migrate Down
+ALTER TABLE role_permissions
+    DROP CONSTRAINT IF EXISTS role_permissions_permission_id_fkey;
+ALTER TABLE role_permissions
+    ADD CONSTRAINT role_permissions_permission_id_fkey
+        FOREIGN KEY (permission_id) REFERENCES permissions (id)
+        ON DELETE CASCADE;
+
+ALTER TABLE user_permissions
+    DROP CONSTRAINT IF EXISTS user_permissions_permission_id_fkey;
+ALTER TABLE user_permissions
+    ADD CONSTRAINT user_permissions_permission_id_fkey
+        FOREIGN KEY (permission_id) REFERENCES permissions (id)
+        ON DELETE CASCADE;

--- a/modules/core/infrastructure/persistence/permission_repository.go
+++ b/modules/core/infrastructure/persistence/permission_repository.go
@@ -24,7 +24,12 @@ const (
 	permissionsInsertQuery = `
 		INSERT INTO permissions (id, name, resource, action, modifier, description)
 		VALUES ($1, $2, $3, $4, $5, $6)
-		ON CONFLICT (name) DO UPDATE SET resource = permissions.resource
+		ON CONFLICT (name) DO UPDATE
+		SET id = EXCLUDED.id,
+		    resource = EXCLUDED.resource,
+		    action = EXCLUDED.action,
+		    modifier = EXCLUDED.modifier,
+		    description = EXCLUDED.description
 		RETURNING id`
 	permissionsUpdateQuery = `
 		UPDATE permissions

--- a/modules/core/infrastructure/persistence/role_repository.go
+++ b/modules/core/infrastructure/persistence/role_repository.go
@@ -45,7 +45,8 @@ const (
 		INSERT INTO permissions (id, name, resource, action, modifier, description)
 		VALUES ($1, $2, $3, $4, $5, $6)
 		ON CONFLICT (name) DO UPDATE
-		SET resource = EXCLUDED.resource,
+		SET id = EXCLUDED.id,
+		    resource = EXCLUDED.resource,
 		    action = EXCLUDED.action,
 		    modifier = EXCLUDED.modifier,
 		    description = EXCLUDED.description


### PR DESCRIPTION
Permission UUIDs drifted because upsert queries used ON CONFLICT (name) but never updated the id column. Add id = EXCLUDED.id to both permissionsInsertQuery and permissionUpsertByNameQuery so future upserts correct stale UUIDs. Add ON UPDATE CASCADE migration to propagate UUID changes to role_permissions and user_permissions FK constraints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Strengthened data consistency for permission management with enhanced cascading updates to dependent records.
  * Enhanced permission data synchronization logic to ensure complete information is maintained during record updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->