### PR TITLE
feat(periodics): add RunTask method for on-demand task execution

### DIFF
--- a/pkg/periodics/interface.go
+++ b/pkg/periodics/interface.go
@@ -83,6 +83,10 @@ type Manager interface {
 	// SubscribeMetrics returns a channel that receives events when task metrics change,
 	// and an unsubscribe function to stop receiving events and close the channel.
 	SubscribeMetrics() (<-chan TaskMetricEvent, func())
+
+	// RunTask executes a registered task immediately (out-of-schedule).
+	// Returns an error if the task is not found, is disabled, or is already running.
+	RunTask(name string) error
 }
 
 // TaskScheduleInfo provides scheduling information for a specific task.

--- a/pkg/periodics/manager.go
+++ b/pkg/periodics/manager.go
@@ -309,6 +309,39 @@ func (m *manager) AddDisabledTaskInfo(name, schedule string) {
 	})
 }
 
+// RunTask executes a registered task immediately (out-of-schedule).
+func (m *manager) RunTask(name string) error {
+	m.mu.RLock()
+	task, exists := m.tasks[name]
+	m.mu.RUnlock()
+
+	if !exists {
+		return fmt.Errorf("task '%s' not found or disabled", name)
+	}
+
+	// Check if already running
+	metrics := m.metrics.GetMetrics()
+	if tm, ok := metrics[name]; ok && tm.IsRunning {
+		return fmt.Errorf("task '%s' is already running", name)
+	}
+
+	executor := m.buildWrappedExecutor(task)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				m.logger.WithFields(logrus.Fields{
+					"task":  name,
+					"panic": r,
+				}).Error("Manually triggered task panicked")
+			}
+		}()
+		m.logger.WithField("task", name).Info("Running periodic task manually")
+		executor()
+	}()
+
+	return nil
+}
+
 // GetRegisteredTasks returns information about all registered tasks (both enabled and disabled).
 func (m *manager) GetRegisteredTasks() []RegisteredTask {
 	m.mu.RLock()


### PR DESCRIPTION
Allow callers to trigger any registered periodic task immediately, outside its cron schedule. The method reuses the same wrapper chain (retry, timeout, metrics, logging) as scheduled runs.

Returns an error if the task is not found, disabled, or already running.