### PR TITLE
Refactor bichat message repository mapping

### DIFF
--- a/modules/bichat/infrastructure/persistence/message_mappers.go
+++ b/modules/bichat/infrastructure/persistence/message_mappers.go
@@ -1,0 +1,155 @@
+// Package persistence provides this package.
+package persistence
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/iota-uz/iota-sdk/modules/bichat/infrastructure/persistence/models"
+	"github.com/iota-uz/iota-sdk/pkg/bichat/types"
+)
+
+type messageScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanMessageModel(scanner messageScanner) (models.MessageModel, error) {
+	var model models.MessageModel
+	err := scanner.Scan(
+		&model.ID,
+		&model.SessionID,
+		&model.Role,
+		&model.Content,
+		&model.AuthorUserID,
+		&model.AuthorFirstName,
+		&model.AuthorLastName,
+		&model.ToolCallsJSON,
+		&model.ToolCallID,
+		&model.CitationsJSON,
+		&model.DebugTraceJSON,
+		&model.QuestionDataJSON,
+		&model.CreatedAt,
+	)
+	if err != nil {
+		return models.MessageModel{}, err
+	}
+
+	return model, nil
+}
+
+func messageDomainToModel(msg types.Message) (*models.MessageModel, error) {
+	if msg == nil {
+		return nil, models.ErrNilMessage
+	}
+
+	toolCallsJSON, err := json.Marshal(msg.ToolCalls())
+	if err != nil {
+		return nil, err
+	}
+
+	citationsJSON, err := json.Marshal(msg.Citations())
+	if err != nil {
+		return nil, err
+	}
+
+	debugTraceJSON, err := json.Marshal(msg.DebugTrace())
+	if err != nil {
+		return nil, err
+	}
+
+	questionDataJSON, err := json.Marshal(msg.QuestionData())
+	if err != nil {
+		return nil, err
+	}
+
+	return &models.MessageModel{
+		ID:               msg.ID(),
+		SessionID:        msg.SessionID(),
+		Role:             msg.Role(),
+		Content:          msg.Content(),
+		AuthorUserID:     msg.AuthorUserID(),
+		AuthorFirstName:  msg.AuthorFirstName(),
+		AuthorLastName:   msg.AuthorLastName(),
+		ToolCallsJSON:    toolCallsJSON,
+		ToolCallID:       msg.ToolCallID(),
+		CitationsJSON:    citationsJSON,
+		DebugTraceJSON:   debugTraceJSON,
+		QuestionDataJSON: questionDataJSON,
+		CreatedAt:        msg.CreatedAt(),
+	}, nil
+}
+
+func messageModelToDomain(
+	model *models.MessageModel,
+	codeOutputs []types.CodeInterpreterOutput,
+	attachments []types.Attachment,
+) (types.Message, error) {
+	if model == nil {
+		return nil, models.ErrNilMessageModel
+	}
+
+	var toolCalls []types.ToolCall
+	if err := json.Unmarshal(model.ToolCallsJSON, &toolCalls); err != nil {
+		return nil, err
+	}
+
+	var citations []types.Citation
+	if err := json.Unmarshal(model.CitationsJSON, &citations); err != nil {
+		return nil, err
+	}
+
+	var debugTrace *types.DebugTrace
+	if len(model.DebugTraceJSON) > 0 && string(model.DebugTraceJSON) != "null" {
+		var trace types.DebugTrace
+		if err := json.Unmarshal(model.DebugTraceJSON, &trace); err != nil {
+			return nil, err
+		}
+		debugTrace = &trace
+	}
+
+	var questionData *types.QuestionData
+	if len(model.QuestionDataJSON) > 0 && string(model.QuestionDataJSON) != "null" {
+		var qd types.QuestionData
+		if err := json.Unmarshal(model.QuestionDataJSON, &qd); err != nil {
+			return nil, err
+		}
+		questionData = &qd
+	}
+
+	opts := []types.MessageOption{
+		types.WithMessageID(model.ID),
+		types.WithSessionID(model.SessionID),
+		types.WithRole(model.Role),
+		types.WithContent(model.Content),
+		types.WithCreatedAt(model.CreatedAt),
+	}
+	if len(toolCalls) > 0 {
+		opts = append(opts, types.WithToolCalls(toolCalls...))
+	}
+	if model.ToolCallID != nil {
+		opts = append(opts, types.WithToolCallID(*model.ToolCallID))
+	}
+	if len(citations) > 0 {
+		opts = append(opts, types.WithCitations(citations...))
+	}
+	if len(codeOutputs) > 0 {
+		opts = append(opts, types.WithCodeOutputs(codeOutputs...))
+	}
+	if len(attachments) > 0 {
+		opts = append(opts, types.WithAttachments(attachments...))
+	}
+	if debugTrace != nil {
+		opts = append(opts, types.WithDebugTrace(debugTrace))
+	}
+	if questionData != nil {
+		opts = append(opts, types.WithQuestionData(questionData))
+	}
+	if model.AuthorUserID != nil {
+		opts = append(opts, types.WithAuthorUserID(*model.AuthorUserID))
+	}
+	if strings.TrimSpace(model.AuthorFirstName) != "" || strings.TrimSpace(model.AuthorLastName) != "" {
+		opts = append(opts, types.WithAuthorName(model.AuthorFirstName, model.AuthorLastName))
+	}
+
+	return types.NewMessage(opts...), nil
+}

