### PR TITLE
Guard optional CRUD showcase controller

### DIFF
--- a/modules/core/component.go
+++ b/modules/core/component.go
@@ -497,7 +497,9 @@ func (c *component) Build(builder *composition.Builder) error {
 				controllers.NewWebSocketController(app),
 				controllers.NewSettingsController(app, resolvedTenantService, resolvedUploadService),
 				controllers.NewSessionController(app, "/settings/sessions"),
-				controllers.NewCrudShowcaseController(app),
+			}
+			if ctrl := controllers.NewCrudShowcaseController(app); ctrl != nil {
+				controllersToRegister = append(controllersToRegister, ctrl)
 			}
 			if c.options.UploadsAuthorizer != nil || c.options.DefaultTenantID != uuid.Nil {
 				controllersToRegister = append(


### PR DESCRIPTION
## Summary
- avoid appending the production CRUD showcase stub when it returns nil
- match the existing `NewShowcaseController` handling in core

## Testing
- `go test ./modules/core/...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where invalid controller instances could cause registration failures. Controllers are now validated before being registered to the system, improving overall stability and preventing potential errors during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->