### PR TITLE
[codex] Fix logout session revocation

### DIFF
--- a/components/base/dropdown.templ
+++ b/components/base/dropdown.templ
@@ -1,5 +1,7 @@
 package base
 
+import "github.com/iota-uz/iota-sdk/pkg/composables"
+
 type DropdownItemProps struct {
 	Href string
 }
@@ -18,6 +20,29 @@ templ DropdownItem(props DropdownItemProps) {
 				{ children... }
 			</button>
 		}
+	</li>
+}
+
+type DropdownFormItemProps struct {
+	Action string
+	Method string
+}
+
+func normalizeDropdownFormMethod(method string) string {
+	if method == "" {
+		return "post"
+	}
+	return method
+}
+
+templ DropdownFormItem(props DropdownFormItemProps) {
+	<li>
+		<form action={ templ.SafeURL(props.Action) } method={ normalizeDropdownFormMethod(props.Method) }>
+			@composables.CSRFTokenField()
+			<button type="submit" class="block w-full p-2 text-left duration-200 hover:bg-surface-400 rounded-md">
+				{ children... }
+			</button>
+		</form>
 	</li>
 }
 

--- a/components/base/dropdown_templ.go
+++ b/components/base/dropdown_templ.go
@@ -8,6 +8,8 @@ package base
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
+import "github.com/iota-uz/iota-sdk/pkg/composables"
+
 type DropdownItemProps struct {
 	Href string
 }
@@ -81,6 +83,85 @@ func DropdownItem(props DropdownItemProps) templ.Component {
 	})
 }
 
