### PR TITLE
fix: add missing i18n keys for EAI permission schema

### DIFF
--- a/modules/core/presentation/locales/en.json
+++ b/modules/core/presentation/locales/en.json
@@ -427,7 +427,13 @@
     "Superadmin": "Super Admin",
     "Testkit": "Test Kit",
     "Warehouse": "Warehouse",
-    "Website": "Website"
+    "Website": "Website",
+    "Insurance": "Insurance",
+    "Claim": "Claims",
+    "EDO": "EDO",
+    "Custom": "EAI Settings",
+    "System": "System",
+    "Reserve": "Reserves"
   },
   "NavigationLinks": {
     "Dashboard": "Dashboard",
@@ -686,17 +692,33 @@
       },
       "PayoutManage": {
         "Label": "Manage Payouts",
-        "_Description": "Full payout management capabilities"
+        "_Description": "Full payout management"
+      },
+      "CRMChatsView": {
+        "Label": "View Chats",
+        "_Description": "View CRM chats"
+      },
+      "CRMPoliciesView": {
+        "Label": "View Policies",
+        "_Description": "View CRM policies"
       }
     },
     "Pipeline": {
       "PipelineView": {
         "Label": "View Pipelines",
-        "_Description": "View pipeline information only"
+        "_Description": "View pipeline information"
       },
       "PipelineManage": {
         "Label": "Manage Pipelines",
-        "_Description": "Full pipeline management capabilities"
+        "_Description": "Full pipeline management"
+      },
+      "LookupView": {
+        "Label": "View Lookups",
+        "_Description": "View pipeline lookups"
+      },
+      "LookupManage": {
+        "Label": "Manage Lookups",
+        "_Description": "Manage pipeline lookups"
       }
     },
     "HRM": {
@@ -721,6 +743,22 @@
       "Export": {
         "Label": "Export Data",
         "_Description": "Export chat data"
+      },
+      "PlaygroundView": {
+        "Label": "Access Playground",
+        "_Description": "Use the AI Chat playground interface"
+      },
+      "LogsView": {
+        "Label": "View Logs",
+        "_Description": "View AI Chat conversation logs"
+      },
+      "ConfigView": {
+        "Label": "View Configuration",
+        "_Description": "View AI Chat configuration settings"
+      },
+      "EvalView": {
+        "Label": "View Evaluation",
+        "_Description": "View AI Chat evaluation tests"
       }
     },
     "Website": {
@@ -730,7 +768,157 @@
       },
       "WebsiteManage": {
         "Label": "Manage Website",
-        "_Description": "Full website management capabilities"
+        "_Description": "Full website management"
+      }
+    },
+    "Insurance": {
+      "PolicyReissueManage": {
+        "Label": "Reissue Policies",
+        "_Description": "Reissue insurance policies"
+      },
+      "ProductView": {
+        "Label": "View Products",
+        "_Description": "View insurance products"
+      },
+      "ProductManage": {
+        "Label": "Manage Products",
+        "_Description": "Full product management"
+      },
+      "AgencyView": {
+        "Label": "View Agencies",
+        "_Description": "View insurance agencies"
+      },
+      "AgencyManage": {
+        "Label": "Manage Agencies",
+        "_Description": "Full agency management"
+      },
+      "IntegratorView": {
+        "Label": "View Integrators",
+        "_Description": "View integrators"
+      },
+      "IntegratorManage": {
+        "Label": "Manage Integrators",
+        "_Description": "Full integrator management"
+      },
+      "PortfolioPoliciesExportManage": {
+        "Label": "Export Policies",
+        "_Description": "Export portfolio policies data"
+      },
+      "PortfolioAdmissionsExportManage": {
+        "Label": "Export Admissions",
+        "_Description": "Export portfolio admissions data"
+      },
+      "PortfolioContractsExportManage": {
+        "Label": "Export Contracts",
+        "_Description": "Export portfolio contracts data"
+      },
+      "PortfolioView": {
+        "Label": "View Portfolio",
+        "_Description": "View insurance portfolio"
+      },
+      "SalesReportView": {
+        "Label": "View Sales Report",
+        "_Description": "View sales report"
+      },
+      "OsagoReportView": {
+        "Label": "View OSAGO Report",
+        "_Description": "View OSAGO report"
+      },
+      "LookupView": {
+        "Label": "View Lookups",
+        "_Description": "View insurance lookups"
+      },
+      "LookupManage": {
+        "Label": "Manage Lookups",
+        "_Description": "Manage insurance lookups"
+      },
+      "LookupOrganizationView": {
+        "Label": "View Organizations",
+        "_Description": "View organizations"
+      },
+      "LookupOrganizationManage": {
+        "Label": "Manage Organizations",
+        "_Description": "Manage organizations"
+      },
+      "LookupVehicleView": {
+        "Label": "View Vehicles",
+        "_Description": "View vehicles"
+      },
+      "LookupVehicleManage": {
+        "Label": "Manage Vehicles",
+        "_Description": "Manage vehicles"
+      },
+      "LookupPersonView": {
+        "Label": "View Persons",
+        "_Description": "View persons"
+      },
+      "LookupPersonManage": {
+        "Label": "Manage Persons",
+        "_Description": "Manage persons"
+      },
+      "LookupRealEstateView": {
+        "Label": "View Real Estate",
+        "_Description": "View real estate"
+      },
+      "LookupRealEstateManage": {
+        "Label": "Manage Real Estate",
+        "_Description": "Manage real estate"
+      },
+      "ClaimView": {
+        "Label": "View Claims",
+        "_Description": "View insurance claims"
+      },
+      "ClaimManage": {
+        "Label": "Manage Claims",
+        "_Description": "Full claims management"
+      },
+      "ClaimsReportView": {
+        "Label": "View Claims Report",
+        "_Description": "View claims report"
+      },
+      "LookupDecisionView": {
+        "Label": "View Decisions",
+        "_Description": "View claim decisions"
+      },
+      "LookupDecisionManage": {
+        "Label": "Manage Decisions",
+        "_Description": "Manage claim decisions"
+      },
+      "ReserveView": {
+        "Label": "View Reserves",
+        "_Description": "View insurance reserves"
+      }
+    },
+    "EDO": {
+      "DocumentView": {
+        "Label": "View Documents",
+        "_Description": "View EDO documents"
+      },
+      "DocumentManage": {
+        "Label": "Manage Documents",
+        "_Description": "Full document management"
+      }
+    },
+    "Custom": {
+      "DashboardView": {
+        "Label": "View Dashboard",
+        "_Description": "View EAI dashboard"
+      },
+      "LookupsView": {
+        "Label": "View Lookups",
+        "_Description": "View EAI lookups"
+      },
+      "LookupsManage": {
+        "Label": "Manage Lookups",
+        "_Description": "Manage EAI lookups"
+      },
+      "SettingsView": {
+        "Label": "View Settings",
+        "_Description": "View EAI settings"
+      },
+      "SystemView": {
+        "Label": "View System",
+        "_Description": "View system information"
       }
     }
   },
