### PR TITLE
[codex] Fix BiChat clarification answers

### DIFF
--- a/modules/bichat/services/hitl/answers.go
+++ b/modules/bichat/services/hitl/answers.go
@@ -1,104 +1,11 @@
 // Package hitl provides this package.
 package hitl
 
-import (
-	"fmt"
-	"strings"
-
-	"github.com/iota-uz/iota-sdk/pkg/bichat/types"
-)
+import "github.com/iota-uz/iota-sdk/pkg/bichat/types"
 
 func NormalizeAnswers(
 	questions []types.QuestionDataItem,
 	rawAnswers map[string]string,
 ) (map[string]string, map[string]types.Answer, error) {
-	normalizedValues := make(map[string]string, len(rawAnswers))
-	normalizedAnswers := make(map[string]types.Answer, len(rawAnswers))
-	questionsByID := make(map[string]types.QuestionDataItem, len(questions))
-	for _, q := range questions {
-		questionsByID[q.ID] = q
-	}
-
-	for questionID, answerValue := range rawAnswers {
-		question, ok := questionsByID[questionID]
-		if !ok {
-			return nil, nil, fmt.Errorf("unknown question id: %s", questionID)
-		}
-
-		if question.Type == "multiple_choice" {
-			parts := splitAnswerParts(answerValue)
-			if len(parts) == 0 {
-				trimmed := strings.TrimSpace(answerValue)
-				normalizedValues[questionID] = trimmed
-				normalizedAnswers[questionID] = types.NewAnswer(trimmed)
-				continue
-			}
-
-			canonicalParts := make([]string, 0, len(parts))
-			seen := make(map[string]struct{}, len(parts))
-			for _, part := range parts {
-				canonical := canonicalizeAnswerPart(part, question.Options)
-				if canonical == "" {
-					continue
-				}
-				if _, exists := seen[canonical]; exists {
-					continue
-				}
-				seen[canonical] = struct{}{}
-				canonicalParts = append(canonicalParts, canonical)
-			}
-
-			if len(canonicalParts) == 0 {
-				trimmed := strings.TrimSpace(answerValue)
-				normalizedValues[questionID] = trimmed
-				normalizedAnswers[questionID] = types.NewAnswer(trimmed)
-			} else if len(canonicalParts) == 1 {
-				normalizedValues[questionID] = canonicalParts[0]
-				normalizedAnswers[questionID] = types.NewAnswer(canonicalParts[0])
-			} else {
-				normalizedValues[questionID] = strings.Join(canonicalParts, ", ")
-				normalizedAnswers[questionID] = types.NewMultiAnswer(canonicalParts)
-			}
-			continue
-		}
-
-		canonical := canonicalizeAnswerPart(answerValue, question.Options)
-		normalizedValues[questionID] = canonical
-		normalizedAnswers[questionID] = types.NewAnswer(canonical)
-	}
-
-	return normalizedValues, normalizedAnswers, nil
-}
-
-func splitAnswerParts(value string) []string {
-	parts := strings.Split(strings.TrimSpace(value), ",")
-	result := make([]string, 0, len(parts))
-	for _, p := range parts {
-		trimmed := strings.TrimSpace(p)
-		if trimmed == "" {
-			continue
-		}
-		result = append(result, trimmed)
-	}
-	return result
-}
-
-func canonicalizeAnswerPart(value string, options []types.QuestionDataOption) string {
-	trimmed := strings.TrimSpace(value)
-	if trimmed == "" {
-		return ""
-	}
-
-	for _, opt := range options {
-		if strings.EqualFold(strings.TrimSpace(opt.ID), trimmed) {
-			return opt.ID
-		}
-	}
-	for _, opt := range options {
-		if strings.EqualFold(strings.TrimSpace(opt.Label), trimmed) {
-			return opt.ID
-		}
-	}
-
-	return trimmed
+	return types.NormalizeQuestionAnswers(questions, rawAnswers)
 }

