### PR TITLE
feat: add kanban lazy loading and touch scrolling

### DIFF
--- a/components/scaffold/kanban/kanban.templ
+++ b/components/scaffold/kanban/kanban.templ
@@ -1,6 +1,11 @@
 package kanban
 
-import "github.com/iota-uz/iota-sdk/modules/core/presentation/templates/layouts"
+import (
+	"net/url"
+
+	"github.com/iota-uz/iota-sdk/components/loaders"
+	"github.com/iota-uz/iota-sdk/modules/core/presentation/templates/layouts"
+)
 
 templ Page[C Card](cfg *Config[C]) {
 	@layouts.Authenticated(layouts.AuthenticatedProps{
@@ -16,6 +21,7 @@ templ Content[C Card](cfg *Config[C]) {
 			opacity: 0.4;
 		}
 	</style>
+	{{ currentParams := CurrentQueryParams(ctx) }}
 	<div x-data="kanban" class="contents">
 		<div class="hidden" id="column-trigger" hx-post={ cfg.ColumnChangeURL } hx-trigger="columnChanged" hx-swap="none" hx-push-url="false" hx-include="this">
 			<input type="hidden" name="colKey" x-model="col.key"/>
@@ -29,11 +35,15 @@ templ Content[C Card](cfg *Config[C]) {
 			<input type="hidden" name="cardOldIndex" x-model="card.oldIndex"/>
 			<input type="hidden" name="cardNewIndex" x-model="card.newIndex"/>
 		</div>
-		<div class="flex bg-gray-200 rounded-lg h-full">
+		<div class="flex bg-gray-200 rounded-lg h-full overflow-hidden">
+			<div class="w-full overflow-x-auto overscroll-x-contain [touch-action:pan-x_pinch-zoom] [-webkit-overflow-scrolling:touch]">
 			<ol
-				class="flex divide-x divide-gray-300 w-full overflow-x-auto"
+				class="flex w-max min-w-full divide-x divide-gray-300"
 				x-sort.ghost
 				x-sort:config="{
+					delayOnTouchOnly: true,
+					delay: 150,
+					touchStartThreshold: 8,
 					onEnd: (event) => {
 						changeCol({
 							key: event.item.dataset.colKey,
@@ -45,16 +55,21 @@ templ Content[C Card](cfg *Config[C]) {
 				}"
 			>
 				for _, c := range cfg.Board.Columns() {
-					<li data-col-key={ c.Key() } x-sort:item class="flex flex-col gap-2 p-3 basis-72 shrink-0 flex-1">
+					<li data-col-key={ c.Key() } x-sort:item class="flex w-72 shrink-0 flex-col gap-2 p-3">
 						<header class="font-medium">
 							@c.Title()
 						</header>
 						<ol
-							class="flex flex-col gap-2 h-full"
+							class="flex min-h-6 flex-col gap-2"
+							id={ ColumnCardsTargetID(c.Key()) }
 							data-col-key={ c.Key() }
 							x-sort.ghost
 							x-sort:group="cards"
-							x-sort:config="{onEnd: (event) => {
+							x-sort:config="{
+								delayOnTouchOnly: true,
+								delay: 150,
+								touchStartThreshold: 8,
+								onEnd: (event) => {
 								changeCard({
 									key: event.item.dataset.cardKey,
 									newCol: event.to.dataset.colKey,
@@ -65,15 +80,34 @@ templ Content[C Card](cfg *Config[C]) {
 								$nextTick(() => htmx.trigger('#card-trigger', 'cardChanged'));
 							}}"
 						>
-							for _, card := range c.Cards() {
-								<li class="cursor-pointer" data-card-key={ card.Key() } x-sort:item>
-									@card.Component()
-								</li>
-							}
+							@ColumnCards(cfg, c, currentParams)
 						</ol>
 					</li>
 				}
 			</ol>
+			</div>
 		</div>
 	</div>
+}
+
+templ ColumnCards[C Card](cfg *Config[C], column Column[C], currentParams url.Values) {
+	for _, card := range column.Cards() {
+		<li class="cursor-pointer" data-card-key={ card.Key() } x-sort:item>
+			@card.Component()
+		</li>
+	}
+	if loadState := cfg.ColumnLoad(column.Key()); cfg.CardLoadURL != "" && loadState != nil {
+		<li
+			class="pointer-events-none flex justify-center py-2"
+			id={ ColumnSpinnerID(column.Key()) }
+			hx-get={ nextColumnChunkURL(cfg.CardLoadURL, column.Key(), loadState, currentParams) }
+			hx-trigger="intersect once"
+			hx-target="this"
+			hx-swap="outerHTML"
+		>
+			@loaders.Spinner(loaders.SpinnerProps{
+				ContainerClass: templ.Classes("flex justify-center items-center py-2"),
+			})
+		</li>
+	}
 }

--- a/components/scaffold/kanban/kanban_templ.go
+++ b/components/scaffold/kanban/kanban_templ.go
@@ -8,7 +8,12 @@ package kanban
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import "github.com/iota-uz/iota-sdk/modules/core/presentation/templates/layouts"
+import (
+	"net/url"
+
+	"github.com/iota-uz/iota-sdk/components/loaders"
+	"github.com/iota-uz/iota-sdk/modules/core/presentation/templates/layouts"
+)
 
 func Page[C Card](cfg *Config[C]) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
@@ -80,51 +85,56 @@ func Content[C Card](cfg *Config[C]) templ.Component {
 			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<style>\n\t\t.sortable-ghost {\n\t\t\topacity: 0.4;\n\t\t}\n\t</style><div x-data=\"kanban\" class=\"contents\"><div class=\"hidden\" id=\"column-trigger\" hx-post=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<style>\n\t\t.sortable-ghost {\n\t\t\topacity: 0.4;\n\t\t}\n\t</style>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		currentParams := CurrentQueryParams(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div x-data=\"kanban\" class=\"contents\"><div class=\"hidden\" id=\"column-trigger\" hx-post=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.ColumnChangeURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 20, Col: 71}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 26, Col: 71}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\" hx-trigger=\"columnChanged\" hx-swap=\"none\" hx-push-url=\"false\" hx-include=\"this\"><input type=\"hidden\" name=\"colKey\" x-model=\"col.key\"> <input type=\"hidden\" name=\"colOldIndex\" x-model=\"col.oldIndex\"> <input type=\"hidden\" name=\"colNewIndex\" x-model=\"col.newIndex\"></div><div class=\"hidden\" id=\"card-trigger\" hx-post=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\" hx-trigger=\"columnChanged\" hx-swap=\"none\" hx-push-url=\"false\" hx-include=\"this\"><input type=\"hidden\" name=\"colKey\" x-model=\"col.key\"> <input type=\"hidden\" name=\"colOldIndex\" x-model=\"col.oldIndex\"> <input type=\"hidden\" name=\"colNewIndex\" x-model=\"col.newIndex\"></div><div class=\"hidden\" id=\"card-trigger\" hx-post=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.CardChangeURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 25, Col: 67}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 31, Col: 67}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\" hx-trigger=\"cardChanged\" hx-swap=\"none\" hx-push-url=\"false\" hx-include=\"this\"><input type=\"hidden\" name=\"cardKey\" x-model=\"card.key\"> <input type=\"hidden\" name=\"cardOldCol\" x-model=\"card.oldCol\"> <input type=\"hidden\" name=\"cardNewCol\" x-model=\"card.newCol\"> <input type=\"hidden\" name=\"cardOldIndex\" x-model=\"card.oldIndex\"> <input type=\"hidden\" name=\"cardNewIndex\" x-model=\"card.newIndex\"></div><div class=\"flex bg-gray-200 rounded-lg h-full\"><ol class=\"flex divide-x divide-gray-300 w-full overflow-x-auto\" x-sort.ghost x-sort:config=\"{\n\t\t\t\t\tonEnd: (event) =&gt; {\n\t\t\t\t\t\tchangeCol({\n\t\t\t\t\t\t\tkey: event.item.dataset.colKey,\n\t\t\t\t\t\t\toldIndex: event.oldIndex,\n\t\t\t\t\t\t\tnewIndex: event.newIndex\n\t\t\t\t\t\t});\n\t\t\t\t\t\t$nextTick(() =&gt; htmx.trigger(&#39;#column-trigger&#39;, &#39;columnChanged&#39;));\n\t\t\t\t\t}\n\t\t\t\t}\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\" hx-trigger=\"cardChanged\" hx-swap=\"none\" hx-push-url=\"false\" hx-include=\"this\"><input type=\"hidden\" name=\"cardKey\" x-model=\"card.key\"> <input type=\"hidden\" name=\"cardOldCol\" x-model=\"card.oldCol\"> <input type=\"hidden\" name=\"cardNewCol\" x-model=\"card.newCol\"> <input type=\"hidden\" name=\"cardOldIndex\" x-model=\"card.oldIndex\"> <input type=\"hidden\" name=\"cardNewIndex\" x-model=\"card.newIndex\"></div><div class=\"flex bg-gray-200 rounded-lg h-full overflow-hidden\"><div class=\"w-full overflow-x-auto overscroll-x-contain [touch-action:pan-x_pinch-zoom] [-webkit-overflow-scrolling:touch]\"><ol class=\"flex w-max min-w-full divide-x divide-gray-300\" x-sort.ghost x-sort:config=\"{\n\t\t\t\t\tdelayOnTouchOnly: true,\n\t\t\t\t\tdelay: 150,\n\t\t\t\t\ttouchStartThreshold: 8,\n\t\t\t\t\tonEnd: (event) =&gt; {\n\t\t\t\t\t\tchangeCol({\n\t\t\t\t\t\t\tkey: event.item.dataset.colKey,\n\t\t\t\t\t\t\toldIndex: event.oldIndex,\n\t\t\t\t\t\t\tnewIndex: event.newIndex\n\t\t\t\t\t\t});\n\t\t\t\t\t\t$nextTick(() =&gt; htmx.trigger(&#39;#column-trigger&#39;, &#39;columnChanged&#39;));\n\t\t\t\t\t}\n\t\t\t\t}\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, c := range cfg.Board.Columns() {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<li data-col-key=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<li data-col-key=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(c.Key())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 48, Col: 31}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 58, Col: 31}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" x-sort:item class=\"flex flex-col gap-2 p-3 basis-72 shrink-0 flex-1\"><header class=\"font-medium\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\" x-sort:item class=\"flex w-72 shrink-0 flex-col gap-2 p-3\"><header class=\"font-medium\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -132,58 +142,142 @@ func Content[C Card](cfg *Config[C]) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</header><ol class=\"flex flex-col gap-2 h-full\" data-col-key=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</header><ol class=\"flex min-h-6 flex-col gap-2\" id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var7 string
-			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(c.Key())
+			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(ColumnCardsTargetID(c.Key()))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 54, Col: 29}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 64, Col: 40}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\" x-sort.ghost x-sort:group=\"cards\" x-sort:config=\"{onEnd: (event) =&gt; {\n\t\t\t\t\t\t\t\tchangeCard({\n\t\t\t\t\t\t\t\t\tkey: event.item.dataset.cardKey,\n\t\t\t\t\t\t\t\t\tnewCol: event.to.dataset.colKey,\n\t\t\t\t\t\t\t\t\toldCol: event.from.dataset.colKey,\n\t\t\t\t\t\t\t\t\toldIndex: event.oldIndex,\n\t\t\t\t\t\t\t\t\tnewIndex: event.newIndex\n\t\t\t\t\t\t\t\t})\n\t\t\t\t\t\t\t\t$nextTick(() =&gt; htmx.trigger(&#39;#card-trigger&#39;, &#39;cardChanged&#39;));\n\t\t\t\t\t\t\t}}\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\" data-col-key=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			for _, card := range c.Cards() {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<li class=\"cursor-pointer\" data-card-key=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var8 string
-				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(card.Key())
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 69, Col: 61}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\" x-sort:item>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = card.Component().Render(ctx, templ_7745c5c3_Buffer)
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</li>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
+			var templ_7745c5c3_Var8 string
+			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(c.Key())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 65, Col: 29}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</ol></li>")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\" x-sort.ghost x-sort:group=\"cards\" x-sort:config=\"{\n\t\t\t\t\t\t\t\tdelayOnTouchOnly: true,\n\t\t\t\t\t\t\t\tdelay: 150,\n\t\t\t\t\t\t\t\ttouchStartThreshold: 8,\n\t\t\t\t\t\t\t\tonEnd: (event) =&gt; {\n\t\t\t\t\t\t\t\tchangeCard({\n\t\t\t\t\t\t\t\t\tkey: event.item.dataset.cardKey,\n\t\t\t\t\t\t\t\t\tnewCol: event.to.dataset.colKey,\n\t\t\t\t\t\t\t\t\toldCol: event.from.dataset.colKey,\n\t\t\t\t\t\t\t\t\toldIndex: event.oldIndex,\n\t\t\t\t\t\t\t\t\tnewIndex: event.newIndex\n\t\t\t\t\t\t\t\t})\n\t\t\t\t\t\t\t\t$nextTick(() =&gt; htmx.trigger(&#39;#card-trigger&#39;, &#39;cardChanged&#39;));\n\t\t\t\t\t\t\t}}\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = ColumnCards(cfg, c, currentParams).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</ol></li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</ol></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</ol></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func ColumnCards[C Card](cfg *Config[C], column Column[C], currentParams url.Values) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		for _, card := range column.Cards() {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<li class=\"cursor-pointer\" data-card-key=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var10 string
+			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(card.Key())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 95, Col: 55}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\" x-sort:item>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = card.Component().Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</li>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if loadState := cfg.ColumnLoad(column.Key()); cfg.CardLoadURL != "" && loadState != nil {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<li class=\"pointer-events-none flex justify-center py-2\" id=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var11 string
+			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(ColumnSpinnerID(column.Key()))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 102, Col: 37}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "\" hx-get=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var12 string
+			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(nextColumnChunkURL(cfg.CardLoadURL, column.Key(), loadState, currentParams))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 103, Col: 87}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\" hx-trigger=\"intersect once\" hx-target=\"this\" hx-swap=\"outerHTML\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = loaders.Spinner(loaders.SpinnerProps{
+				ContainerClass: templ.Classes("flex justify-center items-center py-2"),
+			}).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</li>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
 		return nil
 	})

