### PR TITLE
fix: remove duplicate List function inserted inside GetEdit

### DIFF
--- a/modules/core/presentation/controllers/roles_controller.go
+++ b/modules/core/presentation/controllers/roles_controller.go
@@ -148,19 +148,6 @@ func (c *RolesController) GetEdit(
 		return
 	}
 
-func (c *RolesController) List(
-	r *http.Request,
-	w http.ResponseWriter,
-	logger *logrus.Entry,
-	roleService *services.RoleService,
-) {
-	if err := composables.CanUser(r.Context(), permissions.RoleRead); err != nil {
-		RenderForbidden(w, r)
-		return
-	}
-	params := composables.UsePaginated(r)
-	search := r.URL.Query().Get("name")
-
 	roleEntity, err := roleService.GetByID(r.Context(), id)
 	if err != nil {
 		logger.Errorf("Error retrieving role: %v", err)


### PR DESCRIPTION
A List function definition was incorrectly inserted in the middle of GetEdit's body, causing a syntax error. The List function already exists earlier in the file. Removed the duplicate to restore GetEdit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed the role listing functionality from the roles management interface, including pagination and search capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->