@@ -826,7 +1014,38 @@
     "payout_request": "Payout Request",
     "pipeline": "Pipeline",
     "website": "Website",
-    "session": "Sessions"
+    "session": "Sessions",
+    "bichat_playground": "Playground",
+    "bichat_logs": "Logs",
+    "bichat_config": "Configuration",
+    "bichat_eval": "Evaluation",
+    "crm_chats": "Chats",
+    "crm_policies": "Policies",
+    "insurance_product": "Products",
+    "insurance_agency": "Agencies",
+    "insurance_integrator": "Integrators",
+    "insurance_portfolio": "Portfolio",
+    "insurance_sales_report": "Sales Report",
+    "insurance_osago_report": "OSAGO Report",
+    "insurance_lookup": "Lookups",
+    "insurance_organization": "Organizations",
+    "insurance_vehicle": "Vehicles",
+    "insurance_person": "Persons",
+    "insurance_real_estate": "Real Estate",
+    "insurance_policy_reissue": "Policy Reissue",
+    "insurance_portfolio_policies_export": "Policies Export",
+    "insurance_portfolio_admissions_export": "Admissions Export",
+    "insurance_portfolio_contracts_export": "Contracts Export",
+    "claim": "Claims",
+    "claims_report": "Claims Report",
+    "claim_decision": "Claim Decisions",
+    "edo_document": "Documents",
+    "custom_dashboard": "Dashboard",
+    "custom_lookups": "Lookups",
+    "custom_settings": "Settings",
+    "logsys_system": "System",
+    "reserve": "Reserves",
+    "underwriting_lookup": "Lookups"
   },
   "Roles": {
     "Meta": {

--- a/modules/core/presentation/locales/ru.json
+++ b/modules/core/presentation/locales/ru.json
@@ -427,7 +427,13 @@
     "Superadmin": "Суперадмин",
     "Testkit": "Тестовый набор",
     "Warehouse": "Склад",
-    "Website": "Веб-сайт"
+    "Website": "Веб-сайт",
+    "Insurance": "Страхование",
+    "Claim": "Претензии",
+    "EDO": "ЭДО",
+    "Custom": "Настройки EAI",
+    "System": "Система",
+    "Reserve": "Резервы"
   },
   "NavigationLinks": {
     "Dashboard": "Панель управления",
@@ -687,6 +693,14 @@
       "PayoutManage": {
         "Label": "Управление выплатами",
         "_Description": "Полное управление выплатами"
+      },
+      "CRMChatsView": {
+        "Label": "Просмотр чатов",
+        "_Description": "Просмотр чатов CRM"
+      },
+      "CRMPoliciesView": {
+        "Label": "Просмотр полисов",
+        "_Description": "Просмотр полисов CRM"
       }
     },
     "Pipeline": {
@@ -697,6 +711,14 @@
       "PipelineManage": {
         "Label": "Управление воронками",
         "_Description": "Полное управление воронками"
+      },
+      "LookupView": {
+        "Label": "Просмотр справочников",
+        "_Description": "Просмотр справочников андеррайтинга"
+      },
+      "LookupManage": {
+        "Label": "Управление справочниками",
+        "_Description": "Управление справочниками андеррайтинга"
       }
     },
     "HRM": {
@@ -721,6 +743,22 @@
       "Export": {
         "Label": "Экспорт данных",
         "_Description": "Экспорт данных чата"
+      },
+      "PlaygroundView": {
+        "Label": "Доступ к Песочнице",
+        "_Description": "Использование интерфейса песочницы AI Chat"
+      },
+      "LogsView": {
+        "Label": "Просмотр Логов",
+        "_Description": "Просмотр логов разговоров AI Chat"
+      },
+      "ConfigView": {
+        "Label": "Просмотр Конфигурации",
+        "_Description": "Просмотр настроек конфигурации AI Chat"
+      },
+      "EvalView": {
+        "Label": "Просмотр Оценки",
+        "_Description": "Просмотр тестов оценки AI Chat"
       }
     },
     "Website": {
@@ -729,8 +767,158 @@
         "_Description": "Только просмотр информации о веб-сайте"
       },
       "WebsiteManage": {
-        "Label": "Управление веб-сайтом",
-        "_Description": "Полное управление веб-сайтом"
+        "Label": "Управление сайтом",
+        "_Description": "Полное управление сайтом"
+      }
+    },
+    "Insurance": {
+      "PolicyReissueManage": {
+        "Label": "Перевыпуск полисов",
+        "_Description": "Перевыпуск страховых полисов"
+      },
+      "ProductView": {
+        "Label": "Просмотр продуктов",
+        "_Description": "Просмотр страховых продуктов"
+      },
+      "ProductManage": {
+        "Label": "Управление продуктами",
+        "_Description": "Полное управление продуктами"
+      },
+      "AgencyView": {
+        "Label": "Просмотр агентств",
+        "_Description": "Просмотр страховых агентств"
+      },
+      "AgencyManage": {
+        "Label": "Управление агентствами",
+        "_Description": "Полное управление агентствами"
+      },
+      "IntegratorView": {
+        "Label": "Просмотр интеграторов",
+        "_Description": "Просмотр интеграторов"
+      },
+      "IntegratorManage": {
+        "Label": "Управление интеграторами",
+        "_Description": "Полное управление интеграторами"
+      },
+      "PortfolioPoliciesExportManage": {
+        "Label": "Экспорт полисов",
+        "_Description": "Экспорт данных полисов портфеля"
+      },
+      "PortfolioAdmissionsExportManage": {
+        "Label": "Экспорт поступлений",
+        "_Description": "Экспорт данных поступлений портфеля"
+      },
+      "PortfolioContractsExportManage": {
+        "Label": "Экспорт договоров",
+        "_Description": "Экспорт данных договоров портфеля"
+      },
+      "PortfolioView": {
+        "Label": "Просмотр портфеля",
+        "_Description": "Просмотр страхового портфеля"
+      },
+      "SalesReportView": {
+        "Label": "Отчёт по продажам",
+        "_Description": "Просмотр отчёта по продажам"
+      },
+      "OsagoReportView": {
+        "Label": "Отчёт ОСАГО",
+        "_Description": "Просмотр отчёта ОСАГО"
+      },
+      "LookupView": {
+        "Label": "Просмотр справочников",
+        "_Description": "Просмотр страховых справочников"
+      },
+      "LookupManage": {
+        "Label": "Управление справочниками",
+        "_Description": "Управление страховыми справочниками"
+      },
+      "LookupOrganizationView": {
+        "Label": "Просмотр организаций",
+        "_Description": "Просмотр организаций"
+      },
+      "LookupOrganizationManage": {
+        "Label": "Управление организациями",
+        "_Description": "Управление организациями"
+      },
+      "LookupVehicleView": {
+        "Label": "Просмотр транспорта",
+        "_Description": "Просмотр транспортных средств"
+      },
+      "LookupVehicleManage": {
+        "Label": "Управление транспортом",
+        "_Description": "Управление транспортными средствами"
+      },
+      "LookupPersonView": {
+        "Label": "Просмотр физлиц",
+        "_Description": "Просмотр физических лиц"
+      },
+      "LookupPersonManage": {
+        "Label": "Управление физлицами",
+        "_Description": "Управление физическими лицами"
+      },
+      "LookupRealEstateView": {
+        "Label": "Просмотр недвижимости",
+        "_Description": "Просмотр недвижимости"
+      },
+      "LookupRealEstateManage": {
+        "Label": "Управление недвижимостью",
+        "_Description": "Управление недвижимостью"
+      },
+      "ClaimView": {
+        "Label": "Просмотр претензий",
+        "_Description": "Просмотр страховых претензий"
+      },
+      "ClaimManage": {
+        "Label": "Управление претензиями",
+        "_Description": "Полное управление претензиями"
+      },
+      "ClaimsReportView": {
+        "Label": "Отчёт по претензиям",
+        "_Description": "Просмотр отчёта по претензиям"
+      },
+      "LookupDecisionView": {
+        "Label": "Просмотр решений",
+        "_Description": "Просмотр решений по претензиям"
+      },
+      "LookupDecisionManage": {
+        "Label": "Управление решениями",
+        "_Description": "Управление решениями по претензиям"
+      },
+      "ReserveView": {
+        "Label": "Просмотр резервов",
+        "_Description": "Просмотр страховых резервов"
+      }
+    },
+    "EDO": {
+      "DocumentView": {
+        "Label": "Просмотр документов",
+        "_Description": "Просмотр документов ЭДО"
+      },
+      "DocumentManage": {
+        "Label": "Управление документами",
+        "_Description": "Полное управление документами"
+      }
+    },
+    "Custom": {
+      "DashboardView": {
+        "Label": "Просмотр панели",
+        "_Description": "Просмотр панели EAI"
+      },
+      "LookupsView": {
+        "Label": "Просмотр справочников",
+        "_Description": "Просмотр справочников EAI"
+      },
+      "LookupsManage": {
+        "Label": "Управление справочниками",
+        "_Description": "Управление справочниками EAI"
+      },
+      "SettingsView": {
+        "Label": "Просмотр настроек",
+        "_Description": "Просмотр настроек EAI"
+      },
+      "SystemView": {
+        "Label": "Просмотр системы",
+        "_Description": "Просмотр системной информации"
       }
     }
   },