--- a/modules/bichat/services/hitl/answers_test.go
+++ b/modules/bichat/services/hitl/answers_test.go
@@ -35,6 +35,21 @@ func TestNormalizeAnswers_Scenarios(t *testing.T) {
 			expectedAnswer: "opt_b",
 		},
 		{
+			name: "single choice preserves free text",
+			questions: []types.QuestionDataItem{{
+				ID:   "q1",
+				Type: "single_choice",
+				Options: []types.QuestionDataOption{
+					{ID: "opt_a", Label: "Option A"},
+					{ID: "opt_b", Label: "Option B"},
+				},
+			}},
+			rawAnswers:     map[string]string{"q1": "Custom free text"},
+			questionID:     "q1",
+			expectedValue:  "Custom free text",
+			expectedAnswer: "Custom free text",
+		},
+		{
 			name: "multiple choice dedupes canonical options",
 			questions: []types.QuestionDataItem{{
 				ID:   "q1",
@@ -50,13 +65,28 @@ func TestNormalizeAnswers_Scenarios(t *testing.T) {
 			expectedMultiAnswer: []string{"opt_a", "opt_b"},
 		},
 		{
+			name: "multiple choice preserves custom text",
+			questions: []types.QuestionDataItem{{
+				ID:   "q1",
+				Type: "multiple_choice",
+				Options: []types.QuestionDataOption{
+					{ID: "opt_a", Label: "Option A"},
+					{ID: "opt_b", Label: "Option B"},
+				},
+			}},
+			rawAnswers:     map[string]string{"q1": "Something custom"},
+			questionID:     "q1",
+			expectedValue:  "Something custom",
+			expectedAnswer: "Something custom",
+		},
+		{
 			name: "unknown question id returns validation error",
 			questions: []types.QuestionDataItem{{
 				ID:   "q1",
 				Type: "single_choice",
 			}},
 			rawAnswers:  map[string]string{"q-missing": "something"},
-			expectedErr: "unknown question id: q-missing",
+			expectedErr: "unknown question id",
 		},
 	}
 

--- a/pkg/bichat/types/interrupt.go
+++ b/pkg/bichat/types/interrupt.go
@@ -175,47 +175,9 @@ func NewQuestionData(checkpointID, agentName string, questions []QuestionDataIte
 }
 
 func (qd *QuestionData) normalizeAnswers(answers map[string]string) (map[string]string, error) {
-	if len(answers) == 0 {
-		return nil, fmt.Errorf("%w: at least one answer is required", ErrQuestionDataInvalid)
-	}
-
-	questionsByID := make(map[string]QuestionDataItem, len(qd.Questions))
-	for _, q := range qd.Questions {
-		questionsByID[q.ID] = q
-	}
-	for answerQID, rawAnswer := range answers {
-		question, ok := questionsByID[answerQID]
-		if !ok {
-			return nil, fmt.Errorf("%w: unknown question id %q", ErrQuestionDataInvalid, answerQID)
-		}
-		allowed := make(map[string]struct{}, len(question.Options))
-		for _, opt := range question.Options {
-			allowed[opt.ID] = struct{}{}
-		}
-		candidates := []string{strings.TrimSpace(rawAnswer)}
-		if question.Type == "multiple_choice" {
-			parts := strings.Split(rawAnswer, ",")
-			candidates = make([]string, 0, len(parts))
-			for _, part := range parts {
-				trimmed := strings.TrimSpace(part)
-				if trimmed != "" {
-					candidates = append(candidates, trimmed)
-				}
-			}
-		}
-		if len(candidates) == 0 {
-			return nil, fmt.Errorf("%w: empty answer for question %q", ErrQuestionDataInvalid, answerQID)
-		}
-		for _, candidate := range candidates {
-			if _, exists := allowed[candidate]; !exists {
-				return nil, fmt.Errorf("%w: invalid option %q for question %q", ErrQuestionDataInvalid, candidate, answerQID)
-			}
-		}
-	}
-
-	normalized := make(map[string]string, len(answers))
-	for key, value := range answers {
-		normalized[key] = value
+	normalized, _, err := NormalizeQuestionAnswers(qd.Questions, answers)
+	if err != nil {
+		return nil, err
 	}
 	return normalized, nil
 }

--- a/pkg/bichat/types/question_answers.go
+++ b/pkg/bichat/types/question_answers.go
@@ -1,0 +1,112 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+)
+
+// NormalizeQuestionAnswers canonicalizes submitted answers against the
+// question definitions while still preserving valid free-text responses.
+func NormalizeQuestionAnswers(
+	questions []QuestionDataItem,
+	rawAnswers map[string]string,
+) (map[string]string, map[string]Answer, error) {
+	if len(rawAnswers) == 0 {
+		return nil, nil, fmt.Errorf("%w: at least one answer is required", ErrQuestionDataInvalid)
+	}
+
+	questionsByID := make(map[string]QuestionDataItem, len(questions))
+	for _, q := range questions {
+		questionsByID[q.ID] = q
+	}
+
+	normalizedValues := make(map[string]string, len(rawAnswers))
+	normalizedAnswers := make(map[string]Answer, len(rawAnswers))
+	for questionID, rawAnswer := range rawAnswers {
+		question, ok := questionsByID[questionID]
+		if !ok {
+			return nil, nil, fmt.Errorf("%w: unknown question id %q", ErrQuestionDataInvalid, questionID)
+		}
+
+		normalizedValue, normalizedAnswer, err := normalizeQuestionAnswer(question, rawAnswer)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		normalizedValues[questionID] = normalizedValue
+		normalizedAnswers[questionID] = normalizedAnswer
+	}
+
+	return normalizedValues, normalizedAnswers, nil
+}
+
+func normalizeQuestionAnswer(question QuestionDataItem, rawAnswer string) (string, Answer, error) {
+	if question.Type == "multiple_choice" {
+		parts := splitNormalizedAnswerParts(rawAnswer)
+		if len(parts) == 0 {
+			return "", Answer{}, fmt.Errorf("%w: empty answer for question %q", ErrQuestionDataInvalid, question.ID)
+		}
+
+		canonicalParts := make([]string, 0, len(parts))
+		seen := make(map[string]struct{}, len(parts))
+		for _, part := range parts {
+			canonical := canonicalizeAnswerPart(part, question.Options)
+			if canonical == "" {
+				continue
+			}
+			if _, exists := seen[canonical]; exists {
+				continue
+			}
+			seen[canonical] = struct{}{}
+			canonicalParts = append(canonicalParts, canonical)
+		}
+		if len(canonicalParts) == 0 {
+			return "", Answer{}, fmt.Errorf("%w: empty answer for question %q", ErrQuestionDataInvalid, question.ID)
+		}
+		if len(canonicalParts) == 1 {
+			return canonicalParts[0], NewAnswer(canonicalParts[0]), nil
+		}
+
+		joined := strings.Join(canonicalParts, ", ")
+		return joined, NewMultiAnswer(canonicalParts), nil
+	}
+
+	canonical := canonicalizeAnswerPart(rawAnswer, question.Options)
+	if canonical == "" {
+		return "", Answer{}, fmt.Errorf("%w: empty answer for question %q", ErrQuestionDataInvalid, question.ID)
+	}
+	return canonical, NewAnswer(canonical), nil
+}
+
+func splitNormalizedAnswerParts(value string) []string {
+	parts := strings.Split(strings.TrimSpace(value), ",")
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed == "" {
+			continue
+		}
+		result = append(result, trimmed)
+	}
+	return result
+}
+
+func canonicalizeAnswerPart(value string, options []QuestionDataOption) string {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return ""
+	}
+
+	for _, opt := range options {
+		if strings.EqualFold(strings.TrimSpace(opt.ID), trimmed) {
+			return opt.ID
+		}
+	}
+	for _, opt := range options {
+		if strings.EqualFold(strings.TrimSpace(opt.Label), trimmed) {
+			return opt.ID
+		}
+	}
+
+	return trimmed
+}