--- a/modules/bichat/infrastructure/persistence/message_queries.go
+++ b/modules/bichat/infrastructure/persistence/message_queries.go
@@ -1,0 +1,89 @@
+// Package persistence provides this package.
+package persistence
+
+import (
+	"github.com/iota-uz/iota-sdk/pkg/bichat/domain"
+	"github.com/iota-uz/iota-sdk/pkg/repo"
+)
+
+const (
+	selectMessageColumns = `
+		SELECT
+			m.id,
+			m.session_id,
+			m.role,
+			m.content,
+			m.author_user_id,
+			COALESCE(u.first_name, ''),
+			COALESCE(u.last_name, ''),
+			m.tool_calls,
+			m.tool_call_id,
+			m.citations,
+			m.debug_trace,
+			m.question_data,
+			m.created_at
+	`
+	selectMessageFrom = `
+		FROM bichat.messages m
+		JOIN bichat.sessions s ON m.session_id = s.id
+		LEFT JOIN public.users u ON u.id = m.author_user_id AND u.tenant_id = s.tenant_id
+	`
+)
+
+var (
+	insertMessageQuery = repo.Insert(
+		"bichat.messages",
+		[]string{
+			"id",
+			"session_id",
+			"role",
+			"content",
+			"author_user_id",
+			"tool_calls",
+			"tool_call_id",
+			"citations",
+			"debug_trace",
+			"question_data",
+			"created_at",
+		},
+	)
+	updateMessageQuestionDataQuery = repo.Join(
+		"UPDATE bichat.messages m",
+		"SET question_data = $1",
+		"FROM bichat.sessions s",
+		repo.JoinWhere("m.session_id = s.id", "s.tenant_id = $2", "m.id = $3"),
+	)
+)
+
+func buildSelectMessageQuery() string {
+	return repo.Join(
+		selectMessageColumns,
+		selectMessageFrom,
+		repo.JoinWhere("s.tenant_id = $1", "m.id = $2"),
+	)
+}
+
+func buildSelectSessionMessagesQuery(opts domain.ListOptions) string {
+	parts := []string{
+		selectMessageColumns,
+		selectMessageFrom,
+		repo.JoinWhere("s.tenant_id = $1", "m.session_id = $2"),
+		"ORDER BY m.created_at ASC",
+	}
+
+	if pagination := repo.FormatLimitOffset(opts.Limit, opts.Offset); pagination != "" {
+		parts = append(parts, pagination)
+	}
+
+	return repo.Join(parts...)
+}
+
+func buildSelectPendingQuestionMessageQuery() string {
+	return repo.Join(
+		selectMessageColumns,
+		selectMessageFrom,
+		repo.JoinWhere("s.tenant_id = $1", "m.session_id = $2", "m.question_data->>'status' = 'PENDING'"),
+		"ORDER BY m.created_at DESC, m.id DESC",
+		"LIMIT 1",
+	)
+}

