### PR TITLE
refactor: split settings controller ownership

### DIFF
--- a/modules/core/component.go
+++ b/modules/core/component.go
@@ -260,7 +260,8 @@ func (c *component) Build(builder *composition.Builder) error {
 					}),
 					controllers.NewGroupsController(app, groupService),
 					controllers.NewWebSocketController(app),
-					controllers.NewSettingsController(tenantService, uploadService),
+					controllers.NewSettingsHubController(),
+					controllers.NewSettingsLogoController(tenantService, uploadService),
 					controllers.NewSessionController("/settings/sessions"),
 				)
 				// NewCrudShowcaseController returns nil in the `!dev` build so

--- a/modules/core/presentation/controllers/settings_controller.go
+++ b/modules/core/presentation/controllers/settings_controller.go
@@ -20,28 +20,19 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/middleware"
 )
 
-type SettingsController struct {
-	tenantService *services.TenantService
-	uploadService *services.UploadService
-	basePath      string
+type SettingsHubController struct {
+	basePath string
 }
 
-func NewSettingsController(
-	tenantService *services.TenantService,
-	uploadService *services.UploadService,
-) application.Controller {
-	return &SettingsController{
-		tenantService: tenantService,
-		uploadService: uploadService,
-		basePath:      "/settings",
-	}
+func NewSettingsHubController() application.Controller {
+	return &SettingsHubController{basePath: "/settings"}
 }
 
-func (c *SettingsController) Key() string {
+func (c *SettingsHubController) Key() string {
 	return c.basePath
 }
 
-func (c *SettingsController) Register(r *mux.Router) {
+func (c *SettingsHubController) Register(r *mux.Router) {
 	router := r.PathPrefix(c.basePath).Subrouter()
 	router.Use(
 		middleware.Authorize(),
@@ -52,15 +43,48 @@ func (c *SettingsController) Register(r *mux.Router) {
 		middleware.WithPageContext(),
 	)
 	router.HandleFunc("", c.GetHub).Methods(http.MethodGet)
-	router.HandleFunc("/logo", c.GetLogo).Methods(http.MethodGet)
-	router.HandleFunc("/logo", c.PostLogo).Methods(http.MethodPost)
 }
 
-func (c *SettingsController) GetHub(w http.ResponseWriter, r *http.Request) {
+func (c *SettingsHubController) GetHub(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, c.basePath+"/logo", http.StatusFound)
 }
 
-func (c *SettingsController) GetLogo(w http.ResponseWriter, r *http.Request) {
+type SettingsLogoController struct {
+	tenantService *services.TenantService
+	uploadService *services.UploadService
+	basePath      string
+}
+
+func NewSettingsLogoController(
+	tenantService *services.TenantService,
+	uploadService *services.UploadService,
+) application.Controller {
+	return &SettingsLogoController{
+		tenantService: tenantService,
+		uploadService: uploadService,
+		basePath:      "/settings/logo",
+	}
+}
+
+func (c *SettingsLogoController) Key() string {
+	return c.basePath
+}
+
+func (c *SettingsLogoController) Register(r *mux.Router) {
+	router := r.PathPrefix(c.basePath).Subrouter()
+	router.Use(
+		middleware.Authorize(),
+		middleware.RedirectNotAuthenticated(),
+		middleware.ProvideUser(),
+		middleware.ProvideDynamicLogo(),
+		middleware.NavItems(),
+		middleware.WithPageContext(),
+	)
+	router.HandleFunc("", c.GetLogo).Methods(http.MethodGet)
+	router.HandleFunc("", c.PostLogo).Methods(http.MethodPost)
+}
+
+func (c *SettingsLogoController) GetLogo(w http.ResponseWriter, r *http.Request) {
 	props, err := c.logoProps(r, nil, nil)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -69,7 +93,7 @@ func (c *SettingsController) GetLogo(w http.ResponseWriter, r *http.Request) {
 	templ.Handler(settings.Logo(props)).ServeHTTP(w, r)
 }
 
-func (c *SettingsController) PostLogo(w http.ResponseWriter, r *http.Request) {
+func (c *SettingsLogoController) PostLogo(w http.ResponseWriter, r *http.Request) {
 	logger := composables.UseLogger(r.Context())
 
 	dto, err := composables.UseForm(&dtos.SaveLogosDTO{}, r)
@@ -105,7 +129,6 @@ func (c *SettingsController) PostLogo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if dto.LogoID > 0 {
-		// Validate that the upload exists before setting it
 		exists, err := c.uploadService.Exists(r.Context(), uint(dto.LogoID))
 		if err != nil {
 			logger.WithError(err).Error("failed to check logo upload existence")
@@ -121,7 +144,6 @@ func (c *SettingsController) PostLogo(w http.ResponseWriter, r *http.Request) {
 		tenant = tenant.SetLogoID(&logoID)
 	}
 	if dto.LogoCompactID > 0 {
-		// Validate that the upload exists before setting it
 		exists, err := c.uploadService.Exists(r.Context(), uint(dto.LogoCompactID))
 		if err != nil {
 			logger.WithError(err).Error("failed to check compact logo upload existence")
@@ -137,7 +159,6 @@ func (c *SettingsController) PostLogo(w http.ResponseWriter, r *http.Request) {
 		tenant = tenant.SetLogoCompactID(&logoCompactID)
 	}
 
-	// Handle phone number update
 	if dto.Phone != "" {
 		parsedPhone, err := phone.NewFromE164(dto.Phone)
 		if err != nil {
@@ -153,11 +174,9 @@ func (c *SettingsController) PostLogo(w http.ResponseWriter, r *http.Request) {
 		}
 		tenant = tenant.SetPhone(parsedPhone)
 	} else {
-		// Clear phone if empty
 		tenant = tenant.SetPhone(nil)
 	}
 
-	// Handle email update
 	if dto.Email != "" {
 		parsedEmail, err := internet.NewEmail(dto.Email)
 		if err != nil {
@@ -173,7 +192,6 @@ func (c *SettingsController) PostLogo(w http.ResponseWriter, r *http.Request) {
 		}
 		tenant = tenant.SetEmail(parsedEmail)
 	} else {
-		// Clear email if empty
 		tenant = tenant.SetEmail(nil)
 	}
 
@@ -192,7 +210,7 @@ func (c *SettingsController) PostLogo(w http.ResponseWriter, r *http.Request) {
 	templ.Handler(settings.LogoForm(props)).ServeHTTP(w, r)
 }
 
-func (c *SettingsController) logoProps(r *http.Request, errors map[string]string, tenant tenant.Tenant) (*settings.LogoPageProps, error) {
+func (c *SettingsLogoController) logoProps(r *http.Request, errors map[string]string, tenant tenant.Tenant) (*settings.LogoPageProps, error) {
 	nonNilErrors := make(map[string]string)
 	if errors != nil {
 		nonNilErrors = errors
@@ -227,7 +245,6 @@ func (c *SettingsController) logoProps(r *http.Request, errors map[string]string
 		}
 	}
 
-	// Get phone and email values
 	phoneValue := ""
 	if tenant.Phone() != nil {
 		phoneValue = tenant.Phone().E164()
@@ -239,7 +256,7 @@ func (c *SettingsController) logoProps(r *http.Request, errors map[string]string
 	}
 
 	props := &settings.LogoPageProps{
-		PostPath:          c.basePath + "/logo",
+		PostPath:          c.basePath,
 		LogoUpload:        logoUpload,
 		LogoCompactUpload: logoCompactUpload,
 		Phone:             phoneValue,

--- a/modules/core/presentation/controllers/settings_controller_test.go
+++ b/modules/core/presentation/controllers/settings_controller_test.go
@@ -31,7 +31,7 @@ import (
 // 1x1 transparent PNG
 const PngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
 
-func setupSettingsControllerTest(t *testing.T) (*itf.Suite, *services.TenantService, *services.UploadService) {
+func setupSettingsLogoControllerTest(t *testing.T) (*itf.Suite, *services.TenantService, *services.UploadService) {
 	t.Helper()
 	suite := itf.NewSuiteBuilder(t).WithComponents(core.NewComponent(&core.ModuleOptions{
 		PermissionSchema: &rbac.PermissionSchema{Sets: []rbac.PermissionSet{}},
@@ -56,14 +56,39 @@ func setupSettingsControllerTest(t *testing.T) (*itf.Suite, *services.TenantServ
 	tenantService := itf.GetService[services.TenantService](suite.Environment())
 	uploadService := itf.GetService[services.UploadService](suite.Environment())
 
-	controller := controllers.NewSettingsController(tenantService, uploadService)
+	controller := controllers.NewSettingsLogoController(tenantService, uploadService)
 	suite.Register(controller)
 
 	return suite, tenantService, uploadService
 }
 
-func TestSettingsController_GetLogo(t *testing.T) {
-	suite, tenantService, uploadService := setupSettingsControllerTest(t)
+func TestSettingsHubController_GetHub(t *testing.T) {
+	suite := itf.NewSuiteBuilder(t).WithComponents(core.NewComponent(&core.ModuleOptions{
+		PermissionSchema: &rbac.PermissionSchema{Sets: []rbac.PermissionSet{}},
+	}), finance.NewComponent()).Build().
+		AsUser(user.New("Test", "User", internet.MustParseEmail("test@example.com"), user.UILanguageEN))
+
+	suite.WithMiddleware(func(ctx context.Context, r *http.Request) context.Context {
+		props := sidebar.Props{
+			TabGroups: sidebar.TabGroupCollection{
+				Groups: []sidebar.TabGroup{{
+					Label: "Core",
+					Value: "core",
+					Items: []sidebar.Item{},
+				}},
+			},
+		}
+		return context.WithValue(ctx, constants.SidebarPropsKey, props)
+	})
+
+	suite.Register(controllers.NewSettingsHubController())
+
+	resp := suite.GET("/settings").Expect(t).Status(http.StatusFound)
+	assert.Equal(t, "/settings/logo", resp.Header("Location"))
+}
+
+func TestSettingsLogoController_GetLogo(t *testing.T) {
+	suite, tenantService, uploadService := setupSettingsLogoControllerTest(t)
 
 	// Create a test tenant
 	testTenant, err := tenantService.Create(suite.Environment().Ctx, "Test Tenant", "test.com")
@@ -106,8 +131,8 @@ func TestSettingsController_GetLogo(t *testing.T) {
 	resp.Contains(logoCompactUpload.Path())
 }
 
-func TestSettingsController_PostLogo_Success(t *testing.T) {
-	suite, tenantService, uploadService := setupSettingsControllerTest(t)
+func TestSettingsLogoController_PostLogo_Success(t *testing.T) {
+	suite, tenantService, uploadService := setupSettingsLogoControllerTest(t)
 
 	// Create a test tenant
 	testTenant, err := tenantService.Create(suite.Environment().Ctx, "Test Tenant", "test.com")
@@ -155,8 +180,8 @@ func TestSettingsController_PostLogo_Success(t *testing.T) {
 	assert.Equal(t, int(newLogoCompactUpload.ID()), *updatedTenant.LogoCompactID())
 }
 
-func TestSettingsController_PostLogo_ValidationError(t *testing.T) {
-	suite, tenantService, _ := setupSettingsControllerTest(t)
+func TestSettingsLogoController_PostLogo_ValidationError(t *testing.T) {
+	suite, tenantService, _ := setupSettingsLogoControllerTest(t)
 
 	// Create a test tenant
 	testTenant, err := tenantService.Create(suite.Environment().Ctx, "Test Tenant", "test.com")
@@ -183,8 +208,8 @@ func TestSettingsController_PostLogo_ValidationError(t *testing.T) {
 	assert.Nil(t, updatedTenant.LogoID())
 }
 
-func TestSettingsController_PostLogo_FileUpload(t *testing.T) {
-	suite, tenantService, uploadService := setupSettingsControllerTest(t)
+func TestSettingsLogoController_PostLogo_FileUpload(t *testing.T) {
+	suite, tenantService, uploadService := setupSettingsLogoControllerTest(t)
 
 	// Create a test tenant
 	testTenant, err := tenantService.Create(suite.Environment().Ctx, "Test Tenant", "test.com")
@@ -228,8 +253,8 @@ func TestSettingsController_PostLogo_FileUpload(t *testing.T) {
 }
 
 // Edge case tests for potential 500 errors
-func TestSettingsController_PostLogo_NonExistentUploadID(t *testing.T) {
-	suite, tenantService, _ := setupSettingsControllerTest(t)
+func TestSettingsLogoController_PostLogo_NonExistentUploadID(t *testing.T) {
+	suite, tenantService, _ := setupSettingsLogoControllerTest(t)
 
 	// Create a test tenant
 	testTenant, err := tenantService.Create(suite.Environment().Ctx, "Test Tenant", "test.com")
@@ -259,8 +284,8 @@ func TestSettingsController_PostLogo_NonExistentUploadID(t *testing.T) {
 	assert.Nil(t, updatedTenant.LogoID())
 }
 
-func TestSettingsController_PostLogo_ZeroValues(t *testing.T) {
-	suite, tenantService, _ := setupSettingsControllerTest(t)
+func TestSettingsLogoController_PostLogo_ZeroValues(t *testing.T) {
+	suite, tenantService, _ := setupSettingsLogoControllerTest(t)
 
 	// Create a test tenant
 	testTenant, err := tenantService.Create(suite.Environment().Ctx, "Test Tenant", "test.com")
@@ -288,8 +313,8 @@ func TestSettingsController_PostLogo_ZeroValues(t *testing.T) {
 	assert.Nil(t, updatedTenant.LogoCompactID())
 }
 
-func TestSettingsController_PostLogo_WithExistingLogos(t *testing.T) {
-	suite, tenantService, uploadService := setupSettingsControllerTest(t)
+func TestSettingsLogoController_PostLogo_WithExistingLogos(t *testing.T) {
+	suite, tenantService, uploadService := setupSettingsLogoControllerTest(t)
 
 	// Create a test tenant
 	testTenant, err := tenantService.Create(suite.Environment().Ctx, "Test Tenant", "test.com")
@@ -351,8 +376,8 @@ func TestSettingsController_PostLogo_WithExistingLogos(t *testing.T) {
 	assert.Equal(t, existingCompactLogoID, *updatedTenant.LogoCompactID()) // Should remain unchanged
 }
 
-func TestSettingsController_PostLogo_ExtremelyLargeValues(t *testing.T) {
-	suite, tenantService, _ := setupSettingsControllerTest(t)
+func TestSettingsLogoController_PostLogo_ExtremelyLargeValues(t *testing.T) {
+	suite, tenantService, _ := setupSettingsLogoControllerTest(t)
 
 	// Create a test tenant
 	testTenant, err := tenantService.Create(suite.Environment().Ctx, "Test Tenant", "test.com")
@@ -382,8 +407,8 @@ func TestSettingsController_PostLogo_ExtremelyLargeValues(t *testing.T) {
 	assert.Nil(t, updatedTenant.LogoID())
 }
 
-func TestSettingsController_PostLogo_EmptyForm(t *testing.T) {
-	suite, tenantService, _ := setupSettingsControllerTest(t)
+func TestSettingsLogoController_PostLogo_EmptyForm(t *testing.T) {
+	suite, tenantService, _ := setupSettingsLogoControllerTest(t)
 
 	// Create a test tenant
 	testTenant, err := tenantService.Create(suite.Environment().Ctx, "Test Tenant", "test.com")
@@ -408,8 +433,8 @@ func TestSettingsController_PostLogo_EmptyForm(t *testing.T) {
 	assert.Nil(t, updatedTenant.LogoCompactID())
 }
 
-func TestSettingsController_PostLogo_MalformedContentType(t *testing.T) {
-	suite, tenantService, _ := setupSettingsControllerTest(t)
+func TestSettingsLogoController_PostLogo_MalformedContentType(t *testing.T) {
+	suite, tenantService, _ := setupSettingsLogoControllerTest(t)
 
 	// Create a test tenant
 	testTenant, err := tenantService.Create(suite.Environment().Ctx, "Test Tenant", "test.com")
@@ -433,8 +458,8 @@ func TestSettingsController_PostLogo_MalformedContentType(t *testing.T) {
 	assert.Nil(t, updatedTenant.LogoID())
 }
 
-func TestSettingsController_GetLogo_WithNonExistentUploads(t *testing.T) {
-	suite, tenantService, uploadService := setupSettingsControllerTest(t)
+func TestSettingsLogoController_GetLogo_WithNonExistentUploads(t *testing.T) {
+	suite, tenantService, uploadService := setupSettingsLogoControllerTest(t)
 
 	// Create a test tenant
 	testTenant, err := tenantService.Create(suite.Environment().Ctx, "Test Tenant", "test.com")
@@ -474,8 +499,8 @@ func TestSettingsController_GetLogo_WithNonExistentUploads(t *testing.T) {
 
 // Test cases for phone and email functionality
 
-func TestSettingsController_PostLogo_WithPhoneAndEmail(t *testing.T) {
-	suite, tenantService, uploadService := setupSettingsControllerTest(t)
+func TestSettingsLogoController_PostLogo_WithPhoneAndEmail(t *testing.T) {
+	suite, tenantService, uploadService := setupSettingsLogoControllerTest(t)
 
 	// Create a test tenant
 	testTenant, err := tenantService.Create(suite.Environment().Ctx, "Test Tenant", "test.com")
@@ -518,8 +543,8 @@ func TestSettingsController_PostLogo_WithPhoneAndEmail(t *testing.T) {
 	assert.Equal(t, "test@company.com", updatedTenant.Email().Value())
 }
 
-func TestSettingsController_PostLogo_PhoneValidation(t *testing.T) {
-	suite, tenantService, _ := setupSettingsControllerTest(t)
+func TestSettingsLogoController_PostLogo_PhoneValidation(t *testing.T) {
+	suite, tenantService, _ := setupSettingsLogoControllerTest(t)
 
 	// Create a test tenant
 	testTenant, err := tenantService.Create(suite.Environment().Ctx, "Test Tenant", "test.com")
@@ -599,8 +624,8 @@ func TestSettingsController_PostLogo_PhoneValidation(t *testing.T) {
 	}
 }
 
-func TestSettingsController_PostLogo_EmailValidation(t *testing.T) {
-	suite, tenantService, _ := setupSettingsControllerTest(t)
+func TestSettingsLogoController_PostLogo_EmailValidation(t *testing.T) {
+	suite, tenantService, _ := setupSettingsLogoControllerTest(t)
 
 	// Create a test tenant
 	testTenant, err := tenantService.Create(suite.Environment().Ctx, "Test Tenant", "test.com")
@@ -656,8 +681,8 @@ func TestSettingsController_PostLogo_EmailValidation(t *testing.T) {
 	// the controller's internet.NewEmail() function which validates email structure.
 }
 
-func TestSettingsController_PostLogo_PhoneOnlyUpdate(t *testing.T) {
-	suite, tenantService, _ := setupSettingsControllerTest(t)
+func TestSettingsLogoController_PostLogo_PhoneOnlyUpdate(t *testing.T) {
+	suite, tenantService, _ := setupSettingsLogoControllerTest(t)
 
 	// Create a test tenant with existing email
 	testTenant, err := tenantService.Create(suite.Environment().Ctx, "Test Tenant", "test.com")
@@ -692,8 +717,8 @@ func TestSettingsController_PostLogo_PhoneOnlyUpdate(t *testing.T) {
 	assert.Nil(t, updatedTenant.Email()) // Should be cleared
 }
 
-func TestSettingsController_PostLogo_EmailOnlyUpdate(t *testing.T) {
-	suite, tenantService, _ := setupSettingsControllerTest(t)
+func TestSettingsLogoController_PostLogo_EmailOnlyUpdate(t *testing.T) {
+	suite, tenantService, _ := setupSettingsLogoControllerTest(t)
 
 	// Create a test tenant with existing phone
 	testTenant, err := tenantService.Create(suite.Environment().Ctx, "Test Tenant", "test.com")
@@ -728,8 +753,8 @@ func TestSettingsController_PostLogo_EmailOnlyUpdate(t *testing.T) {
 	assert.Nil(t, updatedTenant.Phone()) // Should be cleared
 }
 
-func TestSettingsController_PostLogo_ClearPhoneAndEmail(t *testing.T) {
-	suite, tenantService, uploadService := setupSettingsControllerTest(t)
+func TestSettingsLogoController_PostLogo_ClearPhoneAndEmail(t *testing.T) {
+	suite, tenantService, uploadService := setupSettingsLogoControllerTest(t)
 
 	// Create a test tenant with existing phone and email
 	testTenant, err := tenantService.Create(suite.Environment().Ctx, "Test Tenant", "test.com")
@@ -778,8 +803,8 @@ func TestSettingsController_PostLogo_ClearPhoneAndEmail(t *testing.T) {
 	assert.Nil(t, updatedTenant.Email())                           // Email should be cleared
 }
 
-func TestSettingsController_GetLogo_WithPhoneAndEmail(t *testing.T) {
-	suite, tenantService, uploadService := setupSettingsControllerTest(t)
+func TestSettingsLogoController_GetLogo_WithPhoneAndEmail(t *testing.T) {
+	suite, tenantService, uploadService := setupSettingsLogoControllerTest(t)
 
 	// Create a test tenant
 	testTenant, err := tenantService.Create(suite.Environment().Ctx, "Test Tenant", "test.com")
@@ -831,8 +856,8 @@ func TestSettingsController_GetLogo_WithPhoneAndEmail(t *testing.T) {
 	resp.Contains("company@example.com") // Email should be displayed
 }
 
-func TestSettingsController_PostLogo_ComplexCombinations(t *testing.T) {
-	suite, tenantService, uploadService := setupSettingsControllerTest(t)
+func TestSettingsLogoController_PostLogo_ComplexCombinations(t *testing.T) {
+	suite, tenantService, uploadService := setupSettingsLogoControllerTest(t)
 
 	testCases := []struct {
 		name        string
@@ -965,8 +990,8 @@ func TestSettingsController_PostLogo_ComplexCombinations(t *testing.T) {
 	}
 }
 
-func TestSettingsController_PostLogo_EdgeCases(t *testing.T) {
-	suite, tenantService, _ := setupSettingsControllerTest(t)
+func TestSettingsLogoController_PostLogo_EdgeCases(t *testing.T) {
+	suite, tenantService, _ := setupSettingsLogoControllerTest(t)
 
 	// Create a test tenant
 	testTenant, err := tenantService.Create(suite.Environment().Ctx, "Test Tenant", "test.com")

--- a/modules/superadmin/component.go
+++ b/modules/superadmin/component.go
@@ -47,6 +47,7 @@ func (c *component) Build(builder *composition.Builder) error {
 	composition.ProvideFunc(builder, services.NewTenantService)
 	composition.ProvideFunc(builder, services.NewTenantUsersService)
 
+	composition.RemoveController(builder, "/")
 	composition.ContributeControllersFunc(builder, func(userService *coreservices.UserService) []application.Controller {
 		return []application.Controller{
 			controllers.NewDashboardController(),

--- a/pkg/composition/engine.go
+++ b/pkg/composition/engine.go
@@ -257,7 +257,7 @@ type Container struct {
 	providerOrder      []*providerEntry
 	resolutionPath     []string
 
-	controllerFactories   []namedFactory[[]application.Controller]
+	controllerBatches     []controllerBatch
 	navItemFactories      []namedFactory[[]types.NavigationItem]
 	localeFactories       []namedFactory[[]*embed.FS]
 	schemaFactories       []namedFactory[[]application.GraphSchema]
@@ -270,12 +270,11 @@ type Container struct {
 	middlewareFactories   []namedFactory[[]mux.MiddlewareFunc]
 	hookFactories         []namedFactory[[]Hook]
 
-	// Controller/hook removal intents collected from builders during
-	// addBuilder, applied as post-collect filters inside materialize.
+	// Hook removal intents are collected from builders during addBuilder and
+	// applied as post-collect filters inside materialize.
 	// Provider removals are processed inline at the top of addBuilder
 	// (per-builder ordering) and are not cached on the container.
-	pendingControllerRemovals []string
-	pendingHookRemovals       []string
+	pendingHookRemovals []string
 
 	controllers        []application.Controller
 	navItems           []types.NavigationItem
@@ -291,6 +290,16 @@ type Container struct {
 	hooks              []Hook
 	runningStops       []namedStop
 	started            bool
+}
+
+type controllerContribution struct {
+	component  string
+	controller application.Controller
+}
+
+type controllerBatch struct {
+	factories []namedFactory[[]application.Controller]
+	removals  []string
 }
 
 func newContainer(context BuildContext, activeCapabilities []Capability) *Container {
@@ -558,7 +567,10 @@ func (c *Container) addBuilder(builder *Builder) error {
 		c.providerOrder = append(c.providerOrder, provider)
 	}
 
-	c.controllerFactories = append(c.controllerFactories, builder.controllerFactories...)
+	c.controllerBatches = append(c.controllerBatches, controllerBatch{
+		factories: append([]namedFactory[[]application.Controller](nil), builder.controllerFactories...),
+		removals:  append([]string(nil), builder.controllerRemovals...),
+	})
 	c.navItemFactories = append(c.navItemFactories, builder.navItemFactories...)
 	c.localeFactories = append(c.localeFactories, builder.localeFactories...)
 	c.schemaFactories = append(c.schemaFactories, builder.schemaFactories...)
@@ -576,11 +588,10 @@ func (c *Container) addBuilder(builder *Builder) error {
 	c.middlewareFactories = append(c.middlewareFactories, builder.middlewareFactories...)
 	c.hookFactories = append(c.hookFactories, builder.hookFactories...)
 
-	// Controller and hook removals cannot be applied here because
-	// materialize hasn't run yet — the contributions they target are still
-	// factory closures. Stash them on the container and let materialize
-	// filter the collected slices after each collectInto call.
-	c.pendingControllerRemovals = append(c.pendingControllerRemovals, builder.controllerRemovals...)
+	// Hook removals cannot be applied here because materialize hasn't run yet
+	// — the contributions they target are still factory closures. Stash them on
+	// the container and let materialize filter the collected slices after each
+	// collectInto call.
 	c.pendingHookRemovals = append(c.pendingHookRemovals, builder.hookRemovals...)
 	return nil
 }
@@ -595,24 +606,28 @@ func (c *Container) instantiateAll() error {
 }
 
 func (c *Container) materialize() error {
-	if err := collectInto(c, c.controllerFactories, &c.controllers); err != nil {
+	controllerContributions, err := c.materializeControllerContributions()
+	if err != nil {
 		return err
 	}
-	// Drop nil controllers — some constructors return nil to signal a
-	// disabled feature (e.g. showcase_controller_prod). Also apply any
-	// pending controller removals by Key(). Doing both filters in one pass
-	// keeps app.Controllers() simple and prevents panics in downstream
-	// sort/iteration code.
-	if len(c.controllers) > 0 {
-		removalSet := stringSet(c.pendingControllerRemovals)
-		filtered := c.controllers[:0]
-		for _, controller := range c.controllers {
+	if len(controllerContributions) > 0 {
+		filtered := make([]application.Controller, 0, len(controllerContributions))
+		owners := make(map[string]string, len(controllerContributions))
+		for _, contribution := range controllerContributions {
+			controller := contribution.controller
 			if controller == nil {
 				continue
 			}
-			if _, removed := removalSet[controller.Key()]; removed {
-				continue
+			if existing, exists := owners[controller.Key()]; exists {
+				return fmt.Errorf(
+					"composition: duplicate controller key %q contributed by %q and %q; call composition.RemoveController(builder, %q) before contributing a replacement",
+					controller.Key(),
+					existing,
+					contribution.component,
+					controller.Key(),
+				)
 			}
+			owners[controller.Key()] = contribution.component
 			filtered = append(filtered, controller)
 		}
 		c.controllers = filtered
@@ -668,6 +683,35 @@ func (c *Container) materialize() error {
 	return nil
 }
 
+func (c *Container) materializeControllerContributions() ([]controllerContribution, error) {
+	contributions := make([]controllerContribution, 0)
+	for _, batch := range c.controllerBatches {
+		if len(batch.removals) > 0 && len(contributions) > 0 {
+			removalSet := stringSet(batch.removals)
+			filtered := contributions[:0]
+			for _, contribution := range contributions {
+				controller := contribution.controller
+				if controller == nil {
+					continue
+				}
+				if _, removed := removalSet[controller.Key()]; removed {
+					continue
+				}
+				filtered = append(filtered, contribution)
+			}
+			contributions = filtered
+		}
+
+		values, err := collectControllerContributions(c, batch.factories)
+		if err != nil {
+			return nil, err
+		}
+		contributions = append(contributions, values...)
+	}
+
+	return contributions, nil
+}
+
 // stringSet builds a lookup set from a slice. Returns nil for empty input
 // so callers can use it in a `_, ok := set[key]` check without allocating
 // when there's nothing to filter.
@@ -709,6 +753,26 @@ func collectInto[T any](container *Container, factories []namedFactory[[]T], tar
 		*target = append(*target, values...)
 	}
 	return nil
+}
+
+func collectControllerContributions(container *Container, factories []namedFactory[[]application.Controller]) ([]controllerContribution, error) {
+	contributions := make([]controllerContribution, 0)
+	for _, entry := range factories {
+		previousPath := container.resolutionPath
+		container.resolutionPath = []string{entry.component, entry.label}
+		values, err := entry.factory(container)
+		container.resolutionPath = previousPath
+		if err != nil {
+			return nil, fmt.Errorf("composition: %s contribution for %q: %w", entry.label, entry.component, err)
+		}
+		for _, controller := range values {
+			contributions = append(contributions, controllerContribution{
+				component:  entry.component,
+				controller: controller,
+			})
+		}
+	}
+	return contributions, nil
 }
 
 func componentActive(descriptor Descriptor, active []Capability) bool {

--- a/pkg/composition/override_test.go
+++ b/pkg/composition/override_test.go
@@ -229,7 +229,10 @@ func TestRemoveProvider_WithoutReplacement_ResolvesToNotProvided(t *testing.T) {
 
 // overrideCtrl is a minimal application.Controller used to exercise the
 // controller-removal filter in materialize.
-type overrideCtrl struct{ key string }
+type overrideCtrl struct {
+	key   string
+	label string
+}
 
 func (c *overrideCtrl) Key() string            { return c.key }
 func (c *overrideCtrl) Register(_ *mux.Router) {}
@@ -280,6 +283,105 @@ func TestRemoveController_NoopForMissingKey(t *testing.T) {
 
 	_, err = engine.Compile(BuildContext{})
 	require.NoError(t, err)
+}
+
+func TestControllerKeys_MustBeUniqueWithoutExplicitRemoval(t *testing.T) {
+	engine := NewEngine()
+	err := engine.Register(
+		testComponent{
+			descriptor: Descriptor{Name: "upstream"},
+			build: func(builder *Builder) error {
+				ContributeControllers(builder, func(*Container) ([]application.Controller, error) {
+					return []application.Controller{&overrideCtrl{key: "/settings", label: "upstream"}}, nil
+				})
+				return nil
+			},
+		},
+		testComponent{
+			descriptor: Descriptor{Name: "downstream", Requires: []string{"upstream"}},
+			build: func(builder *Builder) error {
+				ContributeControllers(builder, func(*Container) ([]application.Controller, error) {
+					return []application.Controller{&overrideCtrl{key: "/settings", label: "downstream"}}, nil
+				})
+				return nil
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	_, err = engine.Compile(BuildContext{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `duplicate controller key "/settings"`)
+	require.Contains(t, err.Error(), `"upstream"`)
+	require.Contains(t, err.Error(), `"downstream"`)
+}
+
+func TestRemoveController_AllowsExplicitControllerReplacement(t *testing.T) {
+	engine := NewEngine()
+	err := engine.Register(
+		testComponent{
+			descriptor: Descriptor{Name: "upstream"},
+			build: func(builder *Builder) error {
+				ContributeControllers(builder, func(*Container) ([]application.Controller, error) {
+					return []application.Controller{&overrideCtrl{key: "/settings", label: "upstream"}}, nil
+				})
+				return nil
+			},
+		},
+		testComponent{
+			descriptor: Descriptor{Name: "downstream", Requires: []string{"upstream"}},
+			build: func(builder *Builder) error {
+				RemoveController(builder, "/settings")
+				ContributeControllers(builder, func(*Container) ([]application.Controller, error) {
+					return []application.Controller{&overrideCtrl{key: "/settings", label: "downstream"}}, nil
+				})
+				return nil
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	container, err := engine.Compile(BuildContext{})
+	require.NoError(t, err)
+
+	ctrls := container.Controllers()
+	require.Len(t, ctrls, 1)
+	ctrl, ok := ctrls[0].(*overrideCtrl)
+	require.True(t, ok)
+	require.Equal(t, "downstream", ctrl.label)
+}
+
+func TestControllerKeys_AllowNestedDistinctRoutes(t *testing.T) {
+	engine := NewEngine()
+	err := engine.Register(
+		testComponent{
+			descriptor: Descriptor{Name: "hub"},
+			build: func(builder *Builder) error {
+				ContributeControllers(builder, func(*Container) ([]application.Controller, error) {
+					return []application.Controller{&overrideCtrl{key: "/settings", label: "hub"}}, nil
+				})
+				return nil
+			},
+		},
+		testComponent{
+			descriptor: Descriptor{Name: "logo", Requires: []string{"hub"}},
+			build: func(builder *Builder) error {
+				ContributeControllers(builder, func(*Container) ([]application.Controller, error) {
+					return []application.Controller{&overrideCtrl{key: "/settings/logo", label: "logo"}}, nil
+				})
+				return nil
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	container, err := engine.Compile(BuildContext{})
+	require.NoError(t, err)
+
+	ctrls := container.Controllers()
+	require.Len(t, ctrls, 2)
+	require.Equal(t, "/settings", ctrls[0].Key())
+	require.Equal(t, "/settings/logo", ctrls[1].Key())
 }
 
 // ----- RemoveHook -----


### PR DESCRIPTION
## Summary
- make composition track controller contributors and fail compilation on duplicate controller keys unless a downstream component explicitly removes the old owner
- split the core settings transport into `SettingsHubController` (`/settings`) and `SettingsLogoController` (`/settings/logo`)
- cover explicit replacement, nested route ownership, and settings redirect/logo behavior with tests

## Testing
- `go test ./pkg/composition ./modules/core/presentation/controllers`

Needed by iota-uz/eai#2243.