+type DropdownFormItemProps struct {
+	Action string
+	Method string
+}
+
+func normalizeDropdownFormMethod(method string) string {
+	if method == "" {
+		return "post"
+	}
+	return method
+}
+
+func DropdownFormItem(props DropdownFormItemProps) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var3 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var3 == nil {
+			templ_7745c5c3_Var3 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<li><form action=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var4 templ.SafeURL = templ.SafeURL(props.Action)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var4)))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\" method=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var5 string
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(normalizeDropdownFormMethod(props.Method))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/dropdown.templ`, Line: 40, Col: 97}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = composables.CSRFTokenField().Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<button type=\"submit\" class=\"block w-full p-2 text-left duration-200 hover:bg-surface-400 rounded-md\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templ_7745c5c3_Var3.Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</button></form></li>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
 type DetailsDropdownProps struct {
 	Summary templ.Component
 	Classes templ.CSSClasses
@@ -109,30 +190,30 @@ func (p *DetailsDropdownProps) render() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var3 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var3 == nil {
-			templ_7745c5c3_Var3 = templ.NopComponent
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		var templ_7745c5c3_Var4 = []any{templ.Classes("relative", p.Classes)}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var4...)
+		var templ_7745c5c3_Var7 = []any{templ.Classes("relative", p.Classes)}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var7...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var5 string
-		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var4).String())
+		var templ_7745c5c3_Var8 string
+		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var7).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/dropdown.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\"><details class=\"relative z-10 peer\" name=\"details-dropdown\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\"><details class=\"relative z-10 peer\" name=\"details-dropdown\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -142,15 +223,15 @@ func (p *DetailsDropdownProps) render() templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<ul class=\"flex flex-col gap-1 mt-1 absolute bg-surface-300 right-0 text-sm rounded-md w-44 overflow-hidden shadow-sm border border-secondary p-1\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<ul class=\"flex flex-col gap-1 mt-1 absolute bg-surface-300 right-0 text-sm rounded-md w-44 overflow-hidden shadow-sm border border-secondary p-1\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templ_7745c5c3_Var3.Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = templ_7745c5c3_Var6.Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</ul></details><details class=\"hidden peer-open:block\" name=\"details-dropdown\"><summary class=\"fixed w-full h-full left-0 top-0\"></summary></details></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</ul></details><details class=\"hidden peer-open:block\" name=\"details-dropdown\"><summary class=\"fixed w-full h-full left-0 top-0\"></summary></details></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -174,12 +255,12 @@ func DetailsDropdown(props *DetailsDropdownProps) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var6 == nil {
-			templ_7745c5c3_Var6 = templ.NopComponent
+		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var9 == nil {
+			templ_7745c5c3_Var9 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Var7 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var10 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -191,13 +272,13 @@ func DetailsDropdown(props *DetailsDropdownProps) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templ_7745c5c3_Var6.Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = templ_7745c5c3_Var9.Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = newDetailsDropdown(props).render().Render(templ.WithChildren(ctx, templ_7745c5c3_Var7), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = newDetailsDropdown(props).render().Render(templ.WithChildren(ctx, templ_7745c5c3_Var10), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/e2e/fixtures/auth.ts
+++ b/e2e/fixtures/auth.ts
@@ -30,7 +30,13 @@ export async function login(page: Page, email: string, password: string, timeout
  * @param page - Playwright page object
  */
 export async function logout(page: Page) {
-	await page.goto('/logout', { waitUntil: 'domcontentloaded' });
+	await page.evaluate(() => {
+		const form = document.createElement('form');
+		form.method = 'POST';
+		form.action = '/logout';
+		document.body.appendChild(form);
+		form.submit();
+	});
 	await page.waitForURL((url) => url.pathname === '/login', { timeout: 10000 });
 	// Enforce a clean session boundary for subsequent login assertions.
 	await page.context().clearCookies();

--- a/modules/core/presentation/controllers/logout_controller.go
+++ b/modules/core/presentation/controllers/logout_controller.go
@@ -2,15 +2,17 @@
 package controllers
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
+	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence"
+	"github.com/iota-uz/iota-sdk/modules/core/services"
 	"github.com/iota-uz/iota-sdk/pkg/application"
 	"github.com/iota-uz/iota-sdk/pkg/configuration"
 	"github.com/iota-uz/iota-sdk/pkg/di"
 
 	"github.com/gorilla/mux"
-	"github.com/iota-uz/iota-sdk/modules/core/services"
 	"github.com/sirupsen/logrus"
 )
 
@@ -26,7 +28,13 @@ func (c *LogoutController) Key() string {
 }
 
 func (c *LogoutController) Register(r *mux.Router) {
-	r.HandleFunc("/logout", di.H(c.Logout)).Methods(http.MethodGet)
+	r.HandleFunc("/logout", di.H(c.Logout)).Methods(http.MethodPost)
+	r.HandleFunc("/logout", c.MethodNotAllowed).Methods(http.MethodGet)
+}
+
+func (c *LogoutController) MethodNotAllowed(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Allow", http.MethodPost)
+	http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 }
 
 func (c *LogoutController) Logout(
@@ -38,7 +46,7 @@ func (c *LogoutController) Logout(
 	conf := configuration.Use()
 
 	if cookie, err := r.Cookie(conf.SidCookieKey); err == nil && cookie.Value != "" {
-		if err := sessionService.Delete(r.Context(), cookie.Value); err != nil {
+		if err := sessionService.Delete(r.Context(), cookie.Value); err != nil && !errors.Is(err, persistence.ErrSessionNotFound) {
 			logger.WithError(err).Warn("failed to delete session on logout")
 		}
 	}

--- a/modules/core/presentation/controllers/logout_controller.go
+++ b/modules/core/presentation/controllers/logout_controller.go
@@ -3,11 +3,15 @@ package controllers
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/iota-uz/iota-sdk/pkg/application"
 	"github.com/iota-uz/iota-sdk/pkg/configuration"
+	"github.com/iota-uz/iota-sdk/pkg/di"
 
 	"github.com/gorilla/mux"
+	"github.com/iota-uz/iota-sdk/modules/core/services"
+	"github.com/sirupsen/logrus"
 )
 
 type LogoutController struct {
@@ -22,17 +26,41 @@ func (c *LogoutController) Key() string {
 }
 
 func (c *LogoutController) Register(r *mux.Router) {
-	r.HandleFunc("/logout", c.Logout).Methods(http.MethodGet)
+	r.HandleFunc("/logout", di.H(c.Logout)).Methods(http.MethodGet)
 }
 
-func (c *LogoutController) Logout(w http.ResponseWriter, r *http.Request) {
+func (c *LogoutController) Logout(
+	w http.ResponseWriter,
+	r *http.Request,
+	sessionService *services.SessionService,
+	logger *logrus.Entry,
+) {
 	conf := configuration.Use()
+
+	if cookie, err := r.Cookie(conf.SidCookieKey); err == nil && cookie.Value != "" {
+		if err := sessionService.Delete(r.Context(), cookie.Value); err != nil {
+			logger.WithError(err).Warn("failed to delete session on logout")
+		}
+	}
+
 	http.SetCookie(
 		w, &http.Cookie{
-			Name:   conf.SidCookieKey,
-			Value:  "",
-			MaxAge: -1,
+			Name:     conf.SidCookieKey,
+			Value:    "",
+			Domain:   conf.Domain,
+			Path:     "/",
+			MaxAge:   -1,
+			Expires:  time.Unix(0, 0),
+			HttpOnly: true,
+			SameSite: http.SameSiteLaxMode,
+			Secure:   conf.GoAppEnvironment == configuration.Production,
 		},
 	)
+
+	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, private")
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("Expires", "0")
+	w.Header().Set("Clear-Site-Data", `"cache", "cookies", "storage"`)
+
 	http.Redirect(w, r, "/login", http.StatusSeeOther)
 }

--- a/modules/core/presentation/controllers/logout_controller_test.go
+++ b/modules/core/presentation/controllers/logout_controller_test.go
@@ -53,7 +53,7 @@ func TestLogoutController_DeletesSessionAndClearsBrowserState(t *testing.T) {
 
 	deletedCookie := response.Cookies()[0]
 	require.Equal(t, config.SidCookieKey, deletedCookie.Name)
-	require.Equal(t, "", deletedCookie.Value)
+	require.Empty(t, deletedCookie.Value)
 	require.Equal(t, config.Domain, deletedCookie.Domain)
 	require.Equal(t, "/", deletedCookie.Path)
 	require.Equal(t, -1, deletedCookie.MaxAge)

--- a/modules/core/presentation/controllers/logout_controller_test.go
+++ b/modules/core/presentation/controllers/logout_controller_test.go
@@ -1,0 +1,66 @@
+package controllers_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/iota-uz/iota-sdk/modules/core"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/session"
+	"github.com/iota-uz/iota-sdk/modules/core/presentation/controllers"
+	"github.com/iota-uz/iota-sdk/modules/core/services"
+	"github.com/iota-uz/iota-sdk/pkg/configuration"
+	"github.com/iota-uz/iota-sdk/pkg/defaults"
+	"github.com/iota-uz/iota-sdk/pkg/itf"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogoutController_DeletesSessionAndClearsBrowserState(t *testing.T) {
+	t.Parallel()
+
+	suite := itf.NewSuiteBuilder(t).WithComponents(core.NewComponent(&core.ModuleOptions{
+		PermissionSchema: defaults.PermissionSchema(),
+	})).AsUser().Build()
+
+	persistTestUser(t, suite.Env())
+
+	controller := controllers.NewLogoutController()
+	suite.Register(controller)
+
+	config := configuration.Use()
+	token := "logout-test-session-token"
+	sessionService := itf.GetService[services.SessionService](suite.Env())
+
+	err := sessionService.Create(suite.Env().Ctx, &session.CreateDTO{
+		UserID:    suite.Env().User.ID(),
+		TenantID:  suite.Env().Tenant.ID,
+		IP:        "127.0.0.1",
+		UserAgent: "logout-test-agent",
+		Token:     token,
+	})
+	require.NoError(t, err)
+
+	response := suite.GET("/logout").
+		Cookie(config.SidCookieKey, token).
+		Expect(t).
+		Status(http.StatusSeeOther).
+		RedirectTo("/login")
+
+	require.Equal(t, "no-store, no-cache, must-revalidate, private", response.Header("Cache-Control"))
+	require.Equal(t, "no-cache", response.Header("Pragma"))
+	require.Equal(t, "0", response.Header("Expires"))
+	require.Equal(t, `"cache", "cookies", "storage"`, response.Header("Clear-Site-Data"))
+
+	deletedCookie := response.Cookies()[0]
+	require.Equal(t, config.SidCookieKey, deletedCookie.Name)
+	require.Equal(t, "", deletedCookie.Value)
+	require.Equal(t, config.Domain, deletedCookie.Domain)
+	require.Equal(t, "/", deletedCookie.Path)
+	require.Equal(t, -1, deletedCookie.MaxAge)
+	require.True(t, deletedCookie.HttpOnly)
+	require.Equal(t, http.SameSiteLaxMode, deletedCookie.SameSite)
+	require.WithinDuration(t, time.Unix(0, 0), deletedCookie.Expires, time.Second)
+
+	_, err = sessionService.GetByToken(suite.Env().Ctx, token)
+	require.Error(t, err)
+}

--- a/modules/core/presentation/controllers/logout_controller_test.go
+++ b/modules/core/presentation/controllers/logout_controller_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/iota-uz/iota-sdk/modules/core"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/session"
+	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence"
 	"github.com/iota-uz/iota-sdk/modules/core/presentation/controllers"
 	"github.com/iota-uz/iota-sdk/modules/core/services"
 	"github.com/iota-uz/iota-sdk/pkg/configuration"
@@ -15,52 +16,97 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestLogoutController_DeletesSessionAndClearsBrowserState(t *testing.T) {
+func TestLogoutController_Scenarios(t *testing.T) {
 	t.Parallel()
 
-	suite := itf.NewSuiteBuilder(t).WithComponents(core.NewComponent(&core.ModuleOptions{
-		PermissionSchema: defaults.PermissionSchema(),
-	})).AsUser().Build()
+	testCases := []struct {
+		name string
+		run  func(t *testing.T, suite *itf.Suite, config *configuration.Configuration, sessionService *services.SessionService)
+	}{
+		{
+			name: "post deletes session and clears browser state",
+			run: func(t *testing.T, suite *itf.Suite, config *configuration.Configuration, sessionService *services.SessionService) {
+				t.Helper()
 
-	persistTestUser(t, suite.Env())
+				token := "logout-test-session-token"
 
-	controller := controllers.NewLogoutController()
-	suite.Register(controller)
+				err := sessionService.Create(suite.Env().Ctx, &session.CreateDTO{
+					UserID:    suite.Env().User.ID(),
+					TenantID:  suite.Env().Tenant.ID,
+					IP:        "127.0.0.1",
+					UserAgent: "logout-test-agent",
+					Token:     token,
+				})
+				require.NoError(t, err)
 
-	config := configuration.Use()
-	token := "logout-test-session-token"
-	sessionService := itf.GetService[services.SessionService](suite.Env())
+				response := suite.POST("/logout").
+					Cookie(config.SidCookieKey, token).
+					Expect(t).
+					Status(http.StatusSeeOther).
+					RedirectTo("/login")
 
-	err := sessionService.Create(suite.Env().Ctx, &session.CreateDTO{
-		UserID:    suite.Env().User.ID(),
-		TenantID:  suite.Env().Tenant.ID,
-		IP:        "127.0.0.1",
-		UserAgent: "logout-test-agent",
-		Token:     token,
-	})
-	require.NoError(t, err)
+				require.Equal(t, "no-store, no-cache, must-revalidate, private", response.Header("Cache-Control"))
+				require.Equal(t, "no-cache", response.Header("Pragma"))
+				require.Equal(t, "0", response.Header("Expires"))
+				require.Equal(t, `"cache", "cookies", "storage"`, response.Header("Clear-Site-Data"))
 
-	response := suite.GET("/logout").
-		Cookie(config.SidCookieKey, token).
-		Expect(t).
-		Status(http.StatusSeeOther).
-		RedirectTo("/login")
+				cookies := response.Cookies()
+				require.NotEmpty(t, cookies, "expected at least one Set-Cookie header")
 
-	require.Equal(t, "no-store, no-cache, must-revalidate, private", response.Header("Cache-Control"))
-	require.Equal(t, "no-cache", response.Header("Pragma"))
-	require.Equal(t, "0", response.Header("Expires"))
-	require.Equal(t, `"cache", "cookies", "storage"`, response.Header("Clear-Site-Data"))
+				var deletedCookie *http.Cookie
+				for _, cookie := range cookies {
+					if cookie.Name == config.SidCookieKey {
+						deletedCookie = cookie
+						break
+					}
+				}
 
-	deletedCookie := response.Cookies()[0]
-	require.Equal(t, config.SidCookieKey, deletedCookie.Name)
-	require.Empty(t, deletedCookie.Value)
-	require.Equal(t, config.Domain, deletedCookie.Domain)
-	require.Equal(t, "/", deletedCookie.Path)
-	require.Equal(t, -1, deletedCookie.MaxAge)
-	require.True(t, deletedCookie.HttpOnly)
-	require.Equal(t, http.SameSiteLaxMode, deletedCookie.SameSite)
-	require.WithinDuration(t, time.Unix(0, 0), deletedCookie.Expires, time.Second)
+				require.NotNil(t, deletedCookie, "expected cleared session cookie to be present")
+				require.Empty(t, deletedCookie.Value)
+				require.Equal(t, config.SidCookieKey, deletedCookie.Name)
+				require.Equal(t, config.Domain, deletedCookie.Domain)
+				require.Equal(t, "/", deletedCookie.Path)
+				require.Equal(t, -1, deletedCookie.MaxAge)
+				require.True(t, deletedCookie.HttpOnly)
+				require.Equal(t, config.GoAppEnvironment == configuration.Production, deletedCookie.Secure)
+				require.Equal(t, http.SameSiteLaxMode, deletedCookie.SameSite)
+				require.WithinDuration(t, time.Unix(0, 0), deletedCookie.Expires, time.Second)
 
-	_, err = sessionService.GetByToken(suite.Env().Ctx, token)
-	require.Error(t, err)
+				_, err = sessionService.GetByToken(suite.Env().Ctx, token)
+				require.ErrorIs(t, err, persistence.ErrSessionNotFound)
+			},
+		},
+		{
+			name: "get returns method not allowed",
+			run: func(t *testing.T, suite *itf.Suite, _ *configuration.Configuration, _ *services.SessionService) {
+				t.Helper()
+
+				response := suite.GET("/logout").
+					Expect(t).
+					Status(http.StatusMethodNotAllowed)
+
+				require.Equal(t, http.MethodPost, response.Header("Allow"))
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			suite := itf.NewSuiteBuilder(t).WithComponents(core.NewComponent(&core.ModuleOptions{
+				PermissionSchema: defaults.PermissionSchema(),
+			})).AsUser().Build()
+
+			persistTestUser(t, suite.Env())
+
+			controller := controllers.NewLogoutController()
+			suite.Register(controller)
+
+			config := configuration.Use()
+			sessionService := itf.GetService[services.SessionService](suite.Env())
+
+			tc.run(t, suite, config, sessionService)
+		})
+	}
 }

--- a/modules/core/presentation/templates/layouts/authenticated.templ
+++ b/modules/core/presentation/templates/layouts/authenticated.templ
@@ -153,7 +153,7 @@ templ Navbar(pageCtx types.PageContext, navbarLeft templ.Component) {
 				@base.DropdownItem(base.DropdownItemProps{Href: "/settings"}) {
 					{ pageCtx.T("NavigationLinks.Navbar.Settings") }
 				}
-				@base.DropdownItem(base.DropdownItemProps{Href: "/logout"}) {
+				@base.DropdownFormItem(base.DropdownFormItemProps{Action: "/logout", Method: "post"}) {
 					{ pageCtx.T("NavigationLinks.Navbar.Logout") }
 				}
 			}

--- a/modules/core/presentation/templates/layouts/authenticated_templ.go
+++ b/modules/core/presentation/templates/layouts/authenticated_templ.go
@@ -391,7 +391,7 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 				}
 				return nil
 			})
-			templ_7745c5c3_Err = base.DropdownItem(base.DropdownItemProps{Href: "/logout"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var15), templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = base.DropdownFormItem(base.DropdownFormItemProps{Action: "/logout", Method: "post"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var15), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}


### PR DESCRIPTION
## Summary
- revoke the server-side session during `/logout` before redirecting
- expire the session cookie with the same browser-facing attributes used at login
- send no-store and clear-site-data headers so browser navigation does not replay stale authenticated state
- add a controller regression test covering session deletion, redirect, headers, and cookie clearing

## Root Cause
The SDK logout controller only cleared the SID cookie and redirected. It did not delete the backing session row, and it did not clear the cookie with the same domain/path attributes used when the cookie was created. That left the session reusable after logout and allowed stale browser state to survive navigation.

## Validation
- `go test ./modules/core/presentation/controllers -count=1`
- `go vet ./modules/core/presentation/controllers`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced logout flow to remove server-side sessions and redirect users to the login page.
  * Clears client state by setting cache-control headers and Clear-Site-Data on logout.
  * Improved cookie clearing with explicit domain, path, expiration, HttpOnly, SameSite Lax, and secure handling.

* **Tests**
  * Added end-to-end test validating session deletion, response headers, cookie clearing, and redirect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->