--- a/modules/bichat/infrastructure/persistence/models/message.go
+++ b/modules/bichat/infrastructure/persistence/models/message.go
@@ -1,0 +1,32 @@
+// Package models provides this package.
+package models
+
+import (
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/pkg/bichat/types"
+)
+
+var (
+	ErrNilMessageModel = errors.New("message model is nil")
+	ErrNilMessage      = errors.New("message is nil")
+)
+
+// MessageModel is the database model for bichat.messages projections.
+type MessageModel struct {
+	ID               uuid.UUID
+	SessionID        uuid.UUID
+	Role             types.Role
+	Content          string
+	AuthorUserID     *int64
+	AuthorFirstName  string
+	AuthorLastName   string
+	ToolCallsJSON    []byte
+	ToolCallID       *string
+	CitationsJSON    []byte
+	DebugTraceJSON   []byte
+	QuestionDataJSON []byte
+	CreatedAt        time.Time
+}

--- a/modules/bichat/infrastructure/persistence/postgres_chat_repository.go
+++ b/modules/bichat/infrastructure/persistence/postgres_chat_repository.go
@@ -243,27 +243,6 @@ const (
 	`
 
 	// Message queries
-	insertMessageQuery = `
-		INSERT INTO bichat.messages (
-			id, session_id, role, content, author_user_id, tool_calls, tool_call_id, citations, debug_trace, question_data, created_at
-		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-	`
-	selectMessageQuery = `
-		SELECT m.id, m.session_id, m.role, m.content, m.author_user_id, COALESCE(u.first_name, ''), COALESCE(u.last_name, ''), m.tool_calls, m.tool_call_id, m.citations, m.debug_trace, m.question_data, m.created_at
-		FROM bichat.messages m
-		JOIN bichat.sessions s ON m.session_id = s.id
-		LEFT JOIN public.users u ON u.id = m.author_user_id AND u.tenant_id = s.tenant_id
-		WHERE s.tenant_id = $1 AND m.id = $2
-	`
-	selectSessionMessagesQuery = `
-		SELECT m.id, m.session_id, m.role, m.content, m.author_user_id, COALESCE(u.first_name, ''), COALESCE(u.last_name, ''), m.tool_calls, m.tool_call_id, m.citations, m.debug_trace, m.question_data, m.created_at
-		FROM bichat.messages m
-		JOIN bichat.sessions s ON m.session_id = s.id
-		LEFT JOIN public.users u ON u.id = m.author_user_id AND u.tenant_id = s.tenant_id
-		WHERE s.tenant_id = $1 AND m.session_id = $2
-		ORDER BY m.created_at ASC
-		LIMIT $3 OFFSET $4
-	`
 	truncateMessagesFromQuery = `
 		DELETE FROM bichat.messages m
 		USING bichat.sessions s
@@ -272,25 +251,6 @@ const (
 		  AND m.session_id = $2
 		  AND m.created_at >= $3
 	`
-	updateMessageQuestionDataQuery = `
-		UPDATE bichat.messages m
-		SET question_data = $1
-		FROM bichat.sessions s
-		WHERE m.session_id = s.id
-		  AND s.tenant_id = $2
-		  AND m.id = $3
-	`
-	selectPendingQuestionMessageQuery = `
-		SELECT m.id, m.session_id, m.role, m.content, m.author_user_id, COALESCE(u.first_name, ''), COALESCE(u.last_name, ''), m.tool_calls, m.tool_call_id, m.citations, m.debug_trace, m.question_data, m.created_at
-		FROM bichat.messages m
-		JOIN bichat.sessions s ON m.session_id = s.id
-		LEFT JOIN public.users u ON u.id = m.author_user_id AND u.tenant_id = s.tenant_id
-		WHERE s.tenant_id = $1 AND m.session_id = $2
-		  AND m.question_data->>'status' = 'PENDING'
-		ORDER BY m.created_at DESC, m.id DESC
-		LIMIT 1
-	`
-
 	selectSessionOwnerUserIDQuery = `
 		SELECT user_id
 		FROM bichat.sessions
@@ -1057,56 +1017,38 @@ func (r *PostgresChatRepository) SaveMessage(ctx context.Context, msg types.Mess
 		return serrors.E(op, err)
 	}
 
-	// Marshal JSONB fields
-	toolCallsJSON, err := json.Marshal(msg.ToolCalls())
+	model, err := messageDomainToModel(msg)
 	if err != nil {
 		return serrors.E(op, err)
 	}
 
-	citationsJSON, err := json.Marshal(msg.Citations())
-	if err != nil {
-		return serrors.E(op, err)
+	if model.CreatedAt.IsZero() {
+		model.CreatedAt = time.Now()
 	}
 
-	debugTraceJSON, err := json.Marshal(msg.DebugTrace())
-	if err != nil {
-		return serrors.E(op, err)
-	}
-
-	questionDataJSON, err := json.Marshal(msg.QuestionData())
-	if err != nil {
-		return serrors.E(op, err)
-	}
-
-	createdAt := msg.CreatedAt()
-	if createdAt.IsZero() {
-		createdAt = time.Now()
-	}
-
-	authorUserID := msg.AuthorUserID()
-	if msg.Role() == types.RoleUser && authorUserID == nil {
+	if model.Role == types.RoleUser && model.AuthorUserID == nil {
 		var ownerUserID int64
-		if err := tx.QueryRow(ctx, selectSessionOwnerUserIDQuery, tenantID, msg.SessionID()).Scan(&ownerUserID); err != nil {
+		if err := tx.QueryRow(ctx, selectSessionOwnerUserIDQuery, tenantID, model.SessionID).Scan(&ownerUserID); err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return serrors.E(op, ErrSessionNotFound)
 			}
 			return serrors.E(op, err)
 		}
-		authorUserID = &ownerUserID
+		model.AuthorUserID = &ownerUserID
 	}
 
 	_, err = tx.Exec(ctx, insertMessageQuery,
-		msg.ID(),
-		msg.SessionID(),
-		msg.Role(),
-		msg.Content(),
-		authorUserID,
-		toolCallsJSON,
-		msg.ToolCallID(),
-		citationsJSON,
-		debugTraceJSON,
-		questionDataJSON,
-		createdAt,
+		model.ID,
+		model.SessionID,
+		model.Role,
+		model.Content,
+		model.AuthorUserID,
+		model.ToolCallsJSON,
+		model.ToolCallID,
+		model.CitationsJSON,
+		model.DebugTraceJSON,
+		model.QuestionDataJSON,
+		model.CreatedAt,
 	)
 	if err != nil {
 		return serrors.E(op, err)
@@ -1117,17 +1059,17 @@ func (r *PostgresChatRepository) SaveMessage(ctx context.Context, msg types.Mess
 	}
 
 	if len(msg.CodeOutputs()) > 0 {
-		msgID := msg.ID()
+		msgID := model.ID
 		for _, output := range msg.CodeOutputs() {
 			outputCreatedAt := output.CreatedAt
 			if outputCreatedAt.IsZero() {
-				outputCreatedAt = createdAt
+				outputCreatedAt = model.CreatedAt
 			}
 
 			codeOutputArtifact := domain.NewArtifact(
 				domain.WithArtifactID(output.ID),
 				domain.WithArtifactTenantID(tenantID),
-				domain.WithArtifactSessionID(msg.SessionID()),
+				domain.WithArtifactSessionID(model.SessionID),
 				domain.WithArtifactMessageID(&msgID),
 				domain.WithArtifactType(domain.ArtifactTypeCodeOutput),
 				domain.WithArtifactName(output.Name),
@@ -1160,37 +1102,7 @@ func (r *PostgresChatRepository) GetMessage(ctx context.Context, id uuid.UUID) (
 		return nil, serrors.E(op, err)
 	}
 
-	var (
-		msgID            uuid.UUID
-		sessionID        uuid.UUID
-		role             types.Role
-		content          string
-		authorUserID     *int64
-		authorFirstName  string
-		authorLastName   string
-		toolCallsJSON    []byte
-		toolCallID       *string
-		citationsJSON    []byte
-		debugTraceJSON   []byte
-		questionDataJSON []byte
-		createdAt        time.Time
-	)
-
-	err = tx.QueryRow(ctx, selectMessageQuery, tenantID, id).Scan(
-		&msgID,
-		&sessionID,
-		&role,
-		&content,
-		&authorUserID,
-		&authorFirstName,
-		&authorLastName,
-		&toolCallsJSON,
-		&toolCallID,
-		&citationsJSON,
-		&debugTraceJSON,
-		&questionDataJSON,
-		&createdAt,
-	)
+	model, err := scanMessageModel(tx.QueryRow(ctx, buildSelectMessageQuery(), tenantID, id))
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, serrors.E(op, ErrMessageNotFound)
@@ -1198,100 +1110,29 @@ func (r *PostgresChatRepository) GetMessage(ctx context.Context, id uuid.UUID) (
 		return nil, serrors.E(op, err)
 	}
 
-	// Unmarshal JSONB fields
-	var toolCalls []types.ToolCall
-	if err := json.Unmarshal(toolCallsJSON, &toolCalls); err != nil {
-		return nil, serrors.E(op, err)
-	}
-
-	var citations []types.Citation
-	if err := json.Unmarshal(citationsJSON, &citations); err != nil {
-		return nil, serrors.E(op, err)
-	}
-
-	var debugTrace *types.DebugTrace
-	if len(debugTraceJSON) > 0 && string(debugTraceJSON) != "null" {
-		var trace types.DebugTrace
-		if err := json.Unmarshal(debugTraceJSON, &trace); err != nil {
-			return nil, serrors.E(op, err)
-		}
-		debugTrace = &trace
-	}
-
-	var questionData *types.QuestionData
-	if len(questionDataJSON) > 0 && string(questionDataJSON) != "null" {
-		var qd types.QuestionData
-		if err := json.Unmarshal(questionDataJSON, &qd); err != nil {
-			return nil, serrors.E(op, err)
-		}
-		questionData = &qd
-	}
-
-	// Load code interpreter outputs
-	codeOutputs, err := r.loadCodeOutputsForMessage(ctx, tenantID, msgID)
-	if err != nil {
-		return nil, serrors.E(op, err)
-	}
-	domainAttachments, err := r.GetMessageAttachments(ctx, msgID)
-	if err != nil {
-		return nil, serrors.E(op, err)
-	}
-	attachments := convertDomainAttachmentsToTypes(domainAttachments)
-
-	// Build message options
-	opts := []types.MessageOption{
-		types.WithMessageID(msgID),
-		types.WithSessionID(sessionID),
-		types.WithRole(role),
-		types.WithContent(content),
-		types.WithCreatedAt(createdAt),
-	}
-	if len(toolCalls) > 0 {
-		opts = append(opts, types.WithToolCalls(toolCalls...))
-	}
-	if toolCallID != nil {
-		opts = append(opts, types.WithToolCallID(*toolCallID))
-	}
-	if len(citations) > 0 {
-		opts = append(opts, types.WithCitations(citations...))
-	}
-	if len(codeOutputs) > 0 {
-		opts = append(opts, types.WithCodeOutputs(codeOutputs...))
-	}
-	if len(attachments) > 0 {
-		opts = append(opts, types.WithAttachments(attachments...))
-	}
-	if debugTrace != nil {
-		opts = append(opts, types.WithDebugTrace(debugTrace))
-	}
-	if questionData != nil {
-		opts = append(opts, types.WithQuestionData(questionData))
-	}
-	if authorUserID != nil {
-		opts = append(opts, types.WithAuthorUserID(*authorUserID))
-	}
-	if strings.TrimSpace(authorFirstName) != "" || strings.TrimSpace(authorLastName) != "" {
-		opts = append(opts, types.WithAuthorName(authorFirstName, authorLastName))
-	}
-
-	return types.NewMessage(opts...), nil
+	return r.hydrateMessageModel(ctx, tenantID, &model)
 }
 
-// messageData holds intermediate message data before code outputs are loaded.
-type messageData struct {
-	msgID        uuid.UUID
-	sessID       uuid.UUID
-	role         types.Role
-	content      string
-	authorUserID *int64
-	authorFirst  string
-	authorLast   string
-	toolCalls    []types.ToolCall
-	toolCallID   *string
-	citations    []types.Citation
-	debugTrace   *types.DebugTrace
-	questionData *types.QuestionData
-	createdAt    time.Time
+func (r *PostgresChatRepository) hydrateMessageModel(
+	ctx context.Context,
+	tenantID uuid.UUID,
+	model *models.MessageModel,
+) (types.Message, error) {
+	codeOutputs, err := r.loadCodeOutputsForMessage(ctx, tenantID, model.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	domainAttachments, err := r.GetMessageAttachments(ctx, model.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	return messageModelToDomain(
+		model,
+		codeOutputs,
+		convertDomainAttachmentsToTypes(domainAttachments),
+	)
 }
 
 // GetSessionMessages retrieves all messages for a session with pagination.
@@ -1308,7 +1149,7 @@ func (r *PostgresChatRepository) GetSessionMessages(ctx context.Context, session
 		return nil, serrors.E(op, err)
 	}
 
-	rows, err := tx.Query(ctx, selectSessionMessagesQuery, tenantID, sessionID, opts.Limit, opts.Offset)
+	rows, err := tx.Query(ctx, buildSelectSessionMessagesQuery(opts), tenantID, sessionID)
 	if err != nil {
 		return nil, serrors.E(op, err)
 	}
@@ -1316,87 +1157,13 @@ func (r *PostgresChatRepository) GetSessionMessages(ctx context.Context, session
 
 	// First pass: collect all message data without nested queries
 	// This avoids "conn busy" error from nested queries on the same connection
-	var messagesData []messageData
+	modelsData := make([]models.MessageModel, 0)
 	for rows.Next() {
-		var (
-			msgID            uuid.UUID
-			sessID           uuid.UUID
-			role             types.Role
-			content          string
-			authorUserID     *int64
-			authorFirstName  string
-			authorLastName   string
-			toolCallsJSON    []byte
-			toolCallID       *string
-			citationsJSON    []byte
-			debugTraceJSON   []byte
-			questionDataJSON []byte
-			createdAt        time.Time
-		)
-
-		err := rows.Scan(
-			&msgID,
-			&sessID,
-			&role,
-			&content,
-			&authorUserID,
-			&authorFirstName,
-			&authorLastName,
-			&toolCallsJSON,
-			&toolCallID,
-			&citationsJSON,
-			&debugTraceJSON,
-			&questionDataJSON,
-			&createdAt,
-		)
-		if err != nil {
-			return nil, serrors.E(op, err)
+		model, scanErr := scanMessageModel(rows)
+		if scanErr != nil {
+			return nil, serrors.E(op, scanErr)
 		}
-
-		// Unmarshal JSONB fields
-		var toolCalls []types.ToolCall
-		if err := json.Unmarshal(toolCallsJSON, &toolCalls); err != nil {
-			return nil, serrors.E(op, err)
-		}
-
-		var citations []types.Citation
-		if err := json.Unmarshal(citationsJSON, &citations); err != nil {
-			return nil, serrors.E(op, err)
-		}
-
-		var debugTrace *types.DebugTrace
-		if len(debugTraceJSON) > 0 && string(debugTraceJSON) != "null" {
-			var trace types.DebugTrace
-			if err := json.Unmarshal(debugTraceJSON, &trace); err != nil {
-				return nil, serrors.E(op, err)
-			}
-			debugTrace = &trace
-		}
-
-		var questionData *types.QuestionData
-		if len(questionDataJSON) > 0 && string(questionDataJSON) != "null" {
-			var qd types.QuestionData
-			if err := json.Unmarshal(questionDataJSON, &qd); err != nil {
-				return nil, serrors.E(op, err)
-			}
-			questionData = &qd
-		}
-
-		messagesData = append(messagesData, messageData{
-			msgID:        msgID,
-			sessID:       sessID,
-			role:         role,
-			content:      content,
-			authorUserID: authorUserID,
-			authorFirst:  authorFirstName,
-			authorLast:   authorLastName,
-			toolCalls:    toolCalls,
-			toolCallID:   toolCallID,
-			citations:    citations,
-			debugTrace:   debugTrace,
-			questionData: questionData,
-			createdAt:    createdAt,
-		})
+		modelsData = append(modelsData, model)
 	}
 
 	if err := rows.Err(); err != nil {
@@ -1404,55 +1171,13 @@ func (r *PostgresChatRepository) GetSessionMessages(ctx context.Context, session
 	}
 
 	// Second pass: load code outputs for each message (rows are now closed)
-	messages := make([]types.Message, 0, len(messagesData))
-	for _, md := range messagesData {
-		codeOutputs, err := r.loadCodeOutputsForMessage(ctx, tenantID, md.msgID)
-		if err != nil {
-			return nil, serrors.E(op, err)
+	messages := make([]types.Message, 0, len(modelsData))
+	for _, model := range modelsData {
+		message, hydrateErr := r.hydrateMessageModel(ctx, tenantID, &model)
+		if hydrateErr != nil {
+			return nil, serrors.E(op, hydrateErr)
 		}
-		domainAttachments, err := r.GetMessageAttachments(ctx, md.msgID)
-		if err != nil {
-			return nil, serrors.E(op, err)
-		}
-		attachments := convertDomainAttachmentsToTypes(domainAttachments)
-
-		// Build message options
-		msgOpts := []types.MessageOption{
-			types.WithMessageID(md.msgID),
-			types.WithSessionID(md.sessID),
-			types.WithRole(md.role),
-			types.WithContent(md.content),
-			types.WithCreatedAt(md.createdAt),
-		}
-		if len(md.toolCalls) > 0 {
-			msgOpts = append(msgOpts, types.WithToolCalls(md.toolCalls...))
-		}
-		if md.toolCallID != nil {
-			msgOpts = append(msgOpts, types.WithToolCallID(*md.toolCallID))
-		}
-		if len(md.citations) > 0 {
-			msgOpts = append(msgOpts, types.WithCitations(md.citations...))
-		}
-		if len(codeOutputs) > 0 {
-			msgOpts = append(msgOpts, types.WithCodeOutputs(codeOutputs...))
-		}
-		if len(attachments) > 0 {
-			msgOpts = append(msgOpts, types.WithAttachments(attachments...))
-		}
-		if md.debugTrace != nil {
-			msgOpts = append(msgOpts, types.WithDebugTrace(md.debugTrace))
-		}
-		if md.questionData != nil {
-			msgOpts = append(msgOpts, types.WithQuestionData(md.questionData))
-		}
-		if md.authorUserID != nil {
-			msgOpts = append(msgOpts, types.WithAuthorUserID(*md.authorUserID))
-		}
-		if strings.TrimSpace(md.authorFirst) != "" || strings.TrimSpace(md.authorLast) != "" {
-			msgOpts = append(msgOpts, types.WithAuthorName(md.authorFirst, md.authorLast))
-		}
-
-		messages = append(messages, types.NewMessage(msgOpts...))
+		messages = append(messages, message)
 	}
 
 	return messages, nil
@@ -1525,37 +1250,7 @@ func (r *PostgresChatRepository) GetPendingQuestionMessage(ctx context.Context, 
 		return nil, serrors.E(op, err)
 	}
 
-	var (
-		msgID            uuid.UUID
-		sessID           uuid.UUID
-		role             types.Role
-		content          string
-		authorUserID     *int64
-		authorFirstName  string
-		authorLastName   string
-		toolCallsJSON    []byte
-		toolCallID       *string
-		citationsJSON    []byte
-		debugTraceJSON   []byte
-		questionDataJSON []byte
-		createdAt        time.Time
-	)
-
-	err = tx.QueryRow(ctx, selectPendingQuestionMessageQuery, tenantID, sessionID).Scan(
-		&msgID,
-		&sessID,
-		&role,
-		&content,
-		&authorUserID,
-		&authorFirstName,
-		&authorLastName,
-		&toolCallsJSON,
-		&toolCallID,
-		&citationsJSON,
-		&debugTraceJSON,
-		&questionDataJSON,
-		&createdAt,
-	)
+	model, err := scanMessageModel(tx.QueryRow(ctx, buildSelectPendingQuestionMessageQuery(), tenantID, sessionID))
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, serrors.E(op, domain.ErrNoPendingQuestion)
@@ -1563,83 +1258,7 @@ func (r *PostgresChatRepository) GetPendingQuestionMessage(ctx context.Context, 
 		return nil, serrors.E(op, err)
 	}
 
-	// Unmarshal JSONB fields
-	var toolCalls []types.ToolCall
-	if err := json.Unmarshal(toolCallsJSON, &toolCalls); err != nil {
-		return nil, serrors.E(op, err)
-	}
-
-	var citations []types.Citation
-	if err := json.Unmarshal(citationsJSON, &citations); err != nil {
-		return nil, serrors.E(op, err)
-	}
-
-	var debugTrace *types.DebugTrace
-	if len(debugTraceJSON) > 0 && string(debugTraceJSON) != "null" {
-		var trace types.DebugTrace
-		if err := json.Unmarshal(debugTraceJSON, &trace); err != nil {
-			return nil, serrors.E(op, err)
-		}
-		debugTrace = &trace
-	}
-
-	var questionData *types.QuestionData
-	if len(questionDataJSON) > 0 && string(questionDataJSON) != "null" {
-		var qd types.QuestionData
-		if err := json.Unmarshal(questionDataJSON, &qd); err != nil {
-			return nil, serrors.E(op, err)
-		}
-		questionData = &qd
-	}
-
-	// Load code interpreter outputs
-	codeOutputs, err := r.loadCodeOutputsForMessage(ctx, tenantID, msgID)
-	if err != nil {
-		return nil, serrors.E(op, err)
-	}
-	domainAttachments, err := r.GetMessageAttachments(ctx, msgID)
-	if err != nil {
-		return nil, serrors.E(op, err)
-	}
-	attachments := convertDomainAttachmentsToTypes(domainAttachments)
-
-	// Build message options
-	opts := []types.MessageOption{
-		types.WithMessageID(msgID),
-		types.WithSessionID(sessID),
-		types.WithRole(role),
-		types.WithContent(content),
-		types.WithCreatedAt(createdAt),
-	}
-	if len(toolCalls) > 0 {
-		opts = append(opts, types.WithToolCalls(toolCalls...))
-	}
-	if toolCallID != nil {
-		opts = append(opts, types.WithToolCallID(*toolCallID))
-	}
-	if len(citations) > 0 {
-		opts = append(opts, types.WithCitations(citations...))
-	}
-	if len(codeOutputs) > 0 {
-		opts = append(opts, types.WithCodeOutputs(codeOutputs...))
-	}
-	if len(attachments) > 0 {
-		opts = append(opts, types.WithAttachments(attachments...))
-	}
-	if debugTrace != nil {
-		opts = append(opts, types.WithDebugTrace(debugTrace))
-	}
-	if questionData != nil {
-		opts = append(opts, types.WithQuestionData(questionData))
-	}
-	if authorUserID != nil {
-		opts = append(opts, types.WithAuthorUserID(*authorUserID))
-	}
-	if strings.TrimSpace(authorFirstName) != "" || strings.TrimSpace(authorLastName) != "" {
-		opts = append(opts, types.WithAuthorName(authorFirstName, authorLastName))
-	}
-
-	return types.NewMessage(opts...), nil
+	return r.hydrateMessageModel(ctx, tenantID, &model)
 }
 
 // Attachment operations

--- a/modules/bichat/infrastructure/persistence/postgres_chat_repository_test.go
+++ b/modules/bichat/infrastructure/persistence/postgres_chat_repository_test.go
@@ -968,6 +968,37 @@ func TestPostgresChatRepository_GetSessionMessages_Pagination(t *testing.T) {
 	assert.Len(t, retrieved, 2)
 }
 
+func TestPostgresChatRepository_GetSessionMessages_ZeroLimitReturnsAll(t *testing.T) {
+	t.Parallel()
+	env := setupTest(t)
+
+	repo := persistence.NewPostgresChatRepository()
+
+	session := mustSession(t,
+		withSessionTenantID(env.Tenant.ID),
+		withSessionUserID(int64(env.User.ID())),
+		withSessionTitle("Zero limit returns all"),
+	)
+	require.NoError(t, repo.CreateSession(env.Ctx, session))
+
+	baseTime := time.Now()
+	for i, content := range []string{"First", "Second", "Third"} {
+		msg := types.UserMessage(
+			content,
+			types.WithSessionID(session.ID()),
+			types.WithCreatedAt(baseTime.Add(time.Duration(i)*time.Millisecond)),
+		)
+		require.NoError(t, repo.SaveMessage(env.Ctx, msg))
+	}
+
+	messages, err := repo.GetSessionMessages(env.Ctx, session.ID(), domain.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, messages, 3)
+	assert.Equal(t, "First", messages[0].Content())
+	assert.Equal(t, "Second", messages[1].Content())
+	assert.Equal(t, "Third", messages[2].Content())
+}
+
 func TestPostgresChatRepository_TruncateMessagesFrom(t *testing.T) {
 	t.Parallel()
 	env := setupTest(t)
@@ -1668,7 +1699,7 @@ func TestPostgresChatRepository_PaginationBoundaries(t *testing.T) {
 		opts := domain.ListOptions{Limit: 0, Offset: 0}
 		messages, err := repo.GetSessionMessages(env.Ctx, session.ID(), opts)
 		require.NoError(t, err)
-		assert.Empty(t, messages)
+		assert.Len(t, messages, 3)
 	})
 
 	t.Run("Offset exceeds total", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- introduce a message db model and dedicated message mapping helpers for bichat persistence
- move bichat message query construction to pkg/repo builders
- fix zero-value ListOptions so session message reads no longer turn into LIMIT 0

## Testing
- go test ./modules/bichat/infrastructure/persistence ./modules/bichat/services

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed message retrieval in chat sessions when pagination has no limit—now correctly returns all messages instead of an empty result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->