### PR TITLE
fix(core): resolve optional AI spotlight holder from DI container

### DIFF
--- a/modules/core/component.go
+++ b/modules/core/component.go
@@ -215,6 +215,7 @@ func (c *component) Build(builder *composition.Builder) error {
 	if builder.Context().HasCapability(composition.CapabilityAPI) {
 		opts := c.options
 		composition.ContributeControllersFunc(builder, func(
+			container *composition.Container,
 			app application.Application,
 			bus eventbus.EventBus,
 			uploadService *services.UploadService,
@@ -225,7 +226,16 @@ func (c *component) Build(builder *composition.Builder) error {
 			tenantService *services.TenantService,
 			groupService *services.GroupService,
 			twoFactorService *coreservices2fa.TwoFactorService,
-		) []application.Controller {
+		) ([]application.Controller, error) {
+			// AI search holder is optional — downstream components (e.g. bichat)
+			// register one via composition.ProvideFunc. Resolve it here so the
+			// spotlight controller gets the wired service instead of a hard
+			// nil. Swallow "not provided" so deployments without bichat keep
+			// working; any other error must surface.
+			aiHolder, err := composition.Resolve[*spotlight.AISearchServiceHolder](container)
+			if err != nil && !composition.IsNotProvided(err) {
+				return nil, err
+			}
 			// Auth and infrastructure controllers — always registered.
 			ctrls := []application.Controller{
 				controllers.NewHealthController(app),
@@ -250,9 +260,10 @@ func (c *component) Build(builder *composition.Builder) error {
 			if !opts.SkipAdminControllers {
 				ctrls = append(ctrls,
 					controllers.NewDashboardController(),
-					// Spotlight controller accepts a nil AI search holder; downstream
-					// components that need AI-assisted search install one explicitly.
-					controllers.NewSpotlightController(app, nil),
+					// aiHolder may be nil when no downstream component registered
+					// an AI search service; the controller is nil-safe and will
+					// surface the feature as unavailable in that case.
+					controllers.NewSpotlightController(app, aiHolder),
 					controllers.NewUsersController(app, userControllerOpts...),
 					controllers.NewRolesController(&controllers.RolesControllerOptions{
 						BasePath:         "/roles",
@@ -275,7 +286,7 @@ func (c *component) Build(builder *composition.Builder) error {
 				}
 			}
 
-			return ctrls
+			return ctrls, nil
 		})
 	}
 


### PR DESCRIPTION
## Summary

- `NewSpotlightController` was hard-wired with `nil` since d93bacb5, leaving AI Spotlight unreachable (`/spotlight/ai/sessions` → 404 `AI Spotlight unavailable`) in every downstream deployment that registers a `*spotlight.AISearchServiceHolder` via `composition.ProvideFunc` (e.g. eai's bichat component).
- Resolve the holder optionally from the composition container and pass it into the controller. Deployments without an AI provider keep working — `composition.IsNotProvided` is swallowed and the controller remains nil-safe.

## Background

eai registers the holder:

```go
composition.ProvideFunc(builder, func(app application.Application) *spotlight.AISearchServiceHolder {
    return &spotlight.AISearchServiceHolder{
        Service: services.NewAISpotlightService(app, fastModel, aiSpotlightQueryExecutor),
    }
})
```

But iota-sdk's `modules/core/component.go` passed a literal `nil` into `NewSpotlightController`, so the controller's `aiSearchService()` returned nil and every AI endpoint short-circuited with 404. The earlier comment claimed downstream components "install one explicitly" — there was no such mechanism.

## Change

- Accept `*composition.Container` as the first callback parameter (the reflection injector already special-cases this type).
- Change return to `([]application.Controller, error)` so container-resolution errors surface.
- `composition.Resolve[*spotlight.AISearchServiceHolder](container)`; swallow `IsNotProvided` for deployments without bichat.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./pkg/composition/... ./modules/core/...`
- [ ] Deploy to staging and verify `POST /spotlight/ai/sessions` no longer returns `AI Spotlight unavailable`
- [ ] Verify deployments without the AI holder still boot and serve non-AI spotlight endpoints

## Notes

Reported broken on eai-backend-staging. Companion issue: AI search broken in browser with `Failed to load resource: /spotlight/ai/sessions ... 404`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled AI search functionality in the admin dashboard by properly resolving the service from the dependency injection container instead of using a null reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->