### PR TITLE
fix(bootstrap): apply DatabaseOptions pool tuning to pgxpool

### DIFF
--- a/pkg/bootstrap/iota.go
+++ b/pkg/bootstrap/iota.go
@@ -57,7 +57,12 @@ func IotaConfigWithServiceName(conf *configuration.Configuration, serviceName st
 			poolCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 			defer cancel()
 
-			pool, err := pgxpool.New(poolCtx, conf.Database.Opts)
+			poolCfg, err := conf.Database.PoolConfig()
+			if err != nil {
+				return nil, nil, fmt.Errorf("bootstrap: build pgxpool config: %w", err)
+			}
+
+			pool, err := pgxpool.NewWithConfig(poolCtx, poolCfg)
 			if err != nil {
 				return nil, nil, err
 			}


### PR DESCRIPTION
## Summary

- `IotaConfig`'s `poolFactory` built the pgxpool via `pgxpool.New(ctx, conf.Database.Opts)`, where `conf.Database.Opts` is the bare DSN produced by `DatabaseOptions.ConnectionString()` (`host/port/user/dbname/password/sslmode` only).
- Because the DSN carried no pool parameters, every env var the SDK already parses into `DatabaseOptions` — `DB_MAX_CONNS`, `DB_MIN_CONNS`, `DB_MAX_CONN_LIFETIME`, `DB_MAX_CONN_LIFETIME_JITTER`, `DB_MAX_CONN_IDLE_TIME`, `DB_HEALTH_CHECK_PERIOD`, `DB_CONNECT_TIMEOUT` — was silently dropped, and the pool ran on pgxpool defaults (`MaxConns=4`, etc.).
- `DatabaseOptions.PoolConfig()` already exists, validates the values, and builds a fully populated `*pgxpool.Config` (including the `AfterConnect` hook that sets `idle_in_transaction_session_timeout`). This PR wires `poolFactory` to use it and creates the pool via `pgxpool.NewWithConfig`.

## Impact

- EAI production (`stack.yml`) configures `DB_MAX_CONNS=200`, `DB_MIN_CONNS=100`, `DB_MAX_CONN_LIFETIME=30m`, `DB_HEALTH_CHECK_PERIOD=30s`, etc. — those were previously no-ops and will now take effect on any consumer that uses `bootstrap.IotaConfig`.
- Existing callers that relied on the default behavior get pool values from `DatabaseOptions` env defaults (`DB_MAX_CONNS=32`, `DB_MIN_CONNS=8`, `DB_MAX_CONN_LIFETIME=1h`, ...), which is already the documented contract of `DatabaseOptions`.

## Test plan

- [x] `go vet ./pkg/bootstrap/...`
- [x] `go vet ./...`
- [x] `go test ./pkg/bootstrap/... ./pkg/configuration/...` (no test files in either package)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced database connection error handling for improved reliability and clearer diagnostics during initialization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->