### PR TITLE
Fix deferred HITL checkpoint finalization

### DIFF
--- a/modules/bichat/services/chat_service_hitl.go
+++ b/modules/bichat/services/chat_service_hitl.go
@@ -194,6 +194,28 @@ func (s *chatServiceImpl) ResumeWithAnswer(ctx context.Context, req bichatservic
 	// Collect agent response
 	result, err := consumeAgentEvents(ctx, gen)
 	if err != nil {
+		if errors.Is(err, agents.ErrCheckpointNotFound) {
+			configuration.Use().Logger().
+				WithError(err).
+				WithField("session_id", req.SessionID.String()).
+				WithField("checkpoint_id", resolvedCheckpointID).
+				Warn("resume checkpoint missing during stream consumption; finalizing pending question as answered")
+
+			if txErr := s.withinTx(ctx, func(txCtx context.Context) error {
+				return s.chatRepo.UpdateMessageQuestionData(txCtx, pendingMsg.ID(), answeredQD)
+			}); txErr != nil {
+				return nil, serrors.E(op, txErr)
+			}
+
+			s.maybeGenerateTitleAfterHITLCompletion(ctx, req.SessionID, false)
+
+			return &bichatservices.SendMessageResponse{
+				UserMessage:      nil,
+				AssistantMessage: nil,
+				Session:          session,
+				Interrupt:        nil,
+			}, nil
+		}
 		return nil, serrors.E(op, err)
 	}
 
@@ -359,6 +381,31 @@ func (s *chatServiceImpl) ResumeWithAnswerAsync(ctx context.Context, req bichats
 
 			result, err := consumeAgentEvents(processCtx, gen)
 			if err != nil {
+				if errors.Is(err, agents.ErrCheckpointNotFound) {
+					if processErr := processCtx.Err(); processErr != nil {
+						active.Broadcast(streamingsvc.TerminalChunk(serrors.E(op, processErr), 0))
+						s.markAsyncQuestionRunFailed(persistCtx, pendingMsgID, failedQuestionData)
+						_ = s.cancelRunState(persistCtx, session.TenantID(), req.SessionID, runID)
+						return
+					}
+					updateCtx, cancel := context.WithTimeout(persistCtx, streamPersistenceTimeout)
+					defer cancel()
+					if txErr := s.withinTx(updateCtx, func(txCtx context.Context) error {
+						return s.chatRepo.UpdateMessageQuestionData(txCtx, pendingMsgID, answeredQuestionData)
+					}); txErr != nil {
+						active.Broadcast(streamingsvc.TerminalChunk(serrors.E(op, txErr), 0))
+						_ = s.cancelRunState(persistCtx, session.TenantID(), req.SessionID, runID)
+						return
+					}
+					if completeErr := s.completeRunState(persistCtx, session.TenantID(), req.SessionID, runID); completeErr != nil {
+						active.Broadcast(streamingsvc.TerminalChunk(serrors.E(op, completeErr), 0))
+						_ = s.cancelRunState(persistCtx, session.TenantID(), req.SessionID, runID)
+						return
+					}
+					s.maybeGenerateTitleAfterHITLCompletion(persistCtx, req.SessionID, false)
+					active.Broadcast(streamingsvc.TerminalChunk(nil, time.Since(startedAt).Milliseconds()))
+					return
+				}
 				active.Broadcast(streamingsvc.TerminalChunk(serrors.E(op, err), 0))
 				s.markAsyncQuestionRunFailed(persistCtx, pendingMsgID, failedQuestionData)
 				_ = s.cancelRunState(persistCtx, session.TenantID(), req.SessionID, runID)
@@ -502,6 +549,28 @@ func (s *chatServiceImpl) RejectPendingQuestion(ctx context.Context, sessionID u
 	// Collect agent response
 	result, err := consumeAgentEvents(ctx, gen)
 	if err != nil {
+		if errors.Is(err, agents.ErrCheckpointNotFound) {
+			configuration.Use().Logger().
+				WithError(err).
+				WithField("session_id", sessionID.String()).
+				WithField("checkpoint_id", qd.CheckpointID).
+				Warn("reject checkpoint missing during stream consumption; finalizing pending question as rejected")
+
+			if txErr := s.withinTx(ctx, func(txCtx context.Context) error {
+				return s.chatRepo.UpdateMessageQuestionData(txCtx, pendingMsg.ID(), rejectedQD)
+			}); txErr != nil {
+				return nil, serrors.E(op, txErr)
+			}
+
+			s.maybeGenerateTitleAfterHITLCompletion(ctx, sessionID, false)
+
+			return &bichatservices.SendMessageResponse{
+				UserMessage:      nil,
+				AssistantMessage: nil,
+				Session:          session,
+				Interrupt:        nil,
+			}, nil
+		}
 		return nil, serrors.E(op, err)
 	}
 
@@ -650,6 +719,31 @@ func (s *chatServiceImpl) RejectPendingQuestionAsync(ctx context.Context, sessio
 
 			result, err := consumeAgentEvents(processCtx, gen)
 			if err != nil {
+				if errors.Is(err, agents.ErrCheckpointNotFound) {
+					if processErr := processCtx.Err(); processErr != nil {
+						active.Broadcast(streamingsvc.TerminalChunk(serrors.E(op, processErr), 0))
+						s.markAsyncQuestionRunFailed(persistCtx, pendingMsgID, failedQuestionData)
+						_ = s.cancelRunState(persistCtx, session.TenantID(), sessionID, runID)
+						return
+					}
+					updateCtx, cancel := context.WithTimeout(persistCtx, streamPersistenceTimeout)
+					defer cancel()
+					if txErr := s.withinTx(updateCtx, func(txCtx context.Context) error {
+						return s.chatRepo.UpdateMessageQuestionData(txCtx, pendingMsgID, rejectedQuestionData)
+					}); txErr != nil {
+						active.Broadcast(streamingsvc.TerminalChunk(serrors.E(op, txErr), 0))
+						_ = s.cancelRunState(persistCtx, session.TenantID(), sessionID, runID)
+						return
+					}
+					if completeErr := s.completeRunState(persistCtx, session.TenantID(), sessionID, runID); completeErr != nil {
+						active.Broadcast(streamingsvc.TerminalChunk(serrors.E(op, completeErr), 0))
+						_ = s.cancelRunState(persistCtx, session.TenantID(), sessionID, runID)
+						return
+					}
+					s.maybeGenerateTitleAfterHITLCompletion(persistCtx, sessionID, false)
+					active.Broadcast(streamingsvc.TerminalChunk(nil, time.Since(startedAt).Milliseconds()))
+					return
+				}
 				active.Broadcast(streamingsvc.TerminalChunk(serrors.E(op, err), 0))
 				s.markAsyncQuestionRunFailed(persistCtx, pendingMsgID, failedQuestionData)
 				_ = s.cancelRunState(persistCtx, session.TenantID(), sessionID, runID)

--- a/modules/bichat/services/chat_service_impl_test.go
+++ b/modules/bichat/services/chat_service_impl_test.go
@@ -443,6 +443,63 @@ func TestChatService_ResumeWithAnswer_CheckpointNotFoundFinalizesAnswered(t *tes
 	assert.Equal(t, "all", updatedQuestionData.Answers["scope"])
 }
 
+func TestChatService_ResumeWithAnswer_DeferredCheckpointNotFoundFinalizesAnswered(t *testing.T) {
+	t.Parallel()
+
+	chatRepo := newMockChatRepository()
+	session := mustSession(t,
+		withSessionTenantID(uuid.New()),
+		withSessionUserID(1),
+		withSessionTitle("resume deferred stale checkpoint"),
+	)
+	require.NoError(t, chatRepo.CreateSession(t.Context(), session))
+
+	qd, err := types.NewQuestionData("cp-missing", "ali", []types.QuestionDataItem{
+		{
+			ID:   "scope",
+			Text: "Scope?",
+			Type: "single_choice",
+			Options: []types.QuestionDataOption{
+				{ID: "sold", Label: "Sold only"},
+				{ID: "all", Label: "All policies"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	pendingMsg := types.NewMessage(
+		types.WithSessionID(session.ID()),
+		types.WithRole(types.RoleAssistant),
+		types.WithContent("Need scope"),
+		types.WithQuestionData(qd),
+	)
+	require.NoError(t, chatRepo.SaveMessage(t.Context(), pendingMsg))
+
+	agentSvc := &stubAgentService{
+		resumeStreamErr: agents.ErrCheckpointNotFound,
+	}
+
+	svc := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	resp, err := svc.ResumeWithAnswer(t.Context(), bichatservices.ResumeRequest{
+		SessionID:    session.ID(),
+		CheckpointID: "cp-missing",
+		Answers: map[string]string{
+			"scope": "all",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.AssistantMessage)
+
+	messages, err := chatRepo.GetSessionMessages(t.Context(), session.ID(), domain.ListOptions{})
+	require.NoError(t, err)
+	require.NotEmpty(t, messages)
+	updatedQuestionData := messages[0].QuestionData()
+	require.NotNil(t, updatedQuestionData)
+	assert.Equal(t, types.QuestionStatusAnswered, updatedQuestionData.Status)
+	assert.Equal(t, "all", updatedQuestionData.Answers["scope"])
+}
+
 func TestChatService_RejectPendingQuestion_CheckpointNotFoundFinalizesRejected(t *testing.T) {
 	t.Parallel()
 
@@ -477,6 +534,57 @@ func TestChatService_RejectPendingQuestion_CheckpointNotFoundFinalizesRejected(t
 
 	agentSvc := &stubAgentService{
 		resumeErr: agents.ErrCheckpointNotFound,
+	}
+
+	svc := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	resp, err := svc.RejectPendingQuestion(t.Context(), session.ID())
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Nil(t, resp.AssistantMessage)
+
+	messages, err := chatRepo.GetSessionMessages(t.Context(), session.ID(), domain.ListOptions{})
+	require.NoError(t, err)
+	require.NotEmpty(t, messages)
+	updatedQuestionData := messages[0].QuestionData()
+	require.NotNil(t, updatedQuestionData)
+	assert.Equal(t, types.QuestionStatusRejected, updatedQuestionData.Status)
+	assert.False(t, messages[0].HasPendingQuestion())
+}
+
+func TestChatService_RejectPendingQuestion_DeferredCheckpointNotFoundFinalizesRejected(t *testing.T) {
+	t.Parallel()
+
+	chatRepo := newMockChatRepository()
+	session := mustSession(t,
+		withSessionTenantID(uuid.New()),
+		withSessionUserID(1),
+		withSessionTitle("reject deferred stale checkpoint"),
+	)
+	require.NoError(t, chatRepo.CreateSession(t.Context(), session))
+
+	qd, err := types.NewQuestionData("cp-missing", "ali", []types.QuestionDataItem{
+		{
+			ID:   "scope",
+			Text: "Scope?",
+			Type: "single_choice",
+			Options: []types.QuestionDataOption{
+				{ID: "sold", Label: "Sold only"},
+				{ID: "all", Label: "All policies"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	pendingMsg := types.NewMessage(
+		types.WithSessionID(session.ID()),
+		types.WithRole(types.RoleAssistant),
+		types.WithContent("Need scope"),
+		types.WithQuestionData(qd),
+	)
+	require.NoError(t, chatRepo.SaveMessage(t.Context(), pendingMsg))
+
+	agentSvc := &stubAgentService{
+		resumeStreamErr: agents.ErrCheckpointNotFound,
 	}
 
 	svc := NewChatService(chatRepo, agentSvc, nil, nil, nil)
@@ -815,6 +923,58 @@ func TestChatService_ResumeWithAnswerAsync_MarksFailureStateWhenWorkerFails(t *t
 	}, 2*time.Second, 20*time.Millisecond)
 }
 
+func TestChatService_ResumeWithAnswerAsync_DeferredCheckpointNotFoundFinalizesAnswered(t *testing.T) {
+	t.Parallel()
+
+	chatRepo := newMockChatRepository()
+	session := mustSession(t,
+		withSessionTenantID(uuid.New()),
+		withSessionUserID(1),
+		withSessionTitle("resume async deferred stale checkpoint"),
+	)
+	require.NoError(t, chatRepo.CreateSession(t.Context(), session))
+
+	qd, err := types.NewQuestionData("cp-async-missing-answer", "ali", []types.QuestionDataItem{
+		{
+			ID:   "scope",
+			Text: "Scope?",
+			Type: "single_choice",
+			Options: []types.QuestionDataOption{
+				{ID: "sold", Label: "Sold only"},
+				{ID: "all", Label: "All policies"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, chatRepo.SaveMessage(t.Context(), types.NewMessage(
+		types.WithSessionID(session.ID()),
+		types.WithRole(types.RoleAssistant),
+		types.WithContent("Need scope"),
+		types.WithQuestionData(qd),
+	)))
+
+	agentSvc := &stubAgentService{resumeStreamErr: agents.ErrCheckpointNotFound}
+	svc := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+
+	_, err = svc.ResumeWithAnswerAsync(t.Context(), bichatservices.ResumeRequest{
+		SessionID:    session.ID(),
+		CheckpointID: "cp-async-missing-answer",
+		Answers: map[string]string{
+			"scope": "all",
+		},
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		messages, messagesErr := chatRepo.GetSessionMessages(t.Context(), session.ID(), domain.ListOptions{})
+		if messagesErr != nil || len(messages) == 0 || messages[0].QuestionData() == nil {
+			return false
+		}
+		return messages[0].QuestionData().Status == types.QuestionStatusAnswered
+	}, 2*time.Second, 20*time.Millisecond)
+}
+
 func TestChatService_RejectPendingQuestionAsync_MarksFailureStateWhenWorkerFails(t *testing.T) {
 	t.Parallel()
 
@@ -858,6 +1018,52 @@ func TestChatService_RejectPendingQuestionAsync_MarksFailureStateWhenWorkerFails
 			return false
 		}
 		return messages[0].QuestionData().Status == types.QuestionStatusRejectFailed
+	}, 2*time.Second, 20*time.Millisecond)
+}
+
+func TestChatService_RejectPendingQuestionAsync_DeferredCheckpointNotFoundFinalizesRejected(t *testing.T) {
+	t.Parallel()
+
+	chatRepo := newMockChatRepository()
+	session := mustSession(t,
+		withSessionTenantID(uuid.New()),
+		withSessionUserID(1),
+		withSessionTitle("reject async deferred stale checkpoint"),
+	)
+	require.NoError(t, chatRepo.CreateSession(t.Context(), session))
+
+	qd, err := types.NewQuestionData("cp-async-missing-reject", "ali", []types.QuestionDataItem{
+		{
+			ID:   "scope",
+			Text: "Scope?",
+			Type: "single_choice",
+			Options: []types.QuestionDataOption{
+				{ID: "sold", Label: "Sold only"},
+				{ID: "all", Label: "All policies"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, chatRepo.SaveMessage(t.Context(), types.NewMessage(
+		types.WithSessionID(session.ID()),
+		types.WithRole(types.RoleAssistant),
+		types.WithContent("Need scope"),
+		types.WithQuestionData(qd),
+	)))
+
+	agentSvc := &stubAgentService{resumeStreamErr: agents.ErrCheckpointNotFound}
+	svc := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+
+	_, err = svc.RejectPendingQuestionAsync(t.Context(), session.ID())
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		messages, messagesErr := chatRepo.GetSessionMessages(t.Context(), session.ID(), domain.ListOptions{})
+		if messagesErr != nil || len(messages) == 0 || messages[0].QuestionData() == nil {
+			return false
+		}
+		return messages[0].QuestionData().Status == types.QuestionStatusRejected
 	}, 2*time.Second, 20*time.Millisecond)
 }
 
@@ -1322,6 +1528,7 @@ type stubAgentService struct {
 	processStreamErr error
 	resumeEvents     []agents.ExecutorEvent
 	resumeErr        error
+	resumeStreamErr  error
 	resumeCalls      int
 	resumeCheckpoint string
 	resumeAnswers    map[string]types.Answer
@@ -1364,6 +1571,7 @@ func (s *stubAgentService) ResumeWithAnswer(ctx context.Context, sessionID uuid.
 		return nil, s.resumeErr
 	}
 	evs := append([]agents.ExecutorEvent{}, s.resumeEvents...)
+	streamErr := s.resumeStreamErr
 	return types.NewGenerator(ctx, func(ctx context.Context, yield func(agents.ExecutorEvent) bool) error {
 		if s.resumeStarted != nil {
 			select {
@@ -1383,7 +1591,7 @@ func (s *stubAgentService) ResumeWithAnswer(ctx context.Context, sessionID uuid.
 				return nil
 			}
 		}
-		return nil
+		return streamErr
 	}), nil
 }
 


### PR DESCRIPTION
## Summary
- handle missing HITL checkpoints when the error is raised during generator consumption instead of generator creation
- finalize answer/reject flows consistently for both sync and async resume paths
- add regression coverage for deferred checkpoint-miss cases

## Testing
- go test ./modules/bichat/services


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of human-in-the-loop conversation flows by gracefully handling edge cases where internal state becomes unavailable. Conversations now complete successfully instead of terminating unexpectedly in both synchronous and asynchronous message processing scenarios.

* **Tests**
  * Added comprehensive test coverage to validate improved error handling for internal state unavailability conditions across multiple conversation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->