@@ -826,7 +1014,38 @@
     "payout_request": "Запросить вывод",
     "pipeline": "Воронка",
     "website": "Веб-сайт",
-    "session": "Сессии"
+    "session": "Сессии",
+    "bichat_playground": "Песочница",
+    "bichat_logs": "Логи",
+    "bichat_config": "Конфигурация",
+    "bichat_eval": "Оценка",
+    "crm_chats": "Чаты",
+    "crm_policies": "Полисы",
+    "insurance_product": "Продукты",
+    "insurance_agency": "Агентства",
+    "insurance_integrator": "Интеграторы",
+    "insurance_portfolio": "Портфель",
+    "insurance_sales_report": "Отчёт по продажам",
+    "insurance_osago_report": "Отчёт ОСАГО",
+    "insurance_lookup": "Справочники",
+    "insurance_organization": "Организации",
+    "insurance_vehicle": "Транспорт",
+    "insurance_person": "Физлица",
+    "insurance_real_estate": "Недвижимость",
+    "insurance_policy_reissue": "Перевыпуск полисов",
+    "insurance_portfolio_policies_export": "Экспорт полисов",
+    "insurance_portfolio_admissions_export": "Экспорт поступлений",
+    "insurance_portfolio_contracts_export": "Экспорт договоров",
+    "claim": "Претензии",
+    "claims_report": "Отчёт по претензиям",
+    "claim_decision": "Решения по претензиям",
+    "edo_document": "Документы",
+    "custom_dashboard": "Панель",
+    "custom_lookups": "Справочники",
+    "custom_settings": "Настройки",
+    "logsys_system": "Система",
+    "reserve": "Резервы",
+    "underwriting_lookup": "Справочники"
   },
   "Roles": {
     "Meta": {

--- a/modules/core/presentation/locales/uz.json
+++ b/modules/core/presentation/locales/uz.json
@@ -427,7 +427,13 @@
     "Superadmin": "Super administrator",
     "Testkit": "Test to'plami",
     "Warehouse": "Ombor",
-    "Website": "Veb-sayt"
+    "Website": "Veb-sayt",
+    "Insurance": "Sug'urta",
+    "Claim": "Da'volar",
+    "EDO": "EHJ",
+    "Custom": "EAI Sozlamalar",
+    "System": "Tizim",
+    "Reserve": "Zaxiralar"
   },
   "NavigationLinks": {
     "Dashboard": "Boshqaruv paneli",
@@ -721,6 +727,22 @@
       "Export": {
         "Label": "Ma'lumotlarni eksport qilish",
         "_Description": "Chat ma'lumotlarini eksport qilish"
+      },
+      "PlaygroundView": {
+        "Label": "Sinov maydoniga kirish",
+        "_Description": "AI Chat sinov maydonidan foydalanish"
+      },
+      "LogsView": {
+        "Label": "Loglarni ko'rish",
+        "_Description": "AI Chat suhbat loglarini ko'rish"
+      },
+      "ConfigView": {
+        "Label": "Konfiguratsiyani ko'rish",
+        "_Description": "AI Chat konfiguratsiya sozlamalarini ko'rish"
+      },
+      "EvalView": {
+        "Label": "Baholashni ko'rish",
+        "_Description": "AI Chat baholash testlarini ko'rish"
       }
     },
     "Website": {
@@ -826,7 +848,38 @@
     "payout_request": "To'lov so'rovi",
     "pipeline": "Quvur liniyasi",
     "website": "Veb-sayt",
-    "session": "Seanslar"
+    "session": "Seanslar",
+    "bichat_playground": "Sinov maydoni",
+    "bichat_logs": "Loglar",
+    "bichat_config": "Konfiguratsiya",
+    "bichat_eval": "Baholash",
+    "crm_chats": "Chatlar",
+    "crm_policies": "Polislar",
+    "insurance_product": "Mahsulotlar",
+    "insurance_agency": "Agentliklar",
+    "insurance_integrator": "Integratorlar",
+    "insurance_portfolio": "Portfel",
+    "insurance_sales_report": "Savdo hisoboti",
+    "insurance_osago_report": "OSAGO hisoboti",
+    "insurance_lookup": "Ma'lumotnomalar",
+    "insurance_organization": "Tashkilotlar",
+    "insurance_vehicle": "Transport",
+    "insurance_person": "Jismoniy shaxslar",
+    "insurance_real_estate": "Ko'chmas mulk",
+    "insurance_policy_reissue": "Polisni qayta chiqarish",
+    "insurance_portfolio_policies_export": "Polislar eksporti",
+    "insurance_portfolio_admissions_export": "Qabul eksporti",
+    "insurance_portfolio_contracts_export": "Shartnomalar eksporti",
+    "claim": "Da'volar",
+    "claims_report": "Da'volar hisoboti",
+    "claim_decision": "Da'vo qarorlari",
+    "edo_document": "Hujjatlar",
+    "custom_dashboard": "Boshqaruv paneli",
+    "custom_lookups": "Ma'lumotnomalar",
+    "custom_settings": "Sozlamalar",
+    "logsys_system": "Tizim",
+    "reserve": "Zaxiralar",
+    "underwriting_lookup": "Ma'lumotnomalar"
   },
   "Roles": {
     "Meta": {

--- a/modules/core/presentation/locales/zh.json
+++ b/modules/core/presentation/locales/zh.json
@@ -427,7 +427,13 @@
     "Superadmin": "超级管理员",
     "Testkit": "测试套件",
     "Warehouse": "仓库",
-    "Website": "网站"
+    "Website": "网站",
+    "Insurance": "保险",
+    "Claim": "索赔",
+    "EDO": "电子文档",
+    "Custom": "EAI 设置",
+    "System": "系统",
+    "Reserve": "储备"
   },
   "NavigationLinks": {
     "Dashboard": "仪表板",
@@ -725,6 +731,22 @@
       "Export": {
         "Label": "导出数据",
         "_Description": "导出聊天数据"
+      },
+      "PlaygroundView": {
+        "Label": "访问测试场",
+        "_Description": "使用 AI Chat 测试场界面"
+      },
+      "LogsView": {
+        "Label": "查看日志",
+        "_Description": "查看 AI Chat 对话日志"
+      },
+      "ConfigView": {
+        "Label": "查看配置",
+        "_Description": "查看 AI Chat 配置设置"
+      },
+      "EvalView": {
+        "Label": "查看评估",
+        "_Description": "查看 AI Chat 评估测试"
       }
     },
     "Website": {
@@ -830,7 +852,38 @@
     "payout_request": "支付请求",
     "pipeline": "管道",
     "website": "网站",
-    "session": "会话"
+    "session": "会话",
+    "bichat_playground": "测试场",
+    "bichat_logs": "日志",
+    "bichat_config": "配置",
+    "bichat_eval": "评估",
+    "crm_chats": "聊天",
+    "crm_policies": "保单",
+    "insurance_product": "产品",
+    "insurance_agency": "代理",
+    "insurance_integrator": "集成商",
+    "insurance_portfolio": "投资组合",
+    "insurance_sales_report": "销售报告",
+    "insurance_osago_report": "OSAGO 报告",
+    "insurance_lookup": "查找",
+    "insurance_organization": "组织",
+    "insurance_vehicle": "车辆",
+    "insurance_person": "个人",
+    "insurance_real_estate": "房地产",
+    "insurance_policy_reissue": "保单重新签发",
+    "insurance_portfolio_policies_export": "保单导出",
+    "insurance_portfolio_admissions_export": "入账导出",
+    "insurance_portfolio_contracts_export": "合同导出",
+    "claim": "索赔",
+    "claims_report": "索赔报告",
+    "claim_decision": "索赔决定",
+    "edo_document": "文件",
+    "custom_dashboard": "仪表板",
+    "custom_lookups": "查找",
+    "custom_settings": "设置",
+    "logsys_system": "系统",
+    "reserve": "储备",
+    "underwriting_lookup": "查找"
   },
   "Roles": {
     "Meta": {


### PR DESCRIPTION
Add Resources, Modules, and PermissionSets translations for all EAI-specific permission entries (Insurance, CRM, EDO, Custom, System, Reserve, BiChat granular) in en/ru/uz/zh locale files.

Without these keys, the roles edit page panics with "i18n missing translation" for Resources.bichat_config etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new modules: Insurance, Claim, EDO, Custom, System, and Reserve
  * Extended BiChat with Playground, Logs, Config, and Eval views
  * Added lookup management capabilities to Pipeline
  * Expanded Website module with Insurance, EDO, and Custom groups
  * Added CRM views for chats and policies

* **Documentation**
  * Updated localization support for English, Russian, Uzbek, and Chinese languages
  * Enhanced translations for all new modules and features across the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->