--- a/components/scaffold/kanban/types.go
+++ b/components/scaffold/kanban/types.go
@@ -1,19 +1,123 @@
 package kanban
 
 import (
+	"context"
+	"net/url"
 	"slices"
+	"strconv"
 
 	"github.com/a-h/templ"
+	"github.com/iota-uz/iota-sdk/pkg/composables"
 )
 
 type Config[C Card] struct {
 	ColumnChangeURL string
 	CardChangeURL   string
+	CardLoadURL     string
+	ColumnLoads     map[string]*ColumnLoadState
 	Board           Board[C]
 }
 
 func NewConfig[C Card](board Board[C], columnChangeURL, cardChangeURL string) *Config[C] {
-	return &Config[C]{Board: board, ColumnChangeURL: columnChangeURL, CardChangeURL: cardChangeURL}
+	return &Config[C]{
+		Board:           board,
+		ColumnChangeURL: columnChangeURL,
+		CardChangeURL:   cardChangeURL,
+		ColumnLoads:     make(map[string]*ColumnLoadState),
+	}
+}
+
+const QueryParamColumn = "kanbanColumn"
+
+const (
+	queryParamPage  = "page"
+	queryParamLimit = "limit"
+)
+
+type ColumnLoadState struct {
+	NextPage int
+	PerPage  int
+}
+
+func (c *Config[C]) WithCardLoadURL(url string) *Config[C] {
+	c.CardLoadURL = url
+	return c
+}
+
+func (c *Config[C]) WithColumnLoad(columnKey string, state *ColumnLoadState) *Config[C] {
+	if c.ColumnLoads == nil {
+		c.ColumnLoads = make(map[string]*ColumnLoadState)
+	}
+
+	if state == nil || state.NextPage < 1 || state.PerPage < 1 {
+		delete(c.ColumnLoads, columnKey)
+		return c
+	}
+
+	c.ColumnLoads[columnKey] = state
+	return c
+}
+
+func (c *Config[C]) WithColumnLoads(loads map[string]*ColumnLoadState) *Config[C] {
+	if c.ColumnLoads == nil {
+		c.ColumnLoads = make(map[string]*ColumnLoadState, len(loads))
+	}
+
+	for key, state := range loads {
+		c.WithColumnLoad(key, state)
+	}
+
+	return c
+}
+
+func (c *Config[C]) ColumnLoad(columnKey string) *ColumnLoadState {
+	if c == nil || c.ColumnLoads == nil {
+		return nil
+	}
+
+	state, ok := c.ColumnLoads[columnKey]
+	if !ok || state == nil || state.NextPage < 1 || state.PerPage < 1 {
+		return nil
+	}
+
+	return state
+}
+
+func CurrentQueryParams(ctx context.Context) url.Values {
+	params, _ := composables.UseParams(ctx)
+	currentParams := url.Values{}
+	if params != nil && params.Request != nil {
+		currentParams = params.Request.URL.Query()
+	}
+
+	return currentParams
+}
+
+func ColumnCardsTargetID(columnKey string) string {
+	return "kanban-column-cards-" + columnKey
+}
+
+func ColumnSpinnerID(columnKey string) string {
+	return "kanban-column-spinner-" + columnKey
+}
+
+func nextColumnChunkURL(baseURL, columnKey string, state *ColumnLoadState, currentParams url.Values) string {
+	if state == nil {
+		return baseURL
+	}
+
+	params := url.Values{}
+	for key, values := range currentParams {
+		for _, value := range values {
+			params.Add(key, value)
+		}
+	}
+
+	params.Set(QueryParamColumn, columnKey)
+	params.Set(queryParamPage, strconv.Itoa(state.NextPage))
+	params.Set(queryParamLimit, strconv.Itoa(state.PerPage))
+
+	return baseURL + "?" + params.Encode()
 }
 
 type Card interface {


### PR DESCRIPTION
## Summary
- add column-level kanban lazy loading support to the shared scaffold
- preserve drag and drop behavior while enabling incremental card loading
- improve horizontal touch scrolling behavior for iPad Safari and other touch devices

## Testing
- templ generate ./components/scaffold/kanban
- go vet ./components/scaffold/kanban/...