--- a/pkg/bichat/types/question_answers_test.go
+++ b/pkg/bichat/types/question_answers_test.go
@@ -1,0 +1,53 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuestionDataSubmitAnswersAcceptsFreeText(t *testing.T) {
+	qd, err := NewQuestionData("checkpoint-1", "ali", []QuestionDataItem{
+		{
+			ID:   "period",
+			Text: "Which period?",
+			Type: "single_choice",
+			Options: []QuestionDataOption{
+				{ID: "ytd", Label: "Year to date"},
+				{ID: "last12", Label: "Last 12 months"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	submitted, err := qd.SubmitAnswers(map[string]string{
+		"period": "Show quarters for last year",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, submitted)
+	assert.Equal(t, QuestionStatusAnswerSubmitted, submitted.Status)
+	assert.Equal(t, "Show quarters for last year", submitted.Answers["period"])
+}
+
+func TestQuestionDataSubmitAnswersCanonicalizesOptionLabels(t *testing.T) {
+	qd, err := NewQuestionData("checkpoint-1", "ali", []QuestionDataItem{
+		{
+			ID:   "slice",
+			Text: "Which slice?",
+			Type: "single_choice",
+			Options: []QuestionDataOption{
+				{ID: "all", Label: "All products"},
+				{ID: "region", Label: "By region"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	submitted, err := qd.SubmitAnswers(map[string]string{
+		"slice": "all products",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, submitted)
+	assert.Equal(t, "all", submitted.Answers["slice"])
+}


### PR DESCRIPTION
## Summary
- make BiChat clarification answers accept free-form "Other" input through a single shared normalization path
- remove the mismatch between resume-time normalization and persisted HITL question validation
- add regression coverage for free-text and canonical option-label handling

## Root Cause
- the BiChat HITL flow normalized free-form answers in one backend path but rejected them later in `QuestionData` validation, causing clarification submission failures after users chose "Other"

## Validation
- `go test ./pkg/bichat/types ./modules/bichat/services/hitl`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Free-form text answers are now preserved for single-choice and multiple-choice questions when no exact option match is found.
  * Enhanced comma-separated answer support for multiple-choice questions with automatic deduplication.

* **Improvements**
  * Centralized answer normalization logic for consistent validation across the application.
  * Case-insensitive option label matching for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->