### PR TITLE
Reconcile analytics views during sync

### DIFF
--- a/pkg/analytics/manager.go
+++ b/pkg/analytics/manager.go
@@ -3,9 +3,13 @@ package analytics
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -20,10 +24,91 @@ func WithSchema(schema string) ManagerOption {
 }
 
 // ViewManager is the single source of truth for analytics view definitions.
-// It holds all registered views and can sync them to the database.
+// It holds all registered views and can reconcile them to the database.
 type ViewManager struct {
 	views  []View
 	schema string
+}
+
+type viewKey struct {
+	schema string
+	name   string
+}
+
+type txBeginner interface {
+	Begin(ctx context.Context) (dbTx, error)
+}
+
+type dbTx interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (dbRows, error)
+	Commit(ctx context.Context) error
+	Rollback(ctx context.Context) error
+}
+
+type dbRows interface {
+	Next() bool
+	Scan(dest ...any) error
+	Err() error
+	Close()
+}
+
+type pgxPoolAdapter struct {
+	pool *pgxpool.Pool
+}
+
+func (a pgxPoolAdapter) Begin(ctx context.Context) (dbTx, error) {
+	tx, err := a.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return pgxTxAdapter{tx: tx}, nil
+}
+
+type pgxTxAdapter struct {
+	tx pgx.Tx
+}
+
+func (a pgxTxAdapter) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	return a.tx.Exec(ctx, sql, args...)
+}
+
+func (a pgxTxAdapter) Query(ctx context.Context, sql string, args ...any) (dbRows, error) {
+	rows, err := a.tx.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, err
+	}
+
+	return pgxRowsAdapter{rows: rows}, nil
+}
+
+func (a pgxTxAdapter) Commit(ctx context.Context) error {
+	return a.tx.Commit(ctx)
+}
+
+func (a pgxTxAdapter) Rollback(ctx context.Context) error {
+	return a.tx.Rollback(ctx)
+}
+
+type pgxRowsAdapter struct {
+	rows pgx.Rows
+}
+
+func (a pgxRowsAdapter) Next() bool {
+	return a.rows.Next()
+}
+
+func (a pgxRowsAdapter) Scan(dest ...any) error {
+	return a.rows.Scan(dest...)
+}
+
+func (a pgxRowsAdapter) Err() error {
+	return a.rows.Err()
+}
+
+func (a pgxRowsAdapter) Close() {
+	a.rows.Close()
 }
 
 // NewViewManager creates a new ViewManager with the given options.
@@ -60,56 +145,55 @@ func (m *ViewManager) Views() []View {
 	return out
 }
 
-// Sync drops and recreates all registered views in the database within a single transaction.
-// Uses DROP CASCADE + CREATE (not CREATE OR REPLACE) to support column type changes.
-// The entire operation is atomic: if any view fails, the transaction rolls back.
-// It does NOT create the schema (assumes it exists from migration).
-// NOTE: DROP CASCADE may remove views that depend on managed views but are not
-// themselves registered. Ensure all inter-dependent views are registered.
+// Sync reconciles managed analytics views in the database to match the
+// registered Go definitions exactly.
+//
+// Managed schemas are inferred from the manager's default schema plus the
+// schemas of registered views. Any regular view currently present in those
+// schemas but missing from the registered definitions is dropped as stale.
+//
+// Views are recreated with DROP VIEW ... CASCADE + CREATE VIEW to support
+// incompatible shape changes. The full reconciliation runs inside one
+// transaction, so failures roll back atomically.
 func (m *ViewManager) Sync(ctx context.Context, pool *pgxpool.Pool) error {
-	if len(m.views) == 0 {
+	if pool == nil {
+		return errors.New("analytics.ViewManager.Sync: nil pool")
+	}
+
+	return m.sync(ctx, pgxPoolAdapter{pool: pool})
+}
+
+func (m *ViewManager) sync(ctx context.Context, beginner txBeginner) error {
+	desiredViews, desiredKeys, err := m.normalizedViews()
+	if err != nil {
+		return fmt.Errorf("analytics.ViewManager.Sync: %w", err)
+	}
+
+	managedSchemas := m.managedSchemas(desiredViews)
+	if len(managedSchemas) == 0 {
 		return nil
 	}
 
-	tx, err := pool.Begin(ctx)
+	tx, err := beginner.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("analytics.ViewManager.Sync: begin tx: %w", err)
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck
 
-	for _, v := range m.views {
-		schema := v.Schema
-		if schema == "" {
-			schema = m.schema
+	existingViews, err := listExistingViews(ctx, tx, managedSchemas)
+	if err != nil {
+		return fmt.Errorf("analytics.ViewManager.Sync: list existing views: %w", err)
+	}
+
+	for _, staleView := range staleViews(existingViews, desiredKeys) {
+		if err := dropView(ctx, tx, staleView); err != nil {
+			return fmt.Errorf("analytics.ViewManager.Sync: drop stale %s.%s: %w", staleView.schema, staleView.name, err)
 		}
+	}
 
-		qualifiedName := fmt.Sprintf("%s.%s", quoteIdent(schema), quoteIdent(v.Name))
-
-		// DROP first to allow column type changes (CREATE OR REPLACE cannot change types).
-		drop := fmt.Sprintf("DROP VIEW IF EXISTS %s CASCADE", qualifiedName)
-		if _, err := tx.Exec(ctx, drop); err != nil {
-			return fmt.Errorf("analytics.ViewManager.Sync: drop %s.%s: %w", schema, v.Name, err)
-		}
-
-		ddl := fmt.Sprintf("CREATE VIEW %s AS %s", qualifiedName, v.SQL)
-		if _, err := tx.Exec(ctx, ddl); err != nil {
-			return fmt.Errorf("analytics.ViewManager.Sync: view %s.%s: %w", schema, v.Name, err)
-		}
-
-		if v.Description != "" {
-			comment := fmt.Sprintf("COMMENT ON VIEW %s.%s IS %s",
-				quoteIdent(schema), quoteIdent(v.Name), quoteLiteral(v.Description))
-			if _, err := tx.Exec(ctx, comment); err != nil {
-				return fmt.Errorf("analytics.ViewManager.Sync: comment on %s.%s: %w", schema, v.Name, err)
-			}
-		}
-
-		for col, comment := range v.ColumnComments {
-			colComment := fmt.Sprintf("COMMENT ON COLUMN %s.%s.%s IS %s",
-				quoteIdent(schema), quoteIdent(v.Name), quoteIdent(col), quoteLiteral(comment))
-			if _, err := tx.Exec(ctx, colComment); err != nil {
-				return fmt.Errorf("analytics.ViewManager.Sync: column comment %s.%s.%s: %w", schema, v.Name, col, err)
-			}
+	for _, view := range desiredViews {
+		if err := recreateView(ctx, tx, view); err != nil {
+			return fmt.Errorf("analytics.ViewManager.Sync: reconcile %s.%s: %w", view.Schema, view.Name, err)
 		}
 	}
 
@@ -118,6 +202,172 @@ func (m *ViewManager) Sync(ctx context.Context, pool *pgxpool.Pool) error {
 	}
 
 	return nil
+}
+
+func (m *ViewManager) normalizedViews() ([]View, map[viewKey]View, error) {
+	normalized := make([]View, len(m.views))
+	seen := make(map[viewKey]View, len(m.views))
+
+	for i, view := range m.views {
+		if view.Schema == "" {
+			view.Schema = m.schema
+		}
+
+		if strings.TrimSpace(view.Schema) == "" {
+			return nil, nil, fmt.Errorf("view %q has empty schema", view.Name)
+		}
+		if strings.TrimSpace(view.Name) == "" {
+			return nil, nil, errors.New("view definition has empty name")
+		}
+		if strings.TrimSpace(view.SQL) == "" {
+			return nil, nil, fmt.Errorf("view %s.%s has empty SQL", view.Schema, view.Name)
+		}
+
+		key := viewKey{schema: view.Schema, name: view.Name}
+		if existing, ok := seen[key]; ok {
+			return nil, nil, fmt.Errorf(
+				"duplicate view definition for %s.%s (existing SQL: %q, duplicate SQL: %q)",
+				key.schema,
+				key.name,
+				existing.SQL,
+				view.SQL,
+			)
+		}
+
+		normalized[i] = view
+		seen[key] = view
+	}
+
+	return normalized, seen, nil
+}
+
+func (m *ViewManager) managedSchemas(views []View) []string {
+	schemas := make(map[string]struct{}, len(views)+1)
+	if strings.TrimSpace(m.schema) != "" {
+		schemas[m.schema] = struct{}{}
+	}
+
+	for _, view := range views {
+		if strings.TrimSpace(view.Schema) == "" {
+			continue
+		}
+		schemas[view.Schema] = struct{}{}
+	}
+
+	if len(schemas) == 0 {
+		return nil
+	}
+
+	out := make([]string, 0, len(schemas))
+	for schema := range schemas {
+		out = append(out, schema)
+	}
+	sort.Strings(out)
+
+	return out
+}
+
+func listExistingViews(ctx context.Context, tx dbTx, schemas []string) ([]viewKey, error) {
+	const sql = `
+SELECT table_schema, table_name
+FROM information_schema.views
+WHERE table_schema = ANY($1::text[])
+ORDER BY table_schema, table_name
+`
+
+	rows, err := tx.Query(ctx, sql, schemas)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var views []viewKey
+	for rows.Next() {
+		var schema string
+		var name string
+		if err := rows.Scan(&schema, &name); err != nil {
+			return nil, err
+		}
+		views = append(views, viewKey{schema: schema, name: name})
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return views, nil
+}
+
+func staleViews(existing []viewKey, desired map[viewKey]View) []viewKey {
+	stale := make([]viewKey, 0, len(existing))
+	for _, view := range existing {
+		if _, ok := desired[view]; ok {
+			continue
+		}
+		stale = append(stale, view)
+	}
+
+	return stale
+}
+
+func recreateView(ctx context.Context, tx dbTx, view View) error {
+	key := viewKey{schema: view.Schema, name: view.Name}
+	if err := dropView(ctx, tx, key); err != nil {
+		return err
+	}
+
+	create := fmt.Sprintf("CREATE VIEW %s AS %s", qualifiedViewName(key), view.SQL)
+	if _, err := tx.Exec(ctx, create); err != nil {
+		return fmt.Errorf("create view: %w", err)
+	}
+
+	if view.Description != "" {
+		comment := fmt.Sprintf("COMMENT ON VIEW %s IS %s", qualifiedViewName(key), quoteLiteral(view.Description))
+		if _, err := tx.Exec(ctx, comment); err != nil {
+			return fmt.Errorf("comment on view: %w", err)
+		}
+	}
+
+	for _, column := range sortedColumnNames(view.ColumnComments) {
+		comment := fmt.Sprintf(
+			"COMMENT ON COLUMN %s.%s IS %s",
+			qualifiedViewName(key),
+			quoteIdent(column),
+			quoteLiteral(view.ColumnComments[column]),
+		)
+		if _, err := tx.Exec(ctx, comment); err != nil {
+			return fmt.Errorf("comment on column %s: %w", column, err)
+		}
+	}
+
+	return nil
+}
+
+func dropView(ctx context.Context, tx dbTx, view viewKey) error {
+	drop := fmt.Sprintf("DROP VIEW IF EXISTS %s CASCADE", qualifiedViewName(view))
+	if _, err := tx.Exec(ctx, drop); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func sortedColumnNames(comments map[string]string) []string {
+	if len(comments) == 0 {
+		return nil
+	}
+
+	columns := make([]string, 0, len(comments))
+	for column := range comments {
+		columns = append(columns, column)
+	}
+	sort.Strings(columns)
+
+	return columns
+}
+
+func qualifiedViewName(view viewKey) string {
+	return fmt.Sprintf("%s.%s", quoteIdent(view.schema), quoteIdent(view.name))
 }
 
 // quoteIdent quotes a SQL identifier to prevent injection.

--- a/pkg/analytics/manager_test.go
+++ b/pkg/analytics/manager_test.go
@@ -1,11 +1,101 @@
 package analytics
 
 import (
+	"context"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/permission"
+	"github.com/jackc/pgx/v5/pgconn"
 )
+
+type fakeBeginner struct {
+	beginCalled bool
+	beginErr    error
+	tx          *fakeTx
+}
+
+func (f *fakeBeginner) Begin(ctx context.Context) (dbTx, error) {
+	f.beginCalled = true
+	if f.beginErr != nil {
+		return nil, f.beginErr
+	}
+
+	return f.tx, nil
+}
+
+type fakeTx struct {
+	querySQL  string
+	queryArgs []any
+	queryErr  error
+	rows      dbRows
+
+	executed  []string
+	execErr   error
+	committed bool
+}
+
+func (f *fakeTx) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	f.executed = append(f.executed, sql)
+	if f.execErr != nil {
+		return pgconn.NewCommandTag(""), f.execErr
+	}
+
+	return pgconn.NewCommandTag("EXEC"), nil
+}
+
+func (f *fakeTx) Query(ctx context.Context, sql string, args ...any) (dbRows, error) {
+	f.querySQL = sql
+	f.queryArgs = args
+	if f.queryErr != nil {
+		return nil, f.queryErr
+	}
+
+	if f.rows == nil {
+		return &fakeRows{}, nil
+	}
+
+	return f.rows, nil
+}
+
+func (f *fakeTx) Commit(ctx context.Context) error {
+	f.committed = true
+	return nil
+}
+
+func (f *fakeTx) Rollback(ctx context.Context) error {
+	return nil
+}
+
+type fakeRows struct {
+	values []viewKey
+	index  int
+	err    error
+}
+
+func (f *fakeRows) Next() bool {
+	if f.index >= len(f.values) {
+		return false
+	}
+
+	f.index++
+	return true
+}
+
+func (f *fakeRows) Scan(dest ...any) error {
+	current := f.values[f.index-1]
+	*(dest[0].(*string)) = current.schema
+	*(dest[1].(*string)) = current.name
+	return nil
+}
+
+func (f *fakeRows) Err() error {
+	return f.err
+}
+
+func (f *fakeRows) Close() {}
 
 func TestNewViewManager_DefaultSchema(t *testing.T) {
 	t.Parallel()
@@ -190,21 +280,37 @@ func TestSchema_ReturnsCorrectValue(t *testing.T) {
 	}
 }
 
-func TestSync_EmptyViews_ReturnsNil(t *testing.T) {
+func TestSync_EmptyManagerDropsManagedSchemaViews(t *testing.T) {
 	t.Parallel()
 
 	m := NewViewManager()
 
-	// Sync with no registered views should return nil (no-op)
-	// Note: We can't actually call Sync without a real database connection,
-	// but we can verify the early return logic by checking the Views slice
-	views := m.Views()
-	if len(views) != 0 {
-		t.Error("expected empty views for no-op Sync test")
+	tx := &fakeTx{
+		rows: &fakeRows{
+			values: []viewKey{
+				{schema: "analytics", name: "old_clients"},
+				{schema: "analytics", name: "old_policies"},
+			},
+		},
+	}
+	beginner := &fakeBeginner{tx: tx}
+
+	err := m.sync(context.Background(), beginner)
+	if err != nil {
+		t.Fatalf("expected sync to succeed, got error: %v", err)
 	}
 
-	// The actual Sync call would require a database connection,
-	// so we're only testing the precondition here
+	expectedSQL := []string{
+		`DROP VIEW IF EXISTS "analytics"."old_clients" CASCADE`,
+		`DROP VIEW IF EXISTS "analytics"."old_policies" CASCADE`,
+	}
+	if !reflect.DeepEqual(tx.executed, expectedSQL) {
+		t.Fatalf("unexpected executed SQL:\nexpected: %#v\ngot: %#v", expectedSQL, tx.executed)
+	}
+
+	if !tx.committed {
+		t.Fatal("expected sync transaction to commit")
+	}
 }
 
 func TestRegister_WithPermissions(t *testing.T) {
@@ -312,5 +418,92 @@ func TestColumnComment_AddsColumnComments(t *testing.T) {
 
 	if views[0].Description != "User table view" {
 		t.Errorf("expected view description to be preserved, got %q", views[0].Description)
+	}
+}
+
+func TestSync_ReconcilesStaleAndDesiredViews(t *testing.T) {
+	t.Parallel()
+
+	m := NewViewManager()
+	m.Register(View{
+		Name:        "kept_view",
+		SQL:         "SELECT 1 AS value",
+		Description: "View description",
+		ColumnComments: map[string]string{
+			"zeta":  "Last column",
+			"alpha": "First column",
+		},
+	})
+
+	tx := &fakeTx{
+		rows: &fakeRows{
+			values: []viewKey{
+				{schema: "analytics", name: "kept_view"},
+				{schema: "analytics", name: "stale_view"},
+			},
+		},
+	}
+	beginner := &fakeBeginner{tx: tx}
+
+	err := m.sync(context.Background(), beginner)
+	if err != nil {
+		t.Fatalf("expected sync to succeed, got error: %v", err)
+	}
+
+	if !strings.Contains(tx.querySQL, "information_schema.views") {
+		t.Fatalf("expected existing-view discovery query, got %q", tx.querySQL)
+	}
+
+	if len(tx.queryArgs) != 1 {
+		t.Fatalf("expected a single query argument, got %d", len(tx.queryArgs))
+	}
+
+	gotSchemas, ok := tx.queryArgs[0].([]string)
+	if !ok {
+		t.Fatalf("expected schemas query arg to be []string, got %T", tx.queryArgs[0])
+	}
+	if !reflect.DeepEqual(gotSchemas, []string{"analytics"}) {
+		t.Fatalf("unexpected managed schemas: %#v", gotSchemas)
+	}
+
+	expectedSQL := []string{
+		`DROP VIEW IF EXISTS "analytics"."stale_view" CASCADE`,
+		`DROP VIEW IF EXISTS "analytics"."kept_view" CASCADE`,
+		`CREATE VIEW "analytics"."kept_view" AS SELECT 1 AS value`,
+		`COMMENT ON VIEW "analytics"."kept_view" IS 'View description'`,
+		`COMMENT ON COLUMN "analytics"."kept_view"."alpha" IS 'First column'`,
+		`COMMENT ON COLUMN "analytics"."kept_view"."zeta" IS 'Last column'`,
+	}
+	if !reflect.DeepEqual(tx.executed, expectedSQL) {
+		t.Fatalf("unexpected executed SQL:\nexpected: %#v\ngot: %#v", expectedSQL, tx.executed)
+	}
+
+	if !tx.committed {
+		t.Fatal("expected sync transaction to commit")
+	}
+}
+
+func TestSync_DuplicateQualifiedViewReturnsError(t *testing.T) {
+	t.Parallel()
+
+	m := NewViewManager()
+	m.Register(
+		View{Name: "users", SQL: "SELECT 1"},
+		View{Name: "users", SQL: "SELECT 2"},
+	)
+
+	beginner := &fakeBeginner{tx: &fakeTx{}}
+
+	err := m.sync(context.Background(), beginner)
+	if err == nil {
+		t.Fatal("expected duplicate view sync to fail")
+	}
+
+	if !strings.Contains(err.Error(), `duplicate view definition for analytics.users`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if beginner.beginCalled {
+		t.Fatal("expected duplicate definition to fail before opening a transaction")
 	}
 }


### PR DESCRIPTION
## Summary
- reconcile managed analytics schemas against the database instead of only recreating registered views
- drop stale views that no longer exist in Go definitions before rebuilding the desired set
- add deterministic helper coverage for stale-view cleanup, duplicate detection, and comment ordering

## Testing
- go test ./pkg/analytics/...
- go test ./modules/bichat/... ./pkg/analytics/...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * View synchronization now validates configurations, rejecting empty or invalid schemas, names, and SQL definitions.
  * Automatically removes stale views that no longer exist in the configuration.
  * Improved error detection for invalid database connections and duplicate view definitions.

* **Refactor**
  * View synchronization operations now execute atomically within a single transaction for improved consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->