### PR TITLE
feat(bichat): resilient run foundation (#732 M1 + state + queue + event log)

### DIFF
--- a/modules/bichat/component.go
+++ b/modules/bichat/component.go
@@ -390,6 +390,9 @@ func newRuntimeStart(b *bichatBundle, pool *pgxpool.Pool) func(ctx context.Conte
 				if closeErr := b.services.CloseTitleQueue(); closeErr != nil {
 					stopErr = errors.Join(stopErr, closeErr)
 				}
+				if closeErr := b.services.CloseSharedRedis(); closeErr != nil {
+					stopErr = errors.Join(stopErr, closeErr)
+				}
 			}
 
 			if b.eventBridge != nil {

--- a/modules/bichat/component.go
+++ b/modules/bichat/component.go
@@ -332,10 +332,38 @@ func newRuntimeStart(b *bichatBundle, pool *pgxpool.Pool) func(ctx context.Conte
 			}()
 		}
 
+		// Stale-run reaper: periodically scans active runs and marks
+		// wedged ones (heartbeat silent for > StaleAfter) as failed so
+		// the sidebar can transition + clients see a terminal error
+		// event. Returns (nil, nil) when Redis is unconfigured.
+		var (
+			reaperCancel context.CancelFunc
+			reaperDone   chan struct{}
+		)
+		reaper, err := b.services.NewRunReaper()
+		if err != nil {
+			return nil, serrors.E(op, err, "failed to create run reaper")
+		}
+		if reaper != nil {
+			reaperCtx, reaperCancelFn := context.WithCancel(context.Background())
+			reaperCancel = reaperCancelFn
+			reaperDone = make(chan struct{})
+			logger := b.config.Logger
+			go func() {
+				defer close(reaperDone)
+				if startErr := reaper.Start(reaperCtx); startErr != nil && logger != nil && !errors.Is(startErr, context.Canceled) {
+					logger.WithError(startErr).Warn("bichat run reaper stopped with error")
+				}
+			}()
+		}
+
 		return func(stopCtx context.Context) error {
 			var stopErr error
 			if titleWorkerCancel != nil {
 				titleWorkerCancel()
+			}
+			if reaperCancel != nil {
+				reaperCancel()
 			}
 			if titleWorkerDone != nil {
 				// Cancel has been called; the worker loop will observe it
@@ -346,6 +374,13 @@ func newRuntimeStart(b *bichatBundle, pool *pgxpool.Pool) func(ctx context.Conte
 				// already cancelled.
 				select {
 				case <-titleWorkerDone:
+				case <-stopCtx.Done():
+					stopErr = errors.Join(stopErr, stopCtx.Err())
+				}
+			}
+			if reaperDone != nil {
+				select {
+				case <-reaperDone:
 				case <-stopCtx.Done():
 					stopErr = errors.Join(stopErr, stopCtx.Err())
 				}

--- a/modules/bichat/config.go
+++ b/modules/bichat/config.go
@@ -260,6 +260,12 @@ type ModuleConfig struct {
 	StreamRequireAccessPermission permission.Permission
 	StreamReadAllPermission       permission.Permission
 
+	// Optional: Stale-run reaper tuning. Zero values fall back to the
+	// defaults in run_reaper.go (15s interval, 60s stale threshold, 30s lock TTL).
+	ReaperInterval       time.Duration
+	ReaperStaleThreshold time.Duration
+	ReaperLockTTL        time.Duration
+
 	// Internal: Build-time state (resolved once during BuildServices).
 	resolvedProjectPromptExtension string
 	projectPromptExtensionResolved bool
@@ -285,6 +291,10 @@ type ServiceContainer struct {
 	titleJobQueue     *services.RedisTitleJobQueue
 	titleQueueConfig  *TitleQueueConfig
 	logger            *logrus.Logger
+	// Reaper tunables forwarded from ModuleConfig. Zero means use defaults.
+	reaperInterval       time.Duration
+	reaperStaleThreshold time.Duration
+	reaperLockTTL        time.Duration
 }
 
 // SessionCommands returns session mutating actions.
@@ -368,9 +378,16 @@ func (sc *ServiceContainer) CloseTitleQueue() error {
 
 // NewRunReaper builds the stale-run reaper when Redis is configured.
 // Returns (nil, nil) when REDIS_URL is unset so the caller can skip
-// the reaper without branching on a sentinel.
+// the reaper without branching on a sentinel. Reaper interval / stale
+// threshold / lock TTL are forwarded from the ModuleConfig tunables;
+// zero values fall back to the per-constant defaults in run_reaper.go.
 func (sc *ServiceContainer) NewRunReaper() (*services.RunReaper, error) {
-	return services.NewConfiguredRunReaperFromEnv(sc.logger)
+	return services.NewConfiguredRunReaperWithTunables(
+		sc.logger,
+		sc.reaperInterval,
+		sc.reaperStaleThreshold,
+		sc.reaperLockTTL,
+	)
 }
 
 // ConfigOption is a functional option for ModuleConfig

--- a/modules/bichat/config.go
+++ b/modules/bichat/config.go
@@ -366,6 +366,13 @@ func (sc *ServiceContainer) CloseTitleQueue() error {
 	return err
 }
 
+// NewRunReaper builds the stale-run reaper when Redis is configured.
+// Returns (nil, nil) when REDIS_URL is unset so the caller can skip
+// the reaper without branching on a sentinel.
+func (sc *ServiceContainer) NewRunReaper() (*services.RunReaper, error) {
+	return services.NewConfiguredRunReaperFromEnv(sc.logger)
+}
+
 // ConfigOption is a functional option for ModuleConfig
 type ConfigOption func(*ModuleConfig)
 

--- a/modules/bichat/config.go
+++ b/modules/bichat/config.go
@@ -291,6 +291,11 @@ type ServiceContainer struct {
 	titleJobQueue     *services.RedisTitleJobQueue
 	titleQueueConfig  *TitleQueueConfig
 	logger            *logrus.Logger
+	// sharedRedisClose is the single owner of the *redis.Client shared across
+	// all Redis-backed components (event log, active-run index, job queue).
+	// Component Close() calls are no-ops when the client was supplied externally.
+	// Call CloseSharedRedis() once during shutdown to release the connection.
+	sharedRedisClose func() error
 	// Reaper tunables forwarded from ModuleConfig. Zero means use defaults.
 	reaperInterval       time.Duration
 	reaperStaleThreshold time.Duration
@@ -374,6 +379,16 @@ func (sc *ServiceContainer) CloseTitleQueue() error {
 	err := sc.titleJobQueue.Close()
 	sc.titleJobQueue = nil
 	return err
+}
+
+// CloseSharedRedis releases the shared *redis.Client that backs the event log,
+// active-run index, and run job queue. Must be called exactly once at shutdown;
+// no-op when Redis was not configured.
+func (sc *ServiceContainer) CloseSharedRedis() error {
+	if sc.sharedRedisClose == nil {
+		return nil
+	}
+	return sc.sharedRedisClose()
 }
 
 // NewRunReaper builds the stale-run reaper when Redis is configured.

--- a/modules/bichat/config_build.go
+++ b/modules/bichat/config_build.go
@@ -181,13 +181,16 @@ func (c *ModuleConfig) BuildServices() (*ServiceContainer, error) {
 	attachmentService := services.NewAttachmentService(fileStorage)
 	artifactService := bichatservices.NewArtifactService(c.ChatRepo, fileStorage, attachmentService)
 
-	chatServices := services.NewChatApplicationServices(
+	chatServices, err := services.NewChatApplicationServices(
 		c.ChatRepo,
 		agentService,
 		c.Model,
 		titleService,
 		titleJobQueue,
 	)
+	if err != nil {
+		return nil, serrors.E(op, err, "failed to initialise Redis-backed chat services")
+	}
 
 	return &ServiceContainer{
 		sessionCommands:      chatServices.SessionCommands,

--- a/modules/bichat/config_build.go
+++ b/modules/bichat/config_build.go
@@ -190,20 +190,23 @@ func (c *ModuleConfig) BuildServices() (*ServiceContainer, error) {
 	)
 
 	return &ServiceContainer{
-		sessionCommands:   chatServices.SessionCommands,
-		sessionQueries:    chatServices.SessionQueries,
-		turnCommands:      chatServices.TurnCommands,
-		turnQueries:       chatServices.TurnQueries,
-		streamCommands:    chatServices.StreamCommands,
-		hitlCommands:      chatServices.HITLCommands,
-		agentService:      agentService,
-		attachmentService: attachmentService,
-		artifactService:   artifactService,
-		observability:     chatServices.Observability,
-		titleService:      titleService,
-		titleJobQueue:     titleJobQueue,
-		titleQueueConfig:  c.TitleQueue,
-		logger:            c.Logger,
+		sessionCommands:      chatServices.SessionCommands,
+		sessionQueries:       chatServices.SessionQueries,
+		turnCommands:         chatServices.TurnCommands,
+		turnQueries:          chatServices.TurnQueries,
+		streamCommands:       chatServices.StreamCommands,
+		hitlCommands:         chatServices.HITLCommands,
+		agentService:         agentService,
+		attachmentService:    attachmentService,
+		artifactService:      artifactService,
+		observability:        chatServices.Observability,
+		titleService:         titleService,
+		titleJobQueue:        titleJobQueue,
+		titleQueueConfig:     c.TitleQueue,
+		logger:               c.Logger,
+		reaperInterval:       c.ReaperInterval,
+		reaperStaleThreshold: c.ReaperStaleThreshold,
+		reaperLockTTL:        c.ReaperLockTTL,
 	}, nil
 }
 

--- a/modules/bichat/config_build.go
+++ b/modules/bichat/config_build.go
@@ -204,6 +204,7 @@ func (c *ModuleConfig) BuildServices() (*ServiceContainer, error) {
 		titleJobQueue:        titleJobQueue,
 		titleQueueConfig:     c.TitleQueue,
 		logger:               c.Logger,
+		sharedRedisClose:     chatServices.CloseSharedRedis,
 		reaperInterval:       c.ReaperInterval,
 		reaperStaleThreshold: c.ReaperStaleThreshold,
 		reaperLockTTL:        c.ReaperLockTTL,

--- a/modules/bichat/config_options.go
+++ b/modules/bichat/config_options.go
@@ -3,6 +3,7 @@ package bichat
 import (
 	"io/fs"
 	"strings"
+	"time"
 
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/permission"
 	coreservices "github.com/iota-uz/iota-sdk/modules/core/services"
@@ -279,5 +280,31 @@ func WithStreamRequireAccessPermission(p permission.Permission) ConfigOption {
 func WithStreamReadAllPermission(p permission.Permission) ConfigOption {
 	return func(c *ModuleConfig) {
 		c.StreamReadAllPermission = p
+	}
+}
+
+// WithReaperInterval sets the polling interval between stale-run reaper sweeps.
+// Default: 15s. Applies only when Redis is configured.
+func WithReaperInterval(d time.Duration) ConfigOption {
+	return func(c *ModuleConfig) {
+		c.ReaperInterval = d
+	}
+}
+
+// WithReaperStaleThreshold sets the maximum age of a run's last heartbeat
+// before the reaper considers it wedged and marks it failed.
+// Default: 60s. Applies only when Redis is configured.
+func WithReaperStaleThreshold(d time.Duration) ConfigOption {
+	return func(c *ModuleConfig) {
+		c.ReaperStaleThreshold = d
+	}
+}
+
+// WithReaperLockTTL sets the TTL of the single-writer reaper lock in Redis.
+// This bounds the time a crashed leader holds the lock before another replica
+// can take over. Default: 30s. Applies only when Redis is configured.
+func WithReaperLockTTL(d time.Duration) ConfigOption {
+	return func(c *ModuleConfig) {
+		c.ReaperLockTTL = d
 	}
 }

--- a/modules/bichat/presentation/controllers/controllers_mount_test.go
+++ b/modules/bichat/presentation/controllers/controllers_mount_test.go
@@ -126,7 +126,8 @@ func newControllerDeps(t *testing.T) controllerDeps {
 		ChatRepo:     chatRepo,
 	})
 
-	chatService := modservices.NewChatService(chatRepo, agentService, model, nil, nil)
+	chatService, err := modservices.NewChatService(chatRepo, agentService, model, nil, nil)
+	require.NoError(t, err)
 	attachmentService := modservices.NewAttachmentService(storage.NewNoOpFileStorage())
 
 	return controllerDeps{

--- a/modules/bichat/presentation/controllers/stream_controller.go
+++ b/modules/bichat/presentation/controllers/stream_controller.go
@@ -594,8 +594,9 @@ func (c *StreamController) TailEvents(w http.ResponseWriter, r *http.Request) {
 // (streaming / completed / cancelled / failed / queued).
 //
 // Tenant scope is taken from the authenticated request context; the
-// handler has no query parameters. Returns 503 when the active-run
-// index is not configured.
+// handler has no query parameters. If the active-run index is not
+// configured or otherwise unavailable, the stream emits an SSE `error`
+// event instead of returning a 503 response.
 func (c *StreamController) TailActiveRuns(w http.ResponseWriter, r *http.Request) {
 	const op serrors.Op = "StreamController.TailActiveRuns"
 
@@ -659,7 +660,7 @@ func (c *StreamController) TailActiveRuns(w http.ResponseWriter, r *http.Request
 	})
 	if err != nil {
 		logger := configuration.Use().Logger()
-		if errors.Is(err, bichatservices.ErrRunEventLogUnavailable) {
+		if errors.Is(err, bichatservices.ErrActiveRunIndexUnavailable) || errors.Is(err, bichatservices.ErrRunEventLogUnavailable) {
 			logger.WithError(serrors.E(op, err)).Warn("TailActiveRuns: active-run index unavailable")
 			writeMu.Lock()
 			defer writeMu.Unlock()

--- a/modules/bichat/presentation/controllers/stream_controller.go
+++ b/modules/bichat/presentation/controllers/stream_controller.go
@@ -480,9 +480,11 @@ func (c *StreamController) ResumeStream(w http.ResponseWriter, r *http.Request) 
 // connection; we forward it to RunEventLog so replay is always cursor-
 // exact.
 //
-// Returns 503 when the event log is not configured (dev/CI without
-// Redis) so clients can fall back to POST /stream/resume. Returns 404
-// when the run is unknown, 400 for malformed input.
+// For malformed input, the handler responds with HTTP 400 before starting
+// the stream. For valid SSE requests, the handler establishes an HTTP 200
+// event stream and reports runtime conditions such as an unavailable event
+// log or an unknown/finished run via an SSE `error` event payload so
+// clients can handle them without switching transports.
 func (c *StreamController) TailEvents(w http.ResponseWriter, r *http.Request) {
 	const op serrors.Op = "StreamController.TailEvents"
 
@@ -560,7 +562,7 @@ func (c *StreamController) TailEvents(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logger := configuration.Use().Logger()
 		if errors.Is(err, bichatservices.ErrRunEventLogUnavailable) {
-			logger.WithError(serrors.E(op, "flush failed", err)).Warn("TailEvents: run event log unavailable")
+			logger.WithError(serrors.E(op, err)).Warn("TailEvents: run event log unavailable")
 			writeMu.Lock()
 			defer writeMu.Unlock()
 			c.sendSSEEvent(w, flusher, "error", httpdto.StreamChunkPayload{
@@ -571,7 +573,7 @@ func (c *StreamController) TailEvents(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if errors.Is(err, bichatservices.ErrRunNotFoundOrFinished) {
-			logger.WithError(serrors.E(op, "flush failed", err)).Warn("TailEvents: run not found or already finished")
+			logger.WithError(serrors.E(op, err)).Warn("TailEvents: run not found or already finished")
 			writeMu.Lock()
 			defer writeMu.Unlock()
 			c.sendSSEEvent(w, flusher, "error", httpdto.StreamChunkPayload{
@@ -658,7 +660,7 @@ func (c *StreamController) TailActiveRuns(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		logger := configuration.Use().Logger()
 		if errors.Is(err, bichatservices.ErrRunEventLogUnavailable) {
-			logger.WithError(serrors.E(op, "flush failed", err)).Warn("TailActiveRuns: active-run index unavailable")
+			logger.WithError(serrors.E(op, err)).Warn("TailActiveRuns: active-run index unavailable")
 			writeMu.Lock()
 			defer writeMu.Unlock()
 			c.sendSSEEvent(w, flusher, "error", map[string]string{

--- a/modules/bichat/presentation/controllers/stream_controller.go
+++ b/modules/bichat/presentation/controllers/stream_controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/iota-uz/iota-sdk/modules/bichat/infrastructure/persistence"
+	bichatmodsvcs "github.com/iota-uz/iota-sdk/modules/bichat/services"
 	"github.com/iota-uz/iota-sdk/pkg/bichat/domain"
 	bichatservices "github.com/iota-uz/iota-sdk/pkg/bichat/services"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
@@ -230,77 +231,13 @@ func (c *StreamController) StreamMessage(w http.ResponseWriter, r *http.Request)
 		default:
 		}
 
-		payload := httpdto.StreamChunkPayload{
-			Type:         string(chunk.Type),
-			Content:      chunk.Content,
-			Citation:     chunk.Citation,
-			Usage:        chunk.Usage,
-			GenerationMs: chunk.GenerationMs,
-			Timestamp:    chunk.Timestamp.UnixMilli(),
-		}
-		if chunk.Tool != nil {
-			toolPayload := &httpdto.ToolEventPayload{
-				CallID:     chunk.Tool.CallID,
-				Name:       chunk.Tool.Name,
-				AgentName:  chunk.Tool.AgentName,
-				Arguments:  chunk.Tool.Arguments,
-				Result:     chunk.Tool.Result,
-				DurationMs: chunk.Tool.DurationMs,
-			}
-			if chunk.Tool.Error != nil {
-				toolPayload.Error = chunk.Tool.Error.Error()
-			}
-			payload.Tool = toolPayload
-		}
-		if chunk.Interrupt != nil {
-			questions := make([]httpdto.InterruptQuestionPayload, 0, len(chunk.Interrupt.Questions))
-			for _, q := range chunk.Interrupt.Questions {
-				options := make([]httpdto.InterruptQuestionOptionPayload, 0, len(q.Options))
-				for _, opt := range q.Options {
-					options = append(options, httpdto.InterruptQuestionOptionPayload{
-						ID:    opt.ID,
-						Label: opt.Label,
-					})
-				}
-				questions = append(questions, httpdto.InterruptQuestionPayload{
-					ID:      q.ID,
-					Text:    q.Text,
-					Type:    string(q.Type),
-					Options: options,
-				})
-			}
-			payload.Interrupt = &httpdto.InterruptEventPayload{
-				CheckpointID:       chunk.Interrupt.CheckpointID,
-				AgentName:          chunk.Interrupt.AgentName,
-				ProviderResponseID: chunk.Interrupt.ProviderResponseID,
-				Questions:          questions,
-			}
-		}
+		eventName, payload, _ := bichatmodsvcs.BuildPayload(chunk)
+		// Post-encode error sanitisation: BuildPayload stores the raw error
+		// string from the chunk, but browsers must only see safe messages.
 		if chunk.Error != nil {
-			// Preserve known provider-facing failures (quota/auth/rate-limit), and
-			// keep all other internal failures generic.
 			payload.Error = c.streamClientErrorMessage(chunk.Error, chunk.Type)
 		}
-		if chunk.RunID != "" {
-			payload.RunID = chunk.RunID
-		}
-		if chunk.Snapshot != nil {
-			payload.Snapshot = &httpdto.StreamSnapshotPayload{
-				PartialContent:  chunk.Snapshot.PartialContent,
-				PartialMetadata: chunk.Snapshot.PartialMetadata,
-			}
-		}
-		if chunk.Type == bichatservices.ChunkTypeTextBlockEnd {
-			seq := chunk.TextBlockSeq
-			payload.TextBlockSeq = &seq
-		}
-
-		// Event name is for SSE clients that care; our frontend reads `data:` lines.
-		eventName := payload.Type
-		if eventName == "" {
-			eventName = string(httpdto.StreamEventChunk)
-		}
-		sendEvent(eventName, payload)
+		sendEvent(string(eventName), payload)
 	})
 
 	if err != nil {
@@ -512,63 +449,13 @@ func (c *StreamController) ResumeStream(w http.ResponseWriter, r *http.Request) 
 	}()
 
 	err := c.streamService.ResumeStream(r.Context(), req.SessionID, req.RunID, func(chunk bichatservices.StreamChunk) {
-		payload := httpdto.StreamChunkPayload{
-			Type:         string(chunk.Type),
-			Content:      chunk.Content,
-			Citation:     chunk.Citation,
-			Usage:        chunk.Usage,
-			GenerationMs: chunk.GenerationMs,
-			Timestamp:    chunk.Timestamp.UnixMilli(),
-		}
-		if chunk.Tool != nil {
-			toolPayload := &httpdto.ToolEventPayload{
-				CallID:     chunk.Tool.CallID,
-				Name:       chunk.Tool.Name,
-				AgentName:  chunk.Tool.AgentName,
-				Arguments:  chunk.Tool.Arguments,
-				Result:     chunk.Tool.Result,
-				DurationMs: chunk.Tool.DurationMs,
-			}
-			if chunk.Tool.Error != nil {
-				toolPayload.Error = chunk.Tool.Error.Error()
-			}
-			payload.Tool = toolPayload
-		}
-		if chunk.Interrupt != nil {
-			questions := make([]httpdto.InterruptQuestionPayload, 0, len(chunk.Interrupt.Questions))
-			for _, q := range chunk.Interrupt.Questions {
-				options := make([]httpdto.InterruptQuestionOptionPayload, 0, len(q.Options))
-				for _, opt := range q.Options {
-					options = append(options, httpdto.InterruptQuestionOptionPayload{ID: opt.ID, Label: opt.Label})
-				}
-				questions = append(questions, httpdto.InterruptQuestionPayload{ID: q.ID, Text: q.Text, Type: string(q.Type), Options: options})
-			}
-			payload.Interrupt = &httpdto.InterruptEventPayload{
-				CheckpointID:       chunk.Interrupt.CheckpointID,
-				AgentName:          chunk.Interrupt.AgentName,
-				ProviderResponseID: chunk.Interrupt.ProviderResponseID,
-				Questions:          questions,
-			}
-		}
+		eventName, payload, _ := bichatmodsvcs.BuildPayload(chunk)
+		// Post-encode error sanitisation: BuildPayload stores the raw error
+		// string from the chunk, but browsers must only see safe messages.
 		if chunk.Error != nil {
 			payload.Error = c.streamClientErrorMessage(chunk.Error, chunk.Type)
 		}
-		if chunk.Snapshot != nil {
-			payload.Snapshot = &httpdto.StreamSnapshotPayload{
-				PartialContent:  chunk.Snapshot.PartialContent,
-				PartialMetadata: chunk.Snapshot.PartialMetadata,
-			}
-		}
-		if chunk.Type == bichatservices.ChunkTypeTextBlockEnd {
-			seq := chunk.TextBlockSeq
-			payload.TextBlockSeq = &seq
-		}
-
-		eventName := payload.Type
-		if eventName == "" {
-			eventName = string(httpdto.StreamEventChunk)
-		}
-		sendEvent(eventName, payload)
+		sendEvent(string(eventName), payload)
 	})
 	if err != nil {
 		if errors.Is(err, bichatservices.ErrRunNotFoundOrFinished) {
@@ -671,8 +558,9 @@ func (c *StreamController) TailEvents(w http.ResponseWriter, r *http.Request) {
 		flusher.Flush()
 	})
 	if err != nil {
+		logger := configuration.Use().Logger()
 		if errors.Is(err, bichatservices.ErrRunEventLogUnavailable) {
-			// Log and emit a synthetic error so the client can fall back.
+			logger.WithError(serrors.E(op, "flush failed", err)).Warn("TailEvents: run event log unavailable")
 			writeMu.Lock()
 			defer writeMu.Unlock()
 			c.sendSSEEvent(w, flusher, "error", httpdto.StreamChunkPayload{
@@ -683,6 +571,7 @@ func (c *StreamController) TailEvents(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if errors.Is(err, bichatservices.ErrRunNotFoundOrFinished) {
+			logger.WithError(serrors.E(op, "flush failed", err)).Warn("TailEvents: run not found or already finished")
 			writeMu.Lock()
 			defer writeMu.Unlock()
 			c.sendSSEEvent(w, flusher, "error", httpdto.StreamChunkPayload{
@@ -692,7 +581,6 @@ func (c *StreamController) TailEvents(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
-		logger := configuration.Use().Logger()
 		logger.WithError(serrors.E(op, err)).Error("TailEvents failed")
 	}
 }
@@ -768,7 +656,9 @@ func (c *StreamController) TailActiveRuns(w http.ResponseWriter, r *http.Request
 		c.sendSSEEvent(w, flusher, evt.Event, payload)
 	})
 	if err != nil {
+		logger := configuration.Use().Logger()
 		if errors.Is(err, bichatservices.ErrRunEventLogUnavailable) {
+			logger.WithError(serrors.E(op, "flush failed", err)).Warn("TailActiveRuns: active-run index unavailable")
 			writeMu.Lock()
 			defer writeMu.Unlock()
 			c.sendSSEEvent(w, flusher, "error", map[string]string{
@@ -776,7 +666,6 @@ func (c *StreamController) TailActiveRuns(w http.ResponseWriter, r *http.Request
 			})
 			return
 		}
-		logger := configuration.Use().Logger()
 		logger.WithError(serrors.E(op, err)).Error("TailActiveRuns failed")
 	}
 }

--- a/modules/bichat/presentation/controllers/stream_controller.go
+++ b/modules/bichat/presentation/controllers/stream_controller.go
@@ -73,6 +73,12 @@ func (c *StreamController) Register(r *mux.Router) {
 	subRouter.HandleFunc("/stream/stop", c.StopStream).Methods("POST")
 	subRouter.HandleFunc("/stream/status", c.StreamStatus).Methods("GET")
 	subRouter.HandleFunc("/stream/resume", c.ResumeStream).Methods("POST")
+	// GET /stream/events is the cursor-based tail endpoint: EventSource
+	// connects here after a POST /stream kicks off a run. Native
+	// EventSource reconnect sends Last-Event-ID, which we forward to
+	// the event log so the browser never sees a dropped event across
+	// network blips / tab sleep.
+	subRouter.HandleFunc("/stream/events", c.TailEvents).Methods("GET")
 }
 
 // StreamMessage handles SSE streaming for a message.
@@ -571,6 +577,116 @@ func (c *StreamController) ResumeStream(w http.ResponseWriter, r *http.Request) 
 		Type:      "done",
 		Timestamp: time.Now().UnixMilli(),
 	})
+}
+
+// TailEvents handles GET /stream/events?sessionId=...&runId=... — a pure
+// SSE reader over the durable per-run Redis event log. The browser's
+// native EventSource auto-reconnect sends Last-Event-ID on every resumed
+// connection; we forward it to RunEventLog so replay is always cursor-
+// exact.
+//
+// Returns 503 when the event log is not configured (dev/CI without
+// Redis) so clients can fall back to POST /stream/resume. Returns 404
+// when the run is unknown, 400 for malformed input.
+func (c *StreamController) TailEvents(w http.ResponseWriter, r *http.Request) {
+	const op serrors.Op = "StreamController.TailEvents"
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	sessionIDStr := r.URL.Query().Get("sessionId")
+	runIDStr := r.URL.Query().Get("runId")
+	if sessionIDStr == "" || runIDStr == "" {
+		http.Error(w, "sessionId and runId are required", http.StatusBadRequest)
+		return
+	}
+	sessionID, err := uuid.Parse(sessionIDStr)
+	if err != nil || sessionID == uuid.Nil {
+		http.Error(w, "sessionId must be a valid UUID", http.StatusBadRequest)
+		return
+	}
+	runID, err := uuid.Parse(runIDStr)
+	if err != nil || runID == uuid.Nil {
+		http.Error(w, "runId must be a valid UUID", http.StatusBadRequest)
+		return
+	}
+	if !c.requireStreamSessionAuth(w, r, sessionID, false) {
+		return
+	}
+
+	// Native EventSource reconnect ships this header; if it's empty the
+	// client wants a full replay from the beginning.
+	lastEventID := strings.TrimSpace(r.Header.Get("Last-Event-ID"))
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	c.sendSSEComment(w, flusher, "stream-open")
+
+	var writeMu sync.Mutex
+	heartbeatStop := make(chan struct{})
+	defer close(heartbeatStop)
+	go func() {
+		ticker := time.NewTicker(streamHeartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-heartbeatStop:
+				return
+			case <-ticker.C:
+				writeMu.Lock()
+				c.sendSSEComment(w, flusher, "ping")
+				writeMu.Unlock()
+			}
+		}
+	}()
+
+	err = c.streamService.TailRunEvents(r.Context(), sessionID, runID, lastEventID, func(evt bichatservices.RunEventDelivery) {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		eventName := evt.Type
+		if eventName == "" {
+			eventName = "chunk"
+		}
+		// Emit SSE triple with id: + event: + data:. The id: line is
+		// what EventSource stores in the browser's internal Last-Event-ID
+		// state so a reconnect targets the right cursor.
+		_, _ = fmt.Fprintf(w, "id: %s\n", evt.StreamID)
+		_, _ = fmt.Fprintf(w, "event: %s\n", eventName)
+		_, _ = fmt.Fprintf(w, "data: %s\n\n", evt.Payload)
+		flusher.Flush()
+	})
+	if err != nil {
+		if errors.Is(err, bichatservices.ErrRunEventLogUnavailable) {
+			// Log and emit a synthetic error so the client can fall back.
+			writeMu.Lock()
+			defer writeMu.Unlock()
+			c.sendSSEEvent(w, flusher, "error", httpdto.StreamChunkPayload{
+				Type:      "error",
+				Error:     "run event log unavailable",
+				Timestamp: time.Now().UnixMilli(),
+			})
+			return
+		}
+		if errors.Is(err, bichatservices.ErrRunNotFoundOrFinished) {
+			writeMu.Lock()
+			defer writeMu.Unlock()
+			c.sendSSEEvent(w, flusher, "error", httpdto.StreamChunkPayload{
+				Type:      "error",
+				Error:     "run not found or already finished",
+				Timestamp: time.Now().UnixMilli(),
+			})
+			return
+		}
+		logger := configuration.Use().Logger()
+		logger.WithError(serrors.E(op, err)).Error("TailEvents failed")
+	}
 }
 
 // Helper methods

--- a/modules/bichat/presentation/controllers/stream_controller.go
+++ b/modules/bichat/presentation/controllers/stream_controller.go
@@ -276,6 +276,10 @@ func (c *StreamController) StreamMessage(w http.ResponseWriter, r *http.Request)
 				PartialMetadata: chunk.Snapshot.PartialMetadata,
 			}
 		}
+		if chunk.Type == bichatservices.ChunkTypeTextBlockEnd {
+			seq := chunk.TextBlockSeq
+			payload.TextBlockSeq = &seq
+		}
 
 		// Event name is for SSE clients that care; our frontend reads `data:` lines.
 		eventName := payload.Type
@@ -540,6 +544,10 @@ func (c *StreamController) ResumeStream(w http.ResponseWriter, r *http.Request) 
 				PartialContent:  chunk.Snapshot.PartialContent,
 				PartialMetadata: chunk.Snapshot.PartialMetadata,
 			}
+		}
+		if chunk.Type == bichatservices.ChunkTypeTextBlockEnd {
+			seq := chunk.TextBlockSeq
+			payload.TextBlockSeq = &seq
 		}
 
 		eventName := payload.Type

--- a/modules/bichat/presentation/controllers/stream_controller.go
+++ b/modules/bichat/presentation/controllers/stream_controller.go
@@ -79,6 +79,10 @@ func (c *StreamController) Register(r *mux.Router) {
 	// the event log so the browser never sees a dropped event across
 	// network blips / tab sleep.
 	subRouter.HandleFunc("/stream/events", c.TailEvents).Methods("GET")
+	// GET /stream/active-runs is the per-tenant sidebar fan-out. Used by
+	// the React chat list to render a status dot next to each session
+	// card without polling /stream/status per session.
+	subRouter.HandleFunc("/stream/active-runs", c.TailActiveRuns).Methods("GET")
 }
 
 // StreamMessage handles SSE streaming for a message.
@@ -686,6 +690,90 @@ func (c *StreamController) TailEvents(w http.ResponseWriter, r *http.Request) {
 		}
 		logger := configuration.Use().Logger()
 		logger.WithError(serrors.E(op, err)).Error("TailEvents failed")
+	}
+}
+
+// TailActiveRuns handles GET /stream/active-runs — the per-tenant
+// sidebar fan-out used by the chat list to render a status dot per
+// session. A connect sends one `snapshot` event per currently-running
+// session, then live `update` events per status transition
+// (streaming / completed / cancelled / failed / queued).
+//
+// Tenant scope is taken from the authenticated request context; the
+// handler has no query parameters. Returns 503 when the active-run
+// index is not configured.
+func (c *StreamController) TailActiveRuns(w http.ResponseWriter, r *http.Request) {
+	const op serrors.Op = "StreamController.TailActiveRuns"
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "Streaming not supported", http.StatusInternalServerError)
+		return
+	}
+	if _, err := composables.UseUser(r.Context()); err != nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+	if c.opts.RequireAccessPermission != nil {
+		if err := composables.CanUser(r.Context(), c.opts.RequireAccessPermission); err != nil {
+			http.Error(w, "Access denied", http.StatusForbidden)
+			return
+		}
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	c.sendSSEComment(w, flusher, "stream-open")
+
+	var writeMu sync.Mutex
+	heartbeatStop := make(chan struct{})
+	defer close(heartbeatStop)
+	go func() {
+		ticker := time.NewTicker(streamHeartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-heartbeatStop:
+				return
+			case <-ticker.C:
+				writeMu.Lock()
+				c.sendSSEComment(w, flusher, "ping")
+				writeMu.Unlock()
+			}
+		}
+	}()
+
+	err := c.streamService.TailActiveRuns(r.Context(), func(evt bichatservices.ActiveRunDelivery) {
+		writeMu.Lock()
+		defer writeMu.Unlock()
+		payload := struct {
+			SessionID string `json:"sessionId"`
+			RunID     string `json:"runId"`
+			Status    string `json:"status"`
+			UpdatedAt int64  `json:"updatedAt"`
+		}{
+			SessionID: evt.SessionID.String(),
+			RunID:     evt.RunID.String(),
+			Status:    evt.Status,
+			UpdatedAt: evt.UpdatedAt,
+		}
+		c.sendSSEEvent(w, flusher, evt.Event, payload)
+	})
+	if err != nil {
+		if errors.Is(err, bichatservices.ErrRunEventLogUnavailable) {
+			writeMu.Lock()
+			defer writeMu.Unlock()
+			c.sendSSEEvent(w, flusher, "error", map[string]string{
+				"error": "active-run index unavailable",
+			})
+			return
+		}
+		logger := configuration.Use().Logger()
+		logger.WithError(serrors.E(op, err)).Error("TailActiveRuns failed")
 	}
 }
 

--- a/modules/bichat/presentation/controllers/stream_controller.go
+++ b/modules/bichat/presentation/controllers/stream_controller.go
@@ -130,6 +130,9 @@ func (c *StreamController) StreamMessage(w http.ResponseWriter, r *http.Request)
 		ReplaceFrom     *uuid.UUID            `json:"replaceFromMessageId,omitempty"`
 		ReasoningEffort *string               `json:"reasoningEffort,omitempty"`
 		Model           *string               `json:"model,omitempty"`
+		// RequestID is the client idempotency key. Duplicate sends with
+		// the same RequestID within ~30 min converge on the same run.
+		RequestID *uuid.UUID `json:"requestId,omitempty"`
 	}
 
 	var req streamRequest
@@ -218,6 +221,7 @@ func (c *StreamController) StreamMessage(w http.ResponseWriter, r *http.Request)
 		ReplaceFromMessageID: req.ReplaceFrom,
 		ReasoningEffort:      req.ReasoningEffort,
 		Model:                req.Model,
+		RequestID:            req.RequestID,
 	}, func(chunk bichatservices.StreamChunk) {
 		// Handle context cancellation
 		select {

--- a/modules/bichat/presentation/controllers/stream_controller.go
+++ b/modules/bichat/presentation/controllers/stream_controller.go
@@ -298,7 +298,7 @@ func (c *StreamController) StreamMessage(w http.ResponseWriter, r *http.Request)
 		// Event name is for SSE clients that care; our frontend reads `data:` lines.
 		eventName := payload.Type
 		if eventName == "" {
-			eventName = "chunk"
+			eventName = string(httpdto.StreamEventChunk)
 		}
 		sendEvent(eventName, payload)
 	})
@@ -566,7 +566,7 @@ func (c *StreamController) ResumeStream(w http.ResponseWriter, r *http.Request) 
 
 		eventName := payload.Type
 		if eventName == "" {
-			eventName = "chunk"
+			eventName = string(httpdto.StreamEventChunk)
 		}
 		sendEvent(eventName, payload)
 	})
@@ -660,7 +660,7 @@ func (c *StreamController) TailEvents(w http.ResponseWriter, r *http.Request) {
 		defer writeMu.Unlock()
 		eventName := evt.Type
 		if eventName == "" {
-			eventName = "chunk"
+			eventName = string(httpdto.StreamEventChunk)
 		}
 		// Emit SSE triple with id: + event: + data:. The id: line is
 		// what EventSource stores in the browser's internal Last-Event-ID

--- a/modules/bichat/presentation/controllers/tail_events_controller_test.go
+++ b/modules/bichat/presentation/controllers/tail_events_controller_test.go
@@ -1,0 +1,203 @@
+package controllers
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/iota-uz/iota-sdk/modules/bichat/infrastructure/persistence"
+	coreuser "github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/user"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/value_objects/internet"
+	"github.com/iota-uz/iota-sdk/pkg/bichat/domain"
+	bichatservices "github.com/iota-uz/iota-sdk/pkg/bichat/services"
+	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeStreamCommands is a minimal StreamCommands stub for controller unit tests.
+type fakeStreamCommands struct {
+	tailRunEventsFunc func(ctx context.Context, sessionID, runID uuid.UUID, from string, onEvent func(bichatservices.RunEventDelivery)) error
+}
+
+func (f *fakeStreamCommands) SendMessageStream(_ context.Context, _ bichatservices.SendMessageRequest, _ func(bichatservices.StreamChunk)) error {
+	return nil
+}
+func (f *fakeStreamCommands) StopGeneration(_ context.Context, _ uuid.UUID) error { return nil }
+func (f *fakeStreamCommands) GetStreamStatus(_ context.Context, _ uuid.UUID) (*bichatservices.StreamStatus, error) {
+	return &bichatservices.StreamStatus{}, nil
+}
+func (f *fakeStreamCommands) ResumeStream(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ func(bichatservices.StreamChunk)) error {
+	return nil
+}
+func (f *fakeStreamCommands) TailRunEvents(ctx context.Context, sessionID, runID uuid.UUID, from string, onEvent func(bichatservices.RunEventDelivery)) error {
+	if f.tailRunEventsFunc != nil {
+		return f.tailRunEventsFunc(ctx, sessionID, runID, from, onEvent)
+	}
+	return bichatservices.ErrRunEventLogUnavailable
+}
+func (f *fakeStreamCommands) TailActiveRuns(_ context.Context, _ func(bichatservices.ActiveRunDelivery)) error {
+	return bichatservices.ErrRunEventLogUnavailable
+}
+
+// fakeSessionQueries satisfies bichatservices.SessionQueries with minimal stubs.
+type fakeSessionQueries struct{}
+
+func (f *fakeSessionQueries) GetSession(_ context.Context, _ uuid.UUID) (domain.Session, error) {
+	return nil, persistence.ErrSessionNotFound
+}
+func (f *fakeSessionQueries) ListUserSessions(_ context.Context, _ int64, _ domain.ListOptions) ([]domain.Session, error) {
+	return nil, nil
+}
+func (f *fakeSessionQueries) CountUserSessions(_ context.Context, _ int64, _ domain.ListOptions) (int, error) {
+	return 0, nil
+}
+func (f *fakeSessionQueries) ListAccessibleSessions(_ context.Context, _ int64, _ domain.ListOptions) ([]domain.SessionSummary, error) {
+	return nil, nil
+}
+func (f *fakeSessionQueries) CountAccessibleSessions(_ context.Context, _ int64, _ domain.ListOptions) (int, error) {
+	return 0, nil
+}
+func (f *fakeSessionQueries) ListAllSessions(_ context.Context, _ int64, _ domain.ListOptions, _ *int64) ([]domain.SessionSummary, error) {
+	return nil, nil
+}
+func (f *fakeSessionQueries) CountAllSessions(_ context.Context, _ domain.ListOptions, _ *int64) (int, error) {
+	return 0, nil
+}
+func (f *fakeSessionQueries) ResolveSessionAccess(_ context.Context, _ uuid.UUID, _ int64, _ bool) (domain.SessionAccess, error) {
+	access, _ := domain.NewSessionAccess(domain.SessionMemberRoleOwner, domain.SessionAccessSourceOwner)
+	return access, nil
+}
+func (f *fakeSessionQueries) ListSessionMembers(_ context.Context, _ uuid.UUID) ([]domain.SessionMember, error) {
+	return nil, nil
+}
+func (f *fakeSessionQueries) GetTenantUser(_ context.Context, _ int64) (domain.SessionUser, error) {
+	return domain.SessionUser{}, nil
+}
+func (f *fakeSessionQueries) ListTenantUsers(_ context.Context) ([]domain.SessionUser, error) {
+	return nil, nil
+}
+
+// testUser builds a minimal coreuser.User for injecting into request context.
+func testUser(t *testing.T) coreuser.User {
+	t.Helper()
+	email, err := internet.NewEmail("test@example.com")
+	require.NoError(t, err)
+	return coreuser.New("Test", "User", email, coreuser.UILanguageEN)
+}
+
+// TestTailEvents_LastEventIDForwardedToService verifies that the
+// Last-Event-ID header value is passed verbatim as the `from` parameter
+// to StreamCommands.TailRunEvents.
+func TestTailEvents_LastEventIDForwardedToService(t *testing.T) {
+	t.Parallel()
+
+	sessionID := uuid.New()
+	runID := uuid.New()
+	const lastEventID = "1712345678000-0"
+
+	var capturedFrom string
+	fake := &fakeStreamCommands{
+		tailRunEventsFunc: func(_ context.Context, _, _ uuid.UUID, from string, onEvent func(bichatservices.RunEventDelivery)) error {
+			capturedFrom = from
+			// Deliver one content event.
+			payload, _ := json.Marshal(map[string]string{"type": "content", "content": "hello"})
+			onEvent(bichatservices.RunEventDelivery{
+				StreamID: "1712345678001-0",
+				Type:     "content",
+				Payload:  payload,
+			})
+			// Deliver terminal done.
+			donePayload, _ := json.Marshal(map[string]string{"type": "done"})
+			onEvent(bichatservices.RunEventDelivery{
+				StreamID: "1712345678002-0",
+				Type:     "done",
+				Payload:  donePayload,
+			})
+			return nil
+		},
+	}
+
+	controller := NewStreamController(fake, &fakeSessionQueries{}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf(
+		"/stream/events?sessionId=%s&runId=%s", sessionID, runID,
+	), nil)
+	req.Header.Set("Last-Event-ID", lastEventID)
+	req = req.WithContext(composables.WithUser(req.Context(), testUser(t)))
+
+	rw := httptest.NewRecorder()
+	router := mux.NewRouter()
+	router.HandleFunc("/stream/events", controller.TailEvents).Methods("GET")
+	router.ServeHTTP(rw, req)
+
+	require.Equal(t, http.StatusOK, rw.Code)
+	assert.Equal(t, lastEventID, capturedFrom, "Last-Event-ID must be forwarded to TailRunEvents")
+
+	body := rw.Body.String()
+	assert.Contains(t, body, "id: 1712345678001-0", "SSE id line must be written")
+	assert.Contains(t, body, "event: content", "SSE event: content line must be written")
+}
+
+// TestTailEvents_MissingParamsReturns400 verifies 400 on missing query params.
+func TestTailEvents_MissingParamsReturns400(t *testing.T) {
+	t.Parallel()
+
+	controller := NewStreamController(&fakeStreamCommands{}, &fakeSessionQueries{}, nil)
+	req := httptest.NewRequest(http.MethodGet, "/stream/events", nil)
+	req = req.WithContext(composables.WithUser(req.Context(), testUser(t)))
+	rw := httptest.NewRecorder()
+
+	router := mux.NewRouter()
+	router.HandleFunc("/stream/events", controller.TailEvents).Methods("GET")
+	router.ServeHTTP(rw, req)
+
+	assert.Equal(t, http.StatusBadRequest, rw.Code)
+}
+
+// TestTailEvents_UnavailableEmitsErrorEvent verifies that when the event log
+// is unavailable the controller emits a synthetic SSE error event (not an HTTP error).
+func TestTailEvents_UnavailableEmitsErrorEvent(t *testing.T) {
+	t.Parallel()
+
+	sessionID := uuid.New()
+	runID := uuid.New()
+
+	// Default fakeStreamCommands returns ErrRunEventLogUnavailable.
+	controller := NewStreamController(&fakeStreamCommands{}, &fakeSessionQueries{}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf(
+		"/stream/events?sessionId=%s&runId=%s", sessionID, runID,
+	), nil)
+	req = req.WithContext(composables.WithUser(req.Context(), testUser(t)))
+
+	rw := httptest.NewRecorder()
+	router := mux.NewRouter()
+	router.HandleFunc("/stream/events", controller.TailEvents).Methods("GET")
+	router.ServeHTTP(rw, req)
+
+	require.Equal(t, http.StatusOK, rw.Code)
+	body := rw.Body.String()
+	assert.Contains(t, body, "event: error", "must emit SSE error event when log unavailable")
+	assert.Contains(t, body, "unavailable", "error payload must mention unavailable")
+}
+
+// parseSSELines splits an SSE body into event line groups (non-empty lines).
+func parseSSELines(body string) []string {
+	var lines []string
+	scanner := bufio.NewScanner(strings.NewReader(body))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "event:") || strings.HasPrefix(line, "id:") || strings.HasPrefix(line, "data:") {
+			lines = append(lines, line)
+		}
+	}
+	return lines
+}

--- a/modules/bichat/presentation/controllers/tail_events_controller_test.go
+++ b/modules/bichat/presentation/controllers/tail_events_controller_test.go
@@ -188,4 +188,3 @@ func TestTailEvents_UnavailableEmitsErrorEvent(t *testing.T) {
 	assert.Contains(t, body, "event: error", "must emit SSE error event when log unavailable")
 	assert.Contains(t, body, "unavailable", "error payload must mention unavailable")
 }
-

--- a/modules/bichat/presentation/controllers/tail_events_controller_test.go
+++ b/modules/bichat/presentation/controllers/tail_events_controller_test.go
@@ -1,13 +1,11 @@
 package controllers
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -108,14 +106,16 @@ func TestTailEvents_LastEventIDForwardedToService(t *testing.T) {
 		tailRunEventsFunc: func(_ context.Context, _, _ uuid.UUID, from string, onEvent func(bichatservices.RunEventDelivery)) error {
 			capturedFrom = from
 			// Deliver one content event.
-			payload, _ := json.Marshal(map[string]string{"type": "content", "content": "hello"})
+			payload, err := json.Marshal(map[string]string{"type": "content", "content": "hello"})
+			require.NoError(t, err)
 			onEvent(bichatservices.RunEventDelivery{
 				StreamID: "1712345678001-0",
 				Type:     "content",
 				Payload:  payload,
 			})
 			// Deliver terminal done.
-			donePayload, _ := json.Marshal(map[string]string{"type": "done"})
+			donePayload, err := json.Marshal(map[string]string{"type": "done"})
+			require.NoError(t, err)
 			onEvent(bichatservices.RunEventDelivery{
 				StreamID: "1712345678002-0",
 				Type:     "done",
@@ -189,15 +189,3 @@ func TestTailEvents_UnavailableEmitsErrorEvent(t *testing.T) {
 	assert.Contains(t, body, "unavailable", "error payload must mention unavailable")
 }
 
-// parseSSELines splits an SSE body into event line groups (non-empty lines).
-func parseSSELines(body string) []string {
-	var lines []string
-	scanner := bufio.NewScanner(strings.NewReader(body))
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "event:") || strings.HasPrefix(line, "id:") || strings.HasPrefix(line, "data:") {
-			lines = append(lines, line)
-		}
-	}
-	return lines
-}

--- a/modules/bichat/services/active_run_index.go
+++ b/modules/bichat/services/active_run_index.go
@@ -123,21 +123,6 @@ func NewRedisActiveRunIndex(cfg RedisActiveRunIndexConfig) (*RedisActiveRunIndex
 	}, nil
 }
 
-// newConfiguredActiveRunIndex mirrors the other newConfigured* helpers:
-// reads REDIS_URL and returns nil on disable so callers degrade to a
-// no-op integration path.
-func newConfiguredActiveRunIndex() ActiveRunIndex {
-	redisURL, ok := envLookup("REDIS_URL")
-	if !ok || strings.TrimSpace(redisURL) == "" {
-		return nil
-	}
-	idx, err := NewRedisActiveRunIndex(RedisActiveRunIndexConfig{RedisURL: redisURL})
-	if err != nil {
-		return nil
-	}
-	return idx
-}
-
 // Upsert implements ActiveRunIndex.
 func (idx *RedisActiveRunIndex) Upsert(ctx context.Context, tenantID uuid.UUID, status ActiveRunStatus) error {
 	const op serrors.Op = "RedisActiveRunIndex.Upsert"
@@ -248,7 +233,7 @@ func (idx *RedisActiveRunIndex) Subscribe(ctx context.Context, tenantID uuid.UUI
 	out := make(chan ActiveRunStatus)
 	go func() {
 		defer close(out)
-		defer sub.Close()
+		defer func() { _ = sub.Close() }()
 		ch := sub.Channel()
 		for {
 			select {

--- a/modules/bichat/services/active_run_index.go
+++ b/modules/bichat/services/active_run_index.go
@@ -84,7 +84,11 @@ type RedisActiveRunIndexConfig struct {
 
 // RedisActiveRunIndex is the Redis hash + pubsub implementation.
 type RedisActiveRunIndex struct {
-	client      *redis.Client
+	client *redis.Client
+	// ownsClient is true only when this instance dialled the connection
+	// itself. When false (client supplied externally), Close is a no-op so
+	// the shared-client path does not tear down the other components.
+	ownsClient  bool
 	keyPrefix   string
 	eventsTopic string
 }
@@ -101,6 +105,7 @@ func NewRedisActiveRunIndex(cfg RedisActiveRunIndexConfig) (*RedisActiveRunIndex
 		events = defaultActiveRunIndexEventsTop
 	}
 
+	ownsClient := cfg.Client == nil
 	client := cfg.Client
 	if client == nil {
 		c, err := newRedisClient(cfg.RedisURL)
@@ -112,6 +117,7 @@ func NewRedisActiveRunIndex(cfg RedisActiveRunIndexConfig) (*RedisActiveRunIndex
 
 	return &RedisActiveRunIndex{
 		client:      client,
+		ownsClient:  ownsClient,
 		keyPrefix:   prefix,
 		eventsTopic: events,
 	}, nil
@@ -267,8 +273,13 @@ func (idx *RedisActiveRunIndex) Subscribe(ctx context.Context, tenantID uuid.UUI
 	return out, nil
 }
 
-// Close releases the underlying Redis connection.
+// Close releases the underlying Redis connection. When the client was
+// supplied externally (ownsClient == false) this is a no-op; the caller
+// that owns the shared *redis.Client is responsible for closing it.
 func (idx *RedisActiveRunIndex) Close() error {
+	if !idx.ownsClient {
+		return nil
+	}
 	return idx.client.Close()
 }
 

--- a/modules/bichat/services/active_run_index.go
+++ b/modules/bichat/services/active_run_index.go
@@ -1,0 +1,281 @@
+// Package services provides this package.
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
+	"github.com/redis/go-redis/v9"
+)
+
+// Redis key and pubsub topic conventions for the per-tenant active run
+// index. The hash holds one entry per streaming (or queued) run keyed by
+// session id — sessions are mutually-exclusive with runs via the
+// generation_run_store SetNX lock, so this is a 1:1 mapping for active
+// work. The pubsub topic carries deltas so subscribers don't have to
+// poll HGETALL on a timer.
+const (
+	defaultActiveRunIndexPrefix    = "bichat:active-runs"
+	defaultActiveRunIndexEventsTop = "bichat:active-runs:events"
+)
+
+// ActiveRunStatus is the canonical shape rendered on sidebar dots and
+// emitted on the status pubsub topic. Terminal statuses (completed /
+// cancelled / failed) are published once and then the hash entry is
+// removed so the sidebar badge fades on its own without polling.
+type ActiveRunStatus struct {
+	SessionID uuid.UUID `json:"session_id"`
+	RunID     uuid.UUID `json:"run_id"`
+	// Status matches domain.GenerationRunStatus values + "queued" (used
+	// by the FIFO queue for messages waiting behind an active run).
+	Status    string    `json:"status"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// ActiveRunIndex is the per-tenant live view of in-flight generations.
+//
+// Upsert/Remove are called by the chat service on every run state
+// transition. Snapshot + Subscribe are used by the sidebar SSE handler
+// to bootstrap then live-update a "generating…" indicator next to each
+// session card without N round-trips on page load.
+type ActiveRunIndex interface {
+	// Upsert writes or overwrites the status of a session's active run.
+	// Publishes a delta on the events topic so tailing clients see it
+	// immediately. Safe to call with terminal statuses — prefer
+	// Remove for the GC step so the hash doesn't grow forever.
+	Upsert(ctx context.Context, tenantID uuid.UUID, status ActiveRunStatus) error
+
+	// PublishAndRemove publishes the final status delta then removes
+	// the hash entry so the sidebar badge can fade. It is the atomic
+	// terminal step — using Upsert(terminal) followed by Remove would
+	// leak a window where a late subscriber sees a stale streaming
+	// entry on HGETALL.
+	PublishAndRemove(ctx context.Context, tenantID uuid.UUID, status ActiveRunStatus) error
+
+	// Remove drops a session entry without publishing, used by GC /
+	// reaper paths where a publish would double-count.
+	Remove(ctx context.Context, tenantID, sessionID uuid.UUID) error
+
+	// Snapshot returns the current live view for the tenant. Ordering
+	// is not guaranteed — callers who want a stable sort should order
+	// by SessionID or UpdatedAt.
+	Snapshot(ctx context.Context, tenantID uuid.UUID) ([]ActiveRunStatus, error)
+
+	// Subscribe returns a channel of delta events. The channel closes
+	// when ctx is cancelled or the underlying pubsub connection
+	// breaks. Subscribers are tenant-scoped: a listener for tenant A
+	// will not receive tenant B events.
+	Subscribe(ctx context.Context, tenantID uuid.UUID) (<-chan ActiveRunStatus, error)
+}
+
+// RedisActiveRunIndexConfig configures the Redis-backed index.
+type RedisActiveRunIndexConfig struct {
+	RedisURL    string
+	KeyPrefix   string
+	EventsTopic string
+	Client      *redis.Client
+}
+
+// RedisActiveRunIndex is the Redis hash + pubsub implementation.
+type RedisActiveRunIndex struct {
+	client      *redis.Client
+	keyPrefix   string
+	eventsTopic string
+}
+
+// NewRedisActiveRunIndex constructs an index bound to the supplied Redis
+// client, or dials a new connection from RedisURL if Client is nil.
+func NewRedisActiveRunIndex(cfg RedisActiveRunIndexConfig) (*RedisActiveRunIndex, error) {
+	prefix := strings.TrimSpace(cfg.KeyPrefix)
+	if prefix == "" {
+		prefix = defaultActiveRunIndexPrefix
+	}
+	events := strings.TrimSpace(cfg.EventsTopic)
+	if events == "" {
+		events = defaultActiveRunIndexEventsTop
+	}
+
+	client := cfg.Client
+	if client == nil {
+		c, err := newRedisClient(cfg.RedisURL)
+		if err != nil {
+			return nil, err
+		}
+		client = c
+	}
+
+	return &RedisActiveRunIndex{
+		client:      client,
+		keyPrefix:   prefix,
+		eventsTopic: events,
+	}, nil
+}
+
+// newConfiguredActiveRunIndex mirrors the other newConfigured* helpers:
+// reads REDIS_URL and returns nil on disable so callers degrade to a
+// no-op integration path.
+func newConfiguredActiveRunIndex() ActiveRunIndex {
+	redisURL, ok := envLookup("REDIS_URL")
+	if !ok || strings.TrimSpace(redisURL) == "" {
+		return nil
+	}
+	idx, err := NewRedisActiveRunIndex(RedisActiveRunIndexConfig{RedisURL: redisURL})
+	if err != nil {
+		return nil
+	}
+	return idx
+}
+
+// Upsert implements ActiveRunIndex.
+func (idx *RedisActiveRunIndex) Upsert(ctx context.Context, tenantID uuid.UUID, status ActiveRunStatus) error {
+	const op serrors.Op = "RedisActiveRunIndex.Upsert"
+	if tenantID == uuid.Nil {
+		return serrors.E(op, serrors.KindValidation, "tenant id is required")
+	}
+	if status.SessionID == uuid.Nil {
+		return serrors.E(op, serrors.KindValidation, "session id is required")
+	}
+	if status.UpdatedAt.IsZero() {
+		status.UpdatedAt = time.Now().UTC()
+	}
+	body, err := json.Marshal(status)
+	if err != nil {
+		return serrors.E(op, "marshal status", err)
+	}
+
+	writeCtx := context.WithoutCancel(ctx)
+	pipe := idx.client.TxPipeline()
+	pipe.HSet(writeCtx, idx.hashKey(tenantID), status.SessionID.String(), body)
+	pipe.Publish(writeCtx, idx.eventsChannel(tenantID), body)
+	if _, err := pipe.Exec(writeCtx); err != nil {
+		return serrors.E(op, "hset+publish", err)
+	}
+	return nil
+}
+
+// PublishAndRemove implements ActiveRunIndex.
+func (idx *RedisActiveRunIndex) PublishAndRemove(ctx context.Context, tenantID uuid.UUID, status ActiveRunStatus) error {
+	const op serrors.Op = "RedisActiveRunIndex.PublishAndRemove"
+	if tenantID == uuid.Nil {
+		return serrors.E(op, serrors.KindValidation, "tenant id is required")
+	}
+	if status.SessionID == uuid.Nil {
+		return serrors.E(op, serrors.KindValidation, "session id is required")
+	}
+	if status.UpdatedAt.IsZero() {
+		status.UpdatedAt = time.Now().UTC()
+	}
+	body, err := json.Marshal(status)
+	if err != nil {
+		return serrors.E(op, "marshal status", err)
+	}
+
+	writeCtx := context.WithoutCancel(ctx)
+	pipe := idx.client.TxPipeline()
+	pipe.Publish(writeCtx, idx.eventsChannel(tenantID), body)
+	pipe.HDel(writeCtx, idx.hashKey(tenantID), status.SessionID.String())
+	if _, err := pipe.Exec(writeCtx); err != nil {
+		return serrors.E(op, "publish+hdel", err)
+	}
+	return nil
+}
+
+// Remove implements ActiveRunIndex.
+func (idx *RedisActiveRunIndex) Remove(ctx context.Context, tenantID, sessionID uuid.UUID) error {
+	const op serrors.Op = "RedisActiveRunIndex.Remove"
+	if tenantID == uuid.Nil || sessionID == uuid.Nil {
+		return serrors.E(op, serrors.KindValidation, "tenant id and session id are required")
+	}
+	writeCtx := context.WithoutCancel(ctx)
+	if err := idx.client.HDel(writeCtx, idx.hashKey(tenantID), sessionID.String()).Err(); err != nil {
+		return serrors.E(op, "hdel", err)
+	}
+	return nil
+}
+
+// Snapshot implements ActiveRunIndex.
+func (idx *RedisActiveRunIndex) Snapshot(ctx context.Context, tenantID uuid.UUID) ([]ActiveRunStatus, error) {
+	const op serrors.Op = "RedisActiveRunIndex.Snapshot"
+	if tenantID == uuid.Nil {
+		return nil, serrors.E(op, serrors.KindValidation, "tenant id is required")
+	}
+	raw, err := idx.client.HGetAll(ctx, idx.hashKey(tenantID)).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return nil, nil
+		}
+		return nil, serrors.E(op, "hgetall", err)
+	}
+	out := make([]ActiveRunStatus, 0, len(raw))
+	for _, v := range raw {
+		var entry ActiveRunStatus
+		if err := json.Unmarshal([]byte(v), &entry); err != nil {
+			// Skip malformed entries rather than failing the whole
+			// snapshot — a single bad write shouldn't break the sidebar.
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out, nil
+}
+
+// Subscribe implements ActiveRunIndex.
+func (idx *RedisActiveRunIndex) Subscribe(ctx context.Context, tenantID uuid.UUID) (<-chan ActiveRunStatus, error) {
+	const op serrors.Op = "RedisActiveRunIndex.Subscribe"
+	if tenantID == uuid.Nil {
+		return nil, serrors.E(op, serrors.KindValidation, "tenant id is required")
+	}
+	sub := idx.client.Subscribe(ctx, idx.eventsChannel(tenantID))
+	// Ensure the subscription is actually established before returning
+	// so callers don't race with the first Publish.
+	if _, err := sub.Receive(ctx); err != nil {
+		_ = sub.Close()
+		return nil, serrors.E(op, "subscribe", err)
+	}
+
+	out := make(chan ActiveRunStatus)
+	go func() {
+		defer close(out)
+		defer sub.Close()
+		ch := sub.Channel()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg, ok := <-ch:
+				if !ok {
+					return
+				}
+				var entry ActiveRunStatus
+				if err := json.Unmarshal([]byte(msg.Payload), &entry); err != nil {
+					continue
+				}
+				select {
+				case out <- entry:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return out, nil
+}
+
+// Close releases the underlying Redis connection.
+func (idx *RedisActiveRunIndex) Close() error {
+	return idx.client.Close()
+}
+
+func (idx *RedisActiveRunIndex) hashKey(tenantID uuid.UUID) string {
+	return fmt.Sprintf("%s:%s", idx.keyPrefix, tenantID.String())
+}
+
+func (idx *RedisActiveRunIndex) eventsChannel(tenantID uuid.UUID) string {
+	return fmt.Sprintf("%s:%s", idx.eventsTopic, tenantID.String())
+}

--- a/modules/bichat/services/active_run_index_test.go
+++ b/modules/bichat/services/active_run_index_test.go
@@ -1,0 +1,149 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestActiveRunIndex(t *testing.T) (*RedisActiveRunIndex, *redis.Client) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	idx, err := NewRedisActiveRunIndex(RedisActiveRunIndexConfig{Client: client})
+	require.NoError(t, err)
+	return idx, client
+}
+
+func TestActiveRunIndex_UpsertAndSnapshot(t *testing.T) {
+	t.Parallel()
+
+	idx, _ := newTestActiveRunIndex(t)
+	tenant := uuid.New()
+
+	entry := ActiveRunStatus{
+		SessionID: uuid.New(),
+		RunID:     uuid.New(),
+		Status:    "streaming",
+	}
+	require.NoError(t, idx.Upsert(context.Background(), tenant, entry))
+
+	snap, err := idx.Snapshot(context.Background(), tenant)
+	require.NoError(t, err)
+	require.Len(t, snap, 1)
+	assert.Equal(t, entry.SessionID, snap[0].SessionID)
+	assert.Equal(t, entry.RunID, snap[0].RunID)
+	assert.Equal(t, "streaming", snap[0].Status)
+	assert.False(t, snap[0].UpdatedAt.IsZero(), "Upsert must stamp UpdatedAt when missing")
+}
+
+func TestActiveRunIndex_UpsertOverwritesStatus(t *testing.T) {
+	t.Parallel()
+
+	idx, _ := newTestActiveRunIndex(t)
+	tenant := uuid.New()
+	session := uuid.New()
+
+	require.NoError(t, idx.Upsert(context.Background(), tenant, ActiveRunStatus{
+		SessionID: session,
+		RunID:     uuid.New(),
+		Status:    "queued",
+	}))
+	require.NoError(t, idx.Upsert(context.Background(), tenant, ActiveRunStatus{
+		SessionID: session,
+		RunID:     uuid.New(),
+		Status:    "streaming",
+	}))
+
+	snap, err := idx.Snapshot(context.Background(), tenant)
+	require.NoError(t, err)
+	require.Len(t, snap, 1, "same session must have exactly one live entry")
+	assert.Equal(t, "streaming", snap[0].Status)
+}
+
+func TestActiveRunIndex_PublishAndRemoveClearsEntry(t *testing.T) {
+	t.Parallel()
+
+	idx, _ := newTestActiveRunIndex(t)
+	tenant := uuid.New()
+	session := uuid.New()
+
+	require.NoError(t, idx.Upsert(context.Background(), tenant, ActiveRunStatus{
+		SessionID: session,
+		RunID:     uuid.New(),
+		Status:    "streaming",
+	}))
+	require.NoError(t, idx.PublishAndRemove(context.Background(), tenant, ActiveRunStatus{
+		SessionID: session,
+		RunID:     uuid.New(),
+		Status:    "completed",
+	}))
+
+	snap, err := idx.Snapshot(context.Background(), tenant)
+	require.NoError(t, err)
+	assert.Empty(t, snap, "PublishAndRemove must drop the entry so late snapshots don't see a stale streaming state")
+}
+
+func TestActiveRunIndex_SnapshotIsTenantScoped(t *testing.T) {
+	t.Parallel()
+
+	idx, _ := newTestActiveRunIndex(t)
+	tenantA := uuid.New()
+	tenantB := uuid.New()
+
+	require.NoError(t, idx.Upsert(context.Background(), tenantA, ActiveRunStatus{
+		SessionID: uuid.New(), RunID: uuid.New(), Status: "streaming",
+	}))
+	require.NoError(t, idx.Upsert(context.Background(), tenantB, ActiveRunStatus{
+		SessionID: uuid.New(), RunID: uuid.New(), Status: "streaming",
+	}))
+
+	snapA, err := idx.Snapshot(context.Background(), tenantA)
+	require.NoError(t, err)
+	require.Len(t, snapA, 1)
+
+	snapB, err := idx.Snapshot(context.Background(), tenantB)
+	require.NoError(t, err)
+	require.Len(t, snapB, 1)
+
+	assert.NotEqual(t, snapA[0].SessionID, snapB[0].SessionID,
+		"tenants must not see each other's active runs")
+}
+
+func TestActiveRunIndex_SubscribeReceivesDeltas(t *testing.T) {
+	t.Parallel()
+
+	idx, _ := newTestActiveRunIndex(t)
+	tenant := uuid.New()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	ch, err := idx.Subscribe(ctx, tenant)
+	require.NoError(t, err)
+
+	// Subscribe returns after the subscription handshake, so Publishes
+	// issued after this point are guaranteed to be delivered.
+	entry := ActiveRunStatus{
+		SessionID: uuid.New(),
+		RunID:     uuid.New(),
+		Status:    "streaming",
+	}
+	require.NoError(t, idx.Upsert(context.Background(), tenant, entry))
+
+	select {
+	case got, ok := <-ch:
+		require.True(t, ok, "subscribe channel closed before event")
+		assert.Equal(t, entry.SessionID, got.SessionID)
+		assert.Equal(t, "streaming", got.Status)
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for subscribe delta")
+	}
+}

--- a/modules/bichat/services/chat_service_helpers.go
+++ b/modules/bichat/services/chat_service_helpers.go
@@ -525,6 +525,8 @@ func consumeAgentEvents(ctx context.Context, gen types.Generator[agents.Executor
 			}
 			recordToolArtifacts(artifactMap, collectCodeInterpreterArtifacts(event.CodeInterpreter, event.FileAnnotations))
 
+		case agents.EventTypeTextBlockEnd:
+			// Text block boundary signal; no accumulation needed in this path.
 		case agents.EventTypeError:
 			var errDetail error
 			if event.Error != nil {

--- a/modules/bichat/services/chat_service_impl.go
+++ b/modules/bichat/services/chat_service_impl.go
@@ -801,7 +801,6 @@ func (s *chatServiceImpl) SendMessageStream(ctx context.Context, req bichatservi
 			_ = s.runJobQueue.ReleaseRequest(context.WithoutCancel(ctx), *req.RequestID)
 		}
 	}
-	runPersisted := false // set true once the TX commits and the run row exists
 
 	if req.RequestID != nil && s.runJobQueue != nil {
 		runID, deduped, claimErr := s.runJobQueue.ClaimRequest(ctx, *req.RequestID, uuid.New())
@@ -918,9 +917,6 @@ func (s *chatServiceImpl) SendMessageStream(ctx context.Context, req bichatservi
 		}
 		return err
 	}
-	runPersisted = true
-	_ = runPersisted // used by the deferred release guard below
-
 	// Decouple generation from request cancellation, but keep request values
 	// (tenant/user/pool/tx) required by downstream services and repositories.
 	processCtx, cancelProcess := context.WithCancel(context.WithoutCancel(ctx))

--- a/modules/bichat/services/chat_service_impl.go
+++ b/modules/bichat/services/chat_service_impl.go
@@ -65,17 +65,21 @@ type chatServiceImpl struct {
 }
 
 // NewChatService creates a production implementation of ChatService.
+// Returns an error when REDIS_URL is set but any Redis component fails to
+// initialise — this prevents a broken Redis config from silently degrading
+// to the in-memory fallback while operators believe Redis is active.
 //
 // Example:
 //
-//	service := NewChatService(chatRepo, agentService, model, titleService, titleQueue)
+//	service, err := NewChatService(chatRepo, agentService, model, titleService, titleQueue)
 func NewChatService(
 	chatRepo domain.ChatRepository,
 	agentService bichatservices.AgentService,
 	model agents.Model,
 	titleService TitleService,
 	titleQueue TitleJobQueue,
-) *chatServiceImpl {
+) (*chatServiceImpl, error) {
+	const op serrors.Op = "NewChatService"
 	runStore := newConfiguredGenerationRunStore()
 	accessRepo := chatRepo.(domain.SessionAccessRepository)
 	// Use a single shared Redis connection for all Redis-backed components so
@@ -84,7 +88,10 @@ func NewChatService(
 	// closeSharedRedis is the single owner of the shared *redis.Client; each
 	// component's Close() is a no-op because the client was supplied
 	// externally. Call CloseSharedRedis() exactly once at shutdown.
-	eventLog, activeRunIndex, runJobQueue, closeSharedRedis := newConfiguredRedisComponents()
+	eventLog, activeRunIndex, runJobQueue, closeSharedRedis, err := newConfiguredRedisComponents()
+	if err != nil {
+		return nil, serrors.E(op, err)
+	}
 	return &chatServiceImpl{
 		chatRepo:           chatRepo,
 		sessionAccess:      accessRepo,
@@ -99,7 +106,7 @@ func NewChatService(
 		closeSharedRedis:   closeSharedRedis,
 		activeStreamCancel: make(map[uuid.UUID]context.CancelFunc),
 		runRegistry:        streamingsvc.NewRunRegistry(),
-	}
+	}, nil
 }
 
 // CloseSharedRedis releases the shared *redis.Client created by
@@ -200,7 +207,9 @@ func (s *chatServiceImpl) StopGeneration(ctx context.Context, sessionID uuid.UUI
 		// diagnose cross-process cancel delivery failures.
 		return serrors.E(op, err)
 	}
-	_ = s.runState.RequestCancel(persistCtx, run.TenantID(), sessionID, run.ID())
+	if err := s.runState.RequestCancel(persistCtx, run.TenantID(), sessionID, run.ID()); err != nil {
+		return serrors.E(op, err)
+	}
 	return nil
 }
 
@@ -634,16 +643,28 @@ func (s *chatServiceImpl) TailActiveRuns(ctx context.Context, onEvent func(bicha
 	if err != nil {
 		return serrors.E(op, err)
 	}
+
+	// snapshotHighWaterMark tracks the highest UpdatedAt seen per session
+	// in the snapshot phase. Any pubsub delta with UpdatedAt ≤ the
+	// snapshot value for the same session is a buffered-but-stale delta
+	// that arrived before we subscribed yet landed in the pubsub buffer
+	// afterward. Forwarding it would regress the sidebar to an older
+	// status, so we drop it.
+	snapshotHighWaterMark := make(map[uuid.UUID]int64, len(snap))
 	for _, entry := range snap {
 		if err := ctx.Err(); err != nil {
 			return nil //nolint:nilerr // context cancelled — clean stop, not an error
+		}
+		ms := entry.UpdatedAt.UnixMilli()
+		if ms > snapshotHighWaterMark[entry.SessionID] {
+			snapshotHighWaterMark[entry.SessionID] = ms
 		}
 		onEvent(bichatservices.ActiveRunDelivery{
 			Event:     "snapshot",
 			SessionID: entry.SessionID,
 			RunID:     entry.RunID,
 			Status:    entry.Status,
-			UpdatedAt: entry.UpdatedAt.UnixMilli(),
+			UpdatedAt: ms,
 		})
 	}
 
@@ -651,12 +672,22 @@ func (s *chatServiceImpl) TailActiveRuns(ctx context.Context, onEvent func(bicha
 		if err := ctx.Err(); err != nil {
 			return nil //nolint:nilerr // context cancelled — clean stop, not an error
 		}
+		ms := entry.UpdatedAt.UnixMilli()
+		// Drop deltas that don't advance beyond the snapshot high-water
+		// mark for this session — they are stale pubsub entries buffered
+		// before the snapshot was taken.
+		if ms <= snapshotHighWaterMark[entry.SessionID] {
+			continue
+		}
+		// Advance the high-water mark so subsequent deltas for the same
+		// session are also deduplicated correctly within the live window.
+		snapshotHighWaterMark[entry.SessionID] = ms
 		onEvent(bichatservices.ActiveRunDelivery{
 			Event:     "update",
 			SessionID: entry.SessionID,
 			RunID:     entry.RunID,
 			Status:    entry.Status,
-			UpdatedAt: entry.UpdatedAt.UnixMilli(),
+			UpdatedAt: ms,
 		})
 	}
 	return nil
@@ -791,19 +822,26 @@ func (s *chatServiceImpl) SendMessageStream(ctx context.Context, req bichatservi
 	// When Redis is not configured (dev/CI) the queue is nil and
 	// dedupe silently no-ops.
 	var claimedRunID uuid.UUID
-	// releaseRequest drops the dedupe mapping so that a retry with the same
-	// requestID can mint a fresh run instead of deduping to a phantom one.
-	// It is called on early-exit error paths (before the run is persisted)
-	// and at terminal run completion. Safe to call multiple times: the Redis
-	// key may already be gone and the implementation swallows redis.Nil.
+	// reqTenantID is used to scope the dedupe key. Resolved from context
+	// (set by HTTP auth middleware); falls back to uuid.Nil when not set
+	// (e.g. internal callers without a request context), in which case
+	// dedupe is skipped safely.
+	reqTenantID, _ := composables.UseTenantID(ctx)
+
+	// releaseRequest drops the tenant-scoped dedupe mapping so that a
+	// retry with the same requestID can mint a fresh run instead of
+	// deduping to a phantom one. Called on early-exit error paths (before
+	// the run is persisted) and at terminal run completion. Safe to call
+	// multiple times: the Redis key may already be gone and the
+	// implementation swallows redis.Nil.
 	releaseRequest := func() {
-		if req.RequestID != nil && s.runJobQueue != nil {
-			_ = s.runJobQueue.ReleaseRequest(context.WithoutCancel(ctx), *req.RequestID)
+		if req.RequestID != nil && s.runJobQueue != nil && reqTenantID != uuid.Nil {
+			_ = s.runJobQueue.ReleaseRequest(context.WithoutCancel(ctx), reqTenantID, *req.RequestID)
 		}
 	}
 
-	if req.RequestID != nil && s.runJobQueue != nil {
-		runID, deduped, claimErr := s.runJobQueue.ClaimRequest(ctx, *req.RequestID, uuid.New())
+	if req.RequestID != nil && s.runJobQueue != nil && reqTenantID != uuid.Nil {
+		runID, deduped, claimErr := s.runJobQueue.ClaimRequest(ctx, reqTenantID, *req.RequestID, uuid.New())
 		if claimErr == nil {
 			if deduped {
 				onChunk(bichatservices.StreamChunk{

--- a/modules/bichat/services/chat_service_impl.go
+++ b/modules/bichat/services/chat_service_impl.go
@@ -279,13 +279,17 @@ func (s *chatServiceImpl) updateRunSnapshot(ctx context.Context, tenantID, sessi
 
 func (s *chatServiceImpl) completeRunState(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error {
 	err := s.runState.CompleteRunState(ctx, tenantID, sessionID, runID)
-	s.publishTerminalStatus(ctx, tenantID, sessionID, runID, string(domain.GenerationRunStatusCompleted))
+	if err == nil {
+		s.publishTerminalStatus(ctx, tenantID, sessionID, runID, string(domain.GenerationRunStatusCompleted))
+	}
 	return err
 }
 
 func (s *chatServiceImpl) cancelRunState(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error {
 	err := s.runState.CancelRunState(ctx, tenantID, sessionID, runID)
-	s.publishTerminalStatus(ctx, tenantID, sessionID, runID, string(domain.GenerationRunStatusCancelled))
+	if err == nil {
+		s.publishTerminalStatus(ctx, tenantID, sessionID, runID, string(domain.GenerationRunStatusCancelled))
+	}
 	return err
 }
 
@@ -537,10 +541,10 @@ func (s *chatServiceImpl) TailRunEvents(
 		return bichatservices.ErrRunEventLogUnavailable
 	}
 
-	// Resolve tenant via persisted run state. The run entry carries the
-	// tenant id so we don't have to plumb it through the request — the
-	// GET /stream/events endpoint is browser-hit and can't be trusted
-	// to carry a tenant header.
+	// Load the persisted run within the tenant scope already carried by
+	// ctx. After lookup succeeds, use the run's tenant id for event-log
+	// replay/tailing. This endpoint must still be invoked with a context
+	// that contains the current tenant.
 	persisted, err := s.getPersistedRunByID(ctx, runID)
 	if err != nil {
 		if errors.Is(err, domain.ErrRunNotFound) || errors.Is(err, domain.ErrNoActiveRun) {
@@ -612,7 +616,7 @@ func (s *chatServiceImpl) TailActiveRuns(ctx context.Context, onEvent func(bicha
 	const op serrors.Op = "chatServiceImpl.TailActiveRuns"
 
 	if s.activeRunIndex == nil {
-		return bichatservices.ErrRunEventLogUnavailable
+		return bichatservices.ErrActiveRunIndexUnavailable
 	}
 	tenantID, err := composables.UseTenantID(ctx)
 	if err != nil {
@@ -787,6 +791,18 @@ func (s *chatServiceImpl) SendMessageStream(ctx context.Context, req bichatservi
 	// When Redis is not configured (dev/CI) the queue is nil and
 	// dedupe silently no-ops.
 	var claimedRunID uuid.UUID
+	// releaseRequest drops the dedupe mapping so that a retry with the same
+	// requestID can mint a fresh run instead of deduping to a phantom one.
+	// It is called on early-exit error paths (before the run is persisted)
+	// and at terminal run completion. Safe to call multiple times: the Redis
+	// key may already be gone and the implementation swallows redis.Nil.
+	releaseRequest := func() {
+		if req.RequestID != nil && s.runJobQueue != nil {
+			_ = s.runJobQueue.ReleaseRequest(context.WithoutCancel(ctx), *req.RequestID)
+		}
+	}
+	runPersisted := false // set true once the TX commits and the run row exists
+
 	if req.RequestID != nil && s.runJobQueue != nil {
 		runID, deduped, claimErr := s.runJobQueue.ClaimRequest(ctx, *req.RequestID, uuid.New())
 		if claimErr == nil {
@@ -891,6 +907,9 @@ func (s *chatServiceImpl) SendMessageStream(ctx context.Context, req bichatservi
 		return nil
 	})
 	if err != nil {
+		// Release the request_id dedupe mapping so the client can retry with the
+		// same requestID and get a fresh run — the current run was never persisted.
+		releaseRequest()
 		if runStateCreated && run != nil && session != nil {
 			_ = s.cancelRunState(context.WithoutCancel(ctx), session.TenantID(), req.SessionID, run.ID())
 		}
@@ -899,6 +918,8 @@ func (s *chatServiceImpl) SendMessageStream(ctx context.Context, req bichatservi
 		}
 		return err
 	}
+	runPersisted = true
+	_ = runPersisted // used by the deferred release guard below
 
 	// Decouple generation from request cancellation, but keep request values
 	// (tenant/user/pool/tx) required by downstream services and repositories.
@@ -969,6 +990,10 @@ func (s *chatServiceImpl) SendMessageStream(ctx context.Context, req bichatservi
 				// (notably test transactions) are no longer in use before returning.
 				for range primaryCh {
 				}
+				// Release request_id dedupe mapping at terminal success so a retry
+				// with the same requestID starts a new run rather than deduping to
+				// the completed one.
+				releaseRequest()
 				return nil
 			}
 			if chunk.Type == bichatservices.ChunkTypeError {
@@ -976,6 +1001,9 @@ func (s *chatServiceImpl) SendMessageStream(ctx context.Context, req bichatservi
 				// Drain until channel closes so the goroutine can persist and exit
 				for range primaryCh {
 				}
+				// Release on terminal error so the client can retry with the same
+				// requestID and get a fresh attempt.
+				releaseRequest()
 				return streamErr
 			}
 		}
@@ -1050,6 +1078,10 @@ func (s *chatServiceImpl) runStreamLoop(
 		case agents.EventTypeContent:
 			active.Mu.Lock()
 			active.Content += event.Content
+			// Track the UTF-16 code unit count incrementally so the
+			// text_block_end boundary path is O(delta) instead of
+			// O(total_content).
+			active.ContentUTF16Len += len(utf16.Encode([]rune(event.Content)))
 			active.Mu.Unlock()
 			chunk.Type = bichatservices.ChunkTypeContent
 			chunk.Content = event.Content
@@ -1057,14 +1089,13 @@ func (s *chatServiceImpl) runStreamLoop(
 
 		case agents.EventTypeTextBlockEnd:
 			active.Mu.Lock()
-			// Record the UTF-16 code unit count at the segment boundary so
-			// resume snapshots can split the accumulated content back into
-			// the blocks the user originally saw.
-			// Offsets are UTF-16 code unit counts so the applet can consume
-			// them directly via str.slice() without byte-index miscounts on
-			// non-ASCII (multi-byte) content.
-			activeContent := active.Content
-			active.TextBlockOffsets = append(active.TextBlockOffsets, len(utf16.Encode([]rune(activeContent))))
+			// Record the running UTF-16 code unit count at the segment
+			// boundary so resume snapshots can split the accumulated content
+			// back into the blocks the user originally saw.
+			// ContentUTF16Len is maintained incrementally on content deltas
+			// above; reading it here is O(1) and does not re-encode the full
+			// accumulated string.
+			active.TextBlockOffsets = append(active.TextBlockOffsets, active.ContentUTF16Len)
 			active.Mu.Unlock()
 			chunk.Type = bichatservices.ChunkTypeTextBlockEnd
 			chunk.TextBlockSeq = event.TextBlockSeq

--- a/modules/bichat/services/chat_service_impl.go
+++ b/modules/bichat/services/chat_service_impl.go
@@ -725,6 +725,17 @@ func (s *chatServiceImpl) runStreamLoop(
 			chunk.Content = event.Content
 			active.Broadcast(chunk)
 
+		case agents.EventTypeTextBlockEnd:
+			active.Mu.Lock()
+			// Record the byte offset of the segment boundary so resume
+			// snapshots can split the accumulated content back into the
+			// blocks the user originally saw.
+			active.TextBlockOffsets = append(active.TextBlockOffsets, len(active.Content))
+			active.Mu.Unlock()
+			chunk.Type = bichatservices.ChunkTypeTextBlockEnd
+			chunk.TextBlockSeq = event.TextBlockSeq
+			active.Broadcast(chunk)
+
 		case agents.EventTypeToolStart:
 			active.Mu.Lock()
 			recordToolEvent(active.ToolCalls, &active.ToolOrder, event.Tool)

--- a/modules/bichat/services/chat_service_impl.go
+++ b/modules/bichat/services/chat_service_impl.go
@@ -432,6 +432,92 @@ func (s *chatServiceImpl) ResumeStream(ctx context.Context, sessionID uuid.UUID,
 	}
 }
 
+// TailRunEvents forwards events from the durable per-run Redis event log
+// to the caller. It resolves tenantID from persisted run state (the HTTP
+// controller only knows session + run ids and the Last-Event-ID header),
+// replays all entries with stream id > from, and then live-tails the log
+// until a terminal event, ctx cancellation, or TTL expiry.
+//
+// Returns:
+//   - bichatservices.ErrRunEventLogUnavailable when Redis is not configured;
+//   - bichatservices.ErrRunNotFoundOrFinished when the run is unknown;
+//   - wrapped errors for the rest.
+//
+// onEvent is called synchronously from the goroutine that drives Tail and
+// must not block; HTTP handlers typically write an SSE `id:` + `event:`
+// + `data:` triple and flush.
+func (s *chatServiceImpl) TailRunEvents(
+	ctx context.Context,
+	sessionID, runID uuid.UUID,
+	from string,
+	onEvent func(bichatservices.RunEventDelivery),
+) error {
+	const op serrors.Op = "chatServiceImpl.TailRunEvents"
+
+	if s.eventLog == nil {
+		return bichatservices.ErrRunEventLogUnavailable
+	}
+
+	// Resolve tenant via persisted run state. The run entry carries the
+	// tenant id so we don't have to plumb it through the request — the
+	// GET /stream/events endpoint is browser-hit and can't be trusted
+	// to carry a tenant header.
+	persisted, err := s.getPersistedRunByID(ctx, runID)
+	if err != nil {
+		if errors.Is(err, domain.ErrRunNotFound) || errors.Is(err, domain.ErrNoActiveRun) {
+			return bichatservices.ErrRunNotFoundOrFinished
+		}
+		return serrors.E(op, err)
+	}
+	if persisted == nil {
+		return bichatservices.ErrRunNotFoundOrFinished
+	}
+	if persisted.SessionID() != sessionID {
+		return serrors.E(op, serrors.KindValidation, "session id mismatch")
+	}
+	tenantID := persisted.TenantID()
+
+	// Step 1: replay missed events synchronously so the client receives
+	// them in a deterministic order before live tailing begins.
+	replayed, err := s.eventLog.Replay(ctx, tenantID, runID, from)
+	if err != nil {
+		return serrors.E(op, err)
+	}
+	lastID := from
+	for _, evt := range replayed {
+		if err := ctx.Err(); err != nil {
+			return nil
+		}
+		onEvent(bichatservices.RunEventDelivery{
+			StreamID: evt.StreamID,
+			Type:     evt.Type,
+			Payload:  append([]byte(nil), evt.Payload...),
+		})
+		lastID = evt.StreamID
+		if IsRunEventTerminal(evt.Type) {
+			return nil
+		}
+	}
+
+	// Step 2: live-tail from the last event id we delivered. Tail closes
+	// the channel on terminal event / ctx cancel / TTL expiry.
+	tailCh, err := s.eventLog.Tail(ctx, tenantID, runID, lastID)
+	if err != nil {
+		return serrors.E(op, err)
+	}
+	for evt := range tailCh {
+		if err := ctx.Err(); err != nil {
+			return nil
+		}
+		onEvent(bichatservices.RunEventDelivery{
+			StreamID: evt.StreamID,
+			Type:     evt.Type,
+			Payload:  append([]byte(nil), evt.Payload...),
+		})
+	}
+	return nil
+}
+
 // SendMessage sends a message to a session and processes it with the agent.
 func (s *chatServiceImpl) SendMessage(ctx context.Context, req bichatservices.SendMessageRequest) (*bichatservices.SendMessageResponse, error) {
 	const op serrors.Op = "chatServiceImpl.SendMessage"

--- a/modules/bichat/services/chat_service_impl.go
+++ b/modules/bichat/services/chat_service_impl.go
@@ -120,7 +120,20 @@ func (s *chatServiceImpl) unregisterStreamCancel(sessionID uuid.UUID) {
 	delete(s.activeStreamCancel, sessionID)
 }
 
-// StopGeneration cancels the active stream for the session; no partial assistant message is persisted.
+// StopGeneration cancels the active stream for the session; no partial
+// assistant message is persisted. The call is idempotent and tries three
+// signals in order:
+//
+//  1. In-process: if this server has the streaming goroutine, we own the
+//     cancel func directly and firing it immediately unblocks the executor.
+//  2. Cross-process: the Redis run state may be owned by a different
+//     worker / replica. Flip the cancel_requested flag so whichever worker
+//     is driving the run sees it on its next tick and drives the Cancel
+//     transition itself. Safe to call even when (1) already fired.
+//
+// When neither mechanism finds an active run the call succeeds silently
+// (see ErrNoActiveRun handling in the controller) so clicking Stop on a
+// run that has just finished is never an error from the user's view.
 func (s *chatServiceImpl) StopGeneration(ctx context.Context, sessionID uuid.UUID) error {
 	s.streamCancelMu.Lock()
 	cancel, ok := s.activeStreamCancel[sessionID]
@@ -131,6 +144,20 @@ func (s *chatServiceImpl) StopGeneration(ctx context.Context, sessionID uuid.UUI
 	if cancel != nil {
 		cancel()
 	}
+
+	// Best-effort persist the cancel intent. If the active run lives on
+	// another process (future: dedicated run worker, replica behind a
+	// load balancer), this is the ONLY signal it will see. Failures
+	// here are logged via serrors and swallowed so the in-process
+	// cancel that already succeeded stays authoritative.
+	run, err := s.runState.GetPersistedRun(ctx, sessionID)
+	if err != nil {
+		if errors.Is(err, domain.ErrNoActiveRun) {
+			return nil
+		}
+		return nil
+	}
+	_ = s.runState.RequestCancel(ctx, run.TenantID(), sessionID, run.ID())
 	return nil
 }
 
@@ -878,6 +905,21 @@ func (s *chatServiceImpl) runStreamLoop(
 		if shouldPersistSnapshot {
 			meta := active.SnapshotMetadata()
 			_ = s.updateRunSnapshot(persistCtx, session.TenantID(), req.SessionID, runID, content, meta)
+			// Refresh heartbeat at the snapshot throttle cadence (2s).
+			// The reaper marks runs whose heartbeat is older than ~60s as
+			// failed, so a 2s cadence leaves comfortable headroom under
+			// slow LLM calls or tool executions.
+			_ = s.runState.Heartbeat(persistCtx, session.TenantID(), req.SessionID, runID)
+			// Check the out-of-band cancel flag. A Stop RPC from another
+			// tab / device sets this flag on the persisted run; we
+			// observe it here and wind the generator down by cancelling
+			// processCtx. The next gen.Next will return ctx.Err() and
+			// the outer loop's cleanup will emit a terminal chunk.
+			if persistedRun, err := s.runState.GetPersistedRun(persistCtx, req.SessionID); err == nil && persistedRun != nil {
+				if persistedRun.CancelRequested() && active.Cancel != nil {
+					active.Cancel()
+				}
+			}
 			active.Mu.Lock()
 			active.LastPersist = time.Now()
 			active.Mu.Unlock()

--- a/modules/bichat/services/chat_service_impl.go
+++ b/modules/bichat/services/chat_service_impl.go
@@ -565,7 +565,7 @@ func (s *chatServiceImpl) TailRunEvents(
 	lastID := from
 	for _, evt := range replayed {
 		if err := ctx.Err(); err != nil {
-			return nil
+			return nil //nolint:nilerr // context cancelled — clean stop, not an error
 		}
 		onEvent(bichatservices.RunEventDelivery{
 			StreamID: evt.StreamID,
@@ -586,7 +586,7 @@ func (s *chatServiceImpl) TailRunEvents(
 	}
 	for evt := range tailCh {
 		if err := ctx.Err(); err != nil {
-			return nil
+			return nil //nolint:nilerr // context cancelled — clean stop, not an error
 		}
 		onEvent(bichatservices.RunEventDelivery{
 			StreamID: evt.StreamID,
@@ -632,7 +632,7 @@ func (s *chatServiceImpl) TailActiveRuns(ctx context.Context, onEvent func(bicha
 	}
 	for _, entry := range snap {
 		if err := ctx.Err(); err != nil {
-			return nil
+			return nil //nolint:nilerr // context cancelled — clean stop, not an error
 		}
 		onEvent(bichatservices.ActiveRunDelivery{
 			Event:     "snapshot",
@@ -645,7 +645,7 @@ func (s *chatServiceImpl) TailActiveRuns(ctx context.Context, onEvent func(bicha
 
 	for entry := range subCh {
 		if err := ctx.Err(); err != nil {
-			return nil
+			return nil //nolint:nilerr // context cancelled — clean stop, not an error
 		}
 		onEvent(bichatservices.ActiveRunDelivery{
 			Event:     "update",

--- a/modules/bichat/services/chat_service_impl.go
+++ b/modules/bichat/services/chat_service_impl.go
@@ -35,6 +35,13 @@ type chatServiceImpl struct {
 	titleService       TitleService
 	titleQueue         TitleJobQueue
 	runState           *streamingsvc.RunStateManager
+	// eventLog mirrors every broadcast chunk into a durable per-run Redis
+	// stream so a client that reconnects (new tab, new device, network
+	// blip) can tail or replay from a cursor instead of reconstructing
+	// state from in-memory buffers. nil when Redis is unconfigured, in
+	// which case only the in-memory broadcaster is used and cross-process
+	// resume is unavailable.
+	eventLog           RunEventLog
 	streamCancelMu     sync.Mutex
 	activeStreamCancel map[uuid.UUID]context.CancelFunc
 	runRegistry        *streamingsvc.RunRegistry
@@ -62,9 +69,18 @@ func NewChatService(
 		titleService:       titleService,
 		titleQueue:         normalizeTitleJobQueue(titleQueue),
 		runState:           streamingsvc.NewRunStateManager(runStore),
+		eventLog:           newConfiguredRunEventLog(),
 		activeStreamCancel: make(map[uuid.UUID]context.CancelFunc),
 		runRegistry:        streamingsvc.NewRunRegistry(),
 	}
+}
+
+// WithEventLog overrides the event log on an existing chatServiceImpl.
+// Test harnesses use this to inject a miniredis-backed log; production
+// code defers to the env-gated constructor in NewChatService.
+func (s *chatServiceImpl) WithEventLog(log RunEventLog) *chatServiceImpl {
+	s.eventLog = log
+	return s
 }
 
 func normalizeTitleJobQueue(queue TitleJobQueue) TitleJobQueue {
@@ -622,6 +638,28 @@ func (s *chatServiceImpl) SendMessageStream(ctx context.Context, req bichatservi
 	// Clear TxKey so persistence always opens its own durable transaction.
 	persistCtx = context.WithValue(persistCtx, constants.TxKey, nil)
 
+	// When a Redis event log is configured, mirror every broadcast into
+	// bichat:run-events:{tenant}:{run_id} so out-of-process readers (the
+	// SSE controller on a reconnect, or another replica of the server)
+	// can tail/replay via Last-Event-ID. Mirror failures are logged
+	// implicitly by the log implementation and deliberately do not break
+	// the in-memory path — an error appending to Redis should not abort
+	// a live agent streaming to its primary client.
+	if s.eventLog != nil {
+		tenantID := session.TenantID()
+		runID := run.ID()
+		active.SetMirror(func(chunk bichatservices.StreamChunk) {
+			eventType, body, err := encodeRunEventFromChunk(chunk)
+			if err != nil {
+				return
+			}
+			_, _ = s.eventLog.Append(persistCtx, tenantID, runID, RunEvent{
+				Type:    eventType,
+				Payload: body,
+			})
+		})
+	}
+
 	go s.runStreamLoop(processCtx, persistCtx, run.ID(), req, session, domainAttachments, startedAt, active)
 
 	onChunk(bichatservices.StreamChunk{
@@ -680,6 +718,13 @@ func (s *chatServiceImpl) runStreamLoop(
 		active.CloseAllSubscribers()
 		s.runRegistry.Remove(active.RunID)
 		s.unregisterStreamCancel(req.SessionID)
+		// Shorten the run-events stream TTL now that the run is done; the
+		// reaper doesn't need it any more and long-lived Redis keys for
+		// every historical run would bloat memory unnecessarily. 5 min
+		// gives slow reconnecting clients a small grace window.
+		if s.eventLog != nil && session != nil {
+			_ = s.eventLog.DropAfterTerminal(persistCtx, session.TenantID(), runID, 5*time.Minute)
+		}
 	}()
 
 	gen, err := s.agentService.ProcessMessage(processCtx, req.SessionID, req.Content, domainAttachments)

--- a/modules/bichat/services/chat_service_impl.go
+++ b/modules/bichat/services/chat_service_impl.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf16"
 
 	"github.com/google/uuid"
 	hitlsvc "github.com/iota-uz/iota-sdk/modules/bichat/services/hitl"
@@ -53,7 +54,11 @@ type chatServiceImpl struct {
 	// nil when Redis is unconfigured → dedupe silently degrades to
 	// the pre-existing "two concurrent sends on same session → second
 	// fails ErrActiveRunExists" behaviour.
-	runJobQueue        *RedisRunJobQueue
+	runJobQueue *RedisRunJobQueue
+	// closeSharedRedis is set when a shared *redis.Client was created by
+	// newConfiguredRedisComponents. Must be called exactly once at shutdown
+	// (via CloseSharedRedis). nil when Redis is unconfigured.
+	closeSharedRedis   func() error
 	streamCancelMu     sync.Mutex
 	activeStreamCancel map[uuid.UUID]context.CancelFunc
 	runRegistry        *streamingsvc.RunRegistry
@@ -76,7 +81,10 @@ func NewChatService(
 	// Use a single shared Redis connection for all Redis-backed components so
 	// the process dials only one connection to Redis. Falls back to nil/noop
 	// when REDIS_URL is unset (dev/CI without Redis).
-	eventLog, activeRunIndex, runJobQueue := newConfiguredRedisComponents()
+	// closeSharedRedis is the single owner of the shared *redis.Client; each
+	// component's Close() is a no-op because the client was supplied
+	// externally. Call CloseSharedRedis() exactly once at shutdown.
+	eventLog, activeRunIndex, runJobQueue, closeSharedRedis := newConfiguredRedisComponents()
 	return &chatServiceImpl{
 		chatRepo:           chatRepo,
 		sessionAccess:      accessRepo,
@@ -88,9 +96,20 @@ func NewChatService(
 		eventLog:           eventLog,
 		activeRunIndex:     activeRunIndex,
 		runJobQueue:        runJobQueue,
+		closeSharedRedis:   closeSharedRedis,
 		activeStreamCancel: make(map[uuid.UUID]context.CancelFunc),
 		runRegistry:        streamingsvc.NewRunRegistry(),
 	}
+}
+
+// CloseSharedRedis releases the shared *redis.Client created by
+// newConfiguredRedisComponents. Must be called exactly once during
+// shutdown; it is a no-op when Redis was not configured.
+func (s *chatServiceImpl) CloseSharedRedis() error {
+	if s.closeSharedRedis == nil {
+		return nil
+	}
+	return s.closeSharedRedis()
 }
 
 // WithEventLog overrides the event log on an existing chatServiceImpl.
@@ -153,6 +172,7 @@ func (s *chatServiceImpl) unregisterStreamCancel(sessionID uuid.UUID) {
 // (see ErrNoActiveRun handling in the controller) so clicking Stop on a
 // run that has just finished is never an error from the user's view.
 func (s *chatServiceImpl) StopGeneration(ctx context.Context, sessionID uuid.UUID) error {
+	const op serrors.Op = "chatServiceImpl.StopGeneration"
 	s.streamCancelMu.Lock()
 	cancel, ok := s.activeStreamCancel[sessionID]
 	if ok {
@@ -165,17 +185,22 @@ func (s *chatServiceImpl) StopGeneration(ctx context.Context, sessionID uuid.UUI
 
 	// Best-effort persist the cancel intent. If the active run lives on
 	// another process (future: dedicated run worker, replica behind a
-	// load balancer), this is the ONLY signal it will see. Failures
-	// here are logged via serrors and swallowed so the in-process
-	// cancel that already succeeded stays authoritative.
-	run, err := s.runState.GetPersistedRun(ctx, sessionID)
+	// load balancer), this is the ONLY signal it will see.
+	//
+	// Use a detached context so the persisted cancel survives a client
+	// disconnect that has already cancelled ctx.
+	persistCtx := context.WithoutCancel(ctx)
+	run, err := s.runState.GetPersistedRun(persistCtx, sessionID)
 	if err != nil {
 		if errors.Is(err, domain.ErrNoActiveRun) {
+			// No active run — idempotent success from the user's view.
 			return nil
 		}
-		return nil
+		// Any other persistence failure is surfaced so operators can
+		// diagnose cross-process cancel delivery failures.
+		return serrors.E(op, err)
 	}
-	_ = s.runState.RequestCancel(ctx, run.TenantID(), sessionID, run.ID())
+	_ = s.runState.RequestCancel(persistCtx, run.TenantID(), sessionID, run.ID())
 	return nil
 }
 
@@ -1032,10 +1057,14 @@ func (s *chatServiceImpl) runStreamLoop(
 
 		case agents.EventTypeTextBlockEnd:
 			active.Mu.Lock()
-			// Record the byte offset of the segment boundary so resume
-			// snapshots can split the accumulated content back into the
-			// blocks the user originally saw.
-			active.TextBlockOffsets = append(active.TextBlockOffsets, len(active.Content))
+			// Record the UTF-16 code unit count at the segment boundary so
+			// resume snapshots can split the accumulated content back into
+			// the blocks the user originally saw.
+			// Offsets are UTF-16 code unit counts so the applet can consume
+			// them directly via str.slice() without byte-index miscounts on
+			// non-ASCII (multi-byte) content.
+			activeContent := active.Content
+			active.TextBlockOffsets = append(active.TextBlockOffsets, len(utf16.Encode([]rune(activeContent))))
 			active.Mu.Unlock()
 			chunk.Type = bichatservices.ChunkTypeTextBlockEnd
 			chunk.TextBlockSeq = event.TextBlockSeq

--- a/modules/bichat/services/chat_service_impl.go
+++ b/modules/bichat/services/chat_service_impl.go
@@ -16,6 +16,7 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/bichat/domain"
 	bichatservices "github.com/iota-uz/iota-sdk/pkg/bichat/services"
 	"github.com/iota-uz/iota-sdk/pkg/bichat/types"
+	"github.com/iota-uz/iota-sdk/pkg/composables"
 	"github.com/iota-uz/iota-sdk/pkg/constants"
 	"github.com/iota-uz/iota-sdk/pkg/serrors"
 )
@@ -28,20 +29,25 @@ const remoteResumePollInterval = time.Second
 // chatServiceImpl is the production implementation of ChatService.
 // It orchestrates chat sessions, messages, and agent execution.
 type chatServiceImpl struct {
-	chatRepo           domain.ChatRepository
-	sessionAccess      domain.SessionAccessRepository
-	agentService       bichatservices.AgentService
-	model              agents.Model
-	titleService       TitleService
-	titleQueue         TitleJobQueue
-	runState           *streamingsvc.RunStateManager
+	chatRepo      domain.ChatRepository
+	sessionAccess domain.SessionAccessRepository
+	agentService  bichatservices.AgentService
+	model         agents.Model
+	titleService  TitleService
+	titleQueue    TitleJobQueue
+	runState      *streamingsvc.RunStateManager
 	// eventLog mirrors every broadcast chunk into a durable per-run Redis
 	// stream so a client that reconnects (new tab, new device, network
 	// blip) can tail or replay from a cursor instead of reconstructing
 	// state from in-memory buffers. nil when Redis is unconfigured, in
 	// which case only the in-memory broadcaster is used and cross-process
 	// resume is unavailable.
-	eventLog           RunEventLog
+	eventLog RunEventLog
+	// activeRunIndex maintains the per-tenant sidebar view of running
+	// sessions. nil when Redis is unconfigured — in that mode sidebar
+	// dots degrade to polling via /stream/status, but the core
+	// streaming path still works.
+	activeRunIndex     ActiveRunIndex
 	streamCancelMu     sync.Mutex
 	activeStreamCancel map[uuid.UUID]context.CancelFunc
 	runRegistry        *streamingsvc.RunRegistry
@@ -70,6 +76,7 @@ func NewChatService(
 		titleQueue:         normalizeTitleJobQueue(titleQueue),
 		runState:           streamingsvc.NewRunStateManager(runStore),
 		eventLog:           newConfiguredRunEventLog(),
+		activeRunIndex:     newConfiguredActiveRunIndex(),
 		activeStreamCancel: make(map[uuid.UUID]context.CancelFunc),
 		runRegistry:        streamingsvc.NewRunRegistry(),
 	}
@@ -203,7 +210,23 @@ func (s *chatServiceImpl) GetStreamStatus(ctx context.Context, sessionID uuid.UU
 }
 
 func (s *chatServiceImpl) createRunState(ctx context.Context, run domain.GenerationRun) (bool, error) {
-	return s.runState.CreateRunState(ctx, run)
+	created, err := s.runState.CreateRunState(ctx, run)
+	if err != nil || !created {
+		return created, err
+	}
+	// Publish "streaming" to the per-tenant active run hash so sidebar
+	// subscribers see the dot light up without waiting for the first
+	// snapshot event. Best-effort: if Redis fan-out fails, the core
+	// stream still works and the client can still pull /stream/status.
+	if s.activeRunIndex != nil {
+		_ = s.activeRunIndex.Upsert(ctx, run.TenantID(), ActiveRunStatus{
+			SessionID: run.SessionID(),
+			RunID:     run.ID(),
+			Status:    string(domain.GenerationRunStatusStreaming),
+			UpdatedAt: time.Now().UTC(),
+		})
+	}
+	return created, nil
 }
 
 func (s *chatServiceImpl) getPersistedRun(ctx context.Context, sessionID uuid.UUID) (domain.GenerationRun, error) {
@@ -219,11 +242,31 @@ func (s *chatServiceImpl) updateRunSnapshot(ctx context.Context, tenantID, sessi
 }
 
 func (s *chatServiceImpl) completeRunState(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error {
-	return s.runState.CompleteRunState(ctx, tenantID, sessionID, runID)
+	err := s.runState.CompleteRunState(ctx, tenantID, sessionID, runID)
+	s.publishTerminalStatus(ctx, tenantID, sessionID, runID, string(domain.GenerationRunStatusCompleted))
+	return err
 }
 
 func (s *chatServiceImpl) cancelRunState(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error {
-	return s.runState.CancelRunState(ctx, tenantID, sessionID, runID)
+	err := s.runState.CancelRunState(ctx, tenantID, sessionID, runID)
+	s.publishTerminalStatus(ctx, tenantID, sessionID, runID, string(domain.GenerationRunStatusCancelled))
+	return err
+}
+
+// publishTerminalStatus is the single choke point for emitting the last
+// sidebar status event. We publish then remove atomically so a snapshot
+// fetched just after the terminal delta doesn't see a stale streaming
+// entry (which would leave a dangling dot on the frontend).
+func (s *chatServiceImpl) publishTerminalStatus(ctx context.Context, tenantID, sessionID, runID uuid.UUID, status string) {
+	if s.activeRunIndex == nil {
+		return
+	}
+	_ = s.activeRunIndex.PublishAndRemove(ctx, tenantID, ActiveRunStatus{
+		SessionID: sessionID,
+		RunID:     runID,
+		Status:    status,
+		UpdatedAt: time.Now().UTC(),
+	})
 }
 
 type asyncRunWorker func(processCtx context.Context, persistCtx context.Context, runID uuid.UUID, session domain.Session, active *streamingsvc.ActiveRun)
@@ -513,6 +556,67 @@ func (s *chatServiceImpl) TailRunEvents(
 			StreamID: evt.StreamID,
 			Type:     evt.Type,
 			Payload:  append([]byte(nil), evt.Payload...),
+		})
+	}
+	return nil
+}
+
+// TailActiveRuns delivers the per-tenant sidebar view: snapshot rows
+// first (each with Event="snapshot"), then live delta events from the
+// active-run index pubsub (each with Event="update"). The handler
+// blocks until ctx is cancelled or the pubsub connection breaks.
+//
+// Snapshot + Subscribe are ordered so a subscriber never misses a delta
+// landed between HGETALL and pubsub establishment: we Subscribe first
+// (the pubsub handshake is the barrier), then HGETALL the current
+// state, then forward live deltas. If an update for session S lands
+// between Subscribe and Snapshot, the snapshot row for S will be the
+// more recent one.
+func (s *chatServiceImpl) TailActiveRuns(ctx context.Context, onEvent func(bichatservices.ActiveRunDelivery)) error {
+	const op serrors.Op = "chatServiceImpl.TailActiveRuns"
+
+	if s.activeRunIndex == nil {
+		return bichatservices.ErrRunEventLogUnavailable
+	}
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return serrors.E(op, err)
+	}
+
+	subCh, err := s.activeRunIndex.Subscribe(ctx, tenantID)
+	if err != nil {
+		return serrors.E(op, err)
+	}
+
+	// Snapshot AFTER Subscribe so we don't miss deltas published
+	// between the two calls (see comment above).
+	snap, err := s.activeRunIndex.Snapshot(ctx, tenantID)
+	if err != nil {
+		return serrors.E(op, err)
+	}
+	for _, entry := range snap {
+		if err := ctx.Err(); err != nil {
+			return nil
+		}
+		onEvent(bichatservices.ActiveRunDelivery{
+			Event:     "snapshot",
+			SessionID: entry.SessionID,
+			RunID:     entry.RunID,
+			Status:    entry.Status,
+			UpdatedAt: entry.UpdatedAt.UnixMilli(),
+		})
+	}
+
+	for entry := range subCh {
+		if err := ctx.Err(); err != nil {
+			return nil
+		}
+		onEvent(bichatservices.ActiveRunDelivery{
+			Event:     "update",
+			SessionID: entry.SessionID,
+			RunID:     entry.RunID,
+			Status:    entry.Status,
+			UpdatedAt: entry.UpdatedAt.UnixMilli(),
 		})
 	}
 	return nil

--- a/modules/bichat/services/chat_service_impl.go
+++ b/modules/bichat/services/chat_service_impl.go
@@ -73,6 +73,10 @@ func NewChatService(
 ) *chatServiceImpl {
 	runStore := newConfiguredGenerationRunStore()
 	accessRepo := chatRepo.(domain.SessionAccessRepository)
+	// Use a single shared Redis connection for all Redis-backed components so
+	// the process dials only one connection to Redis. Falls back to nil/noop
+	// when REDIS_URL is unset (dev/CI without Redis).
+	eventLog, activeRunIndex, runJobQueue := newConfiguredRedisComponents()
 	return &chatServiceImpl{
 		chatRepo:           chatRepo,
 		sessionAccess:      accessRepo,
@@ -81,9 +85,9 @@ func NewChatService(
 		titleService:       titleService,
 		titleQueue:         normalizeTitleJobQueue(titleQueue),
 		runState:           streamingsvc.NewRunStateManager(runStore),
-		eventLog:           newConfiguredRunEventLog(),
-		activeRunIndex:     newConfiguredActiveRunIndex(),
-		runJobQueue:        newConfiguredRunJobQueue(),
+		eventLog:           eventLog,
+		activeRunIndex:     activeRunIndex,
+		runJobQueue:        runJobQueue,
 		activeStreamCancel: make(map[uuid.UUID]context.CancelFunc),
 		runRegistry:        streamingsvc.NewRunRegistry(),
 	}

--- a/modules/bichat/services/chat_service_impl.go
+++ b/modules/bichat/services/chat_service_impl.go
@@ -47,7 +47,13 @@ type chatServiceImpl struct {
 	// sessions. nil when Redis is unconfigured — in that mode sidebar
 	// dots degrade to polling via /stream/status, but the core
 	// streaming path still works.
-	activeRunIndex     ActiveRunIndex
+	activeRunIndex ActiveRunIndex
+	// runJobQueue is used only for its ClaimRequest side (not XAdd):
+	// request_id idempotency in the inline SendMessageStream path.
+	// nil when Redis is unconfigured → dedupe silently degrades to
+	// the pre-existing "two concurrent sends on same session → second
+	// fails ErrActiveRunExists" behaviour.
+	runJobQueue        *RedisRunJobQueue
 	streamCancelMu     sync.Mutex
 	activeStreamCancel map[uuid.UUID]context.CancelFunc
 	runRegistry        *streamingsvc.RunRegistry
@@ -77,6 +83,7 @@ func NewChatService(
 		runState:           streamingsvc.NewRunStateManager(runStore),
 		eventLog:           newConfiguredRunEventLog(),
 		activeRunIndex:     newConfiguredActiveRunIndex(),
+		runJobQueue:        newConfiguredRunJobQueue(),
 		activeStreamCancel: make(map[uuid.UUID]context.CancelFunc),
 		runRegistry:        streamingsvc.NewRunRegistry(),
 	}
@@ -742,6 +749,32 @@ func (s *chatServiceImpl) SendMessageStream(ctx context.Context, req bichatservi
 	const op serrors.Op = "chatServiceImpl.SendMessageStream"
 	startedAt := time.Now()
 
+	// request_id dedupe: if the client supplied an idempotency key,
+	// claim it before doing any real work. A duplicate send within
+	// the ~30 min dedupe window converges on the existing run — we
+	// emit stream_started with the existing run id then delegate to
+	// the resume path so the second sender tails the same stream as
+	// the first. This mirrors the cross-device UX from the plan.
+	// When Redis is not configured (dev/CI) the queue is nil and
+	// dedupe silently no-ops.
+	var claimedRunID uuid.UUID
+	if req.RequestID != nil && s.runJobQueue != nil {
+		runID, deduped, claimErr := s.runJobQueue.ClaimRequest(ctx, *req.RequestID, uuid.New())
+		if claimErr == nil {
+			if deduped {
+				onChunk(bichatservices.StreamChunk{
+					Type:      bichatservices.ChunkTypeStreamStarted,
+					RunID:     runID.String(),
+					Timestamp: time.Now(),
+				})
+				return s.ResumeStream(ctx, req.SessionID, runID, onChunk)
+			}
+			claimedRunID = runID
+		}
+		// Claim error falls through without dedupe — a Redis blip must
+		// not prevent the user's message from sending.
+	}
+
 	var session domain.Session
 	var err error
 
@@ -778,6 +811,12 @@ func (s *chatServiceImpl) SendMessageStream(ctx context.Context, req bichatservi
 		}
 
 		run, err = domain.NewGenerationRun(domain.GenerationRunSpec{
+			// claimedRunID is the UUID reserved by ClaimRequest when a
+			// request_id was supplied — preserving it means the dedupe
+			// mapping points to the correct run (and a retry within
+			// the dedupe window attaches correctly). uuid.Nil causes
+			// NewGenerationRun to mint a fresh id.
+			ID:        claimedRunID,
 			SessionID: req.SessionID,
 			TenantID:  session.TenantID(),
 			UserID:    session.UserID(),

--- a/modules/bichat/services/chat_service_impl_test.go
+++ b/modules/bichat/services/chat_service_impl_test.go
@@ -66,7 +66,8 @@ func TestChatService_UnarchiveSession(t *testing.T) {
 	t.Parallel()
 
 	chatRepo := newMockChatRepository()
-	svc := NewChatService(chatRepo, nil, nil, nil, nil)
+	svc, err := NewChatService(chatRepo, nil, nil, nil, nil)
+	require.NoError(t, err)
 
 	session := mustSession(t,
 		withSessionTenantID(uuid.New()),
@@ -92,7 +93,8 @@ func TestChatService_ClearSessionHistory(t *testing.T) {
 	t.Parallel()
 
 	chatRepo := newMockChatRepository()
-	svc := NewChatService(chatRepo, nil, nil, nil, nil)
+	svc, err := NewChatService(chatRepo, nil, nil, nil, nil)
+	require.NoError(t, err)
 
 	session := mustSession(t,
 		withSessionTenantID(uuid.New()),
@@ -146,7 +148,8 @@ func TestChatService_CompactSessionHistory(t *testing.T) {
 	chatRepo := newMockChatRepository()
 	model := newMockModel()
 	model.response.Message = types.AssistantMessage("## Conversation Summary\nCompacted response")
-	svc := NewChatService(chatRepo, nil, model, nil, nil)
+	svc, err := NewChatService(chatRepo, nil, model, nil, nil)
+	require.NoError(t, err)
 
 	session := mustSession(t,
 		withSessionTenantID(uuid.New()),
@@ -189,7 +192,8 @@ func TestChatService_CompactSessionHistory_EmptyHistory(t *testing.T) {
 
 	chatRepo := newMockChatRepository()
 	model := newMockModel()
-	svc := NewChatService(chatRepo, nil, model, nil, nil)
+	svc, err := NewChatService(chatRepo, nil, model, nil, nil)
+	require.NoError(t, err)
 
 	session := mustSession(t,
 		withSessionTenantID(uuid.New()),
@@ -216,7 +220,8 @@ func TestChatService_MaybeReplaceHistoryFromMessage_TruncatesFromUserMessage(t *
 	t.Parallel()
 
 	chatRepo := newMockChatRepository()
-	svc := NewChatService(chatRepo, nil, nil, nil, nil)
+	svc, err := NewChatService(chatRepo, nil, nil, nil, nil)
+	require.NoError(t, err)
 
 	session := mustSession(t,
 		withSessionTenantID(uuid.New()),
@@ -274,7 +279,8 @@ func TestChatService_SendMessage_RejectsWhileQuestionOpen(t *testing.T) {
 	} {
 		t.Run(string(status), func(t *testing.T) {
 			chatRepo := newMockChatRepository()
-			svc := NewChatService(chatRepo, nil, nil, nil, nil)
+			svc, err := NewChatService(chatRepo, nil, nil, nil, nil)
+			require.NoError(t, err)
 
 			session := mustSession(t,
 				withSessionTenantID(uuid.New()),
@@ -289,13 +295,14 @@ func TestChatService_SendMessage_RejectsWhileQuestionOpen(t *testing.T) {
 				types.WithQuestionData(mustQuestionDataWithStatus(t, "cp-open", status)),
 			)))
 
-			_, err := svc.SendMessage(t.Context(), bichatservices.SendMessageRequest{
+			var sendErr error
+			_, sendErr = svc.SendMessage(t.Context(), bichatservices.SendMessageRequest{
 				SessionID: session.ID(),
 				UserID:    1,
 				Content:   "continue",
 			})
-			require.Error(t, err)
-			require.ErrorContains(t, err, errHITLPendingQuestionOpen.Error())
+			require.Error(t, sendErr)
+			require.ErrorContains(t, sendErr, errHITLPendingQuestionOpen.Error())
 
 			messages, msgErr := chatRepo.GetSessionMessages(t.Context(), session.ID(), domain.ListOptions{})
 			require.NoError(t, msgErr)
@@ -313,7 +320,8 @@ func TestChatService_SendMessageStream_RejectsWhileQuestionOpen(t *testing.T) {
 	} {
 		t.Run(string(status), func(t *testing.T) {
 			chatRepo := newMockChatRepository()
-			svc := NewChatService(chatRepo, nil, nil, nil, nil)
+			svc, err := NewChatService(chatRepo, nil, nil, nil, nil)
+			require.NoError(t, err)
 
 			session := mustSession(t,
 				withSessionTenantID(uuid.New()),
@@ -328,13 +336,13 @@ func TestChatService_SendMessageStream_RejectsWhileQuestionOpen(t *testing.T) {
 				types.WithQuestionData(mustQuestionDataWithStatus(t, "cp-open-stream", status)),
 			)))
 
-			err := svc.SendMessageStream(t.Context(), bichatservices.SendMessageRequest{
+			streamErr := svc.SendMessageStream(t.Context(), bichatservices.SendMessageRequest{
 				SessionID: session.ID(),
 				UserID:    1,
 				Content:   "continue",
 			}, func(bichatservices.StreamChunk) {})
-			require.Error(t, err)
-			require.ErrorContains(t, err, errHITLPendingQuestionOpen.Error())
+			require.Error(t, streamErr)
+			require.ErrorContains(t, streamErr, errHITLPendingQuestionOpen.Error())
 
 			messages, msgErr := chatRepo.GetSessionMessages(t.Context(), session.ID(), domain.ListOptions{})
 			require.NoError(t, msgErr)
@@ -347,7 +355,8 @@ func TestChatService_MaybeReplaceHistoryFromMessage_RejectsNonUserMessage(t *tes
 	t.Parallel()
 
 	chatRepo := newMockChatRepository()
-	svc := NewChatService(chatRepo, nil, nil, nil, nil)
+	svc, err := NewChatService(chatRepo, nil, nil, nil, nil)
+	require.NoError(t, err)
 
 	session := mustSession(t,
 		withSessionTenantID(uuid.New()),
@@ -360,9 +369,9 @@ func TestChatService_MaybeReplaceHistoryFromMessage_RejectsNonUserMessage(t *tes
 	require.NoError(t, chatRepo.SaveMessage(t.Context(), assistant))
 
 	replaceFromID := assistant.ID()
-	_, err := svc.maybeReplaceHistoryFromMessage(t.Context(), session, &replaceFromID)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "replaceFromMessageId must point to a user message")
+	_, replaceErr := svc.maybeReplaceHistoryFromMessage(t.Context(), session, &replaceFromID)
+	require.Error(t, replaceErr)
+	assert.Contains(t, replaceErr.Error(), "replaceFromMessageId must point to a user message")
 }
 
 func TestChatService_ResumeWithAnswer_InterruptPersistsPendingState(t *testing.T) {
@@ -421,7 +430,8 @@ func TestChatService_ResumeWithAnswer_InterruptPersistsPendingState(t *testing.T
 		},
 	}
 
-	svc := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	require.NoError(t, err)
 	resp, err := svc.ResumeWithAnswer(t.Context(), bichatservices.ResumeRequest{
 		SessionID:    session.ID(),
 		CheckpointID: "cp-prev",
@@ -484,7 +494,8 @@ func TestChatService_ResumeWithAnswer_UsesCanonicalCheckpointAndNormalizesLabels
 		},
 	}
 
-	svc := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	require.NoError(t, err)
 	resp, err := svc.ResumeWithAnswer(t.Context(), bichatservices.ResumeRequest{
 		SessionID:    session.ID(),
 		CheckpointID: "cp-stale-from-client",
@@ -543,7 +554,8 @@ func TestChatService_ResumeWithAnswer_CheckpointNotFoundFinalizesAnswered(t *tes
 		resumeErr: agents.ErrCheckpointNotFound,
 	}
 
-	svc := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	require.NoError(t, err)
 	resp, err := svc.ResumeWithAnswer(t.Context(), bichatservices.ResumeRequest{
 		SessionID:    session.ID(),
 		CheckpointID: "cp-missing",
@@ -600,7 +612,8 @@ func TestChatService_RejectPendingQuestion_CheckpointNotFoundFinalizesRejected(t
 		resumeErr: agents.ErrCheckpointNotFound,
 	}
 
-	svc := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	require.NoError(t, err)
 	resp, err := svc.RejectPendingQuestion(t.Context(), session.ID())
 	require.NoError(t, err)
 	require.NotNil(t, resp)
@@ -722,7 +735,8 @@ func TestChatService_HITLDeferredCheckpointNotFoundFinalizesTerminalState(t *tes
 			)))
 
 			agentSvc := &stubAgentService{resumeStreamErr: agents.ErrCheckpointNotFound}
-			svc := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+			svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+			require.NoError(t, err)
 
 			resp := tt.invoke(t, svc, session.ID())
 			if tt.assertResponse {
@@ -802,7 +816,8 @@ func TestChatService_ResumeWithAnswerAsync_PersistsSubmittedStateBeforeWorkerCom
 		},
 	}
 
-	svc := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	require.NoError(t, err)
 	_, err = svc.ResumeWithAnswerAsync(t.Context(), bichatservices.ResumeRequest{
 		SessionID:    session.ID(),
 		CheckpointID: "cp-async-submit",
@@ -874,7 +889,8 @@ func TestChatService_RejectPendingQuestionAsync_PersistsSubmittedStateBeforeWork
 		},
 	}
 
-	svc := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	require.NoError(t, err)
 	_, err = svc.RejectPendingQuestionAsync(t.Context(), session.ID())
 	require.NoError(t, err)
 
@@ -938,7 +954,8 @@ func TestChatService_ResumeWithAnswerAsync_ReusesExistingRunForDuplicateAnswers(
 		},
 	}
 
-	svc := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	require.NoError(t, err)
 	firstAccepted, err := svc.ResumeWithAnswerAsync(t.Context(), bichatservices.ResumeRequest{
 		SessionID:    session.ID(),
 		CheckpointID: "cp-async-idempotent-answer",
@@ -1010,7 +1027,8 @@ func TestChatService_RejectPendingQuestionAsync_ReusesExistingRunForDuplicateRej
 		},
 	}
 
-	svc := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	require.NoError(t, err)
 	firstAccepted, err := svc.RejectPendingQuestionAsync(t.Context(), session.ID())
 	require.NoError(t, err)
 
@@ -1061,7 +1079,8 @@ func TestChatService_ResumeWithAnswerAsync_MarksFailureStateWhenWorkerFails(t *t
 	)))
 
 	agentSvc := &stubAgentService{resumeErr: assert.AnError}
-	svc := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	require.NoError(t, err)
 
 	_, err = svc.ResumeWithAnswerAsync(t.Context(), bichatservices.ResumeRequest{
 		SessionID:    session.ID(),
@@ -1113,7 +1132,8 @@ func TestChatService_RejectPendingQuestionAsync_MarksFailureStateWhenWorkerFails
 	)))
 
 	agentSvc := &stubAgentService{resumeErr: assert.AnError}
-	svc := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	require.NoError(t, err)
 
 	_, err = svc.RejectPendingQuestionAsync(t.Context(), session.ID())
 	require.NoError(t, err)
@@ -1169,7 +1189,8 @@ func TestChatService_ResumeWithAnswer_TriggersTitleGenerationAfterCompletion(t *
 		},
 	}
 
-	svc := NewChatService(chatRepo, agentSvc, nil, titleService, nil)
+	svc, err := NewChatService(chatRepo, agentSvc, nil, titleService, nil)
+	require.NoError(t, err)
 	_, err = svc.ResumeWithAnswer(env.Ctx, bichatservices.ResumeRequest{
 		SessionID:    session.ID(),
 		CheckpointID: "cp-title-resume",
@@ -1244,7 +1265,8 @@ func TestChatService_ResumeWithAnswer_DoesNotTriggerTitleGenerationWhenInterrupt
 		},
 	}
 
-	svc := NewChatService(chatRepo, agentSvc, nil, titleService, nil)
+	svc, err := NewChatService(chatRepo, agentSvc, nil, titleService, nil)
+	require.NoError(t, err)
 	_, err = svc.ResumeWithAnswer(t.Context(), bichatservices.ResumeRequest{
 		SessionID:    session.ID(),
 		CheckpointID: "cp-title-resume-continued",
@@ -1303,7 +1325,8 @@ func TestChatService_RejectPendingQuestion_TriggersTitleGenerationAfterCompletio
 		},
 	}
 
-	svc := NewChatService(chatRepo, agentSvc, nil, titleService, nil)
+	svc, err := NewChatService(chatRepo, agentSvc, nil, titleService, nil)
+	require.NoError(t, err)
 	_, err = svc.RejectPendingQuestion(env.Ctx, session.ID())
 	require.NoError(t, err)
 
@@ -1356,7 +1379,8 @@ func TestChatService_ResumeWithAnswerAsync_TriggersTitleGenerationAfterCompletio
 		},
 	}
 
-	svc := NewChatService(chatRepo, agentSvc, nil, titleService, nil)
+	svc, err := NewChatService(chatRepo, agentSvc, nil, titleService, nil)
+	require.NoError(t, err)
 	_, err = svc.ResumeWithAnswerAsync(env.Ctx, bichatservices.ResumeRequest{
 		SessionID:    session.ID(),
 		CheckpointID: "cp-title-resume-async",
@@ -1415,7 +1439,8 @@ func TestChatService_RejectPendingQuestionAsync_TriggersTitleGenerationAfterComp
 		},
 	}
 
-	svc := NewChatService(chatRepo, agentSvc, nil, titleService, nil)
+	svc, err := NewChatService(chatRepo, agentSvc, nil, titleService, nil)
+	require.NoError(t, err)
 	_, err = svc.RejectPendingQuestionAsync(env.Ctx, session.ID())
 	require.NoError(t, err)
 
@@ -1450,13 +1475,14 @@ func TestChatService_SendMessageStream_StreamErrorStillTriggersTitleGeneration(t
 		processStreamErr: assert.AnError,
 	}
 
-	svc := NewChatService(chatRepo, agentSvc, nil, titleService, nil)
-	err := svc.SendMessageStream(t.Context(), bichatservices.SendMessageRequest{
+	svc, err := NewChatService(chatRepo, agentSvc, nil, titleService, nil)
+	require.NoError(t, err)
+	streamErr := svc.SendMessageStream(t.Context(), bichatservices.SendMessageRequest{
 		SessionID: session.ID(),
 		Content:   "first user message",
 	}, func(_ bichatservices.StreamChunk) {})
 
-	require.ErrorIs(t, err, assert.AnError)
+	require.ErrorIs(t, streamErr, assert.AnError)
 
 	messages, msgErr := chatRepo.GetSessionMessages(t.Context(), session.ID(), domain.ListOptions{})
 	require.NoError(t, msgErr)
@@ -1506,10 +1532,11 @@ func TestChatService_SendMessageStream_DoneEmittedAfterAssistantPersistence(t *t
 		},
 	}
 
-	svc := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	require.NoError(t, err)
 
 	doneSawPersistedAssistant := false
-	err := svc.SendMessageStream(t.Context(), bichatservices.SendMessageRequest{
+	streamErr := svc.SendMessageStream(t.Context(), bichatservices.SendMessageRequest{
 		SessionID: session.ID(),
 		Content:   "hello",
 	}, func(chunk bichatservices.StreamChunk) {
@@ -1521,7 +1548,7 @@ func TestChatService_SendMessageStream_DoneEmittedAfterAssistantPersistence(t *t
 		doneSawPersistedAssistant = len(messages) >= 2 && messages[len(messages)-1].Role() == types.RoleAssistant
 	})
 
-	require.NoError(t, err)
+	require.NoError(t, streamErr)
 	require.True(t, doneSawPersistedAssistant, "done must be emitted only after assistant message is persisted")
 }
 
@@ -1554,15 +1581,16 @@ func TestChatService_SendMessageStream_ClearsRequestTxForAsyncPersistence(t *tes
 			{Type: agents.EventTypeDone},
 		},
 	}
-	svc := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	require.NoError(t, err)
 
 	ctx := context.WithValue(context.Background(), constants.TxKey, struct{}{})
-	err := svc.SendMessageStream(ctx, bichatservices.SendMessageRequest{
+	streamErr := svc.SendMessageStream(ctx, bichatservices.SendMessageRequest{
 		SessionID: session.ID(),
 		UserID:    1,
 		Content:   "hello",
 	}, func(_ bichatservices.StreamChunk) {})
-	require.NoError(t, err)
+	require.NoError(t, streamErr)
 
 	messages, msgErr := chatRepo.GetSessionMessages(context.Background(), session.ID(), domain.ListOptions{})
 	require.NoError(t, msgErr)
@@ -1814,10 +1842,11 @@ func TestChatService_StopGeneration_NoErrorWhenNoActiveStream(t *testing.T) {
 	t.Parallel()
 
 	chatRepo := newMockChatRepository()
-	svc := NewChatService(chatRepo, nil, nil, nil, nil)
-
-	err := svc.StopGeneration(context.Background(), uuid.New())
+	svc, err := NewChatService(chatRepo, nil, nil, nil, nil)
 	require.NoError(t, err)
+
+	stopErr := svc.StopGeneration(context.Background(), uuid.New())
+	require.NoError(t, stopErr)
 }
 
 func TestChatService_SendMessageStream_ClientDisconnectStillPersistsAssistant(t *testing.T) {
@@ -1838,7 +1867,8 @@ func TestChatService_SendMessageStream_ClientDisconnectStillPersistsAssistant(t 
 		},
 	}
 
-	svc := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -1857,14 +1887,12 @@ func TestChatService_SendMessageStream_ClientDisconnectStillPersistsAssistant(t 
 	}()
 
 	<-streamDone
-	var (
-		messages []types.Message
-		err      error
-	)
+	var messages []types.Message
 	deadline := time.Now().Add(2 * time.Second)
 	for {
-		messages, err = chatRepo.GetSessionMessages(context.Background(), session.ID(), domain.ListOptions{})
-		require.NoError(t, err)
+		var msgErr error
+		messages, msgErr = chatRepo.GetSessionMessages(context.Background(), session.ID(), domain.ListOptions{})
+		require.NoError(t, msgErr)
 		if len(messages) == 2 {
 			break
 		}
@@ -1897,7 +1925,8 @@ func TestChatService_SendMessageStream_StopGenerationDoesNotPersistAssistant(t *
 		},
 	}
 
-	svc := NewChatService(chatRepo, cancelAgent, nil, nil, nil)
+	svc, err := NewChatService(chatRepo, cancelAgent, nil, nil, nil)
+	require.NoError(t, err)
 	ctx := context.Background()
 	streamDone := make(chan struct{})
 	go func() {
@@ -1949,7 +1978,8 @@ func TestChatService_GetStreamStatus_ReturnsInactiveWhenNoRun(t *testing.T) {
 	t.Parallel()
 
 	chatRepo := newMockChatRepository()
-	svc := NewChatService(chatRepo, nil, nil, nil, nil)
+	svc, err := NewChatService(chatRepo, nil, nil, nil, nil)
+	require.NoError(t, err)
 
 	sessionID := uuid.New()
 	status, err := svc.GetStreamStatus(context.Background(), sessionID)
@@ -1962,10 +1992,11 @@ func TestChatService_ResumeStream_ReturnsErrWhenRunNotFound(t *testing.T) {
 	t.Parallel()
 
 	chatRepo := newMockChatRepository()
-	svc := NewChatService(chatRepo, nil, nil, nil, nil)
+	svc, err := NewChatService(chatRepo, nil, nil, nil, nil)
+	require.NoError(t, err)
 
 	sessionID := uuid.New()
 	runID := uuid.New()
-	err := svc.ResumeStream(context.Background(), sessionID, runID, func(bichatservices.StreamChunk) {})
-	require.ErrorIs(t, err, bichatservices.ErrRunNotFoundOrFinished)
+	resumeErr := svc.ResumeStream(context.Background(), sessionID, runID, func(bichatservices.StreamChunk) {})
+	require.ErrorIs(t, resumeErr, bichatservices.ErrRunNotFoundOrFinished)
 }

--- a/modules/bichat/services/chat_services_api.go
+++ b/modules/bichat/services/chat_services_api.go
@@ -16,6 +16,8 @@ type ChatApplicationServices struct {
 	StreamCommands  bichatservices.StreamCommands
 	HITLCommands    bichatservices.HITLCommands
 	Observability   *StreamObservability
+	// core holds the single chatServiceImpl so shutdown helpers can reach it.
+	core            *chatServiceImpl
 }
 
 type sessionCommandsService struct{ *chatServiceImpl }
@@ -42,5 +44,16 @@ func NewChatApplicationServices(
 		StreamCommands:  &streamCommandsService{chatServiceImpl: core},
 		HITLCommands:    &hitlCommandsService{chatServiceImpl: core},
 		Observability:   NewStreamObservability(core.runRegistry),
+		core:            core,
 	}
+}
+
+// CloseSharedRedis releases the shared *redis.Client that backs all Redis
+// components. Must be called exactly once at shutdown; no-op when Redis is
+// unconfigured.
+func (s *ChatApplicationServices) CloseSharedRedis() error {
+	if s.core == nil {
+		return nil
+	}
+	return s.core.CloseSharedRedis()
 }

--- a/modules/bichat/services/chat_services_api.go
+++ b/modules/bichat/services/chat_services_api.go
@@ -28,14 +28,19 @@ type streamCommandsService struct{ *chatServiceImpl }
 type hitlCommandsService struct{ *chatServiceImpl }
 
 // NewChatApplicationServices builds command/query service facades.
+// Returns an error when REDIS_URL is set but any Redis component fails to
+// initialise (see NewChatService).
 func NewChatApplicationServices(
 	chatRepo domain.ChatRepository,
 	agentService bichatservices.AgentService,
 	model agents.Model,
 	titleService TitleService,
 	titleQueue TitleJobQueue,
-) ChatApplicationServices {
-	core := NewChatService(chatRepo, agentService, model, titleService, titleQueue)
+) (ChatApplicationServices, error) {
+	core, err := NewChatService(chatRepo, agentService, model, titleService, titleQueue)
+	if err != nil {
+		return ChatApplicationServices{}, err
+	}
 	return ChatApplicationServices{
 		SessionCommands: &sessionCommandsService{chatServiceImpl: core},
 		SessionQueries:  &sessionQueriesService{chatServiceImpl: core},
@@ -45,7 +50,7 @@ func NewChatApplicationServices(
 		HITLCommands:    &hitlCommandsService{chatServiceImpl: core},
 		Observability:   NewStreamObservability(core.runRegistry),
 		core:            core,
-	}
+	}, nil
 }
 
 // CloseSharedRedis releases the shared *redis.Client that backs all Redis

--- a/modules/bichat/services/chat_services_api.go
+++ b/modules/bichat/services/chat_services_api.go
@@ -17,7 +17,7 @@ type ChatApplicationServices struct {
 	HITLCommands    bichatservices.HITLCommands
 	Observability   *StreamObservability
 	// core holds the single chatServiceImpl so shutdown helpers can reach it.
-	core            *chatServiceImpl
+	core *chatServiceImpl
 }
 
 type sessionCommandsService struct{ *chatServiceImpl }

--- a/modules/bichat/services/cross_tenant_isolation_test.go
+++ b/modules/bichat/services/cross_tenant_isolation_test.go
@@ -1,0 +1,78 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCrossTenantIsolation_ReplayReturnsEmpty verifies that tenant B cannot
+// read events appended for tenant A's run, even when tenant B knows the run
+// ID. The stream key embeds the tenant ID so a guessed run ID is useless
+// across tenant boundaries.
+func TestCrossTenantIsolation_ReplayReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	log, _ := newTestRunEventLog(t)
+	tenantA := uuid.New()
+	tenantB := uuid.New()
+	runA := uuid.New()
+
+	// Append an event as tenant A.
+	body, err := json.Marshal(map[string]string{"text": "secret"})
+	require.NoError(t, err)
+	_, err = log.Append(context.Background(), tenantA, runA, RunEvent{
+		Type:    "content",
+		Payload: body,
+	})
+	require.NoError(t, err)
+
+	// Tenant B tries to replay using tenant A's run ID — must see nothing.
+	events, err := log.Replay(context.Background(), tenantB, runA, RunEventStreamStart)
+	require.NoError(t, err)
+	assert.Empty(t, events, "tenant B must not see tenant A's events")
+}
+
+// TestCrossTenantIsolation_TailReturnsNoEvents verifies that tailing with
+// tenant B's context against tenant A's run ID yields no events within a
+// short deadline. The stream key for tenant B is different from tenant A's
+// so XREAD returns nothing.
+func TestCrossTenantIsolation_TailReturnsNoEvents(t *testing.T) {
+	t.Parallel()
+
+	log, _ := newTestRunEventLog(t)
+	tenantA := uuid.New()
+	tenantB := uuid.New()
+	runA := uuid.New()
+
+	// Append an event as tenant A.
+	body, err := json.Marshal(map[string]string{"text": "secret"})
+	require.NoError(t, err)
+	_, err = log.Append(context.Background(), tenantA, runA, RunEvent{
+		Type:    "content",
+		Payload: body,
+	})
+	require.NoError(t, err)
+
+	// Tenant B tails the same run ID — must receive nothing within the deadline.
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	ch, err := log.Tail(ctx, tenantB, runA, RunEventStreamStart)
+	require.NoError(t, err)
+
+	select {
+	case evt, ok := <-ch:
+		if ok {
+			t.Errorf("tenant B received an event from tenant A's run: type=%q", evt.Type)
+		}
+		// Channel closed without yielding data — acceptable (ctx deadline).
+	case <-ctx.Done():
+		// Context expired before any event arrived — correct isolation.
+	}
+}

--- a/modules/bichat/services/generation_run_store.go
+++ b/modules/bichat/services/generation_run_store.go
@@ -303,6 +303,8 @@ func (s *redisGenerationRunStore) RequestCancel(ctx context.Context, tenantID, s
 // worker on every streaming iteration so the reaper can detect wedged
 // runs. The operation is racy-safe under the single-writer assumption
 // (one worker owns a given run at a time), same as UpdateRunSnapshot.
+// Idempotent no-op when the run is missing or not in streaming status;
+// callers must not treat those cases as errors.
 func (s *redisGenerationRunStore) Heartbeat(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error {
 	const op serrors.Op = "redisGenerationRunStore.Heartbeat"
 
@@ -311,10 +313,10 @@ func (s *redisGenerationRunStore) Heartbeat(ctx context.Context, tenantID, sessi
 		return serrors.E(op, err)
 	}
 	if !found {
-		return domain.ErrNoActiveRun
+		return nil
 	}
 	if record.ID != runID.String() || record.Status != string(domain.GenerationRunStatusStreaming) {
-		return domain.ErrNoActiveRun
+		return nil
 	}
 	now := time.Now().UTC()
 	record.LastHeartbeatAt = now

--- a/modules/bichat/services/generation_run_store.go
+++ b/modules/bichat/services/generation_run_store.go
@@ -29,6 +29,16 @@ type generationRunStore interface {
 	UpdateRunSnapshot(ctx context.Context, tenantID, sessionID, runID uuid.UUID, partialContent string, partialMetadata map[string]any) error
 	CompleteRun(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error
 	CancelRun(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error
+	// FailRun is the system-initiated terminal transition. Used by workers
+	// on unrecoverable errors and by the reaper on stale heartbeats.
+	FailRun(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error
+	// RequestCancel flips the cancel flag on an active run without moving
+	// it to a terminal status. The owning worker observes the flag on its
+	// next heartbeat/snapshot tick and drives the actual CancelRun call.
+	RequestCancel(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error
+	// Heartbeat refreshes LastHeartbeatAt so the reaper knows the run is
+	// still progressing. Idempotent; no-op on terminal states.
+	Heartbeat(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error
 }
 
 type redisGenerationRunStoreConfig struct {
@@ -54,6 +64,12 @@ type persistedGenerationRun struct {
 	PartialMeta    map[string]any `json:"partial_metadata"`
 	StartedAt      time.Time      `json:"started_at"`
 	LastUpdatedAt  time.Time      `json:"last_updated_at"`
+	// CancelRequested is flipped by Stop RPCs; the worker polls it.
+	CancelRequested bool `json:"cancel_requested,omitempty"`
+	// LastHeartbeatAt is refreshed by the worker; the reaper fails runs
+	// whose heartbeat has gone stale. Zero-value means "never heartbeated"
+	// (e.g. a queued-but-not-started run).
+	LastHeartbeatAt time.Time `json:"last_heartbeat_at,omitempty"`
 }
 
 func newConfiguredGenerationRunStore() generationRunStore {
@@ -118,15 +134,17 @@ func (s *redisGenerationRunStore) CreateRun(ctx context.Context, run domain.Gene
 	}
 
 	record := persistedGenerationRun{
-		ID:             run.ID().String(),
-		SessionID:      run.SessionID().String(),
-		TenantID:       run.TenantID().String(),
-		UserID:         run.UserID(),
-		Status:         string(domain.GenerationRunStatusStreaming),
-		PartialContent: run.PartialContent(),
-		PartialMeta:    cloneMetadata(run.PartialMetadata()),
-		StartedAt:      run.StartedAt().UTC(),
-		LastUpdatedAt:  run.LastUpdatedAt().UTC(),
+		ID:              run.ID().String(),
+		SessionID:       run.SessionID().String(),
+		TenantID:        run.TenantID().String(),
+		UserID:          run.UserID(),
+		Status:          string(domain.GenerationRunStatusStreaming),
+		PartialContent:  run.PartialContent(),
+		PartialMeta:     cloneMetadata(run.PartialMetadata()),
+		StartedAt:       run.StartedAt().UTC(),
+		LastUpdatedAt:   run.LastUpdatedAt().UTC(),
+		CancelRequested: run.CancelRequested(),
+		LastHeartbeatAt: run.LastHeartbeatAt().UTC(),
 	}
 	if record.StartedAt.IsZero() {
 		record.StartedAt = time.Now().UTC()
@@ -245,6 +263,68 @@ func (s *redisGenerationRunStore) CancelRun(ctx context.Context, tenantID, sessi
 	return s.finishRun(ctx, tenantID, sessionID, runID, domain.GenerationRunStatusCancelled)
 }
 
+func (s *redisGenerationRunStore) FailRun(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error {
+	return s.finishRun(ctx, tenantID, sessionID, runID, domain.GenerationRunStatusFailed)
+}
+
+// RequestCancel flips the cancel flag on the active run and refreshes
+// LastUpdatedAt. It is a no-op if the session has no active run or if the
+// active run's id doesn't match runID — this keeps repeated Stop RPCs
+// idempotent without leaking state.
+func (s *redisGenerationRunStore) RequestCancel(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error {
+	const op serrors.Op = "redisGenerationRunStore.RequestCancel"
+
+	record, found, err := s.loadRun(ctx, tenantID, sessionID)
+	if err != nil {
+		return serrors.E(op, err)
+	}
+	if !found {
+		return nil
+	}
+	if record.ID != runID.String() {
+		return nil
+	}
+	if record.Status != string(domain.GenerationRunStatusStreaming) {
+		return nil
+	}
+	if record.CancelRequested {
+		// Already requested; nothing to persist.
+		return nil
+	}
+	record.CancelRequested = true
+	record.LastUpdatedAt = time.Now().UTC()
+	if err := s.saveRun(ctx, tenantID, sessionID, record); err != nil {
+		return serrors.E(op, "persist cancel request", err)
+	}
+	return nil
+}
+
+// Heartbeat refreshes LastHeartbeatAt + LastUpdatedAt. Called from the
+// worker on every streaming iteration so the reaper can detect wedged
+// runs. The operation is racy-safe under the single-writer assumption
+// (one worker owns a given run at a time), same as UpdateRunSnapshot.
+func (s *redisGenerationRunStore) Heartbeat(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error {
+	const op serrors.Op = "redisGenerationRunStore.Heartbeat"
+
+	record, found, err := s.loadRun(ctx, tenantID, sessionID)
+	if err != nil {
+		return serrors.E(op, err)
+	}
+	if !found {
+		return domain.ErrNoActiveRun
+	}
+	if record.ID != runID.String() || record.Status != string(domain.GenerationRunStatusStreaming) {
+		return domain.ErrNoActiveRun
+	}
+	now := time.Now().UTC()
+	record.LastHeartbeatAt = now
+	record.LastUpdatedAt = now
+	if err := s.saveRun(ctx, tenantID, sessionID, record); err != nil {
+		return serrors.E(op, "persist heartbeat", err)
+	}
+	return nil
+}
+
 func (s *redisGenerationRunStore) finishRun(ctx context.Context, tenantID, sessionID, runID uuid.UUID, status domain.GenerationRunStatus) error {
 	const op serrors.Op = "redisGenerationRunStore.finishRun"
 
@@ -359,6 +439,8 @@ func mapPersistedGenerationRunToDomain(r persistedGenerationRun) (domain.Generat
 		PartialMetadata: cloneMetadata(r.PartialMeta),
 		StartedAt:       r.StartedAt,
 		LastUpdatedAt:   r.LastUpdatedAt,
+		CancelRequested: r.CancelRequested,
+		LastHeartbeatAt: r.LastHeartbeatAt,
 	})
 }
 

--- a/modules/bichat/services/redis_clients.go
+++ b/modules/bichat/services/redis_clients.go
@@ -1,0 +1,49 @@
+// Package services provides this package.
+package services
+
+import (
+	"strings"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// NewSharedRedisClient returns a single *redis.Client built from REDIS_URL.
+// Returns nil, nil when REDIS_URL is unset (caller falls back to in-memory).
+// Callers close it via the component's shutdown hook.
+func NewSharedRedisClient() (*redis.Client, error) {
+	redisURL, ok := envLookup("REDIS_URL")
+	if !ok || strings.TrimSpace(redisURL) == "" {
+		return nil, nil
+	}
+	return newRedisClient(redisURL)
+}
+
+// newConfiguredRedisComponents builds all Redis-backed infrastructure from a
+// single shared client so the process dials only one connection to Redis.
+// Returns all nils when Redis is not configured (REDIS_URL unset).
+func newConfiguredRedisComponents() (RunEventLog, ActiveRunIndex, *RedisRunJobQueue) {
+	client, err := NewSharedRedisClient()
+	if err != nil || client == nil {
+		return nil, nil, nil
+	}
+
+	eventLog, err := NewRedisRunEventLog(RedisRunEventLogConfig{Client: client})
+	if err != nil {
+		_ = client.Close()
+		return nil, nil, nil
+	}
+
+	index, err := NewRedisActiveRunIndex(RedisActiveRunIndexConfig{Client: client})
+	if err != nil {
+		_ = client.Close()
+		return nil, nil, nil
+	}
+
+	queue, err := NewRedisRunJobQueue(RedisRunJobQueueConfig{Client: client})
+	if err != nil {
+		_ = client.Close()
+		return nil, nil, nil
+	}
+
+	return eventLog, index, queue
+}

--- a/modules/bichat/services/redis_clients.go
+++ b/modules/bichat/services/redis_clients.go
@@ -21,29 +21,36 @@ func NewSharedRedisClient() (*redis.Client, error) {
 // newConfiguredRedisComponents builds all Redis-backed infrastructure from a
 // single shared client so the process dials only one connection to Redis.
 // Returns all nils when Redis is not configured (REDIS_URL unset).
-func newConfiguredRedisComponents() (RunEventLog, ActiveRunIndex, *RedisRunJobQueue) {
+//
+// Ownership invariant: each component's Close() is a no-op because the
+// client was supplied externally (ownsClient == false). The caller MUST
+// invoke the returned closeFunc exactly once during shutdown to release the
+// shared connection. The closeFunc is nil when Redis is not configured.
+func newConfiguredRedisComponents() (RunEventLog, ActiveRunIndex, *RedisRunJobQueue, func() error) {
 	client, err := NewSharedRedisClient()
 	if err != nil || client == nil {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
+
+	closeClient := func() error { return client.Close() }
 
 	eventLog, err := NewRedisRunEventLog(RedisRunEventLogConfig{Client: client})
 	if err != nil {
 		_ = client.Close()
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
 	index, err := NewRedisActiveRunIndex(RedisActiveRunIndexConfig{Client: client})
 	if err != nil {
 		_ = client.Close()
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
 	queue, err := NewRedisRunJobQueue(RedisRunJobQueueConfig{Client: client})
 	if err != nil {
 		_ = client.Close()
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
-	return eventLog, index, queue
+	return eventLog, index, queue, closeClient
 }

--- a/modules/bichat/services/redis_clients.go
+++ b/modules/bichat/services/redis_clients.go
@@ -20,16 +20,26 @@ func NewSharedRedisClient() (*redis.Client, error) {
 
 // newConfiguredRedisComponents builds all Redis-backed infrastructure from a
 // single shared client so the process dials only one connection to Redis.
-// Returns all nils when Redis is not configured (REDIS_URL unset).
+//
+// When REDIS_URL is unset or empty the function returns all nils and a nil
+// error: this is the intentional "no Redis" path (in-memory fallback). When
+// REDIS_URL IS set but any construction step fails the error is returned so
+// the caller can surface the misconfiguration loudly instead of silently
+// degrading to the in-memory fallback with a broken Redis connection.
 //
 // Ownership invariant: each component's Close() is a no-op because the
 // client was supplied externally (ownsClient == false). The caller MUST
 // invoke the returned closeFunc exactly once during shutdown to release the
 // shared connection. The closeFunc is nil when Redis is not configured.
-func newConfiguredRedisComponents() (RunEventLog, ActiveRunIndex, *RedisRunJobQueue, func() error) {
+func newConfiguredRedisComponents() (RunEventLog, ActiveRunIndex, *RedisRunJobQueue, func() error, error) {
 	client, err := NewSharedRedisClient()
-	if err != nil || client == nil {
-		return nil, nil, nil, nil
+	if err != nil {
+		// REDIS_URL was set but dialling failed — surface the error.
+		return nil, nil, nil, nil, err
+	}
+	if client == nil {
+		// REDIS_URL unset — intentional in-memory fallback, not an error.
+		return nil, nil, nil, nil, nil
 	}
 
 	closeClient := func() error { return client.Close() }
@@ -37,20 +47,20 @@ func newConfiguredRedisComponents() (RunEventLog, ActiveRunIndex, *RedisRunJobQu
 	eventLog, err := NewRedisRunEventLog(RedisRunEventLogConfig{Client: client})
 	if err != nil {
 		_ = client.Close()
-		return nil, nil, nil, nil
+		return nil, nil, nil, nil, err
 	}
 
 	index, err := NewRedisActiveRunIndex(RedisActiveRunIndexConfig{Client: client})
 	if err != nil {
 		_ = client.Close()
-		return nil, nil, nil, nil
+		return nil, nil, nil, nil, err
 	}
 
 	queue, err := NewRedisRunJobQueue(RedisRunJobQueueConfig{Client: client})
 	if err != nil {
 		_ = client.Close()
-		return nil, nil, nil, nil
+		return nil, nil, nil, nil, err
 	}
 
-	return eventLog, index, queue, closeClient
+	return eventLog, index, queue, closeClient, nil
 }

--- a/modules/bichat/services/redis_clients.go
+++ b/modules/bichat/services/redis_clients.go
@@ -13,7 +13,7 @@ import (
 func NewSharedRedisClient() (*redis.Client, error) {
 	redisURL, ok := envLookup("REDIS_URL")
 	if !ok || strings.TrimSpace(redisURL) == "" {
-		return nil, nil
+		return nil, nil //nolint:nilnil // REDIS_URL unset means graceful in-memory fallback; nil return is the signal
 	}
 	return newRedisClient(redisURL)
 }

--- a/modules/bichat/services/run_event_log.go
+++ b/modules/bichat/services/run_event_log.go
@@ -236,6 +236,24 @@ func (l *RedisRunEventLog) Tail(ctx context.Context, tenantID, runID uuid.UUID, 
 			}).Result()
 			if err != nil {
 				if errors.Is(err, redis.Nil) {
+					// BLOCK timeout — check whether the stream key still exists.
+					// After DropAfterTerminal the key may have expired; if so,
+					// there is no point keeping the tail goroutine and SSE
+					// connection alive forever with only heartbeats.
+					exists, existsErr := l.client.Exists(ctx, key).Result()
+					if existsErr != nil {
+						// Context cancellation or deadline: clean exit.
+						if errors.Is(existsErr, context.Canceled) || errors.Is(existsErr, context.DeadlineExceeded) {
+							return
+						}
+						// Redis error on the Exists check — conservative: exit rather
+						// than spinning indefinitely on a potentially gone key.
+						return
+					}
+					if exists == 0 {
+						// Stream key no longer exists (expired / dropped). End tail.
+						return
+					}
 					continue
 				}
 				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
@@ -247,6 +265,7 @@ func (l *RedisRunEventLog) Tail(ctx context.Context, tenantID, runID uuid.UUID, 
 				for _, msg := range stream.Messages {
 					evt, perr := decodeRunEvent(msg)
 					if perr != nil {
+						cursor = msg.ID // advance past the malformed entry to avoid re-reading it
 						continue
 					}
 					cursor = evt.StreamID

--- a/modules/bichat/services/run_event_log.go
+++ b/modules/bichat/services/run_event_log.go
@@ -105,11 +105,15 @@ type RedisRunEventLogConfig struct {
 
 // RedisRunEventLog is the Redis Streams implementation.
 type RedisRunEventLog struct {
-	client    *redis.Client
-	keyPrefix string
-	maxLen    int64
-	ttl       time.Duration
-	blockTime time.Duration
+	client *redis.Client
+	// ownsClient is true only when this instance dialled the connection
+	// itself. When false (client supplied externally), Close is a no-op so
+	// the shared-client path does not tear down the other components.
+	ownsClient bool
+	keyPrefix  string
+	maxLen     int64
+	ttl        time.Duration
+	blockTime  time.Duration
 }
 
 // NewRedisRunEventLog constructs a log bound to the supplied client, or
@@ -132,6 +136,7 @@ func NewRedisRunEventLog(cfg RedisRunEventLogConfig) (*RedisRunEventLog, error) 
 		blockTime = defaultRunEventTailBlock
 	}
 
+	ownsClient := cfg.Client == nil
 	client := cfg.Client
 	if client == nil {
 		c, err := newRedisClient(cfg.RedisURL)
@@ -142,11 +147,12 @@ func NewRedisRunEventLog(cfg RedisRunEventLogConfig) (*RedisRunEventLog, error) 
 	}
 
 	return &RedisRunEventLog{
-		client:    client,
-		keyPrefix: prefix,
-		maxLen:    maxLen,
-		ttl:       ttl,
-		blockTime: blockTime,
+		client:     client,
+		ownsClient: ownsClient,
+		keyPrefix:  prefix,
+		maxLen:     maxLen,
+		ttl:        ttl,
+		blockTime:  blockTime,
 	}, nil
 }
 
@@ -288,8 +294,13 @@ func (l *RedisRunEventLog) DropAfterTerminal(ctx context.Context, tenantID, runI
 	return nil
 }
 
-// Close releases the underlying Redis connection.
+// Close releases the underlying Redis connection. When the client was
+// supplied externally (ownsClient == false) this is a no-op; the caller
+// that owns the shared *redis.Client is responsible for closing it.
 func (l *RedisRunEventLog) Close() error {
+	if !l.ownsClient {
+		return nil
+	}
 	return l.client.Close()
 }
 

--- a/modules/bichat/services/run_event_log.go
+++ b/modules/bichat/services/run_event_log.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/pkg/httpdto"
 	"github.com/iota-uz/iota-sdk/pkg/serrors"
 	"github.com/redis/go-redis/v9"
 )
@@ -30,20 +31,11 @@ const (
 	RunEventStreamStart = "0"
 )
 
-// Terminal event types: once one of these lands in a stream the log is
-// effectively closed and Tail consumers should exit. Keep this list in sync
-// with bichatservices.ChunkType* and with run_executor.go emit paths.
-var runEventTerminalTypes = map[string]struct{}{
-	"done":      {},
-	"cancelled": {},
-	"error":     {},
-	"failed":    {},
-}
-
 // IsRunEventTerminal reports whether the event type ends the stream.
+// Delegates to httpdto.IsTerminal so the set of terminal types has a
+// single source of truth shared with the TS applet.
 func IsRunEventTerminal(eventType string) bool {
-	_, ok := runEventTerminalTypes[eventType]
-	return ok
+	return httpdto.IsTerminal(httpdto.StreamEventType(eventType))
 }
 
 // RunEvent is a single entry in a run's event log. Payload is an opaque

--- a/modules/bichat/services/run_event_log.go
+++ b/modules/bichat/services/run_event_log.go
@@ -76,22 +76,6 @@ type RunEventLog interface {
 	DropAfterTerminal(ctx context.Context, tenantID, runID uuid.UUID, ttl time.Duration) error
 }
 
-// newConfiguredRunEventLog builds a Redis-backed log from REDIS_URL when
-// set, or returns nil so callers fall back to the in-memory broadcaster
-// only. Matches newConfiguredGenerationRunStore semantics: logging a
-// warning on disable is the expected dev/test path.
-func newConfiguredRunEventLog() RunEventLog {
-	redisURL, ok := envLookup("REDIS_URL")
-	if !ok || strings.TrimSpace(redisURL) == "" {
-		return nil
-	}
-	log, err := NewRedisRunEventLog(RedisRunEventLogConfig{RedisURL: redisURL})
-	if err != nil {
-		return nil
-	}
-	return log
-}
-
 // RedisRunEventLogConfig configures the Redis-backed log. Zero values fall
 // back to the defaults above.
 type RedisRunEventLogConfig struct {

--- a/modules/bichat/services/run_event_log.go
+++ b/modules/bichat/services/run_event_log.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -13,6 +14,10 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/serrors"
 	"github.com/redis/go-redis/v9"
 )
+
+// envLookup is extracted so tests can stub the env; in production it
+// delegates to os.LookupEnv.
+var envLookup = os.LookupEnv
 
 // Redis conventions for the per-run event log.
 const (
@@ -77,6 +82,22 @@ type RunEventLog interface {
 	// runs get garbage-collected without bloating Redis. Safe to call on
 	// an already-expired key.
 	DropAfterTerminal(ctx context.Context, tenantID, runID uuid.UUID, ttl time.Duration) error
+}
+
+// newConfiguredRunEventLog builds a Redis-backed log from REDIS_URL when
+// set, or returns nil so callers fall back to the in-memory broadcaster
+// only. Matches newConfiguredGenerationRunStore semantics: logging a
+// warning on disable is the expected dev/test path.
+func newConfiguredRunEventLog() RunEventLog {
+	redisURL, ok := envLookup("REDIS_URL")
+	if !ok || strings.TrimSpace(redisURL) == "" {
+		return nil
+	}
+	log, err := NewRedisRunEventLog(RedisRunEventLogConfig{RedisURL: redisURL})
+	if err != nil {
+		return nil
+	}
+	return log
 }
 
 // RedisRunEventLogConfig configures the Redis-backed log. Zero values fall

--- a/modules/bichat/services/run_event_log.go
+++ b/modules/bichat/services/run_event_log.go
@@ -350,14 +350,15 @@ func decodeRunEvent(msg redis.XMessage) (RunEvent, error) {
 		return RunEvent{}, fmt.Errorf("event type is not a string (id=%s)", msg.ID)
 	}
 
-	var payload json.RawMessage
-	if raw, ok := msg.Values["payload"]; ok {
-		bytes, err := coerceBytes(raw)
-		if err != nil {
-			return RunEvent{}, fmt.Errorf("decode payload (id=%s): %w", msg.ID, err)
-		}
-		payload = append(payload, bytes...)
+	rawPayload, ok := msg.Values["payload"]
+	if !ok {
+		return RunEvent{}, fmt.Errorf("missing payload field (id=%s)", msg.ID)
 	}
+	payloadBytes, err := coerceBytes(rawPayload)
+	if err != nil {
+		return RunEvent{}, fmt.Errorf("decode payload (id=%s): %w", msg.ID, err)
+	}
+	payload := json.RawMessage(payloadBytes)
 	return RunEvent{
 		StreamID: msg.ID,
 		Type:     typ,

--- a/modules/bichat/services/run_event_log.go
+++ b/modules/bichat/services/run_event_log.go
@@ -1,0 +1,339 @@
+// Package services provides this package.
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
+	"github.com/redis/go-redis/v9"
+)
+
+// Redis conventions for the per-run event log.
+const (
+	defaultRunEventLogPrefix = "bichat:run-events"
+	defaultRunEventLogMaxLen = 5_000
+	defaultRunEventLogTTL    = 2 * time.Hour
+	defaultRunEventTailBlock = 5 * time.Second
+	// RunEventStreamStart is the sentinel cursor for "replay from the
+	// beginning of the stream". Use it when a client has no Last-Event-ID.
+	RunEventStreamStart = "0"
+)
+
+// Terminal event types: once one of these lands in a stream the log is
+// effectively closed and Tail consumers should exit. Keep this list in sync
+// with bichatservices.ChunkType* and with run_executor.go emit paths.
+var runEventTerminalTypes = map[string]struct{}{
+	"done":      {},
+	"cancelled": {},
+	"error":     {},
+	"failed":    {},
+}
+
+// IsRunEventTerminal reports whether the event type ends the stream.
+func IsRunEventTerminal(eventType string) bool {
+	_, ok := runEventTerminalTypes[eventType]
+	return ok
+}
+
+// RunEvent is a single entry in a run's event log. Payload is an opaque
+// JSON blob — usually a marshalled httpdto.StreamChunkPayload — so the
+// transport layer does not need to know about internal service types.
+type RunEvent struct {
+	// StreamID is the Redis stream id assigned at append time, e.g.
+	// "1712345678000-0". Clients use this verbatim for Last-Event-ID.
+	StreamID string
+	// Type is the event kind and powers terminal detection.
+	Type string
+	// Payload is the JSON-encoded data line sent to the SSE client.
+	Payload json.RawMessage
+}
+
+// RunEventLog is the durable replay+tail surface for a single run.
+type RunEventLog interface {
+	// Append writes a new event and returns the assigned stream id. The
+	// key TTL is refreshed on every append so an active run keeps its
+	// event window open even if the TTL constant is much smaller than the
+	// run's worst-case runtime.
+	Append(ctx context.Context, tenantID, runID uuid.UUID, event RunEvent) (string, error)
+
+	// Replay returns all events with stream id strictly greater than `from`.
+	// Use RunEventStreamStart ("0") to start at the very beginning.
+	Replay(ctx context.Context, tenantID, runID uuid.UUID, from string) ([]RunEvent, error)
+
+	// Tail returns a channel that yields each event appended after `from`
+	// and is closed when a terminal event is observed, the stream is
+	// deleted, or ctx is cancelled. The channel is unbuffered: callers
+	// MUST consume without long blocking or the XREAD goroutine will
+	// back-pressure itself.
+	Tail(ctx context.Context, tenantID, runID uuid.UUID, from string) (<-chan RunEvent, error)
+
+	// DropAfterTerminal sets a short TTL on the stream key so terminated
+	// runs get garbage-collected without bloating Redis. Safe to call on
+	// an already-expired key.
+	DropAfterTerminal(ctx context.Context, tenantID, runID uuid.UUID, ttl time.Duration) error
+}
+
+// RedisRunEventLogConfig configures the Redis-backed log. Zero values fall
+// back to the defaults above.
+type RedisRunEventLogConfig struct {
+	RedisURL  string
+	KeyPrefix string
+	MaxLen    int64
+	TTL       time.Duration
+	BlockTime time.Duration
+	Client    *redis.Client
+}
+
+// RedisRunEventLog is the Redis Streams implementation.
+type RedisRunEventLog struct {
+	client    *redis.Client
+	keyPrefix string
+	maxLen    int64
+	ttl       time.Duration
+	blockTime time.Duration
+}
+
+// NewRedisRunEventLog constructs a log bound to the supplied client, or
+// dials a new connection from RedisURL if Client is nil.
+func NewRedisRunEventLog(cfg RedisRunEventLogConfig) (*RedisRunEventLog, error) {
+	prefix := strings.TrimSpace(cfg.KeyPrefix)
+	if prefix == "" {
+		prefix = defaultRunEventLogPrefix
+	}
+	maxLen := cfg.MaxLen
+	if maxLen <= 0 {
+		maxLen = defaultRunEventLogMaxLen
+	}
+	ttl := cfg.TTL
+	if ttl <= 0 {
+		ttl = defaultRunEventLogTTL
+	}
+	blockTime := cfg.BlockTime
+	if blockTime <= 0 {
+		blockTime = defaultRunEventTailBlock
+	}
+
+	client := cfg.Client
+	if client == nil {
+		c, err := newRedisClient(cfg.RedisURL)
+		if err != nil {
+			return nil, err
+		}
+		client = c
+	}
+
+	return &RedisRunEventLog{
+		client:    client,
+		keyPrefix: prefix,
+		maxLen:    maxLen,
+		ttl:       ttl,
+		blockTime: blockTime,
+	}, nil
+}
+
+// Append implements RunEventLog.
+func (l *RedisRunEventLog) Append(ctx context.Context, tenantID, runID uuid.UUID, event RunEvent) (string, error) {
+	const op serrors.Op = "RedisRunEventLog.Append"
+
+	if tenantID == uuid.Nil {
+		return "", serrors.E(op, serrors.KindValidation, "tenant id is required")
+	}
+	if runID == uuid.Nil {
+		return "", serrors.E(op, serrors.KindValidation, "run id is required")
+	}
+	if strings.TrimSpace(event.Type) == "" {
+		return "", serrors.E(op, serrors.KindValidation, "event type is required")
+	}
+
+	// context.WithoutCancel: appending a terminal event while the caller's
+	// request context is already cancelled (e.g. client disconnect) still
+	// needs to land — other tailing clients depend on seeing the terminal
+	// marker. This mirrors the policy in RunJobQueue.Enqueue.
+	writeCtx := context.WithoutCancel(ctx)
+
+	key := l.streamKey(tenantID, runID)
+	id, err := l.client.XAdd(writeCtx, &redis.XAddArgs{
+		Stream: key,
+		MaxLen: l.maxLen,
+		Approx: true,
+		Values: map[string]any{
+			"type":    event.Type,
+			"payload": []byte(event.Payload),
+		},
+	}).Result()
+	if err != nil {
+		return "", serrors.E(op, "xadd run event", err)
+	}
+
+	// Refresh the TTL on every write so a long-running execution doesn't
+	// have its replay window expire mid-run.
+	if err := l.client.Expire(writeCtx, key, l.ttl).Err(); err != nil {
+		return "", serrors.E(op, "refresh run event ttl", err)
+	}
+	return id, nil
+}
+
+// Replay implements RunEventLog.
+func (l *RedisRunEventLog) Replay(ctx context.Context, tenantID, runID uuid.UUID, from string) ([]RunEvent, error) {
+	const op serrors.Op = "RedisRunEventLog.Replay"
+	key := l.streamKey(tenantID, runID)
+
+	start := l.replayStart(from)
+	entries, err := l.client.XRange(ctx, key, start, "+").Result()
+	if err != nil {
+		return nil, serrors.E(op, "xrange run events", err)
+	}
+
+	out := make([]RunEvent, 0, len(entries))
+	for _, entry := range entries {
+		evt, perr := decodeRunEvent(entry)
+		if perr != nil {
+			return nil, serrors.E(op, perr)
+		}
+		out = append(out, evt)
+	}
+	return out, nil
+}
+
+// Tail implements RunEventLog.
+//
+// Behaviour: a background goroutine loops over XREAD BLOCK, forwarding each
+// new entry to the returned channel. The goroutine (and the channel) exits
+// when (a) context is cancelled, (b) a terminal event is observed, or (c)
+// Redis returns a non-recoverable error. Redis `nil` on the BLOCK timeout
+// is treated as a normal idle and triggers another read.
+func (l *RedisRunEventLog) Tail(ctx context.Context, tenantID, runID uuid.UUID, from string) (<-chan RunEvent, error) {
+	const op serrors.Op = "RedisRunEventLog.Tail"
+	if tenantID == uuid.Nil {
+		return nil, serrors.E(op, serrors.KindValidation, "tenant id is required")
+	}
+	if runID == uuid.Nil {
+		return nil, serrors.E(op, serrors.KindValidation, "run id is required")
+	}
+	key := l.streamKey(tenantID, runID)
+	cursor := l.tailStart(from)
+
+	out := make(chan RunEvent)
+	go func() {
+		defer close(out)
+		for {
+			if ctx.Err() != nil {
+				return
+			}
+			res, err := l.client.XRead(ctx, &redis.XReadArgs{
+				Streams: []string{key, cursor},
+				Count:   32,
+				Block:   l.blockTime,
+			}).Result()
+			if err != nil {
+				if errors.Is(err, redis.Nil) {
+					continue
+				}
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					return
+				}
+				return
+			}
+			for _, stream := range res {
+				for _, msg := range stream.Messages {
+					evt, perr := decodeRunEvent(msg)
+					if perr != nil {
+						continue
+					}
+					cursor = evt.StreamID
+					select {
+					case out <- evt:
+					case <-ctx.Done():
+						return
+					}
+					if IsRunEventTerminal(evt.Type) {
+						return
+					}
+				}
+			}
+		}
+	}()
+	return out, nil
+}
+
+// DropAfterTerminal implements RunEventLog.
+func (l *RedisRunEventLog) DropAfterTerminal(ctx context.Context, tenantID, runID uuid.UUID, ttl time.Duration) error {
+	const op serrors.Op = "RedisRunEventLog.DropAfterTerminal"
+	if ttl <= 0 {
+		ttl = 5 * time.Minute
+	}
+	key := l.streamKey(tenantID, runID)
+	if err := l.client.Expire(ctx, key, ttl).Err(); err != nil {
+		return serrors.E(op, "set terminal ttl", err)
+	}
+	return nil
+}
+
+// Close releases the underlying Redis connection.
+func (l *RedisRunEventLog) Close() error {
+	return l.client.Close()
+}
+
+func (l *RedisRunEventLog) streamKey(tenantID, runID uuid.UUID) string {
+	return fmt.Sprintf("%s:%s:%s", l.keyPrefix, tenantID.String(), runID.String())
+}
+
+// replayStart normalises a cursor for XRANGE. XRANGE is inclusive on both
+// ends so callers who want "events AFTER id X" need the exclusive "(X"
+// form. An empty cursor or the sentinel "0" means "from the beginning"
+// and maps to "-".
+func (l *RedisRunEventLog) replayStart(from string) string {
+	from = strings.TrimSpace(from)
+	if from == "" || from == RunEventStreamStart || from == "0-0" {
+		return "-"
+	}
+	if strings.HasPrefix(from, "(") {
+		return from
+	}
+	return "(" + from
+}
+
+// tailStart normalises a cursor for XREAD. XREAD is exclusive on the
+// `from` side so we pass the raw id — the sentinel "0" means "from the
+// beginning" which is what a brand-new SSE consumer gets.
+func (l *RedisRunEventLog) tailStart(from string) string {
+	from = strings.TrimSpace(from)
+	if from == "" {
+		return RunEventStreamStart
+	}
+	if strings.HasPrefix(from, "(") {
+		return strings.TrimPrefix(from, "(")
+	}
+	return from
+}
+
+func decodeRunEvent(msg redis.XMessage) (RunEvent, error) {
+	typVal, ok := msg.Values["type"]
+	if !ok {
+		return RunEvent{}, fmt.Errorf("missing event type field (id=%s)", msg.ID)
+	}
+	typ, ok := typVal.(string)
+	if !ok {
+		return RunEvent{}, fmt.Errorf("event type is not a string (id=%s)", msg.ID)
+	}
+
+	var payload json.RawMessage
+	if raw, ok := msg.Values["payload"]; ok {
+		bytes, err := coerceBytes(raw)
+		if err != nil {
+			return RunEvent{}, fmt.Errorf("decode payload (id=%s): %w", msg.ID, err)
+		}
+		payload = append(payload, bytes...)
+	}
+	return RunEvent{
+		StreamID: msg.ID,
+		Type:     typ,
+		Payload:  payload,
+	}, nil
+}

--- a/modules/bichat/services/run_event_log_race_test.go
+++ b/modules/bichat/services/run_event_log_race_test.go
@@ -1,0 +1,115 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunEventLog_ConcurrentAppendsTailReceivesTerminal spawns multiple
+// goroutines appending content events and one appending a terminal "done".
+// It asserts the Tail consumer sees at least one terminal event and that
+// the channel closes cleanly. Run with -race to validate no data races.
+func TestRunEventLog_ConcurrentAppendsTailReceivesTerminal(t *testing.T) {
+	t.Parallel()
+
+	log, _ := newTestRunEventLog(t)
+	tenant := uuid.New()
+	run := uuid.New()
+
+	// Pre-seed one event so Tail has something to read immediately, avoiding
+	// XREAD BLOCK flakiness on empty streams in miniredis.
+	appendEvent(t, log, tenant, run, "content", map[string]string{"text": "seed"})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ch, err := log.Tail(ctx, tenant, run, RunEventStreamStart)
+	require.NoError(t, err)
+
+	const writers = 4
+	const eventsPerWriter = 50
+
+	var wg sync.WaitGroup
+	// Spawn content writers.
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(writerIdx int) {
+			defer wg.Done()
+			for j := 0; j < eventsPerWriter; j++ {
+				body, _ := json.Marshal(map[string]any{"writer": writerIdx, "seq": j})
+				_, _ = log.Append(context.Background(), tenant, run, RunEvent{
+					Type:    "content",
+					Payload: body,
+				})
+			}
+		}(i)
+	}
+
+	// One goroutine appends the terminal event after all writers have queued.
+	go func() {
+		wg.Wait()
+		body, _ := json.Marshal(map[string]string{})
+		_, _ = log.Append(context.Background(), tenant, run, RunEvent{
+			Type:    "done",
+			Payload: body,
+		})
+	}()
+
+	// Consumer drains the channel; channel must close after a terminal event.
+	var sawTerminal bool
+	for evt := range ch {
+		if IsRunEventTerminal(evt.Type) {
+			sawTerminal = true
+		}
+	}
+
+	assert.True(t, sawTerminal, "consumer must see a terminal event before channel closes")
+}
+
+// TestRunEventLog_TailCancelStopsGoroutine verifies that cancelling the context
+// closes the Tail channel without leaking the XREAD goroutine. The test uses a
+// very short blockTime so the goroutine exits quickly on context cancellation.
+func TestRunEventLog_TailCancelStopsGoroutine(t *testing.T) {
+	t.Parallel()
+
+	// newTestRunEventLog already uses 30ms blockTime — suitable for this test.
+	log, _ := newTestRunEventLog(t)
+
+	tenant := uuid.New()
+	run := uuid.New()
+
+	// Seed one event so the first XREAD returns immediately.
+	appendEvent(t, log, tenant, run, "content", map[string]string{"text": "hi"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch, err := log.Tail(ctx, tenant, run, RunEventStreamStart)
+	require.NoError(t, err)
+
+	// Drain the seeded event.
+	select {
+	case _, ok := <-ch:
+		if !ok {
+			// Channel already closed — that's fine.
+			return
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for seeded event")
+	}
+
+	// Cancel and verify the channel closes within the block timeout.
+	cancel()
+	select {
+	case _, ok := <-ch:
+		assert.False(t, ok, "channel must close after context cancel")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("goroutine did not exit after context cancel")
+	}
+}

--- a/modules/bichat/services/run_event_log_race_test.go
+++ b/modules/bichat/services/run_event_log_race_test.go
@@ -36,18 +36,28 @@ func TestRunEventLog_ConcurrentAppendsTailReceivesTerminal(t *testing.T) {
 	const writers = 4
 	const eventsPerWriter = 50
 
+	var (
+		appendErrsMu sync.Mutex
+		appendErrs   []error
+	)
+
 	var wg sync.WaitGroup
-	// Spawn content writers.
+	// Spawn content writers; capture Append errors so the test can assert
+	// on them after the consumer loop finishes.
 	for i := 0; i < writers; i++ {
 		wg.Add(1)
 		go func(writerIdx int) {
 			defer wg.Done()
 			for j := 0; j < eventsPerWriter; j++ {
 				body, _ := json.Marshal(map[string]any{"writer": writerIdx, "seq": j}) //nolint:errchkjson // map[string]any with int values cannot fail
-				_, _ = log.Append(context.Background(), tenant, run, RunEvent{
+				if _, err := log.Append(context.Background(), tenant, run, RunEvent{
 					Type:    "content",
 					Payload: body,
-				})
+				}); err != nil {
+					appendErrsMu.Lock()
+					appendErrs = append(appendErrs, err)
+					appendErrsMu.Unlock()
+				}
 			}
 		}(i)
 	}
@@ -70,6 +80,12 @@ func TestRunEventLog_ConcurrentAppendsTailReceivesTerminal(t *testing.T) {
 		}
 	}
 
+	// Ensure all writer goroutines have exited before inspecting errors.
+	wg.Wait()
+	appendErrsMu.Lock()
+	errs := appendErrs
+	appendErrsMu.Unlock()
+	require.Empty(t, errs, "Append must not fail under concurrent load")
 	assert.True(t, sawTerminal, "consumer must see a terminal event before channel closes")
 }
 

--- a/modules/bichat/services/run_event_log_race_test.go
+++ b/modules/bichat/services/run_event_log_race_test.go
@@ -43,7 +43,7 @@ func TestRunEventLog_ConcurrentAppendsTailReceivesTerminal(t *testing.T) {
 		go func(writerIdx int) {
 			defer wg.Done()
 			for j := 0; j < eventsPerWriter; j++ {
-				body, _ := json.Marshal(map[string]any{"writer": writerIdx, "seq": j})
+				body, _ := json.Marshal(map[string]any{"writer": writerIdx, "seq": j}) //nolint:errchkjson // map[string]any with int values cannot fail
 				_, _ = log.Append(context.Background(), tenant, run, RunEvent{
 					Type:    "content",
 					Payload: body,
@@ -55,7 +55,7 @@ func TestRunEventLog_ConcurrentAppendsTailReceivesTerminal(t *testing.T) {
 	// One goroutine appends the terminal event after all writers have queued.
 	go func() {
 		wg.Wait()
-		body, _ := json.Marshal(map[string]string{})
+		body, _ := json.Marshal(map[string]string{}) //nolint:errchkjson // empty map cannot fail
 		_, _ = log.Append(context.Background(), tenant, run, RunEvent{
 			Type:    "done",
 			Payload: body,

--- a/modules/bichat/services/run_event_log_test.go
+++ b/modules/bichat/services/run_event_log_test.go
@@ -110,7 +110,7 @@ func TestRedisRunEventLog_TailClosesOnTerminal(t *testing.T) {
 	ch, err := log.Tail(ctx, tenant, run, RunEventStreamStart)
 	require.NoError(t, err)
 
-	var seen []string
+	seen := make([]string, 0, 3) // 2 content + 1 done seeded above
 	for evt := range ch {
 		seen = append(seen, evt.Type)
 	}

--- a/modules/bichat/services/run_event_log_test.go
+++ b/modules/bichat/services/run_event_log_test.go
@@ -1,0 +1,180 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestRunEventLog(t *testing.T) (*RedisRunEventLog, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	log, err := NewRedisRunEventLog(RedisRunEventLogConfig{
+		RedisURL:  mr.Addr(),
+		BlockTime: 30 * time.Millisecond, // short block so Tail exits quickly in tests
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = log.Close() })
+	return log, mr
+}
+
+func appendEvent(t *testing.T, log *RedisRunEventLog, tenant, run uuid.UUID, typ string, payload any) string {
+	t.Helper()
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
+	id, err := log.Append(context.Background(), tenant, run, RunEvent{Type: typ, Payload: body})
+	require.NoError(t, err)
+	return id
+}
+
+func TestRedisRunEventLog_AppendRefreshesTTL(t *testing.T) {
+	t.Parallel()
+
+	log, mr := newTestRunEventLog(t)
+	tenant, run := uuid.New(), uuid.New()
+
+	id1 := appendEvent(t, log, tenant, run, "content", map[string]string{"text": "hi"})
+	require.NotEmpty(t, id1)
+
+	key := log.streamKey(tenant, run)
+	ttl := mr.TTL(key)
+	assert.Greater(t, ttl, time.Duration(0), "TTL must be positive after append")
+
+	// Fast-forward time to just under the configured TTL; a second append
+	// should refresh the TTL back to ~2h.
+	mr.FastForward(time.Hour)
+	beforeSecond := mr.TTL(key)
+	appendEvent(t, log, tenant, run, "content", map[string]string{"text": "again"})
+	afterSecond := mr.TTL(key)
+
+	assert.Greater(t, afterSecond, beforeSecond, "Append must refresh TTL")
+}
+
+func TestRedisRunEventLog_ReplayReturnsEventsInOrder(t *testing.T) {
+	t.Parallel()
+
+	log, _ := newTestRunEventLog(t)
+	tenant, run := uuid.New(), uuid.New()
+
+	appendEvent(t, log, tenant, run, "content", map[string]string{"text": "one"})
+	appendEvent(t, log, tenant, run, "content", map[string]string{"text": "two"})
+	appendEvent(t, log, tenant, run, "done", map[string]string{})
+
+	events, err := log.Replay(context.Background(), tenant, run, RunEventStreamStart)
+	require.NoError(t, err)
+	require.Len(t, events, 3)
+	assert.Equal(t, "content", events[0].Type)
+	assert.Equal(t, "content", events[1].Type)
+	assert.Equal(t, "done", events[2].Type)
+}
+
+func TestRedisRunEventLog_ReplayFromCursorIsExclusive(t *testing.T) {
+	t.Parallel()
+
+	log, _ := newTestRunEventLog(t)
+	tenant, run := uuid.New(), uuid.New()
+
+	first := appendEvent(t, log, tenant, run, "content", map[string]string{"text": "one"})
+	appendEvent(t, log, tenant, run, "content", map[string]string{"text": "two"})
+	appendEvent(t, log, tenant, run, "done", map[string]string{})
+
+	// Replaying from first must skip the first event (exclusive semantics).
+	events, err := log.Replay(context.Background(), tenant, run, first)
+	require.NoError(t, err)
+	require.Len(t, events, 2)
+	assert.Equal(t, "content", events[0].Type)
+	assert.Equal(t, "done", events[1].Type)
+}
+
+func TestRedisRunEventLog_TailClosesOnTerminal(t *testing.T) {
+	t.Parallel()
+
+	log, _ := newTestRunEventLog(t)
+	tenant, run := uuid.New(), uuid.New()
+
+	// Pre-seed so Tail has something to read immediately; avoids flakes
+	// from miniredis not supporting XREAD BLOCK with zero entries.
+	appendEvent(t, log, tenant, run, "content", map[string]string{"text": "one"})
+	appendEvent(t, log, tenant, run, "content", map[string]string{"text": "two"})
+	appendEvent(t, log, tenant, run, "done", map[string]string{})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	ch, err := log.Tail(ctx, tenant, run, RunEventStreamStart)
+	require.NoError(t, err)
+
+	var seen []string
+	for evt := range ch {
+		seen = append(seen, evt.Type)
+	}
+	assert.Equal(t, []string{"content", "content", "done"}, seen, "tail must stop at the terminal done event")
+}
+
+func TestRedisRunEventLog_TailHonoursContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	log, _ := newTestRunEventLog(t)
+	tenant, run := uuid.New(), uuid.New()
+
+	appendEvent(t, log, tenant, run, "content", map[string]string{"text": "ping"})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := log.Tail(ctx, tenant, run, RunEventStreamStart)
+	require.NoError(t, err)
+
+	// Drain the seeded event, then cancel — channel must close promptly.
+	select {
+	case evt, ok := <-ch:
+		require.True(t, ok)
+		assert.Equal(t, "content", evt.Type)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for seeded event")
+	}
+	cancel()
+	select {
+	case _, ok := <-ch:
+		assert.False(t, ok, "channel must close after context cancel")
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("tail did not exit on context cancel")
+	}
+}
+
+func TestRedisRunEventLog_DropAfterTerminalShortensTTL(t *testing.T) {
+	t.Parallel()
+
+	log, mr := newTestRunEventLog(t)
+	tenant, run := uuid.New(), uuid.New()
+
+	appendEvent(t, log, tenant, run, "done", map[string]string{})
+
+	before := mr.TTL(log.streamKey(tenant, run))
+	require.NoError(t, log.DropAfterTerminal(context.Background(), tenant, run, 30*time.Second))
+	after := mr.TTL(log.streamKey(tenant, run))
+
+	assert.Less(t, after, before, "terminal TTL must be shorter than the live TTL")
+	assert.Greater(t, after, time.Duration(0))
+}
+
+func TestIsRunEventTerminal(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]bool{
+		"content":   false,
+		"tool_end":  false,
+		"done":      true,
+		"cancelled": true,
+		"error":     true,
+		"failed":    true,
+	}
+	for typ, want := range cases {
+		got := IsRunEventTerminal(typ)
+		assert.Equal(t, want, got, "IsRunEventTerminal(%q)", typ)
+	}
+}

--- a/modules/bichat/services/run_job_queue.go
+++ b/modules/bichat/services/run_job_queue.go
@@ -1,0 +1,265 @@
+// Package services provides this package.
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
+	"github.com/redis/go-redis/v9"
+)
+
+// Redis object key shapes for the bichat run queue. These are kept in sync
+// with the title-queue naming so the two systems coexist without overlap.
+const (
+	defaultRunQueueStream       = "bichat:run:jobs"
+	defaultRunQueueDedupePrefix = "bichat:run:request"
+	defaultRunQueueDedupeTTL    = 30 * time.Minute
+	defaultRunQueueMaxLen       = 10_000
+)
+
+// RunJobPayload describes a generation job handed off from the HTTP handler
+// to the background worker. The payload is self-contained so the worker does
+// not need the original request context: all deps (tenant, session, model
+// overrides, upload references) come in through the JSON blob.
+//
+// Attachments are referenced by upload ID rather than serialised as full
+// domain.Attachment objects. The worker re-resolves uploads via the
+// attachment service so binary references stay in PostgreSQL, not Redis.
+type RunJobPayload struct {
+	// Identity / routing.
+	TenantID  uuid.UUID `json:"tenant_id"`
+	SessionID uuid.UUID `json:"session_id"`
+	UserID    int64     `json:"user_id"`
+
+	// RequestID is the client-supplied idempotency key. Two enqueues with the
+	// same RequestID resolve to the same RunID (see Enqueue).
+	RequestID uuid.UUID `json:"request_id"`
+
+	// RunID is assigned by the queue on first enqueue and returned to the
+	// caller so the controller can point SSE readers at the right event log.
+	RunID uuid.UUID `json:"run_id"`
+
+	// Message body.
+	Content   string  `json:"content"`
+	UploadIDs []int64 `json:"upload_ids,omitempty"`
+
+	// Edit/regenerate support.
+	ReplaceFromMessageID *uuid.UUID `json:"replace_from_message_id,omitempty"`
+
+	// Per-request overrides.
+	ReasoningEffort *string `json:"reasoning_effort,omitempty"`
+	Model           *string `json:"model,omitempty"`
+	DebugMode       bool    `json:"debug_mode,omitempty"`
+
+	// Delivery metadata: incremented on retry.
+	Attempt    int       `json:"attempt"`
+	EnqueuedAt time.Time `json:"enqueued_at"`
+}
+
+// RunJobQueue enqueues generation jobs and enforces request-level idempotency.
+type RunJobQueue interface {
+	// Enqueue posts a job to the stream. When a job with the same RequestID
+	// has already been queued within the dedupe TTL window, the existing
+	// RunID is returned and deduped is true; no new stream entry is written.
+	// The RunID on the returned payload is authoritative.
+	Enqueue(ctx context.Context, payload RunJobPayload) (runID uuid.UUID, deduped bool, err error)
+}
+
+// RedisRunJobQueueConfig configures the Redis-backed queue. Stream, prefix
+// and TTL default to the constants above when left zero.
+type RedisRunJobQueueConfig struct {
+	RedisURL     string
+	Stream       string
+	DedupePrefix string
+	DedupeTTL    time.Duration
+	MaxLen       int64
+	Client       *redis.Client
+}
+
+// RedisRunJobQueue is the Redis Streams implementation of RunJobQueue.
+type RedisRunJobQueue struct {
+	client       *redis.Client
+	stream       string
+	dedupePrefix string
+	dedupeTTL    time.Duration
+	maxLen       int64
+}
+
+// NewRedisRunJobQueue constructs a queue bound to the supplied Redis client,
+// or dials a new connection from RedisURL if Client is nil.
+func NewRedisRunJobQueue(cfg RedisRunJobQueueConfig) (*RedisRunJobQueue, error) {
+	stream := strings.TrimSpace(cfg.Stream)
+	if stream == "" {
+		stream = defaultRunQueueStream
+	}
+
+	dedupePrefix := strings.TrimSpace(cfg.DedupePrefix)
+	if dedupePrefix == "" {
+		dedupePrefix = defaultRunQueueDedupePrefix
+	}
+
+	dedupeTTL := cfg.DedupeTTL
+	if dedupeTTL <= 0 {
+		dedupeTTL = defaultRunQueueDedupeTTL
+	}
+
+	maxLen := cfg.MaxLen
+	if maxLen <= 0 {
+		maxLen = defaultRunQueueMaxLen
+	}
+
+	client := cfg.Client
+	if client == nil {
+		c, err := newRedisClient(cfg.RedisURL)
+		if err != nil {
+			return nil, err
+		}
+		client = c
+	}
+
+	return &RedisRunJobQueue{
+		client:       client,
+		stream:       stream,
+		dedupePrefix: dedupePrefix,
+		dedupeTTL:    dedupeTTL,
+		maxLen:       maxLen,
+	}, nil
+}
+
+// Enqueue implements RunJobQueue.
+//
+// The idempotency contract is: the first caller with a given RequestID wins
+// the SetNX on bichat:run:request:{request_id} and assigns a fresh RunID
+// (either the one on the payload or a newly generated UUID). Subsequent
+// callers with the same RequestID receive that same RunID and a deduped=true
+// flag; no additional stream entry is produced. This lets clients retry the
+// same message send across network blips without double-running the agent.
+func (q *RedisRunJobQueue) Enqueue(ctx context.Context, payload RunJobPayload) (uuid.UUID, bool, error) {
+	const op serrors.Op = "RedisRunJobQueue.Enqueue"
+
+	if payload.TenantID == uuid.Nil {
+		return uuid.Nil, false, serrors.E(op, serrors.KindValidation, "tenant id is required")
+	}
+	if payload.SessionID == uuid.Nil {
+		return uuid.Nil, false, serrors.E(op, serrors.KindValidation, "session id is required")
+	}
+	if payload.RequestID == uuid.Nil {
+		return uuid.Nil, false, serrors.E(op, serrors.KindValidation, "request id is required")
+	}
+
+	// The caller may supply a RunID (e.g. retries promoted off the retry
+	// schedule). When empty, mint a fresh one — but do not commit to it
+	// until SetNX wins, otherwise a losing caller would return a RunID
+	// that isn't actually the authoritative one.
+	assignedRunID := payload.RunID
+	if assignedRunID == uuid.Nil {
+		assignedRunID = uuid.New()
+	}
+
+	dedupeKey := q.dedupeKey(payload.RequestID)
+	enqueueCtx := context.WithoutCancel(ctx)
+
+	acquired, err := q.client.SetNX(enqueueCtx, dedupeKey, assignedRunID.String(), q.dedupeTTL).Result()
+	if err != nil {
+		return uuid.Nil, false, serrors.E(op, "set run dedupe key", err)
+	}
+	if !acquired {
+		// Duplicate send: look up the run id assigned by the first writer.
+		existing, getErr := q.client.Get(enqueueCtx, dedupeKey).Result()
+		if getErr != nil {
+			if errors.Is(getErr, redis.Nil) {
+				// The dedupe key expired between the SetNX race and our Get.
+				// Treat as a stale dedupe record and retry enqueue from scratch.
+				return q.Enqueue(ctx, payload)
+			}
+			return uuid.Nil, false, serrors.E(op, "read run dedupe key", getErr)
+		}
+		existingID, parseErr := uuid.Parse(existing)
+		if parseErr != nil {
+			return uuid.Nil, false, serrors.E(op, "parse existing run id", parseErr)
+		}
+		return existingID, true, nil
+	}
+
+	payload.RunID = assignedRunID
+	if payload.EnqueuedAt.IsZero() {
+		payload.EnqueuedAt = time.Now().UTC()
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		_, _ = q.client.Del(enqueueCtx, dedupeKey).Result()
+		return uuid.Nil, false, serrors.E(op, "marshal run payload", err)
+	}
+
+	_, err = q.client.XAdd(enqueueCtx, &redis.XAddArgs{
+		Stream: q.stream,
+		MaxLen: q.maxLen,
+		Approx: true,
+		Values: map[string]any{
+			"tenant_id":   payload.TenantID.String(),
+			"session_id":  payload.SessionID.String(),
+			"request_id":  payload.RequestID.String(),
+			"run_id":      payload.RunID.String(),
+			"attempt":     fmt.Sprintf("%d", payload.Attempt),
+			"enqueued_at": payload.EnqueuedAt.Format(time.RFC3339Nano),
+			"payload":     body,
+		},
+	}).Result()
+	if err != nil {
+		cleanupCtx := context.WithoutCancel(ctx)
+		_, _ = q.client.Del(cleanupCtx, dedupeKey).Result()
+		return uuid.Nil, false, serrors.E(op, "xadd run job", err)
+	}
+	_, _ = q.client.XTrimMaxLenApprox(enqueueCtx, q.stream, q.maxLen, 1).Result()
+
+	return payload.RunID, false, nil
+}
+
+// Close releases the underlying Redis connection.
+func (q *RedisRunJobQueue) Close() error {
+	return q.client.Close()
+}
+
+func (q *RedisRunJobQueue) dedupeKey(requestID uuid.UUID) string {
+	return fmt.Sprintf("%s:%s", q.dedupePrefix, requestID.String())
+}
+
+// ParseRunJobPayload reads a payload back out of a Redis stream entry.
+// It tolerates older producers that only wrote scalar indexed fields by
+// falling back when the "payload" field is missing.
+func ParseRunJobPayload(values map[string]any) (RunJobPayload, error) {
+	const op serrors.Op = "ParseRunJobPayload"
+
+	raw, ok := values["payload"]
+	if !ok {
+		return RunJobPayload{}, serrors.E(op, serrors.KindValidation, "missing payload field")
+	}
+	body, err := coerceBytes(raw)
+	if err != nil {
+		return RunJobPayload{}, serrors.E(op, "coerce payload bytes", err)
+	}
+
+	var payload RunJobPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return RunJobPayload{}, serrors.E(op, "unmarshal run job payload", err)
+	}
+	return payload, nil
+}
+
+func coerceBytes(v any) ([]byte, error) {
+	switch typed := v.(type) {
+	case string:
+		return []byte(typed), nil
+	case []byte:
+		return typed, nil
+	default:
+		return nil, fmt.Errorf("unsupported payload encoding %T", v)
+	}
+}

--- a/modules/bichat/services/run_job_queue.go
+++ b/modules/bichat/services/run_job_queue.go
@@ -95,21 +95,6 @@ type RedisRunJobQueue struct {
 	maxLen       int64
 }
 
-// newConfiguredRunJobQueue mirrors the other newConfigured* helpers:
-// reads REDIS_URL and returns nil on disable so callers can degrade
-// to the pre-queue behaviour.
-func newConfiguredRunJobQueue() *RedisRunJobQueue {
-	redisURL, ok := envLookup("REDIS_URL")
-	if !ok || strings.TrimSpace(redisURL) == "" {
-		return nil
-	}
-	q, err := NewRedisRunJobQueue(RedisRunJobQueueConfig{RedisURL: redisURL})
-	if err != nil {
-		return nil
-	}
-	return q
-}
-
 // NewRedisRunJobQueue constructs a queue bound to the supplied Redis client,
 // or dials a new connection from RedisURL if Client is nil.
 func NewRedisRunJobQueue(cfg RedisRunJobQueueConfig) (*RedisRunJobQueue, error) {

--- a/modules/bichat/services/run_job_queue.go
+++ b/modules/bichat/services/run_job_queue.go
@@ -163,7 +163,7 @@ func (q *RedisRunJobQueue) Enqueue(ctx context.Context, payload RunJobPayload) (
 	// path and the queued path share one implementation — diverging
 	// them would make the dedupe contract subtly different between
 	// the two code paths.
-	runID, deduped, err := q.ClaimRequest(ctx, payload.RequestID, payload.RunID)
+	runID, deduped, err := q.ClaimRequest(ctx, payload.TenantID, payload.RequestID, payload.RunID)
 	if err != nil {
 		return uuid.Nil, false, serrors.E(op, err)
 	}
@@ -177,7 +177,7 @@ func (q *RedisRunJobQueue) Enqueue(ctx context.Context, payload RunJobPayload) (
 
 	body, err := json.Marshal(payload)
 	if err != nil {
-		_, _ = q.client.Del(context.WithoutCancel(ctx), q.dedupeKey(payload.RequestID)).Result()
+		_, _ = q.client.Del(context.WithoutCancel(ctx), q.dedupeKey(payload.TenantID, payload.RequestID)).Result()
 		return uuid.Nil, false, serrors.E(op, "marshal run payload", err)
 	}
 
@@ -197,7 +197,7 @@ func (q *RedisRunJobQueue) Enqueue(ctx context.Context, payload RunJobPayload) (
 		},
 	}).Result()
 	if err != nil {
-		_, _ = q.client.Del(enqueueCtx, q.dedupeKey(payload.RequestID)).Result()
+		_, _ = q.client.Del(enqueueCtx, q.dedupeKey(payload.TenantID, payload.RequestID)).Result()
 		return uuid.Nil, false, serrors.E(op, "xadd run job", err)
 	}
 	_, _ = q.client.XTrimMaxLenApprox(enqueueCtx, q.stream, q.maxLen, 1).Result()
@@ -218,11 +218,15 @@ func (q *RedisRunJobQueue) Enqueue(ctx context.Context, payload RunJobPayload) (
 //     (existingRunID, true, nil).
 //   - Expired-between-SetNX-and-Get is retried.
 //
-// When assignedRunID is uuid.Nil a fresh one is minted on a winning
-// claim.
-func (q *RedisRunJobQueue) ClaimRequest(ctx context.Context, requestID, assignedRunID uuid.UUID) (uuid.UUID, bool, error) {
+// tenantID scopes the lock so distinct tenants with the same requestID
+// get distinct RunIDs (cross-tenant isolation).
+// When assignedRunID is uuid.Nil a fresh one is minted on a winning claim.
+func (q *RedisRunJobQueue) ClaimRequest(ctx context.Context, tenantID, requestID, assignedRunID uuid.UUID) (uuid.UUID, bool, error) {
 	const op serrors.Op = "RedisRunJobQueue.ClaimRequest"
 	const maxRetries = 3
+	if tenantID == uuid.Nil {
+		return uuid.Nil, false, serrors.E(op, serrors.KindValidation, "tenant id is required")
+	}
 	if requestID == uuid.Nil {
 		return uuid.Nil, false, serrors.E(op, serrors.KindValidation, "request id is required")
 	}
@@ -230,7 +234,7 @@ func (q *RedisRunJobQueue) ClaimRequest(ctx context.Context, requestID, assigned
 	if candidate == uuid.Nil {
 		candidate = uuid.New()
 	}
-	dedupeKey := q.dedupeKey(requestID)
+	dedupeKey := q.dedupeKey(tenantID, requestID)
 	writeCtx := context.WithoutCancel(ctx)
 
 	// The SetNX→Get sequence has a narrow window where the key expires between
@@ -264,15 +268,15 @@ func (q *RedisRunJobQueue) ClaimRequest(ctx context.Context, requestID, assigned
 	return uuid.Nil, false, serrors.E(op, "request dedupe retry exhausted")
 }
 
-// ReleaseRequest drops the dedupe mapping for a request_id. Called on
-// terminal transitions so repeated send-with-same-id after completion
-// starts a new run rather than attaching to the finished one. Safe to
-// call with an expired key (redis.Nil is swallowed).
-func (q *RedisRunJobQueue) ReleaseRequest(ctx context.Context, requestID uuid.UUID) error {
-	if requestID == uuid.Nil {
+// ReleaseRequest drops the tenant-scoped dedupe mapping for a request_id.
+// Called on terminal transitions so repeated send-with-same-id after
+// completion starts a new run rather than attaching to the finished one.
+// Safe to call with an expired key (redis.Nil is swallowed).
+func (q *RedisRunJobQueue) ReleaseRequest(ctx context.Context, tenantID, requestID uuid.UUID) error {
+	if tenantID == uuid.Nil || requestID == uuid.Nil {
 		return nil
 	}
-	if _, err := q.client.Del(context.WithoutCancel(ctx), q.dedupeKey(requestID)).Result(); err != nil {
+	if _, err := q.client.Del(context.WithoutCancel(ctx), q.dedupeKey(tenantID, requestID)).Result(); err != nil {
 		if errors.Is(err, redis.Nil) {
 			return nil
 		}
@@ -291,13 +295,17 @@ func (q *RedisRunJobQueue) Close() error {
 	return q.client.Close()
 }
 
-func (q *RedisRunJobQueue) dedupeKey(requestID uuid.UUID) string {
-	return fmt.Sprintf("%s:%s", q.dedupePrefix, requestID.String())
+// dedupeKey scopes the idempotency key to a (tenant, request) pair so one
+// tenant cannot claim another tenant's request_id. Format mirrors
+// RedisTitleJobQueue.dedupeKey: prefix:tenantID:requestID.
+func (q *RedisRunJobQueue) dedupeKey(tenantID, requestID uuid.UUID) string {
+	return fmt.Sprintf("%s:%s:%s", q.dedupePrefix, tenantID.String(), requestID.String())
 }
 
 // ParseRunJobPayload reads a payload back out of a Redis stream entry.
-// It tolerates older producers that only wrote scalar indexed fields by
-// falling back when the "payload" field is missing.
+// Entries without a "payload" field are rejected as corrupt — no back-compat
+// with an older format exists. Hard-fail is intentional: we don't support
+// mixed-version rollout for this queue.
 func ParseRunJobPayload(values map[string]any) (RunJobPayload, error) {
 	const op serrors.Op = "ParseRunJobPayload"
 

--- a/modules/bichat/services/run_job_queue.go
+++ b/modules/bichat/services/run_job_queue.go
@@ -84,7 +84,11 @@ type RedisRunJobQueueConfig struct {
 
 // RedisRunJobQueue is the Redis Streams implementation of RunJobQueue.
 type RedisRunJobQueue struct {
-	client       *redis.Client
+	client *redis.Client
+	// ownsClient is true only when this instance dialled the connection
+	// itself. When false (client supplied externally), Close is a no-op so
+	// the shared-client path does not tear down the other components.
+	ownsClient   bool
 	stream       string
 	dedupePrefix string
 	dedupeTTL    time.Duration
@@ -129,6 +133,7 @@ func NewRedisRunJobQueue(cfg RedisRunJobQueueConfig) (*RedisRunJobQueue, error) 
 		maxLen = defaultRunQueueMaxLen
 	}
 
+	ownsClient := cfg.Client == nil
 	client := cfg.Client
 	if client == nil {
 		c, err := newRedisClient(cfg.RedisURL)
@@ -140,6 +145,7 @@ func NewRedisRunJobQueue(cfg RedisRunJobQueueConfig) (*RedisRunJobQueue, error) 
 
 	return &RedisRunJobQueue{
 		client:       client,
+		ownsClient:   ownsClient,
 		stream:       stream,
 		dedupePrefix: dedupePrefix,
 		dedupeTTL:    dedupeTTL,
@@ -231,6 +237,7 @@ func (q *RedisRunJobQueue) Enqueue(ctx context.Context, payload RunJobPayload) (
 // claim.
 func (q *RedisRunJobQueue) ClaimRequest(ctx context.Context, requestID, assignedRunID uuid.UUID) (uuid.UUID, bool, error) {
 	const op serrors.Op = "RedisRunJobQueue.ClaimRequest"
+	const maxRetries = 3
 	if requestID == uuid.Nil {
 		return uuid.Nil, false, serrors.E(op, serrors.KindValidation, "request id is required")
 	}
@@ -241,25 +248,35 @@ func (q *RedisRunJobQueue) ClaimRequest(ctx context.Context, requestID, assigned
 	dedupeKey := q.dedupeKey(requestID)
 	writeCtx := context.WithoutCancel(ctx)
 
-	acquired, err := q.client.SetNX(writeCtx, dedupeKey, candidate.String(), q.dedupeTTL).Result()
-	if err != nil {
-		return uuid.Nil, false, serrors.E(op, "set request dedupe key", err)
-	}
-	if acquired {
-		return candidate, false, nil
-	}
-	existing, err := q.client.Get(writeCtx, dedupeKey).Result()
-	if err != nil {
-		if errors.Is(err, redis.Nil) {
-			return q.ClaimRequest(ctx, requestID, assignedRunID)
+	// The SetNX→Get sequence has a narrow window where the key expires between
+	// the two operations. We retry up to maxRetries times instead of recursing
+	// so stack depth is bounded regardless of Redis timing.
+	for attempt := range maxRetries {
+		acquired, err := q.client.SetNX(writeCtx, dedupeKey, candidate.String(), q.dedupeTTL).Result()
+		if err != nil {
+			return uuid.Nil, false, serrors.E(op, "set request dedupe key", err)
 		}
-		return uuid.Nil, false, serrors.E(op, "read request dedupe key", err)
+		if acquired {
+			return candidate, false, nil
+		}
+		existing, err := q.client.Get(writeCtx, dedupeKey).Result()
+		if err != nil {
+			if errors.Is(err, redis.Nil) {
+				// Key expired between SetNX and Get — retry.
+				if attempt < maxRetries-1 {
+					continue
+				}
+				return uuid.Nil, false, serrors.E(op, "request dedupe retry exhausted")
+			}
+			return uuid.Nil, false, serrors.E(op, "read request dedupe key", err)
+		}
+		existingID, parseErr := uuid.Parse(existing)
+		if parseErr != nil {
+			return uuid.Nil, false, serrors.E(op, "parse existing run id", parseErr)
+		}
+		return existingID, true, nil
 	}
-	existingID, parseErr := uuid.Parse(existing)
-	if parseErr != nil {
-		return uuid.Nil, false, serrors.E(op, "parse existing run id", parseErr)
-	}
-	return existingID, true, nil
+	return uuid.Nil, false, serrors.E(op, "request dedupe retry exhausted")
 }
 
 // ReleaseRequest drops the dedupe mapping for a request_id. Called on
@@ -279,8 +296,13 @@ func (q *RedisRunJobQueue) ReleaseRequest(ctx context.Context, requestID uuid.UU
 	return nil
 }
 
-// Close releases the underlying Redis connection.
+// Close releases the underlying Redis connection. When the client was
+// supplied externally (ownsClient == false) this is a no-op; the caller
+// that owns the shared *redis.Client is responsible for closing it.
 func (q *RedisRunJobQueue) Close() error {
+	if !q.ownsClient {
+		return nil
+	}
 	return q.client.Close()
 }
 

--- a/modules/bichat/services/run_job_queue.go
+++ b/modules/bichat/services/run_job_queue.go
@@ -91,6 +91,21 @@ type RedisRunJobQueue struct {
 	maxLen       int64
 }
 
+// newConfiguredRunJobQueue mirrors the other newConfigured* helpers:
+// reads REDIS_URL and returns nil on disable so callers can degrade
+// to the pre-queue behaviour.
+func newConfiguredRunJobQueue() *RedisRunJobQueue {
+	redisURL, ok := envLookup("REDIS_URL")
+	if !ok || strings.TrimSpace(redisURL) == "" {
+		return nil
+	}
+	q, err := NewRedisRunJobQueue(RedisRunJobQueueConfig{RedisURL: redisURL})
+	if err != nil {
+		return nil
+	}
+	return q
+}
+
 // NewRedisRunJobQueue constructs a queue bound to the supplied Redis client,
 // or dials a new connection from RedisURL if Client is nil.
 func NewRedisRunJobQueue(cfg RedisRunJobQueueConfig) (*RedisRunJobQueue, error) {
@@ -153,51 +168,29 @@ func (q *RedisRunJobQueue) Enqueue(ctx context.Context, payload RunJobPayload) (
 		return uuid.Nil, false, serrors.E(op, serrors.KindValidation, "request id is required")
 	}
 
-	// The caller may supply a RunID (e.g. retries promoted off the retry
-	// schedule). When empty, mint a fresh one — but do not commit to it
-	// until SetNX wins, otherwise a losing caller would return a RunID
-	// that isn't actually the authoritative one.
-	assignedRunID := payload.RunID
-	if assignedRunID == uuid.Nil {
-		assignedRunID = uuid.New()
-	}
-
-	dedupeKey := q.dedupeKey(payload.RequestID)
-	enqueueCtx := context.WithoutCancel(ctx)
-
-	acquired, err := q.client.SetNX(enqueueCtx, dedupeKey, assignedRunID.String(), q.dedupeTTL).Result()
+	// Delegate the SetNX dance to ClaimRequest so the inline request
+	// path and the queued path share one implementation — diverging
+	// them would make the dedupe contract subtly different between
+	// the two code paths.
+	runID, deduped, err := q.ClaimRequest(ctx, payload.RequestID, payload.RunID)
 	if err != nil {
-		return uuid.Nil, false, serrors.E(op, "set run dedupe key", err)
+		return uuid.Nil, false, serrors.E(op, err)
 	}
-	if !acquired {
-		// Duplicate send: look up the run id assigned by the first writer.
-		existing, getErr := q.client.Get(enqueueCtx, dedupeKey).Result()
-		if getErr != nil {
-			if errors.Is(getErr, redis.Nil) {
-				// The dedupe key expired between the SetNX race and our Get.
-				// Treat as a stale dedupe record and retry enqueue from scratch.
-				return q.Enqueue(ctx, payload)
-			}
-			return uuid.Nil, false, serrors.E(op, "read run dedupe key", getErr)
-		}
-		existingID, parseErr := uuid.Parse(existing)
-		if parseErr != nil {
-			return uuid.Nil, false, serrors.E(op, "parse existing run id", parseErr)
-		}
-		return existingID, true, nil
+	if deduped {
+		return runID, true, nil
 	}
-
-	payload.RunID = assignedRunID
+	payload.RunID = runID
 	if payload.EnqueuedAt.IsZero() {
 		payload.EnqueuedAt = time.Now().UTC()
 	}
 
 	body, err := json.Marshal(payload)
 	if err != nil {
-		_, _ = q.client.Del(enqueueCtx, dedupeKey).Result()
+		_, _ = q.client.Del(context.WithoutCancel(ctx), q.dedupeKey(payload.RequestID)).Result()
 		return uuid.Nil, false, serrors.E(op, "marshal run payload", err)
 	}
 
+	enqueueCtx := context.WithoutCancel(ctx)
 	_, err = q.client.XAdd(enqueueCtx, &redis.XAddArgs{
 		Stream: q.stream,
 		MaxLen: q.maxLen,
@@ -213,13 +206,77 @@ func (q *RedisRunJobQueue) Enqueue(ctx context.Context, payload RunJobPayload) (
 		},
 	}).Result()
 	if err != nil {
-		cleanupCtx := context.WithoutCancel(ctx)
-		_, _ = q.client.Del(cleanupCtx, dedupeKey).Result()
+		_, _ = q.client.Del(enqueueCtx, q.dedupeKey(payload.RequestID)).Result()
 		return uuid.Nil, false, serrors.E(op, "xadd run job", err)
 	}
 	_, _ = q.client.XTrimMaxLenApprox(enqueueCtx, q.stream, q.maxLen, 1).Result()
 
 	return payload.RunID, false, nil
+}
+
+// ClaimRequest acquires the request_id dedupe lock WITHOUT enqueuing a
+// stream entry. It is used by the inline SendMessageStream path (where
+// execution stays in-process on the current server) so that duplicate
+// clicks / concurrent tabs sharing a request_id converge to the same
+// run_id without pushing a phantom job onto bichat:run:jobs. Semantics
+// mirror Enqueue's dedupe phase:
+//
+//   - First claim wins SetNX → returns (assignedRunID, false, nil).
+//     Caller must eventually Release on terminal or accept the TTL.
+//   - Subsequent claim reads the existing mapping → returns
+//     (existingRunID, true, nil).
+//   - Expired-between-SetNX-and-Get is retried.
+//
+// When assignedRunID is uuid.Nil a fresh one is minted on a winning
+// claim.
+func (q *RedisRunJobQueue) ClaimRequest(ctx context.Context, requestID, assignedRunID uuid.UUID) (uuid.UUID, bool, error) {
+	const op serrors.Op = "RedisRunJobQueue.ClaimRequest"
+	if requestID == uuid.Nil {
+		return uuid.Nil, false, serrors.E(op, serrors.KindValidation, "request id is required")
+	}
+	candidate := assignedRunID
+	if candidate == uuid.Nil {
+		candidate = uuid.New()
+	}
+	dedupeKey := q.dedupeKey(requestID)
+	writeCtx := context.WithoutCancel(ctx)
+
+	acquired, err := q.client.SetNX(writeCtx, dedupeKey, candidate.String(), q.dedupeTTL).Result()
+	if err != nil {
+		return uuid.Nil, false, serrors.E(op, "set request dedupe key", err)
+	}
+	if acquired {
+		return candidate, false, nil
+	}
+	existing, err := q.client.Get(writeCtx, dedupeKey).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return q.ClaimRequest(ctx, requestID, assignedRunID)
+		}
+		return uuid.Nil, false, serrors.E(op, "read request dedupe key", err)
+	}
+	existingID, parseErr := uuid.Parse(existing)
+	if parseErr != nil {
+		return uuid.Nil, false, serrors.E(op, "parse existing run id", parseErr)
+	}
+	return existingID, true, nil
+}
+
+// ReleaseRequest drops the dedupe mapping for a request_id. Called on
+// terminal transitions so repeated send-with-same-id after completion
+// starts a new run rather than attaching to the finished one. Safe to
+// call with an expired key (redis.Nil is swallowed).
+func (q *RedisRunJobQueue) ReleaseRequest(ctx context.Context, requestID uuid.UUID) error {
+	if requestID == uuid.Nil {
+		return nil
+	}
+	if _, err := q.client.Del(context.WithoutCancel(ctx), q.dedupeKey(requestID)).Result(); err != nil {
+		if errors.Is(err, redis.Nil) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 // Close releases the underlying Redis connection.

--- a/modules/bichat/services/run_job_queue_test.go
+++ b/modules/bichat/services/run_job_queue_test.go
@@ -160,6 +160,65 @@ func TestRedisRunJobQueue_Enqueue_HonoursCallerSuppliedRunID(t *testing.T) {
 	assert.Equal(t, requested, returned, "queue must preserve caller-supplied RunID")
 }
 
+func TestRedisRunJobQueue_ClaimRequest_DoesNotEnqueueStreamEntry(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	queue, err := NewRedisRunJobQueue(RedisRunJobQueueConfig{
+		RedisURL: mr.Addr(),
+		Stream:   "bichat:run:test-claim",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = queue.Close() })
+
+	requestID := uuid.New()
+	assigned := uuid.New()
+	runID, deduped, err := queue.ClaimRequest(context.Background(), requestID, assigned)
+	require.NoError(t, err)
+	assert.False(t, deduped, "first claim must not be marked deduped")
+	assert.Equal(t, assigned, runID, "first claim must return the caller-supplied run id")
+
+	length, xlenErr := queue.client.XLen(context.Background(), queue.stream).Result()
+	require.NoError(t, xlenErr)
+	assert.Equal(t, int64(0), length, "ClaimRequest must not push to the job stream")
+}
+
+func TestRedisRunJobQueue_ClaimRequest_DuplicateReturnsExistingRunID(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	queue, err := NewRedisRunJobQueue(RedisRunJobQueueConfig{RedisURL: mr.Addr()})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = queue.Close() })
+
+	requestID := uuid.New()
+	first, _, err := queue.ClaimRequest(context.Background(), requestID, uuid.New())
+	require.NoError(t, err)
+
+	second, deduped, err := queue.ClaimRequest(context.Background(), requestID, uuid.New())
+	require.NoError(t, err)
+	assert.True(t, deduped, "duplicate claim must be flagged")
+	assert.Equal(t, first, second, "duplicate claim must return the original run id")
+}
+
+func TestRedisRunJobQueue_ReleaseRequest_AllowsFreshRunAfterRelease(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	queue, err := NewRedisRunJobQueue(RedisRunJobQueueConfig{RedisURL: mr.Addr()})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = queue.Close() })
+
+	requestID := uuid.New()
+	first, _, err := queue.ClaimRequest(context.Background(), requestID, uuid.New())
+	require.NoError(t, err)
+	require.NoError(t, queue.ReleaseRequest(context.Background(), requestID))
+
+	second, _, err := queue.ClaimRequest(context.Background(), requestID, uuid.New())
+	require.NoError(t, err)
+	assert.NotEqual(t, first, second, "released request id must produce a new run")
+}
+
 func TestParseRunJobPayload_RoundTripsViaRedis(t *testing.T) {
 	t.Parallel()
 

--- a/modules/bichat/services/run_job_queue_test.go
+++ b/modules/bichat/services/run_job_queue_test.go
@@ -171,9 +171,10 @@ func TestRedisRunJobQueue_ClaimRequest_DoesNotEnqueueStreamEntry(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = queue.Close() })
 
+	tenantID := uuid.New()
 	requestID := uuid.New()
 	assigned := uuid.New()
-	runID, deduped, err := queue.ClaimRequest(context.Background(), requestID, assigned)
+	runID, deduped, err := queue.ClaimRequest(context.Background(), tenantID, requestID, assigned)
 	require.NoError(t, err)
 	assert.False(t, deduped, "first claim must not be marked deduped")
 	assert.Equal(t, assigned, runID, "first claim must return the caller-supplied run id")
@@ -191,11 +192,12 @@ func TestRedisRunJobQueue_ClaimRequest_DuplicateReturnsExistingRunID(t *testing.
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = queue.Close() })
 
+	tenantID := uuid.New()
 	requestID := uuid.New()
-	first, _, err := queue.ClaimRequest(context.Background(), requestID, uuid.New())
+	first, _, err := queue.ClaimRequest(context.Background(), tenantID, requestID, uuid.New())
 	require.NoError(t, err)
 
-	second, deduped, err := queue.ClaimRequest(context.Background(), requestID, uuid.New())
+	second, deduped, err := queue.ClaimRequest(context.Background(), tenantID, requestID, uuid.New())
 	require.NoError(t, err)
 	assert.True(t, deduped, "duplicate claim must be flagged")
 	assert.Equal(t, first, second, "duplicate claim must return the original run id")
@@ -209,12 +211,13 @@ func TestRedisRunJobQueue_ReleaseRequest_AllowsFreshRunAfterRelease(t *testing.T
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = queue.Close() })
 
+	tenantID := uuid.New()
 	requestID := uuid.New()
-	first, _, err := queue.ClaimRequest(context.Background(), requestID, uuid.New())
+	first, _, err := queue.ClaimRequest(context.Background(), tenantID, requestID, uuid.New())
 	require.NoError(t, err)
-	require.NoError(t, queue.ReleaseRequest(context.Background(), requestID))
+	require.NoError(t, queue.ReleaseRequest(context.Background(), tenantID, requestID))
 
-	second, _, err := queue.ClaimRequest(context.Background(), requestID, uuid.New())
+	second, _, err := queue.ClaimRequest(context.Background(), tenantID, requestID, uuid.New())
 	require.NoError(t, err)
 	assert.NotEqual(t, first, second, "released request id must produce a new run")
 }
@@ -257,4 +260,32 @@ func TestParseRunJobPayload_RoundTripsViaRedis(t *testing.T) {
 	assert.Equal(t, original.DebugMode, parsed.DebugMode)
 	// Queue assigns a RunID when the caller omits one; round-trip must preserve it.
 	assert.NotEqual(t, uuid.Nil, parsed.RunID)
+}
+
+// TestRedisRunJobQueue_ClaimRequest_CrossTenantIsolation asserts that two
+// distinct tenants sharing the same request_id get distinct RunIDs. This is
+// the regression test for R6/R11: the dedupe key must be scoped to
+// (tenant_id, request_id) so one tenant cannot claim another tenant's run.
+func TestRedisRunJobQueue_ClaimRequest_CrossTenantIsolation(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	queue, err := NewRedisRunJobQueue(RedisRunJobQueueConfig{RedisURL: mr.Addr()})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = queue.Close() })
+
+	// Same request_id shared by two distinct tenants.
+	sharedRequestID := uuid.New()
+	tenantA := uuid.New()
+	tenantB := uuid.New()
+
+	runA, dedupedA, err := queue.ClaimRequest(context.Background(), tenantA, sharedRequestID, uuid.New())
+	require.NoError(t, err)
+	require.False(t, dedupedA, "first claim for tenant A must not be deduped")
+
+	runB, dedupedB, err := queue.ClaimRequest(context.Background(), tenantB, sharedRequestID, uuid.New())
+	require.NoError(t, err)
+	require.False(t, dedupedB, "first claim for tenant B with same request_id must not be deduped")
+
+	assert.NotEqual(t, runA, runB, "distinct tenants with the same request_id must get distinct RunIDs")
 }

--- a/modules/bichat/services/run_job_queue_test.go
+++ b/modules/bichat/services/run_job_queue_test.go
@@ -1,0 +1,201 @@
+package services
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedisRunJobQueue_Enqueue_FirstCallWritesStreamEntry(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	queue, err := NewRedisRunJobQueue(RedisRunJobQueueConfig{
+		RedisURL: mr.Addr(),
+		Stream:   "bichat:run:test-enqueue",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = queue.Close() })
+
+	payload := RunJobPayload{
+		TenantID:  uuid.New(),
+		SessionID: uuid.New(),
+		UserID:    7,
+		RequestID: uuid.New(),
+		Content:   "hi",
+	}
+
+	runID, deduped, err := queue.Enqueue(context.Background(), payload)
+	require.NoError(t, err)
+	require.False(t, deduped, "first enqueue must not be marked deduped")
+	require.NotEqual(t, uuid.Nil, runID, "queue must assign a run id when payload leaves it empty")
+
+	length, xlenErr := queue.client.XLen(context.Background(), queue.stream).Result()
+	require.NoError(t, xlenErr)
+	assert.Equal(t, int64(1), length, "first enqueue must write exactly one stream entry")
+}
+
+func TestRedisRunJobQueue_Enqueue_DedupesOnSameRequestID(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	queue, err := NewRedisRunJobQueue(RedisRunJobQueueConfig{
+		RedisURL:  mr.Addr(),
+		Stream:    "bichat:run:test-dedupe",
+		DedupeTTL: 5 * time.Minute,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = queue.Close() })
+
+	requestID := uuid.New()
+	base := RunJobPayload{
+		TenantID:  uuid.New(),
+		SessionID: uuid.New(),
+		UserID:    1,
+		RequestID: requestID,
+		Content:   "duplicate",
+	}
+
+	firstID, dedupedFirst, err := queue.Enqueue(context.Background(), base)
+	require.NoError(t, err)
+	require.False(t, dedupedFirst)
+
+	// Second enqueue with the SAME request_id must return the same run id
+	// and be marked deduped. It must NOT add a new stream entry.
+	secondID, dedupedSecond, err := queue.Enqueue(context.Background(), base)
+	require.NoError(t, err)
+	require.True(t, dedupedSecond, "duplicate enqueue must be flagged")
+	assert.Equal(t, firstID, secondID, "duplicate enqueue must return the original run id")
+
+	length, xlenErr := queue.client.XLen(context.Background(), queue.stream).Result()
+	require.NoError(t, xlenErr)
+	assert.Equal(t, int64(1), length, "duplicate enqueue must not produce a new stream entry")
+}
+
+func TestRedisRunJobQueue_Enqueue_DistinctRequestIDsProduceDistinctRuns(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	queue, err := NewRedisRunJobQueue(RedisRunJobQueueConfig{
+		RedisURL: mr.Addr(),
+		Stream:   "bichat:run:test-distinct",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = queue.Close() })
+
+	tenant := uuid.New()
+	session := uuid.New()
+
+	first, _, err := queue.Enqueue(context.Background(), RunJobPayload{
+		TenantID: tenant, SessionID: session, RequestID: uuid.New(), Content: "a",
+	})
+	require.NoError(t, err)
+	second, _, err := queue.Enqueue(context.Background(), RunJobPayload{
+		TenantID: tenant, SessionID: session, RequestID: uuid.New(), Content: "b",
+	})
+	require.NoError(t, err)
+
+	assert.NotEqual(t, first, second, "distinct request ids must yield distinct run ids")
+
+	length, xlenErr := queue.client.XLen(context.Background(), queue.stream).Result()
+	require.NoError(t, xlenErr)
+	assert.Equal(t, int64(2), length, "distinct request ids must produce two stream entries")
+}
+
+func TestRedisRunJobQueue_Enqueue_RejectsInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	queue, err := NewRedisRunJobQueue(RedisRunJobQueueConfig{
+		RedisURL: mr.Addr(),
+		Stream:   "bichat:run:test-validation",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = queue.Close() })
+
+	tenant := uuid.New()
+	session := uuid.New()
+	reqID := uuid.New()
+
+	cases := []struct {
+		name    string
+		payload RunJobPayload
+	}{
+		{"missing tenant", RunJobPayload{SessionID: session, RequestID: reqID}},
+		{"missing session", RunJobPayload{TenantID: tenant, RequestID: reqID}},
+		{"missing request id", RunJobPayload{TenantID: tenant, SessionID: session}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := queue.Enqueue(context.Background(), tc.payload)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestRedisRunJobQueue_Enqueue_HonoursCallerSuppliedRunID(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	queue, err := NewRedisRunJobQueue(RedisRunJobQueueConfig{
+		RedisURL: mr.Addr(),
+		Stream:   "bichat:run:test-caller-runid",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = queue.Close() })
+
+	requested := uuid.New()
+	returned, _, err := queue.Enqueue(context.Background(), RunJobPayload{
+		TenantID:  uuid.New(),
+		SessionID: uuid.New(),
+		RequestID: uuid.New(),
+		RunID:     requested,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, requested, returned, "queue must preserve caller-supplied RunID")
+}
+
+func TestParseRunJobPayload_RoundTripsViaRedis(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	queue, err := NewRedisRunJobQueue(RedisRunJobQueueConfig{
+		RedisURL: mr.Addr(),
+		Stream:   "bichat:run:test-roundtrip",
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = queue.Close() })
+
+	original := RunJobPayload{
+		TenantID:  uuid.New(),
+		SessionID: uuid.New(),
+		UserID:    42,
+		RequestID: uuid.New(),
+		Content:   "hello",
+		UploadIDs: []int64{1, 2, 3},
+		DebugMode: true,
+	}
+	_, _, err = queue.Enqueue(context.Background(), original)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	entries, err := queue.client.XRange(ctx, queue.stream, "-", "+").Result()
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	parsed, err := ParseRunJobPayload(entries[0].Values)
+	require.NoError(t, err)
+	assert.Equal(t, original.TenantID, parsed.TenantID)
+	assert.Equal(t, original.SessionID, parsed.SessionID)
+	assert.Equal(t, original.UserID, parsed.UserID)
+	assert.Equal(t, original.Content, parsed.Content)
+	assert.Equal(t, original.UploadIDs, parsed.UploadIDs)
+	assert.Equal(t, original.DebugMode, parsed.DebugMode)
+	// Queue assigns a RunID when the caller omits one; round-trip must preserve it.
+	assert.NotEqual(t, uuid.Nil, parsed.RunID)
+}

--- a/modules/bichat/services/run_reaper.go
+++ b/modules/bichat/services/run_reaper.go
@@ -89,7 +89,7 @@ func NewConfiguredRunReaperWithTunables(
 		return nil, err
 	}
 	if client == nil {
-		return nil, nil
+		return nil, nil //nolint:nilnil // REDIS_URL unset means graceful in-memory fallback; nil return is the signal
 	}
 	store, err := newRedisGenerationRunStore(redisGenerationRunStoreConfig{Client: client})
 	if err != nil {
@@ -245,7 +245,7 @@ func (r *RunReaper) sweep(ctx context.Context) error {
 
 	for {
 		if err := ctx.Err(); err != nil {
-			return nil
+			return nil //nolint:nilerr // context cancelled — clean stop, not an error
 		}
 		keys, next, err := r.client.Scan(ctx, cursor, pattern, defaultReaperScanBatchSize).Result()
 		if err != nil {

--- a/modules/bichat/services/run_reaper.go
+++ b/modules/bichat/services/run_reaper.go
@@ -1,0 +1,348 @@
+// Package services provides this package.
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/pkg/bichat/domain"
+	"github.com/iota-uz/iota-sdk/pkg/httpdto"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
+	"github.com/redis/go-redis/v9"
+	"github.com/sirupsen/logrus"
+)
+
+// Default reaper knobs. Polling every 15s with a 60s staleness threshold
+// means a wedged run is surfaced to users within a minute without making
+// Redis SCAN + HGETALL + GetRunByID a dominant load source.
+const (
+	defaultReaperPollInterval  = 15 * time.Second
+	defaultReaperStaleAfter    = 60 * time.Second
+	defaultReaperLockKey       = "bichat:run:reaper:lock"
+	defaultReaperLockTTL       = 30 * time.Second
+	defaultReaperScanBatchSize = 100
+)
+
+// RunReaperConfig configures the stale-run reaper.
+type RunReaperConfig struct {
+	Client         *redis.Client
+	RedisURL       string
+	RunStore       generationRunStore
+	EventLog       RunEventLog
+	ActiveRunIndex ActiveRunIndex
+	Logger         *logrus.Logger
+	// PollInterval is the time between sweeps. Defaults to 15s.
+	PollInterval time.Duration
+	// StaleAfter is the maximum age of LastHeartbeatAt before a run is
+	// considered wedged. Defaults to 60s. Heartbeats tick every ~2s
+	// from the chat service so 60s leaves ~30 missed ticks of headroom.
+	StaleAfter time.Duration
+	// KeyPrefix matches the active-run index key prefix. Defaults to
+	// the index's default, which is the common case.
+	KeyPrefix string
+}
+
+// RunReaper periodically marks runs whose worker has gone silent as
+// failed. The reaper is the critical piece of the "worker crash
+// mid-LLM" recovery path: without it, a killed worker leaves a hash
+// entry claiming streaming forever and the sidebar never transitions.
+type RunReaper struct {
+	client         *redis.Client
+	runStore       generationRunStore
+	eventLog       RunEventLog
+	index          ActiveRunIndex
+	logger         *logrus.Logger
+	pollInterval   time.Duration
+	staleAfter     time.Duration
+	keyPrefix      string
+	now            func() time.Time
+	instanceLockID string
+}
+
+// NewConfiguredRunReaperFromEnv builds a reaper from REDIS_URL with
+// fresh Redis-backed store / event log / index instances. It returns
+// (nil, nil) when REDIS_URL is unset so callers can skip the reaper
+// without branching on a sentinel. Errors are returned only for
+// genuine startup failures (bad Redis connection, etc).
+func NewConfiguredRunReaperFromEnv(logger *logrus.Logger) (*RunReaper, error) {
+	redisURL, ok := envLookup("REDIS_URL")
+	if !ok || strings.TrimSpace(redisURL) == "" {
+		return nil, nil
+	}
+	client, err := newRedisClient(redisURL)
+	if err != nil {
+		return nil, err
+	}
+	store, err := newRedisGenerationRunStore(redisGenerationRunStoreConfig{Client: client})
+	if err != nil {
+		return nil, err
+	}
+	eventLog, err := NewRedisRunEventLog(RedisRunEventLogConfig{Client: client})
+	if err != nil {
+		return nil, err
+	}
+	index, err := NewRedisActiveRunIndex(RedisActiveRunIndexConfig{Client: client})
+	if err != nil {
+		return nil, err
+	}
+	return NewRunReaper(RunReaperConfig{
+		Client:         client,
+		RunStore:       store,
+		EventLog:       eventLog,
+		ActiveRunIndex: index,
+		Logger:         logger,
+	})
+}
+
+// NewRunReaper constructs a reaper bound to the given dependencies. The
+// Redis client is required for SCAN; the store is required for reading
+// LastHeartbeatAt + driving Fail; the event log and index are optional
+// (when nil we still fail the run in the store, but skip the terminal
+// event / sidebar publish).
+func NewRunReaper(cfg RunReaperConfig) (*RunReaper, error) {
+	const op serrors.Op = "NewRunReaper"
+	if cfg.RunStore == nil {
+		return nil, serrors.E(op, serrors.KindValidation, "run store is required")
+	}
+	client := cfg.Client
+	if client == nil {
+		c, err := newRedisClient(cfg.RedisURL)
+		if err != nil {
+			return nil, err
+		}
+		client = c
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = logrus.StandardLogger()
+	}
+	poll := cfg.PollInterval
+	if poll <= 0 {
+		poll = defaultReaperPollInterval
+	}
+	stale := cfg.StaleAfter
+	if stale <= 0 {
+		stale = defaultReaperStaleAfter
+	}
+	prefix := strings.TrimSpace(cfg.KeyPrefix)
+	if prefix == "" {
+		prefix = defaultActiveRunIndexPrefix
+	}
+
+	return &RunReaper{
+		client:         client,
+		runStore:       cfg.RunStore,
+		eventLog:       cfg.EventLog,
+		index:          cfg.ActiveRunIndex,
+		logger:         logger,
+		pollInterval:   poll,
+		staleAfter:     stale,
+		keyPrefix:      prefix,
+		now:            time.Now,
+		instanceLockID: uuid.NewString(),
+	}, nil
+}
+
+// Start runs the reaper loop until ctx is cancelled. It acquires a
+// process-wide lock before each sweep so that multiple replicas can
+// run the reaper safely — only one sweeps at a time, but if the
+// lock-holder crashes another takes over on the next TTL expiry.
+func (r *RunReaper) Start(ctx context.Context) error {
+	ticker := time.NewTicker(r.pollInterval)
+	defer ticker.Stop()
+
+	// Kick off an immediate sweep so a freshly-booted process doesn't
+	// wait a full PollInterval before noticing stale runs from before
+	// the restart.
+	r.sweepIfLeader(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			r.sweepIfLeader(ctx)
+		}
+	}
+}
+
+// sweepIfLeader is a single tick: acquire the single-writer lock,
+// run one full sweep, release. Silently skips when another replica
+// already holds the lock.
+func (r *RunReaper) sweepIfLeader(ctx context.Context) {
+	acquired, err := r.client.SetNX(ctx, defaultReaperLockKey, r.instanceLockID, defaultReaperLockTTL).Result()
+	if err != nil {
+		r.logger.WithError(err).Warn("run reaper lock acquire failed")
+		return
+	}
+	if !acquired {
+		return
+	}
+	defer r.releaseLock(ctx)
+
+	if err := r.sweep(ctx); err != nil {
+		r.logger.WithError(err).Warn("run reaper sweep failed")
+	}
+}
+
+// releaseLock drops the leader lock ONLY if this instance still holds
+// it. The Lua compare-and-delete pattern prevents a slow instance
+// from releasing another instance's reacquired lock.
+func (r *RunReaper) releaseLock(ctx context.Context) {
+	const script = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+else
+  return 0
+end
+`
+	_, err := r.client.Eval(ctx, script, []string{defaultReaperLockKey}, r.instanceLockID).Result()
+	if err != nil && err != redis.Nil {
+		r.logger.WithError(err).Warn("run reaper lock release failed")
+	}
+}
+
+// sweep visits every per-tenant active-run hash, loads the runs that
+// are streaming, and fails any whose heartbeat is older than
+// StaleAfter.
+func (r *RunReaper) sweep(ctx context.Context) error {
+	const op serrors.Op = "RunReaper.sweep"
+
+	cursor := uint64(0)
+	cutoff := r.now().Add(-r.staleAfter)
+	pattern := r.keyPrefix + ":*"
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil
+		}
+		keys, next, err := r.client.Scan(ctx, cursor, pattern, defaultReaperScanBatchSize).Result()
+		if err != nil {
+			return serrors.E(op, "scan active-run keys", err)
+		}
+		for _, key := range keys {
+			tenantID, ok := parseTenantFromActiveRunKey(r.keyPrefix, key)
+			if !ok {
+				continue
+			}
+			if err := r.sweepTenant(ctx, tenantID, cutoff); err != nil {
+				r.logger.WithError(err).WithField("tenant_id", tenantID.String()).Warn("run reaper tenant sweep failed")
+			}
+		}
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+	return nil
+}
+
+func (r *RunReaper) sweepTenant(ctx context.Context, tenantID uuid.UUID, cutoff time.Time) error {
+	const op serrors.Op = "RunReaper.sweepTenant"
+
+	hashKey := fmt.Sprintf("%s:%s", r.keyPrefix, tenantID.String())
+	raw, err := r.client.HGetAll(ctx, hashKey).Result()
+	if err != nil {
+		return serrors.E(op, "hgetall tenant", err)
+	}
+	for sessionIDStr, value := range raw {
+		var entry ActiveRunStatus
+		if err := json.Unmarshal([]byte(value), &entry); err != nil {
+			continue
+		}
+		// Only streaming runs are candidates for reaping. Queued runs
+		// haven't heartbeated yet and completed/cancelled/failed ones
+		// should already be purged by PublishAndRemove.
+		if entry.Status != string(domain.GenerationRunStatusStreaming) {
+			continue
+		}
+		sessionID, err := uuid.Parse(sessionIDStr)
+		if err != nil {
+			continue
+		}
+
+		persisted, err := r.runStore.GetRunByID(ctx, tenantID, entry.RunID)
+		if err != nil {
+			continue
+		}
+		last := persisted.LastHeartbeatAt()
+		if last.IsZero() {
+			// Never heartbeated — use StartedAt as the liveness proxy
+			// so a worker that crashes before its first tick still
+			// gets reaped.
+			last = persisted.StartedAt()
+		}
+		if last.After(cutoff) {
+			continue
+		}
+		r.failStaleRun(ctx, tenantID, sessionID, entry.RunID, last)
+	}
+	return nil
+}
+
+// failStaleRun transitions one run into the failed terminal state and
+// publishes the matching events. Best-effort: each step swallows
+// errors so a failure in one step (e.g. Redis connection blip) does
+// not abort the whole sweep.
+func (r *RunReaper) failStaleRun(ctx context.Context, tenantID, sessionID, runID uuid.UUID, lastSeen time.Time) {
+	r.logger.WithFields(logrus.Fields{
+		"tenant_id":  tenantID.String(),
+		"session_id": sessionID.String(),
+		"run_id":     runID.String(),
+		"last_seen":  lastSeen.Format(time.RFC3339Nano),
+	}).Warn("reaping stale bichat run")
+
+	_ = r.runStore.FailRun(ctx, tenantID, sessionID, runID)
+
+	if r.eventLog != nil {
+		errPayload := httpdto.StreamChunkPayload{
+			Type:      "error",
+			Error:     "generation failed: worker stopped heartbeating",
+			Timestamp: r.now().UnixMilli(),
+		}
+		body, err := json.Marshal(errPayload)
+		if err == nil {
+			_, _ = r.eventLog.Append(ctx, tenantID, runID, RunEvent{
+				Type:    "error",
+				Payload: body,
+			})
+			// Drop the log soon; the sidebar has already updated and
+			// reconnecting clients will get the terminal event during
+			// the grace window.
+			_ = r.eventLog.DropAfterTerminal(ctx, tenantID, runID, 5*time.Minute)
+		}
+	}
+
+	if r.index != nil {
+		_ = r.index.PublishAndRemove(ctx, tenantID, ActiveRunStatus{
+			SessionID: sessionID,
+			RunID:     runID,
+			Status:    string(domain.GenerationRunStatusFailed),
+			UpdatedAt: r.now().UTC(),
+		})
+	}
+}
+
+// parseTenantFromActiveRunKey extracts the tenant uuid from a
+// bichat:active-runs:{tenant} key. Returns false for keys that don't
+// match the expected shape (events channel, etc).
+func parseTenantFromActiveRunKey(prefix, key string) (uuid.UUID, bool) {
+	remainder := strings.TrimPrefix(key, prefix+":")
+	if remainder == key {
+		return uuid.Nil, false
+	}
+	// Skip pubsub event channel keys: bichat:active-runs:events:<tenant>.
+	if strings.HasPrefix(remainder, "events:") {
+		return uuid.Nil, false
+	}
+	tenantID, err := uuid.Parse(remainder)
+	if err != nil {
+		return uuid.Nil, false
+	}
+	return tenantID, true
+}

--- a/modules/bichat/services/run_reaper.go
+++ b/modules/bichat/services/run_reaper.go
@@ -41,6 +41,9 @@ type RunReaperConfig struct {
 	// considered wedged. Defaults to 60s. Heartbeats tick every ~2s
 	// from the chat service so 60s leaves ~30 missed ticks of headroom.
 	StaleAfter time.Duration
+	// LockTTL is the TTL of the single-writer reaper lock. A crashed
+	// leader releases the lock after this duration. Defaults to 30s.
+	LockTTL time.Duration
 	// KeyPrefix matches the active-run index key prefix. Defaults to
 	// the index's default, which is the common case.
 	KeyPrefix string
@@ -58,6 +61,7 @@ type RunReaper struct {
 	logger         *logrus.Logger
 	pollInterval   time.Duration
 	staleAfter     time.Duration
+	lockTTL        time.Duration
 	keyPrefix      string
 	now            func() time.Time
 	instanceLockID string
@@ -69,13 +73,23 @@ type RunReaper struct {
 // without branching on a sentinel. Errors are returned only for
 // genuine startup failures (bad Redis connection, etc).
 func NewConfiguredRunReaperFromEnv(logger *logrus.Logger) (*RunReaper, error) {
-	redisURL, ok := envLookup("REDIS_URL")
-	if !ok || strings.TrimSpace(redisURL) == "" {
-		return nil, nil
-	}
-	client, err := newRedisClient(redisURL)
+	return NewConfiguredRunReaperWithTunables(logger, 0, 0, 0)
+}
+
+// NewConfiguredRunReaperWithTunables is like NewConfiguredRunReaperFromEnv
+// but accepts explicit poll interval, stale threshold, and lock TTL so
+// callers can override the defaults without touching the env. Zero values
+// fall back to the package-level defaults.
+func NewConfiguredRunReaperWithTunables(
+	logger *logrus.Logger,
+	interval, staleThreshold, lockTTL time.Duration,
+) (*RunReaper, error) {
+	client, err := NewSharedRedisClient()
 	if err != nil {
 		return nil, err
+	}
+	if client == nil {
+		return nil, nil
 	}
 	store, err := newRedisGenerationRunStore(redisGenerationRunStoreConfig{Client: client})
 	if err != nil {
@@ -95,6 +109,9 @@ func NewConfiguredRunReaperFromEnv(logger *logrus.Logger) (*RunReaper, error) {
 		EventLog:       eventLog,
 		ActiveRunIndex: index,
 		Logger:         logger,
+		PollInterval:   interval,
+		StaleAfter:     staleThreshold,
+		LockTTL:        lockTTL,
 	})
 }
 
@@ -129,6 +146,10 @@ func NewRunReaper(cfg RunReaperConfig) (*RunReaper, error) {
 	if stale <= 0 {
 		stale = defaultReaperStaleAfter
 	}
+	lockTTL := cfg.LockTTL
+	if lockTTL <= 0 {
+		lockTTL = defaultReaperLockTTL
+	}
 	prefix := strings.TrimSpace(cfg.KeyPrefix)
 	if prefix == "" {
 		prefix = defaultActiveRunIndexPrefix
@@ -142,6 +163,7 @@ func NewRunReaper(cfg RunReaperConfig) (*RunReaper, error) {
 		logger:         logger,
 		pollInterval:   poll,
 		staleAfter:     stale,
+		lockTTL:        lockTTL,
 		keyPrefix:      prefix,
 		now:            time.Now,
 		instanceLockID: uuid.NewString(),
@@ -175,12 +197,16 @@ func (r *RunReaper) Start(ctx context.Context) error {
 // run one full sweep, release. Silently skips when another replica
 // already holds the lock.
 func (r *RunReaper) sweepIfLeader(ctx context.Context) {
-	acquired, err := r.client.SetNX(ctx, defaultReaperLockKey, r.instanceLockID, defaultReaperLockTTL).Result()
+	acquired, err := r.client.SetNX(ctx, defaultReaperLockKey, r.instanceLockID, r.lockTTL).Result()
 	if err != nil {
 		r.logger.WithError(err).Warn("run reaper lock acquire failed")
 		return
 	}
 	if !acquired {
+		// Another replica holds the lock — this is normal in multi-process
+		// deployments. Debug-level so operators can distinguish "running
+		// elsewhere" from a broken reaper (which would emit Warn/Error).
+		r.logger.Debug("reaper lock held by another instance, skipping sweep")
 		return
 	}
 	defer r.releaseLock(ctx)

--- a/modules/bichat/services/run_reaper_test.go
+++ b/modules/bichat/services/run_reaper_test.go
@@ -1,0 +1,174 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/pkg/bichat/domain"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildReaperHarness wires a reaper against a miniredis-backed store +
+// event log + index so the sweep exercises the same code path used in
+// production without a live Redis or Postgres.
+func buildReaperHarness(t *testing.T, staleAfter time.Duration) (*RunReaper, *miniredis.Miniredis, generationRunStore, ActiveRunIndex, *RedisRunEventLog) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	store, err := newRedisGenerationRunStore(redisGenerationRunStoreConfig{Client: client})
+	require.NoError(t, err)
+
+	index, err := NewRedisActiveRunIndex(RedisActiveRunIndexConfig{Client: client})
+	require.NoError(t, err)
+
+	log, err := NewRedisRunEventLog(RedisRunEventLogConfig{Client: client})
+	require.NoError(t, err)
+
+	reaper, err := NewRunReaper(RunReaperConfig{
+		Client:         client,
+		RunStore:       store,
+		EventLog:       log,
+		ActiveRunIndex: index,
+		PollInterval:   10 * time.Millisecond,
+		StaleAfter:     staleAfter,
+	})
+	require.NoError(t, err)
+	return reaper, mr, store, index, log
+}
+
+func createStreamingRun(t *testing.T, store generationRunStore, tenantID, sessionID uuid.UUID, heartbeat time.Time) uuid.UUID {
+	t.Helper()
+	run, err := domain.NewGenerationRun(domain.GenerationRunSpec{
+		SessionID:       sessionID,
+		TenantID:        tenantID,
+		UserID:          1,
+		StartedAt:       heartbeat,
+		LastHeartbeatAt: heartbeat,
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.CreateRun(context.Background(), run))
+	return run.ID()
+}
+
+func TestRunReaper_SweepFailsStaleRun(t *testing.T) {
+	t.Parallel()
+
+	reaper, _, store, index, log := buildReaperHarness(t, 50*time.Millisecond)
+	tenant := uuid.New()
+	session := uuid.New()
+
+	// Heartbeat older than the stale threshold.
+	runID := createStreamingRun(t, store, tenant, session, time.Now().Add(-time.Second))
+	require.NoError(t, index.Upsert(context.Background(), tenant, ActiveRunStatus{
+		SessionID: session,
+		RunID:     runID,
+		Status:    string(domain.GenerationRunStatusStreaming),
+		UpdatedAt: time.Now(),
+	}))
+
+	// Seed a pending event so we can assert the reaper appends a
+	// terminal error after it.
+	_, err := log.Append(context.Background(), tenant, runID, RunEvent{
+		Type:    "content",
+		Payload: json.RawMessage(`{"text":"hi"}`),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, reaper.sweep(context.Background()))
+
+	// Run state: transitioned to failed.
+	persisted, err := store.GetRunByID(context.Background(), tenant, runID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.GenerationRunStatusFailed, persisted.Status(),
+		"stale run must be moved to failed status")
+
+	// Index: emptied (PublishAndRemove runs on terminal).
+	snap, err := index.Snapshot(context.Background(), tenant)
+	require.NoError(t, err)
+	assert.Empty(t, snap, "reaped run must be cleared from the sidebar index")
+
+	// Event log: final entry must be the error terminal.
+	events, err := log.Replay(context.Background(), tenant, runID, "")
+	require.NoError(t, err)
+	require.NotEmpty(t, events)
+	assert.Equal(t, "error", events[len(events)-1].Type,
+		"reaper must append a terminal error event so tailing clients see the transition")
+}
+
+func TestRunReaper_SweepLeavesFreshRunAlone(t *testing.T) {
+	t.Parallel()
+
+	reaper, _, store, index, _ := buildReaperHarness(t, 10*time.Second)
+	tenant := uuid.New()
+	session := uuid.New()
+
+	// Heartbeat "just now".
+	runID := createStreamingRun(t, store, tenant, session, time.Now())
+	require.NoError(t, index.Upsert(context.Background(), tenant, ActiveRunStatus{
+		SessionID: session,
+		RunID:     runID,
+		Status:    string(domain.GenerationRunStatusStreaming),
+		UpdatedAt: time.Now(),
+	}))
+
+	require.NoError(t, reaper.sweep(context.Background()))
+
+	persisted, err := store.GetRunByID(context.Background(), tenant, runID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.GenerationRunStatusStreaming, persisted.Status(),
+		"fresh run must not be reaped")
+
+	snap, err := index.Snapshot(context.Background(), tenant)
+	require.NoError(t, err)
+	assert.Len(t, snap, 1, "fresh run must stay in the sidebar index")
+}
+
+func TestRunReaper_SweepSkipsNonStreamingEntries(t *testing.T) {
+	t.Parallel()
+
+	reaper, _, _, index, _ := buildReaperHarness(t, 10*time.Millisecond)
+	tenant := uuid.New()
+
+	// A queued row older than stale — reaper must NOT touch queued
+	// entries (they haven't started streaming yet so LastHeartbeatAt
+	// semantics don't apply).
+	require.NoError(t, index.Upsert(context.Background(), tenant, ActiveRunStatus{
+		SessionID: uuid.New(),
+		RunID:     uuid.New(),
+		Status:    "queued",
+		UpdatedAt: time.Now().Add(-time.Minute),
+	}))
+
+	require.NoError(t, reaper.sweep(context.Background()))
+
+	snap, err := index.Snapshot(context.Background(), tenant)
+	require.NoError(t, err)
+	require.Len(t, snap, 1, "queued rows must be left alone by the reaper")
+	assert.Equal(t, "queued", snap[0].Status)
+}
+
+func TestParseTenantFromActiveRunKey(t *testing.T) {
+	t.Parallel()
+
+	id := uuid.New()
+
+	got, ok := parseTenantFromActiveRunKey("bichat:active-runs", "bichat:active-runs:"+id.String())
+	require.True(t, ok)
+	assert.Equal(t, id, got)
+
+	// Pubsub event channel is not a hash — must be rejected.
+	_, ok = parseTenantFromActiveRunKey("bichat:active-runs", "bichat:active-runs:events:"+id.String())
+	assert.False(t, ok, "events channel keys must not be treated as tenant hashes")
+
+	// Unrelated key — must be rejected.
+	_, ok = parseTenantFromActiveRunKey("bichat:active-runs", "bichat:title:jobs")
+	assert.False(t, ok)
+}

--- a/modules/bichat/services/run_reaper_test.go
+++ b/modules/bichat/services/run_reaper_test.go
@@ -134,7 +134,7 @@ func TestRunReaper_SweepLeavesFreshRunAlone(t *testing.T) {
 func TestRunReaper_SweepSkipsNonStreamingEntries(t *testing.T) {
 	t.Parallel()
 
-	reaper, _, _, index, _ := buildReaperHarness(t, 10*time.Millisecond)
+	reaper, _, _, index, _ := buildReaperHarness(t, 10*time.Millisecond) //nolint:dogsled // harness returns 5 values; only reaper and index needed here
 	tenant := uuid.New()
 
 	// A queued row older than stale — reaper must NOT touch queued

--- a/modules/bichat/services/run_session_queue.go
+++ b/modules/bichat/services/run_session_queue.go
@@ -1,0 +1,183 @@
+// Package services provides this package.
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
+	"github.com/redis/go-redis/v9"
+)
+
+// Per-session FIFO queue key conventions. Distinct from the global run
+// queue (bichat:run:jobs): the session queue holds messages waiting
+// behind an already-active run in the same session, preserving send
+// order so "send A, send B while A is running" runs A then B.
+const (
+	defaultRunSessionQueuePrefix = "bichat:run:queue"
+	defaultRunSessionQueueMaxLen = 200
+	// sessionQueueTTL lets forgotten queues GC eventually; the normal
+	// path pops entries as they land. 24h is comfortable headroom for
+	// a session that's been abandoned mid-queue.
+	defaultRunSessionQueueTTL = 24 * time.Hour
+)
+
+// QueuedRunJob is the shape pushed into the per-session FIFO. It is the
+// subset of RunJobPayload the FIFO needs to reconstruct a valid enqueue
+// when the active run terminates.
+type QueuedRunJob struct {
+	Payload  RunJobPayload `json:"payload"`
+	QueuedAt time.Time     `json:"queued_at"`
+}
+
+// RunSessionQueue is the per-session FIFO. Push appends to the back,
+// Pop drains from the front, Len reports depth (used by the sidebar to
+// show "3 waiting" badges).
+type RunSessionQueue interface {
+	Push(ctx context.Context, tenantID, sessionID uuid.UUID, job QueuedRunJob) error
+	Pop(ctx context.Context, tenantID, sessionID uuid.UUID) (QueuedRunJob, bool, error)
+	Len(ctx context.Context, tenantID, sessionID uuid.UUID) (int64, error)
+}
+
+// RedisRunSessionQueueConfig configures the Redis-backed FIFO.
+type RedisRunSessionQueueConfig struct {
+	Client    *redis.Client
+	RedisURL  string
+	KeyPrefix string
+	MaxLen    int64
+	TTL       time.Duration
+}
+
+// RedisRunSessionQueue is the Redis list implementation.
+type RedisRunSessionQueue struct {
+	client    *redis.Client
+	keyPrefix string
+	maxLen    int64
+	ttl       time.Duration
+}
+
+// NewRedisRunSessionQueue constructs a FIFO bound to the supplied Redis
+// client, or dials a new connection from RedisURL if Client is nil.
+func NewRedisRunSessionQueue(cfg RedisRunSessionQueueConfig) (*RedisRunSessionQueue, error) {
+	prefix := strings.TrimSpace(cfg.KeyPrefix)
+	if prefix == "" {
+		prefix = defaultRunSessionQueuePrefix
+	}
+	maxLen := cfg.MaxLen
+	if maxLen <= 0 {
+		maxLen = defaultRunSessionQueueMaxLen
+	}
+	ttl := cfg.TTL
+	if ttl <= 0 {
+		ttl = defaultRunSessionQueueTTL
+	}
+
+	client := cfg.Client
+	if client == nil {
+		c, err := newRedisClient(cfg.RedisURL)
+		if err != nil {
+			return nil, err
+		}
+		client = c
+	}
+
+	return &RedisRunSessionQueue{
+		client:    client,
+		keyPrefix: prefix,
+		maxLen:    maxLen,
+		ttl:       ttl,
+	}, nil
+}
+
+// newConfiguredRunSessionQueue mirrors the other newConfigured* helpers.
+func newConfiguredRunSessionQueue() RunSessionQueue {
+	redisURL, ok := envLookup("REDIS_URL")
+	if !ok || strings.TrimSpace(redisURL) == "" {
+		return nil
+	}
+	q, err := NewRedisRunSessionQueue(RedisRunSessionQueueConfig{RedisURL: redisURL})
+	if err != nil {
+		return nil
+	}
+	return q
+}
+
+// Push implements RunSessionQueue.
+//
+// Uses RPUSH so Pop (LPOP) drains in FIFO order. After pushing the new
+// entry we trim the list to maxLen with LTRIM and refresh the TTL so
+// an active session's queue never GCs from under us. If the list has
+// grown past maxLen the OLDEST entries are dropped — losing the
+// middle of the queue is preferable to dropping the newest messages
+// the user just sent.
+func (q *RedisRunSessionQueue) Push(ctx context.Context, tenantID, sessionID uuid.UUID, job QueuedRunJob) error {
+	const op serrors.Op = "RedisRunSessionQueue.Push"
+	if tenantID == uuid.Nil || sessionID == uuid.Nil {
+		return serrors.E(op, serrors.KindValidation, "tenant id and session id are required")
+	}
+	if job.QueuedAt.IsZero() {
+		job.QueuedAt = time.Now().UTC()
+	}
+	body, err := json.Marshal(job)
+	if err != nil {
+		return serrors.E(op, "marshal queued job", err)
+	}
+	key := q.listKey(tenantID, sessionID)
+	writeCtx := context.WithoutCancel(ctx)
+	pipe := q.client.TxPipeline()
+	pipe.RPush(writeCtx, key, body)
+	if q.maxLen > 0 {
+		pipe.LTrim(writeCtx, key, -q.maxLen, -1)
+	}
+	pipe.Expire(writeCtx, key, q.ttl)
+	if _, err := pipe.Exec(writeCtx); err != nil {
+		return serrors.E(op, "push queued job", err)
+	}
+	return nil
+}
+
+// Pop implements RunSessionQueue. Returns (job, true, nil) when a job
+// was drained, (zero, false, nil) on empty, or a wrapped error.
+func (q *RedisRunSessionQueue) Pop(ctx context.Context, tenantID, sessionID uuid.UUID) (QueuedRunJob, bool, error) {
+	const op serrors.Op = "RedisRunSessionQueue.Pop"
+	if tenantID == uuid.Nil || sessionID == uuid.Nil {
+		return QueuedRunJob{}, false, serrors.E(op, serrors.KindValidation, "tenant id and session id are required")
+	}
+	raw, err := q.client.LPop(ctx, q.listKey(tenantID, sessionID)).Bytes()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return QueuedRunJob{}, false, nil
+		}
+		return QueuedRunJob{}, false, serrors.E(op, "lpop", err)
+	}
+	var job QueuedRunJob
+	if err := json.Unmarshal(raw, &job); err != nil {
+		return QueuedRunJob{}, false, serrors.E(op, "unmarshal queued job", err)
+	}
+	return job, true, nil
+}
+
+// Len implements RunSessionQueue.
+func (q *RedisRunSessionQueue) Len(ctx context.Context, tenantID, sessionID uuid.UUID) (int64, error) {
+	const op serrors.Op = "RedisRunSessionQueue.Len"
+	if tenantID == uuid.Nil || sessionID == uuid.Nil {
+		return 0, serrors.E(op, serrors.KindValidation, "tenant id and session id are required")
+	}
+	n, err := q.client.LLen(ctx, q.listKey(tenantID, sessionID)).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return 0, nil
+		}
+		return 0, serrors.E(op, "llen", err)
+	}
+	return n, nil
+}
+
+func (q *RedisRunSessionQueue) listKey(tenantID, sessionID uuid.UUID) string {
+	return fmt.Sprintf("%s:%s:%s", q.keyPrefix, tenantID.String(), sessionID.String())
+}

--- a/modules/bichat/services/run_session_queue.go
+++ b/modules/bichat/services/run_session_queue.go
@@ -155,11 +155,10 @@ func (q *RedisRunSessionQueue) Len(ctx context.Context, tenantID, sessionID uuid
 	if tenantID == uuid.Nil || sessionID == uuid.Nil {
 		return 0, serrors.E(op, serrors.KindValidation, "tenant id and session id are required")
 	}
+	// LLEN returns 0 (not redis.Nil) for a missing key, so no redis.Nil
+	// branch is needed here.
 	n, err := q.client.LLen(ctx, q.listKey(tenantID, sessionID)).Result()
 	if err != nil {
-		if errors.Is(err, redis.Nil) {
-			return 0, nil
-		}
 		return 0, serrors.E(op, "llen", err)
 	}
 	return n, nil

--- a/modules/bichat/services/run_session_queue.go
+++ b/modules/bichat/services/run_session_queue.go
@@ -94,18 +94,6 @@ func NewRedisRunSessionQueue(cfg RedisRunSessionQueueConfig) (*RedisRunSessionQu
 	}, nil
 }
 
-// newConfiguredRunSessionQueue mirrors the other newConfigured* helpers.
-func newConfiguredRunSessionQueue() RunSessionQueue {
-	redisURL, ok := envLookup("REDIS_URL")
-	if !ok || strings.TrimSpace(redisURL) == "" {
-		return nil
-	}
-	q, err := NewRedisRunSessionQueue(RedisRunSessionQueueConfig{RedisURL: redisURL})
-	if err != nil {
-		return nil
-	}
-	return q
-}
 
 // Push implements RunSessionQueue.
 //

--- a/modules/bichat/services/run_session_queue.go
+++ b/modules/bichat/services/run_session_queue.go
@@ -94,7 +94,6 @@ func NewRedisRunSessionQueue(cfg RedisRunSessionQueueConfig) (*RedisRunSessionQu
 	}, nil
 }
 
-
 // Push implements RunSessionQueue.
 //
 // Uses RPUSH so Pop (LPOP) drains in FIFO order. After pushing the new

--- a/modules/bichat/services/run_session_queue_test.go
+++ b/modules/bichat/services/run_session_queue_test.go
@@ -1,0 +1,138 @@
+package services
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestRunSessionQueue(t *testing.T) *RedisRunSessionQueue {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	q, err := NewRedisRunSessionQueue(RedisRunSessionQueueConfig{Client: client})
+	require.NoError(t, err)
+	return q
+}
+
+func TestRedisRunSessionQueue_PushAndPopPreservesFIFO(t *testing.T) {
+	t.Parallel()
+
+	q := newTestRunSessionQueue(t)
+	tenant := uuid.New()
+	session := uuid.New()
+
+	contents := []string{"first", "second", "third"}
+	for _, c := range contents {
+		require.NoError(t, q.Push(context.Background(), tenant, session, QueuedRunJob{
+			Payload: RunJobPayload{Content: c, RequestID: uuid.New()},
+		}))
+	}
+
+	got := make([]string, 0, len(contents))
+	for i := 0; i < len(contents); i++ {
+		job, ok, err := q.Pop(context.Background(), tenant, session)
+		require.NoError(t, err)
+		require.True(t, ok)
+		got = append(got, job.Payload.Content)
+	}
+	assert.Equal(t, contents, got, "queue must drain in push order")
+
+	// Extra Pop on empty must report false without error.
+	_, ok, err := q.Pop(context.Background(), tenant, session)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestRedisRunSessionQueue_IsSessionScoped(t *testing.T) {
+	t.Parallel()
+
+	q := newTestRunSessionQueue(t)
+	tenant := uuid.New()
+	sessionA := uuid.New()
+	sessionB := uuid.New()
+
+	require.NoError(t, q.Push(context.Background(), tenant, sessionA, QueuedRunJob{
+		Payload: RunJobPayload{Content: "A"},
+	}))
+	require.NoError(t, q.Push(context.Background(), tenant, sessionB, QueuedRunJob{
+		Payload: RunJobPayload{Content: "B"},
+	}))
+
+	got, ok, err := q.Pop(context.Background(), tenant, sessionA)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "A", got.Payload.Content)
+
+	// Session A queue is now empty — B must still have its entry.
+	_, ok, err = q.Pop(context.Background(), tenant, sessionA)
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	got, ok, err = q.Pop(context.Background(), tenant, sessionB)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "B", got.Payload.Content)
+}
+
+func TestRedisRunSessionQueue_LenReportsDepth(t *testing.T) {
+	t.Parallel()
+
+	q := newTestRunSessionQueue(t)
+	tenant := uuid.New()
+	session := uuid.New()
+
+	initial, err := q.Len(context.Background(), tenant, session)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), initial, "new sessions start at zero depth")
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, q.Push(context.Background(), tenant, session, QueuedRunJob{
+			Payload: RunJobPayload{Content: "x"},
+		}))
+	}
+	n, err := q.Len(context.Background(), tenant, session)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), n)
+}
+
+func TestRedisRunSessionQueue_MaxLenDropsOldestEntries(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+	q, err := NewRedisRunSessionQueue(RedisRunSessionQueueConfig{
+		Client: client,
+		MaxLen: 2,
+	})
+	require.NoError(t, err)
+
+	tenant := uuid.New()
+	session := uuid.New()
+	for _, c := range []string{"A", "B", "C", "D"} {
+		require.NoError(t, q.Push(context.Background(), tenant, session, QueuedRunJob{
+			Payload: RunJobPayload{Content: c},
+		}))
+	}
+
+	// Only the last two entries must survive.
+	n, err := q.Len(context.Background(), tenant, session)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), n)
+
+	first, ok, err := q.Pop(context.Background(), tenant, session)
+	require.NoError(t, err)
+	require.True(t, ok)
+	second, ok, err := q.Pop(context.Background(), tenant, session)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, []string{"C", "D"}, []string{first.Payload.Content, second.Payload.Content},
+		"MaxLen trim must drop oldest entries, preserving the newest two")
+}

--- a/modules/bichat/services/stream_event_codec.go
+++ b/modules/bichat/services/stream_event_codec.go
@@ -86,6 +86,10 @@ func BuildPayload(chunk bichatservices.StreamChunk) (httpdto.StreamEventType, ht
 	if eventType == "" {
 		eventType = string(httpdto.StreamEventChunk)
 	}
+	// Overwrite payload.Type with the resolved event name (including the
+	// "chunk" fallback) so the SSE event: line and the JSON body.type field
+	// always agree for persisted/replayed events.
+	payload.Type = eventType
 
 	return httpdto.StreamEventType(eventType), payload, nil
 }

--- a/modules/bichat/services/stream_event_codec.go
+++ b/modules/bichat/services/stream_event_codec.go
@@ -1,0 +1,99 @@
+// Package services provides this package.
+package services
+
+import (
+	"encoding/json"
+	"strings"
+
+	bichatservices "github.com/iota-uz/iota-sdk/pkg/bichat/services"
+	"github.com/iota-uz/iota-sdk/pkg/httpdto"
+)
+
+// encodeRunEventFromChunk converts an in-memory StreamChunk into the wire
+// event-type + JSON payload written to the per-run Redis event log.
+//
+// The payload shape is httpdto.StreamChunkPayload, the same struct the HTTP
+// controller sends down an SSE response. Encoding happens once (at write
+// time) so controllers tailing Redis can forward payloads verbatim —
+// readers never need to know about the internal StreamChunk shape.
+//
+// The returned event type matches httpdto's `type` field conventions. When
+// the chunk type is empty we default to "chunk" to keep parity with the
+// controller's fallback (stream_controller.go:282).
+func encodeRunEventFromChunk(chunk bichatservices.StreamChunk) (string, []byte, error) {
+	payload := httpdto.StreamChunkPayload{
+		Type:         string(chunk.Type),
+		Content:      chunk.Content,
+		Citation:     chunk.Citation,
+		Usage:        chunk.Usage,
+		GenerationMs: chunk.GenerationMs,
+		Timestamp:    chunk.Timestamp.UnixMilli(),
+		RunID:        chunk.RunID,
+	}
+	if chunk.Tool != nil {
+		toolPayload := &httpdto.ToolEventPayload{
+			CallID:     chunk.Tool.CallID,
+			Name:       chunk.Tool.Name,
+			AgentName:  chunk.Tool.AgentName,
+			Arguments:  chunk.Tool.Arguments,
+			Result:     chunk.Tool.Result,
+			DurationMs: chunk.Tool.DurationMs,
+		}
+		if chunk.Tool.Error != nil {
+			toolPayload.Error = chunk.Tool.Error.Error()
+		}
+		payload.Tool = toolPayload
+	}
+	if chunk.Interrupt != nil {
+		questions := make([]httpdto.InterruptQuestionPayload, 0, len(chunk.Interrupt.Questions))
+		for _, q := range chunk.Interrupt.Questions {
+			options := make([]httpdto.InterruptQuestionOptionPayload, 0, len(q.Options))
+			for _, opt := range q.Options {
+				options = append(options, httpdto.InterruptQuestionOptionPayload{
+					ID:    opt.ID,
+					Label: opt.Label,
+				})
+			}
+			questions = append(questions, httpdto.InterruptQuestionPayload{
+				ID:      q.ID,
+				Text:    q.Text,
+				Type:    string(q.Type),
+				Options: options,
+			})
+		}
+		payload.Interrupt = &httpdto.InterruptEventPayload{
+			CheckpointID:       chunk.Interrupt.CheckpointID,
+			AgentName:          chunk.Interrupt.AgentName,
+			ProviderResponseID: chunk.Interrupt.ProviderResponseID,
+			Questions:          questions,
+		}
+	}
+	if chunk.Error != nil {
+		// Redis log stores the raw error string; the HTTP layer sanitises
+		// before emitting to browsers (see stream_controller.streamClientErrorMessage).
+		// Including the raw message here is fine because the event log is
+		// server-side only.
+		payload.Error = chunk.Error.Error()
+	}
+	if chunk.Snapshot != nil {
+		payload.Snapshot = &httpdto.StreamSnapshotPayload{
+			PartialContent:  chunk.Snapshot.PartialContent,
+			PartialMetadata: chunk.Snapshot.PartialMetadata,
+		}
+	}
+	if chunk.Type == bichatservices.ChunkTypeTextBlockEnd {
+		seq := chunk.TextBlockSeq
+		payload.TextBlockSeq = &seq
+	}
+
+	eventType := strings.TrimSpace(string(chunk.Type))
+	if eventType == "" {
+		eventType = "chunk"
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", nil, err
+	}
+	return eventType, body, nil
+}

--- a/modules/bichat/services/stream_event_codec.go
+++ b/modules/bichat/services/stream_event_codec.go
@@ -65,10 +65,10 @@ func BuildPayload(chunk bichatservices.StreamChunk) (httpdto.StreamEventType, ht
 		}
 	}
 	if chunk.Error != nil {
-		// Redis log stores the raw error string; the HTTP layer sanitises
-		// before emitting to browsers (see stream_controller.streamClientErrorMessage).
-		// Including the raw message here is fine because the event log is
-		// server-side only.
+		// Store the raw error string here; encodeRunEventFromChunk applies
+		// sanitizeChunkError before persisting to Redis so replay paths never
+		// expose provider internals. The live HTTP path is sanitised by
+		// stream_controller.streamClientErrorMessage.
 		payload.Error = chunk.Error.Error()
 	}
 	if chunk.Snapshot != nil {
@@ -90,13 +90,41 @@ func BuildPayload(chunk bichatservices.StreamChunk) (httpdto.StreamEventType, ht
 	return httpdto.StreamEventType(eventType), payload, nil
 }
 
+// sanitizeChunkError returns a safe error string for storage in the Redis
+// event log so that replayed events via GET /stream/events cannot leak raw
+// internal error text (e.g. provider stack traces) to browsers.
+//
+// The sanitization logic mirrors StreamController.streamClientErrorMessage.
+// Keep both in sync when updating error-handling behaviour.
+func sanitizeChunkError(chunk bichatservices.StreamChunk) string {
+	if chunk.Error == nil {
+		return ""
+	}
+	if chunk.Type != bichatservices.ChunkTypeError {
+		// Non-error chunk types (e.g. tool errors) carry localised tool info;
+		// preserve them so the applet can display tool-level error detail.
+		return chunk.Error.Error()
+	}
+	// For terminal error chunks, return a generic safe message to avoid
+	// leaking provider internals. The applet only needs to know the run failed.
+	return "An error occurred while processing your request"
+}
+
 // encodeRunEventFromChunk is the internal shim used by the Redis event-log
-// appender. It delegates to BuildPayload and marshals the result so the
-// call site in chat_service_impl.go does not need to change.
+// appender. It delegates to BuildPayload, applies error sanitisation so the
+// stored JSON never contains raw internal error strings, then marshals the
+// result. Only sanitised text is written to Redis; the HTTP layer uses an
+// equivalent sanitiser (StreamController.streamClientErrorMessage) on the
+// live stream path.
 func encodeRunEventFromChunk(chunk bichatservices.StreamChunk) (string, []byte, error) {
 	eventType, payload, err := BuildPayload(chunk)
 	if err != nil {
 		return "", nil, err
+	}
+	// Sanitise before storing so replay over GET /stream/events cannot expose
+	// raw provider error strings. Mirrors the controller's post-encode step.
+	if chunk.Error != nil {
+		payload.Error = sanitizeChunkError(chunk)
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {

--- a/modules/bichat/services/stream_event_codec.go
+++ b/modules/bichat/services/stream_event_codec.go
@@ -88,7 +88,7 @@ func encodeRunEventFromChunk(chunk bichatservices.StreamChunk) (string, []byte, 
 
 	eventType := strings.TrimSpace(string(chunk.Type))
 	if eventType == "" {
-		eventType = "chunk"
+		eventType = string(httpdto.StreamEventChunk)
 	}
 
 	body, err := json.Marshal(payload)

--- a/modules/bichat/services/stream_event_codec.go
+++ b/modules/bichat/services/stream_event_codec.go
@@ -9,18 +9,14 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/httpdto"
 )
 
-// encodeRunEventFromChunk converts an in-memory StreamChunk into the wire
-// event-type + JSON payload written to the per-run Redis event log.
+// BuildPayload converts an in-memory StreamChunk into the typed
+// httpdto.StreamEventType + httpdto.StreamChunkPayload pair. It is the
+// single encoding point for all chunk types; callers that need a []byte
+// (e.g. the Redis event-log appender) marshal the returned struct themselves.
 //
-// The payload shape is httpdto.StreamChunkPayload, the same struct the HTTP
-// controller sends down an SSE response. Encoding happens once (at write
-// time) so controllers tailing Redis can forward payloads verbatim —
-// readers never need to know about the internal StreamChunk shape.
-//
-// The returned event type matches httpdto's `type` field conventions. When
-// the chunk type is empty we default to "chunk" to keep parity with the
-// controller's fallback (stream_controller.go:282).
-func encodeRunEventFromChunk(chunk bichatservices.StreamChunk) (string, []byte, error) {
+// When the chunk type is empty we default to StreamEventChunk ("chunk") to
+// keep parity with the controller's fallback.
+func BuildPayload(chunk bichatservices.StreamChunk) (httpdto.StreamEventType, httpdto.StreamChunkPayload, error) {
 	payload := httpdto.StreamChunkPayload{
 		Type:         string(chunk.Type),
 		Content:      chunk.Content,
@@ -91,9 +87,20 @@ func encodeRunEventFromChunk(chunk bichatservices.StreamChunk) (string, []byte, 
 		eventType = string(httpdto.StreamEventChunk)
 	}
 
+	return httpdto.StreamEventType(eventType), payload, nil
+}
+
+// encodeRunEventFromChunk is the internal shim used by the Redis event-log
+// appender. It delegates to BuildPayload and marshals the result so the
+// call site in chat_service_impl.go does not need to change.
+func encodeRunEventFromChunk(chunk bichatservices.StreamChunk) (string, []byte, error) {
+	eventType, payload, err := BuildPayload(chunk)
+	if err != nil {
+		return "", nil, err
+	}
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return "", nil, err
 	}
-	return eventType, body, nil
+	return string(eventType), body, nil
 }

--- a/modules/bichat/services/stream_event_codec_test.go
+++ b/modules/bichat/services/stream_event_codec_test.go
@@ -99,7 +99,13 @@ func TestEncodeRunEventFromChunk_SnapshotRoundTrip(t *testing.T) {
 func TestEncodeRunEventFromChunk_EmptyTypeFallsBackToChunk(t *testing.T) {
 	t.Parallel()
 
-	eventType, _, err := encodeRunEventFromChunk(bichatservices.StreamChunk{})
+	eventType, body, err := encodeRunEventFromChunk(bichatservices.StreamChunk{})
 	require.NoError(t, err)
 	assert.Equal(t, "chunk", eventType, "empty chunk type must fall back to the controller default")
+
+	// payload.Type must match the resolved SSE event name so persisted/replayed
+	// payloads round-trip cleanly: event: chunk / data: {"type":"chunk",...}.
+	var decoded httpdto.StreamChunkPayload
+	require.NoError(t, json.Unmarshal(body, &decoded))
+	assert.Equal(t, "chunk", decoded.Type, "payload.Type must equal the resolved event name including the fallback")
 }

--- a/modules/bichat/services/stream_event_codec_test.go
+++ b/modules/bichat/services/stream_event_codec_test.go
@@ -1,0 +1,105 @@
+package services
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	bichatservices "github.com/iota-uz/iota-sdk/pkg/bichat/services"
+	"github.com/iota-uz/iota-sdk/pkg/bichat/types"
+	"github.com/iota-uz/iota-sdk/pkg/httpdto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeRunEventFromChunk_Content(t *testing.T) {
+	t.Parallel()
+
+	chunk := bichatservices.StreamChunk{
+		Type:      bichatservices.ChunkTypeContent,
+		Content:   "hello",
+		Timestamp: time.UnixMilli(1_700_000_000_000),
+	}
+	eventType, body, err := encodeRunEventFromChunk(chunk)
+	require.NoError(t, err)
+	assert.Equal(t, "content", eventType)
+
+	var decoded httpdto.StreamChunkPayload
+	require.NoError(t, json.Unmarshal(body, &decoded))
+	assert.Equal(t, "content", decoded.Type)
+	assert.Equal(t, "hello", decoded.Content)
+	assert.Equal(t, int64(1_700_000_000_000), decoded.Timestamp)
+}
+
+func TestEncodeRunEventFromChunk_TextBlockEndCarriesSeq(t *testing.T) {
+	t.Parallel()
+
+	chunk := bichatservices.StreamChunk{
+		Type:         bichatservices.ChunkTypeTextBlockEnd,
+		TextBlockSeq: 2,
+		Timestamp:    time.Now(),
+	}
+	eventType, body, err := encodeRunEventFromChunk(chunk)
+	require.NoError(t, err)
+	assert.Equal(t, "text_block_end", eventType)
+
+	var decoded httpdto.StreamChunkPayload
+	require.NoError(t, json.Unmarshal(body, &decoded))
+	require.NotNil(t, decoded.TextBlockSeq, "text_block_end must surface the seq number")
+	assert.Equal(t, 2, *decoded.TextBlockSeq)
+}
+
+func TestEncodeRunEventFromChunk_ToolAndError(t *testing.T) {
+	t.Parallel()
+
+	chunk := bichatservices.StreamChunk{
+		Type: bichatservices.ChunkTypeToolEnd,
+		Tool: &bichatservices.ToolEvent{
+			CallID:     "c1",
+			Name:       "sql_execute",
+			Arguments:  `{"query":"SELECT 1"}`,
+			Result:     "[[1]]",
+			Error:      errors.New("timeout"),
+			DurationMs: 42,
+		},
+		Timestamp: time.Now(),
+	}
+	_, body, err := encodeRunEventFromChunk(chunk)
+	require.NoError(t, err)
+
+	var decoded httpdto.StreamChunkPayload
+	require.NoError(t, json.Unmarshal(body, &decoded))
+	require.NotNil(t, decoded.Tool)
+	assert.Equal(t, "c1", decoded.Tool.CallID)
+	assert.Equal(t, "sql_execute", decoded.Tool.Name)
+	assert.Equal(t, "timeout", decoded.Tool.Error)
+	assert.EqualValues(t, 42, decoded.Tool.DurationMs)
+}
+
+func TestEncodeRunEventFromChunk_SnapshotRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	chunk := bichatservices.StreamChunk{
+		Type: bichatservices.ChunkTypeSnapshot,
+		Snapshot: &bichatservices.StreamSnapshot{
+			PartialContent:  "hi",
+			PartialMetadata: map[string]any{"tool_calls": []types.ToolCall{}},
+		},
+	}
+	_, body, err := encodeRunEventFromChunk(chunk)
+	require.NoError(t, err)
+
+	var decoded httpdto.StreamChunkPayload
+	require.NoError(t, json.Unmarshal(body, &decoded))
+	require.NotNil(t, decoded.Snapshot)
+	assert.Equal(t, "hi", decoded.Snapshot.PartialContent)
+}
+
+func TestEncodeRunEventFromChunk_EmptyTypeFallsBackToChunk(t *testing.T) {
+	t.Parallel()
+
+	eventType, _, err := encodeRunEventFromChunk(bichatservices.StreamChunk{})
+	require.NoError(t, err)
+	assert.Equal(t, "chunk", eventType, "empty chunk type must fall back to the controller default")
+}

--- a/modules/bichat/services/streaming/run_registry.go
+++ b/modules/bichat/services/streaming/run_registry.go
@@ -22,10 +22,13 @@ type ActiveRun struct {
 	ToolOrder   []string
 	ArtifactMap map[string]types.ToolArtifact
 	LastPersist time.Time
-	// TextBlockOffsets are byte offsets into Content marking the end of each
-	// completed assistant text segment. The first entry corresponds to seq 0,
-	// the second to seq 1, etc. The trailing un-closed segment (if any) is
-	// implicit and runs from the last offset to len(Content).
+	// TextBlockOffsets are UTF-16 code unit counts into Content marking the
+	// end of each completed assistant text segment. The first entry
+	// corresponds to seq 0, the second to seq 1, etc. The trailing
+	// un-closed segment (if any) is implicit and runs from the last offset
+	// to the UTF-16 length of Content.
+	// Using UTF-16 units (not Go byte offsets) lets the applet consume them
+	// directly via str.slice() without miscounts on non-ASCII characters.
 	TextBlockOffsets []int
 
 	subscribers map[chan bichatservices.StreamChunk]struct{}

--- a/modules/bichat/services/streaming/run_registry.go
+++ b/modules/bichat/services/streaming/run_registry.go
@@ -22,6 +22,11 @@ type ActiveRun struct {
 	ToolOrder   []string
 	ArtifactMap map[string]types.ToolArtifact
 	LastPersist time.Time
+	// TextBlockOffsets are byte offsets into Content marking the end of each
+	// completed assistant text segment. The first entry corresponds to seq 0,
+	// the second to seq 1, etc. The trailing un-closed segment (if any) is
+	// implicit and runs from the last offset to len(Content).
+	TextBlockOffsets []int
 
 	subscribers map[chan bichatservices.StreamChunk]struct{}
 	Mu          sync.RWMutex
@@ -85,7 +90,13 @@ func (r *ActiveRun) SnapshotMetadata() map[string]any {
 	r.Mu.RLock()
 	defer r.Mu.RUnlock()
 	ordered := orderedToolCalls(r.ToolCalls, r.ToolOrder)
-	return map[string]any{"tool_calls": ordered}
+	meta := map[string]any{"tool_calls": ordered}
+	if len(r.TextBlockOffsets) > 0 {
+		offsets := make([]int, len(r.TextBlockOffsets))
+		copy(offsets, r.TextBlockOffsets)
+		meta["text_block_offsets"] = offsets
+	}
+	return meta
 }
 
 func orderedToolCalls(toolCalls map[string]types.ToolCall, toolOrder []string) []types.ToolCall {

--- a/modules/bichat/services/streaming/run_registry.go
+++ b/modules/bichat/services/streaming/run_registry.go
@@ -30,6 +30,10 @@ type ActiveRun struct {
 	// Using UTF-16 units (not Go byte offsets) lets the applet consume them
 	// directly via str.slice() without miscounts on non-ASCII characters.
 	TextBlockOffsets []int
+	// ContentUTF16Len is the running UTF-16 code unit count for Content.
+	// Updated incrementally on every content delta so text_block_end
+	// boundary recording is O(delta) rather than O(total_content).
+	ContentUTF16Len int
 
 	subscribers map[chan bichatservices.StreamChunk]struct{}
 	// mirrorFn is an optional side-effect hook invoked by Broadcast AFTER

--- a/modules/bichat/services/streaming/run_registry.go
+++ b/modules/bichat/services/streaming/run_registry.go
@@ -29,7 +29,13 @@ type ActiveRun struct {
 	TextBlockOffsets []int
 
 	subscribers map[chan bichatservices.StreamChunk]struct{}
-	Mu          sync.RWMutex
+	// mirrorFn is an optional side-effect hook invoked by Broadcast AFTER
+	// in-memory subscribers are notified. It lets callers dual-write the
+	// chunk to a durable store (e.g. RunEventLog on Redis) without the
+	// runStreamLoop having to care where the event ends up. Installed via
+	// SetMirror at run creation time.
+	mirrorFn func(bichatservices.StreamChunk)
+	Mu       sync.RWMutex
 }
 
 func NewActiveRun(runID, sessionID uuid.UUID, cancel context.CancelFunc, startedAt time.Time) *ActiveRun {
@@ -68,13 +74,26 @@ func (r *ActiveRun) SubscriberCount() int {
 
 func (r *ActiveRun) Broadcast(chunk bichatservices.StreamChunk) {
 	r.Mu.RLock()
-	defer r.Mu.RUnlock()
+	mirror := r.mirrorFn
 	for ch := range r.subscribers {
 		select {
 		case ch <- chunk:
 		default:
 		}
 	}
+	r.Mu.RUnlock()
+	if mirror != nil {
+		mirror(chunk)
+	}
+}
+
+// SetMirror installs a side-effect hook invoked after every Broadcast.
+// Passing nil clears the hook. Safe to call concurrently with Broadcast
+// — the hook is captured under the same RLock that the broadcast uses.
+func (r *ActiveRun) SetMirror(fn func(bichatservices.StreamChunk)) {
+	r.Mu.Lock()
+	r.mirrorFn = fn
+	r.Mu.Unlock()
 }
 
 func (r *ActiveRun) CloseAllSubscribers() {

--- a/modules/bichat/services/streaming/run_registry_test.go
+++ b/modules/bichat/services/streaming/run_registry_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf16"
 
 	"github.com/google/uuid"
 	bichatservices "github.com/iota-uz/iota-sdk/pkg/bichat/services"
@@ -145,6 +146,40 @@ func TestRunRegistry_ActiveCounters(t *testing.T) {
 	reg.Remove(first.RunID)
 	require.Equal(t, 1, reg.ActiveRuns())
 	require.Equal(t, 1, reg.ActiveSubscribers())
+}
+
+// TestActiveRun_ContentUTF16LenIncremental verifies that ContentUTF16Len
+// matches the reference UTF-16 encoding of the full accumulated content when
+// content deltas are applied one at a time, including non-ASCII (multi-byte)
+// characters where Go byte length != UTF-16 code unit count.
+func TestActiveRun_ContentUTF16LenIncremental(t *testing.T) {
+	t.Parallel()
+
+	deltas := []string{
+		"Hello ",
+		"世界", // non-ASCII: each rune is 1 UTF-16 code unit in BMP
+		" and ",
+		"𝄞",     // U+1D11E MUSICAL SYMBOL G CLEF: outside BMP, 2 UTF-16 code units
+		" done",
+	}
+
+	run := NewActiveRun(uuid.New(), uuid.New(), context.CancelFunc(func() {}), time.Now())
+
+	for _, delta := range deltas {
+		run.Mu.Lock()
+		run.Content += delta
+		run.ContentUTF16Len += len(utf16.Encode([]rune(delta)))
+		run.Mu.Unlock()
+	}
+
+	run.Mu.RLock()
+	content := run.Content
+	gotLen := run.ContentUTF16Len
+	run.Mu.RUnlock()
+
+	wantLen := len(utf16.Encode([]rune(content)))
+	require.Equal(t, wantLen, gotLen,
+		"incremental ContentUTF16Len must match full re-encode of accumulated content")
 }
 
 func TestRunRegistry_ActiveCountersAfterReplacingSessionRun(t *testing.T) {

--- a/modules/bichat/services/streaming/run_registry_test.go
+++ b/modules/bichat/services/streaming/run_registry_test.go
@@ -63,6 +63,45 @@ func TestActiveRun_SubscriberLifecycleAndSnapshot(t *testing.T) {
 	require.False(t, ok, "CloseAllSubscribers should close subscriber channel")
 }
 
+func TestActiveRun_SetMirrorCalledForEveryBroadcast(t *testing.T) {
+	run := NewActiveRun(uuid.New(), uuid.New(), context.CancelFunc(func() {}), time.Now())
+
+	var seen []bichatservices.ChunkType
+	var seenMu sync.Mutex
+	run.SetMirror(func(chunk bichatservices.StreamChunk) {
+		seenMu.Lock()
+		defer seenMu.Unlock()
+		seen = append(seen, chunk.Type)
+	})
+
+	run.Broadcast(bichatservices.StreamChunk{Type: bichatservices.ChunkTypeContent})
+	run.Broadcast(bichatservices.StreamChunk{Type: bichatservices.ChunkTypeToolStart})
+	run.Broadcast(bichatservices.StreamChunk{Type: bichatservices.ChunkTypeDone})
+
+	seenMu.Lock()
+	defer seenMu.Unlock()
+	require.Equal(t, []bichatservices.ChunkType{
+		bichatservices.ChunkTypeContent,
+		bichatservices.ChunkTypeToolStart,
+		bichatservices.ChunkTypeDone,
+	}, seen)
+}
+
+func TestActiveRun_SetMirrorDoesNotBlockOnSlowSubscribers(t *testing.T) {
+	run := NewActiveRun(uuid.New(), uuid.New(), context.CancelFunc(func() {}), time.Now())
+
+	// Unbuffered channel: Broadcast's default-case drop must still fire
+	// the mirror so the durable log isn't starved by a slow client.
+	slow := make(chan bichatservices.StreamChunk)
+	run.AddSubscriber(slow)
+
+	var mirrored int
+	run.SetMirror(func(chunk bichatservices.StreamChunk) { mirrored++ })
+
+	run.Broadcast(bichatservices.StreamChunk{Type: bichatservices.ChunkTypeContent})
+	require.Equal(t, 1, mirrored, "mirror must fire even when the subscriber channel is full")
+}
+
 func TestActiveRun_ConcurrentAddRemove(t *testing.T) {
 	run := NewActiveRun(uuid.New(), uuid.New(), context.CancelFunc(func() {}), time.Now())
 	var wg sync.WaitGroup

--- a/modules/bichat/services/streaming/run_registry_test.go
+++ b/modules/bichat/services/streaming/run_registry_test.go
@@ -159,7 +159,7 @@ func TestActiveRun_ContentUTF16LenIncremental(t *testing.T) {
 		"Hello ",
 		"世界", // non-ASCII: each rune is 1 UTF-16 code unit in BMP
 		" and ",
-		"𝄞",     // U+1D11E MUSICAL SYMBOL G CLEF: outside BMP, 2 UTF-16 code units
+		"𝄞", // U+1D11E MUSICAL SYMBOL G CLEF: outside BMP, 2 UTF-16 code units
 		" done",
 	}
 

--- a/modules/bichat/services/streaming/run_state.go
+++ b/modules/bichat/services/streaming/run_state.go
@@ -18,6 +18,9 @@ type RunStateStore interface {
 	UpdateRunSnapshot(ctx context.Context, tenantID, sessionID, runID uuid.UUID, partialContent string, partialMetadata map[string]any) error
 	CompleteRun(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error
 	CancelRun(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error
+	FailRun(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error
+	RequestCancel(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error
+	Heartbeat(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error
 }
 
 type RunStateManager struct {
@@ -97,6 +100,49 @@ func (m *RunStateManager) CancelRunState(ctx context.Context, tenantID, sessionI
 		return nil
 	}
 	if err := m.store.CancelRun(ctx, tenantID, sessionID, runID); err != nil {
+		return serrors.E(op, err)
+	}
+	return nil
+}
+
+// FailRunState drives a system-initiated terminal transition. Callers must
+// also write a terminal error event to the run's RunEventLog so tailing
+// clients observe the transition.
+func (m *RunStateManager) FailRunState(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error {
+	const op serrors.Op = "runStateManager.FailRunState"
+	if m == nil || m.store == nil {
+		return nil
+	}
+	if err := m.store.FailRun(ctx, tenantID, sessionID, runID); err != nil {
+		return serrors.E(op, err)
+	}
+	return nil
+}
+
+// RequestCancel flips the cancel flag on the active run. The worker owns
+// the transition to the Cancelled status; this RPC only records intent.
+// Idempotent.
+func (m *RunStateManager) RequestCancel(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error {
+	const op serrors.Op = "runStateManager.RequestCancel"
+	if m == nil || m.store == nil {
+		return nil
+	}
+	if err := m.store.RequestCancel(ctx, tenantID, sessionID, runID); err != nil {
+		return serrors.E(op, err)
+	}
+	return nil
+}
+
+// Heartbeat refreshes the liveness timestamp on the active run. Called
+// from the worker every few seconds of streaming so the reaper can
+// distinguish between a healthy long-running LLM call and a wedged
+// worker that silently died.
+func (m *RunStateManager) Heartbeat(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error {
+	const op serrors.Op = "runStateManager.Heartbeat"
+	if m == nil || m.store == nil {
+		return nil
+	}
+	if err := m.store.Heartbeat(ctx, tenantID, sessionID, runID); err != nil {
 		return serrors.E(op, err)
 	}
 	return nil

--- a/modules/bichat/services/tail_run_events_test.go
+++ b/modules/bichat/services/tail_run_events_test.go
@@ -121,7 +121,7 @@ func TestChatService_TailRunEvents_HonoursLastEventID(t *testing.T) {
 func TestChatService_TailRunEvents_MissingRunReturnsSentinel(t *testing.T) {
 	t.Parallel()
 
-	svc, _, _, _ := newTailTestService(t)
+	svc, _, _, _ := newTailTestService(t) //nolint:dogsled // harness returns 4 values; only svc needed here
 
 	ctx := composables.WithTenantID(context.Background(), uuid.New())
 	err := svc.TailRunEvents(ctx, uuid.New(), uuid.New(), "", func(evt bichatservices.RunEventDelivery) {

--- a/modules/bichat/services/tail_run_events_test.go
+++ b/modules/bichat/services/tail_run_events_test.go
@@ -1,0 +1,157 @@
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/modules/bichat/services/streaming"
+	"github.com/iota-uz/iota-sdk/pkg/bichat/domain"
+	bichatservices "github.com/iota-uz/iota-sdk/pkg/bichat/services"
+	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTailTestService stitches a minimal chatServiceImpl that exercises
+// only the TailRunEvents path. Fields unused by the method are left nil
+// deliberately — instantiating the full graph would drag the ITF harness
+// in and we're unit-testing the tail flow here.
+func newTailTestService(t *testing.T) (*chatServiceImpl, *miniredis.Miniredis, generationRunStore, *RedisRunEventLog) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	store, err := newRedisGenerationRunStore(redisGenerationRunStoreConfig{Client: client})
+	require.NoError(t, err)
+
+	log, err := NewRedisRunEventLog(RedisRunEventLogConfig{
+		Client:    client,
+		BlockTime: 30 * time.Millisecond,
+	})
+	require.NoError(t, err)
+
+	svc := &chatServiceImpl{
+		runState: streaming.NewRunStateManager(store),
+		eventLog: log,
+	}
+	return svc, mr, store, log
+}
+
+func seedTailRun(t *testing.T, store generationRunStore, tenantID, sessionID, runID uuid.UUID) {
+	t.Helper()
+	run, err := domain.NewGenerationRun(domain.GenerationRunSpec{
+		ID:        runID,
+		SessionID: sessionID,
+		TenantID:  tenantID,
+		UserID:    1,
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.CreateRun(context.Background(), run))
+}
+
+func TestChatService_TailRunEvents_ReplayThenTerminal(t *testing.T) {
+	t.Parallel()
+
+	svc, _, store, log := newTailTestService(t)
+	tenantID := uuid.New()
+	sessionID := uuid.New()
+	runID := uuid.New()
+	seedTailRun(t, store, tenantID, sessionID, runID)
+
+	push := func(typ string, body any) {
+		payload, err := json.Marshal(body)
+		require.NoError(t, err)
+		_, err = log.Append(context.Background(), tenantID, runID, RunEvent{Type: typ, Payload: payload})
+		require.NoError(t, err)
+	}
+	push("content", map[string]string{"text": "a"})
+	push("content", map[string]string{"text": "b"})
+	push("done", map[string]string{})
+
+	ctx, cancel := context.WithTimeout(composables.WithTenantID(context.Background(), tenantID), 2*time.Second)
+	defer cancel()
+
+	var seen []string
+	err := svc.TailRunEvents(ctx, sessionID, runID, "", func(evt bichatservices.RunEventDelivery) {
+		seen = append(seen, evt.Type)
+		assert.NotEmpty(t, evt.StreamID, "every delivered event must carry a stream id")
+		assert.NotEmpty(t, evt.Payload, "payload must round-trip")
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"content", "content", "done"}, seen)
+}
+
+func TestChatService_TailRunEvents_HonoursLastEventID(t *testing.T) {
+	t.Parallel()
+
+	svc, _, store, log := newTailTestService(t)
+	tenantID := uuid.New()
+	sessionID := uuid.New()
+	runID := uuid.New()
+	seedTailRun(t, store, tenantID, sessionID, runID)
+
+	firstID, err := log.Append(context.Background(), tenantID, runID,
+		RunEvent{Type: "content", Payload: json.RawMessage(`{"text":"one"}`)})
+	require.NoError(t, err)
+	_, err = log.Append(context.Background(), tenantID, runID,
+		RunEvent{Type: "content", Payload: json.RawMessage(`{"text":"two"}`)})
+	require.NoError(t, err)
+	_, err = log.Append(context.Background(), tenantID, runID,
+		RunEvent{Type: "done", Payload: json.RawMessage(`{}`)})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(composables.WithTenantID(context.Background(), tenantID), 2*time.Second)
+	defer cancel()
+
+	var seen []string
+	err = svc.TailRunEvents(ctx, sessionID, runID, firstID, func(evt bichatservices.RunEventDelivery) {
+		seen = append(seen, evt.Type)
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"content", "done"}, seen,
+		"passing the first event's id must skip it and resume with the next (Last-Event-ID semantics)")
+}
+
+func TestChatService_TailRunEvents_MissingRunReturnsSentinel(t *testing.T) {
+	t.Parallel()
+
+	svc, _, _, _ := newTailTestService(t)
+
+	ctx := composables.WithTenantID(context.Background(), uuid.New())
+	err := svc.TailRunEvents(ctx, uuid.New(), uuid.New(), "", func(evt bichatservices.RunEventDelivery) {
+		t.Fatalf("onEvent must not be called for missing run: %+v", evt)
+	})
+	require.ErrorIs(t, err, bichatservices.ErrRunNotFoundOrFinished)
+}
+
+func TestChatService_TailRunEvents_SessionMismatchRejected(t *testing.T) {
+	t.Parallel()
+
+	svc, _, store, _ := newTailTestService(t)
+	tenantID := uuid.New()
+	sessionID := uuid.New()
+	runID := uuid.New()
+	seedTailRun(t, store, tenantID, sessionID, runID)
+
+	ctx := composables.WithTenantID(context.Background(), tenantID)
+	err := svc.TailRunEvents(ctx, uuid.New(), runID, "", func(evt bichatservices.RunEventDelivery) {
+		t.Fatalf("must not deliver events across sessions: %+v", evt)
+	})
+	require.Error(t, err, "session id mismatch must fail the tail")
+}
+
+func TestChatService_TailRunEvents_NoLogReturnsSentinel(t *testing.T) {
+	t.Parallel()
+
+	svc := &chatServiceImpl{} // no runState, no eventLog
+	err := svc.TailRunEvents(context.Background(), uuid.New(), uuid.New(), "", func(evt bichatservices.RunEventDelivery) {
+		t.Fatalf("onEvent must not be called when event log is unconfigured")
+	})
+	require.ErrorIs(t, err, bichatservices.ErrRunEventLogUnavailable)
+}

--- a/pkg/bichat/agents/delegation.go
+++ b/pkg/bichat/agents/delegation.go
@@ -227,6 +227,8 @@ eventLoop:
 		case EventTypeInterrupt:
 			// Child agent requested user interaction - not supported in delegation
 			return "", fmt.Errorf("child agent %q requested interrupt (not supported in delegation)", args.SubagentType)
+		case EventTypeTextBlockEnd:
+			// Text block boundary; no action needed for delegation results.
 		case EventTypeToolStart, EventTypeToolEnd:
 			// Forward child tool events to parent stream with agent identity.
 			if event.Tool != nil {

--- a/pkg/bichat/agents/executor.go
+++ b/pkg/bichat/agents/executor.go
@@ -70,6 +70,13 @@ const (
 	// Prefer EventTypeContent in new code.
 	EventTypeChunk ExecutorEventType = "content"
 
+	// EventTypeTextBlockEnd is emitted to mark the end of an assistant text segment.
+	// It is emitted before the first tool_start of an iteration when prior text has
+	// been streamed, so consumers can render text/tool_call/text/tool_call sequences
+	// as distinct blocks instead of one merged paragraph. The TextBlockSeq field on
+	// the event identifies the segment ordinal within an Execute call (zero-based).
+	EventTypeTextBlockEnd ExecutorEventType = "text_block_end"
+
 	// EventTypeToolStart is emitted when a tool execution begins.
 	EventTypeToolStart ExecutorEventType = "tool_start"
 
@@ -174,6 +181,12 @@ type ExecutorEvent struct {
 	// FileAnnotations holds file references extracted from Result.
 	// It is populated when Type == EventTypeDone and files were generated.
 	FileAnnotations []types.FileAnnotation
+
+	// TextBlockSeq is the ordinal of an assistant text segment within an Execute
+	// call. It is populated when Type == EventTypeTextBlockEnd; the first segment
+	// is 0, the second is 1, and so on. Consumers use it to attribute streamed
+	// content chunks to a specific block when tool calls split a turn.
+	TextBlockSeq int
 }
 
 // ToolEvent represents a tool execution event.
@@ -487,10 +500,24 @@ func (e *Executor) Execute(ctx context.Context, input Input) types.Generator[Exe
 			input.isResume,
 		))
 
+		// Track text-block segmentation across iterations. textBlockSeq is the
+		// running ordinal of completed text segments within this Execute call;
+		// it is included on every EventTypeTextBlockEnd we yield so consumers can
+		// attribute content chunks to the correct block when tool calls split a
+		// turn.
+		textBlockSeq := 0
+
 		// Start ReAct loop
 		iteration := 0
 		for iteration < e.maxIterations {
 			iteration++
+
+			// Per-iteration text-block tracking. iterTextEmitted flips true the
+			// first time we yield a content chunk inside this iteration;
+			// iterTextBlockEnded flips true once the closing EventTypeTextBlockEnd
+			// has been yielded so we never emit it twice for the same segment.
+			iterTextEmitted := false
+			iterTextBlockEnded := false
 
 			// Determine which tools to use (override if e.tools is set)
 			tools := e.tools
@@ -619,6 +646,29 @@ func (e *Executor) Execute(ctx context.Context, input Input) types.Generator[Exe
 				return m
 			}
 
+			// emitTextBlockEndIfNeeded yields an EventTypeTextBlockEnd marker when
+			// the current iteration has streamed any text and the marker has not
+			// already been emitted. It is called both from the speculative tool
+			// path (inside startSpecTool, before yielding the first tool_start)
+			// and from the synchronous executeToolCalls path so that consumers
+			// always see the closing marker for an assistant text segment before
+			// any tool_start that follows it. Returns false only if the consumer
+			// has stopped (yield returned false).
+			emitTextBlockEndIfNeeded := func() bool {
+				if !iterTextEmitted || iterTextBlockEnded {
+					return true
+				}
+				if !yield(ExecutorEvent{
+					Type:         EventTypeTextBlockEnd,
+					TextBlockSeq: textBlockSeq,
+				}) {
+					return false
+				}
+				iterTextBlockEnded = true
+				textBlockSeq++
+				return true
+			}
+
 			handleSpecResult := func(tr specToolResult) bool {
 				if !specEnabled {
 					return true
@@ -730,6 +780,13 @@ func (e *Executor) Execute(ctx context.Context, input Input) types.Generator[Exe
 				}
 				specStarted[callID] = struct{}{}
 
+				// Close the text segment that preceded this tool call, if any,
+				// so the consumer can flush it as its own block.
+				if !emitTextBlockEndIfNeeded() {
+					specCancel()
+					return false
+				}
+
 				// Emit tool start event
 				_ = e.eventBus.Publish(specToolCtx, events.NewToolStartEventWithTrace(
 					input.SessionID,
@@ -810,6 +867,7 @@ func (e *Executor) Execute(ctx context.Context, input Input) types.Generator[Exe
 				// Yield chunk event
 				if chunk.Delta != "" {
 					chunks = append(chunks, chunk.Delta)
+					iterTextEmitted = true
 					if !yield(ExecutorEvent{
 						Type:    EventTypeContent,
 						Content: chunk.Delta,
@@ -1016,6 +1074,11 @@ func (e *Executor) Execute(ctx context.Context, input Input) types.Generator[Exe
 					}
 				}
 			} else {
+				// Synchronous path: close any pending text segment before
+				// executeToolCalls yields its first tool_start event.
+				if !emitTextBlockEndIfNeeded() {
+					return nil
+				}
 				toolResults, interrupt, toolErr = e.executeToolCalls(ctx, input.SessionID, input.TenantID, traceID, tools, toolCalls, yield)
 			}
 

--- a/pkg/bichat/agents/executor_test.go
+++ b/pkg/bichat/agents/executor_test.go
@@ -1521,3 +1521,212 @@ func TestExecutor_InterruptTool_IsExclusive(t *testing.T) {
 		t.Fatalf("expected other tool not to execute in same batch as interrupt")
 	}
 }
+
+// TestExecutor_TextBlockEnd_TextThenToolThenText asserts that executor emits a
+// EventTypeTextBlockEnd marker between an iteration's streamed text and the
+// first tool_start, and that the marker carries an incrementing TextBlockSeq.
+// The final text segment after the last tool call has no closing marker — the
+// done event implicitly closes it.
+func TestExecutor_TextBlockEnd_TextThenToolThenText(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	weatherTool := agents.NewTool(
+		"get_weather",
+		"Gets weather for a location",
+		map[string]any{},
+		func(ctx context.Context, input string) (string, error) { return "sunny", nil },
+	)
+
+	agent := newMockAgent("text-block-agent", weatherTool)
+	agent.setToolResult("get_weather", "sunny")
+
+	model := newMockModel(
+		mockResponse{
+			content: "Let me check the weather.",
+			toolCalls: []types.ToolCall{
+				{ID: "call_1", Name: "get_weather", Arguments: `{"location":"SF"}`},
+			},
+			finishReason: "tool_calls",
+		},
+		mockResponse{
+			content:      "It is sunny.",
+			finishReason: "stop",
+		},
+	)
+
+	executor := agents.NewExecutor(agent, model)
+	input := agents.Input{
+		Messages:  []types.Message{types.UserMessage("Weather in SF?")},
+		SessionID: uuid.New(),
+		TenantID:  uuid.New(),
+	}
+
+	gen := executor.Execute(ctx, input)
+	defer gen.Close()
+
+	type observation struct {
+		typ agents.ExecutorEventType
+		seq int
+	}
+	var observed []observation
+	for {
+		ev, err := gen.Next(ctx)
+		if err != nil {
+			if errors.Is(err, types.ErrGeneratorDone) {
+				break
+			}
+			t.Fatalf("unexpected generator error: %v", err)
+		}
+		switch ev.Type {
+		case agents.EventTypeContent, agents.EventTypeToolStart, agents.EventTypeToolEnd, agents.EventTypeTextBlockEnd, agents.EventTypeDone:
+			observed = append(observed, observation{typ: ev.Type, seq: ev.TextBlockSeq})
+		case agents.EventTypeError:
+			t.Fatalf("unexpected error event: %v", ev.Error)
+		}
+	}
+
+	// Assert exactly one text_block_end before the tool sequence, with seq=0.
+	textBlockIdx := -1
+	toolStartIdx := -1
+	for i, o := range observed {
+		if o.typ == agents.EventTypeTextBlockEnd {
+			require.Equal(t, -1, textBlockIdx, "exactly one text_block_end expected, got a second at index %d", i)
+			require.Equal(t, 0, o.seq, "first text_block_end must have seq=0")
+			textBlockIdx = i
+		}
+		if o.typ == agents.EventTypeToolStart && toolStartIdx == -1 {
+			toolStartIdx = i
+		}
+	}
+	require.NotEqual(t, -1, textBlockIdx, "expected one text_block_end event")
+	require.NotEqual(t, -1, toolStartIdx, "expected at least one tool_start event")
+	require.Less(t, textBlockIdx, toolStartIdx, "text_block_end must precede tool_start")
+
+	// Final assistant text after the tool has no closing text_block_end (done implies it).
+	doneIdx := -1
+	for i, o := range observed {
+		if o.typ == agents.EventTypeDone {
+			doneIdx = i
+		}
+	}
+	require.NotEqual(t, -1, doneIdx, "expected done event")
+	for _, o := range observed[toolStartIdx+1:doneIdx] {
+		require.NotEqual(t, agents.EventTypeTextBlockEnd, o.typ, "should not emit a closing text_block_end for the final segment")
+	}
+}
+
+// TestExecutor_TextBlockEnd_MultipleTurns asserts seq increments across
+// multiple iterations, each producing a text + tool_call boundary.
+func TestExecutor_TextBlockEnd_MultipleTurns(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	tool := agents.NewTool(
+		"do_thing",
+		"do_thing",
+		map[string]any{},
+		func(ctx context.Context, input string) (string, error) { return "ok", nil },
+	)
+
+	agent := newMockAgent("multi-turn-agent", tool)
+	agent.setToolResult("do_thing", "ok")
+
+	model := newMockModel(
+		mockResponse{
+			content:      "First step.",
+			toolCalls:    []types.ToolCall{{ID: "c1", Name: "do_thing", Arguments: "{}"}},
+			finishReason: "tool_calls",
+		},
+		mockResponse{
+			content:      "Second step.",
+			toolCalls:    []types.ToolCall{{ID: "c2", Name: "do_thing", Arguments: "{}"}},
+			finishReason: "tool_calls",
+		},
+		mockResponse{
+			content:      "All done.",
+			finishReason: "stop",
+		},
+	)
+
+	executor := agents.NewExecutor(agent, model)
+	input := agents.Input{
+		Messages:  []types.Message{types.UserMessage("Run it")},
+		SessionID: uuid.New(),
+		TenantID:  uuid.New(),
+	}
+
+	gen := executor.Execute(ctx, input)
+	defer gen.Close()
+
+	var seqs []int
+	for {
+		ev, err := gen.Next(ctx)
+		if err != nil {
+			if errors.Is(err, types.ErrGeneratorDone) {
+				break
+			}
+			t.Fatalf("unexpected generator error: %v", err)
+		}
+		if ev.Type == agents.EventTypeTextBlockEnd {
+			seqs = append(seqs, ev.TextBlockSeq)
+		}
+	}
+
+	require.Equal(t, []int{0, 1}, seqs, "expected two text_block_end events with seqs 0 and 1")
+}
+
+// TestExecutor_TextBlockEnd_NoTextBeforeTool asserts that no text_block_end is
+// emitted when an iteration produces only a tool call with no preceding text.
+func TestExecutor_TextBlockEnd_NoTextBeforeTool(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	tool := agents.NewTool(
+		"do_thing",
+		"do_thing",
+		map[string]any{},
+		func(ctx context.Context, input string) (string, error) { return "ok", nil },
+	)
+
+	agent := newMockAgent("no-text-agent", tool)
+	agent.setToolResult("do_thing", "ok")
+
+	model := newMockModel(
+		mockResponse{
+			content:      "",
+			toolCalls:    []types.ToolCall{{ID: "c1", Name: "do_thing", Arguments: "{}"}},
+			finishReason: "tool_calls",
+		},
+		mockResponse{
+			content:      "Done.",
+			finishReason: "stop",
+		},
+	)
+
+	executor := agents.NewExecutor(agent, model)
+	input := agents.Input{
+		Messages:  []types.Message{types.UserMessage("go")},
+		SessionID: uuid.New(),
+		TenantID:  uuid.New(),
+	}
+
+	gen := executor.Execute(ctx, input)
+	defer gen.Close()
+
+	for {
+		ev, err := gen.Next(ctx)
+		if err != nil {
+			if errors.Is(err, types.ErrGeneratorDone) {
+				break
+			}
+			t.Fatalf("unexpected generator error: %v", err)
+		}
+		if ev.Type == agents.EventTypeTextBlockEnd {
+			t.Fatalf("did not expect any text_block_end events when no text precedes tool_start")
+		}
+	}
+}

--- a/pkg/bichat/agents/executor_test.go
+++ b/pkg/bichat/agents/executor_test.go
@@ -1612,7 +1612,7 @@ func TestExecutor_TextBlockEnd_TextThenToolThenText(t *testing.T) {
 		}
 	}
 	require.NotEqual(t, -1, doneIdx, "expected done event")
-	for _, o := range observed[toolStartIdx+1:doneIdx] {
+	for _, o := range observed[toolStartIdx+1 : doneIdx] {
 		require.NotEqual(t, agents.EventTypeTextBlockEnd, o.typ, "should not emit a closing text_block_end for the final segment")
 	}
 }

--- a/pkg/bichat/agents/executor_test.go
+++ b/pkg/bichat/agents/executor_test.go
@@ -302,7 +302,8 @@ func TestExecutor_SingleTurn(t *testing.T) {
 			finalResult = event.Result
 		case agents.EventTypeError:
 			t.Fatalf("Unexpected error event: %v", event.Error)
-		case agents.EventTypeToolStart, agents.EventTypeToolEnd, agents.EventTypeInterrupt, agents.EventTypeThinking:
+		case agents.EventTypeToolStart, agents.EventTypeToolEnd, agents.EventTypeInterrupt,
+			agents.EventTypeThinking, agents.EventTypeTextBlockEnd:
 			// no-op for this test
 		}
 	}
@@ -414,7 +415,8 @@ func TestExecutor_ToolCalls(t *testing.T) {
 			toolEndEvent = event.Tool
 		case agents.EventTypeError:
 			t.Fatalf("Unexpected error event: %v", event.Error)
-		case agents.EventTypeChunk, agents.EventTypeInterrupt, agents.EventTypeDone, agents.EventTypeThinking:
+		case agents.EventTypeChunk, agents.EventTypeInterrupt, agents.EventTypeDone,
+			agents.EventTypeThinking, agents.EventTypeTextBlockEnd:
 			// no-op for this test
 		}
 	}
@@ -1584,6 +1586,8 @@ func TestExecutor_TextBlockEnd_TextThenToolThenText(t *testing.T) {
 			observed = append(observed, observation{typ: ev.Type, seq: ev.TextBlockSeq})
 		case agents.EventTypeError:
 			t.Fatalf("unexpected error event: %v", ev.Error)
+		case agents.EventTypeInterrupt, agents.EventTypeThinking:
+			// no-op: these events are not relevant to the text_block_end assertion
 		}
 	}
 

--- a/pkg/bichat/domain/generation_run.go
+++ b/pkg/bichat/domain/generation_run.go
@@ -15,6 +15,12 @@ const (
 	GenerationRunStatusStreaming GenerationRunStatus = "streaming"
 	GenerationRunStatusCompleted GenerationRunStatus = "completed"
 	GenerationRunStatusCancelled GenerationRunStatus = "cancelled"
+	// GenerationRunStatusFailed marks a run that was terminated by an
+	// unrecoverable error (LLM provider, tool crash, stale heartbeat).
+	// Semantically distinct from Cancelled: cancelled was user-initiated,
+	// failed was system-initiated. Frontend surfaces a "Regenerate" CTA
+	// on failed runs and does not persist the partial message.
+	GenerationRunStatusFailed GenerationRunStatus = "failed"
 )
 
 var (
@@ -32,6 +38,17 @@ type GenerationRunSpec struct {
 	PartialMetadata map[string]any
 	StartedAt       time.Time
 	LastUpdatedAt   time.Time
+	// CancelRequested is the out-of-band flag a Stop RPC flips while the
+	// worker is streaming. Workers poll this between executor iterations
+	// and promote it into a GenerationRunStatusCancelled transition.
+	// Rehydrated in-flight runs preserve the request so a reclaiming
+	// worker sees the user's intent.
+	CancelRequested bool
+	// LastHeartbeatAt is refreshed by the worker during execution. The
+	// reaper uses it to detect wedged runs (e.g. worker crash mid-LLM
+	// call) and transition them to GenerationRunStatusFailed without
+	// needing to observe the process itself.
+	LastHeartbeatAt time.Time
 }
 
 // GenerationRun represents an in-progress or recently finished streaming run.
@@ -45,10 +62,31 @@ type GenerationRun interface {
 	PartialMetadata() map[string]any
 	StartedAt() time.Time
 	LastUpdatedAt() time.Time
+	// CancelRequested reports whether a Stop RPC has flipped the cancel
+	// flag on this run. Workers poll this between executor iterations.
+	CancelRequested() bool
+	// LastHeartbeatAt is the most recent wall-clock time at which the
+	// worker proved the run was still making progress. Zero while the
+	// run is queued or has never heartbeated.
+	LastHeartbeatAt() time.Time
 
 	UpdateSnapshot(partialContent string, partialMetadata map[string]any, now time.Time) (GenerationRun, error)
 	Complete(now time.Time) (GenerationRun, error)
 	Cancel(now time.Time) (GenerationRun, error)
+	// Fail transitions a streaming run to the terminal failed status.
+	// It is used by workers on unrecoverable errors and by the reaper
+	// when a run's heartbeat goes stale. Callers should also write a
+	// corresponding terminal event onto the RunEventLog so tailing
+	// clients observe the transition.
+	Fail(now time.Time) (GenerationRun, error)
+	// RequestCancel sets the out-of-band cancel flag. It does NOT move
+	// the run to the Cancelled status; the worker does that after it
+	// observes the flag and winds execution down. Returns a new run
+	// with CancelRequested==true and a refreshed LastUpdatedAt.
+	RequestCancel(now time.Time) (GenerationRun, error)
+	// Heartbeat refreshes LastHeartbeatAt + LastUpdatedAt without
+	// mutating the snapshot. Only valid while streaming.
+	Heartbeat(now time.Time) (GenerationRun, error)
 }
 
 type generationRun struct {
@@ -61,6 +99,8 @@ type generationRun struct {
 	partialMetadata map[string]any
 	startedAt       time.Time
 	lastUpdatedAt   time.Time
+	cancelRequested bool
+	lastHeartbeatAt time.Time
 }
 
 func cloneRunMetadata(meta map[string]any) map[string]any {
@@ -76,7 +116,7 @@ func cloneRunMetadata(meta map[string]any) map[string]any {
 
 func validateRunStatus(status GenerationRunStatus) bool {
 	switch status {
-	case GenerationRunStatusStreaming, GenerationRunStatusCompleted, GenerationRunStatusCancelled:
+	case GenerationRunStatusStreaming, GenerationRunStatusCompleted, GenerationRunStatusCancelled, GenerationRunStatusFailed:
 		return true
 	default:
 		return false
@@ -129,6 +169,8 @@ func NewGenerationRun(spec GenerationRunSpec) (GenerationRun, error) {
 		partialMetadata: cloneRunMetadata(spec.PartialMetadata),
 		startedAt:       startedAt,
 		lastUpdatedAt:   lastUpdatedAt,
+		cancelRequested: spec.CancelRequested,
+		lastHeartbeatAt: spec.LastHeartbeatAt,
 	}, nil
 }
 
@@ -159,6 +201,8 @@ func RehydrateGenerationRun(spec GenerationRunSpec) (GenerationRun, error) {
 		partialMetadata: cloneRunMetadata(spec.PartialMetadata),
 		startedAt:       startedAt,
 		lastUpdatedAt:   lastUpdatedAt,
+		cancelRequested: spec.CancelRequested,
+		lastHeartbeatAt: spec.LastHeartbeatAt,
 	}, nil
 }
 
@@ -177,8 +221,10 @@ func (r *generationRun) PartialContent() string      { return r.partialContent }
 func (r *generationRun) PartialMetadata() map[string]any {
 	return cloneRunMetadata(r.partialMetadata)
 }
-func (r *generationRun) StartedAt() time.Time     { return r.startedAt }
-func (r *generationRun) LastUpdatedAt() time.Time { return r.lastUpdatedAt }
+func (r *generationRun) StartedAt() time.Time       { return r.startedAt }
+func (r *generationRun) LastUpdatedAt() time.Time   { return r.lastUpdatedAt }
+func (r *generationRun) CancelRequested() bool      { return r.cancelRequested }
+func (r *generationRun) LastHeartbeatAt() time.Time { return r.lastHeartbeatAt }
 
 func (r *generationRun) UpdateSnapshot(partialContent string, partialMetadata map[string]any, now time.Time) (GenerationRun, error) {
 	if r.status != GenerationRunStatusStreaming {
@@ -208,5 +254,44 @@ func (r *generationRun) Cancel(now time.Time) (GenerationRun, error) {
 	c := r.copy()
 	c.status = GenerationRunStatusCancelled
 	c.lastUpdatedAt = normalizeRunNow(now)
+	return c, nil
+}
+
+// Fail transitions a streaming run to the terminal failed status. Mirrors
+// Cancel's guard: only a live run can fail; double-failing is a no-op
+// transition error so callers don't accidentally clobber a completed run.
+func (r *generationRun) Fail(now time.Time) (GenerationRun, error) {
+	if r.status != GenerationRunStatusStreaming {
+		return nil, ErrInvalidGenerationRunTransition
+	}
+	c := r.copy()
+	c.status = GenerationRunStatusFailed
+	c.lastUpdatedAt = normalizeRunNow(now)
+	return c, nil
+}
+
+// RequestCancel sets the out-of-band cancel flag. The run stays in the
+// streaming state until the worker observes the flag and drives a Cancel
+// transition. Safe to call repeatedly; already-requested stays requested.
+func (r *generationRun) RequestCancel(now time.Time) (GenerationRun, error) {
+	if r.status != GenerationRunStatusStreaming {
+		return nil, ErrInvalidGenerationRunTransition
+	}
+	c := r.copy()
+	c.cancelRequested = true
+	c.lastUpdatedAt = normalizeRunNow(now)
+	return c, nil
+}
+
+// Heartbeat refreshes the liveness timestamps without touching the snapshot
+// or status. Only meaningful while streaming.
+func (r *generationRun) Heartbeat(now time.Time) (GenerationRun, error) {
+	if r.status != GenerationRunStatusStreaming {
+		return nil, ErrInvalidGenerationRunTransition
+	}
+	ts := normalizeRunNow(now)
+	c := r.copy()
+	c.lastHeartbeatAt = ts
+	c.lastUpdatedAt = ts
 	return c, nil
 }

--- a/pkg/bichat/domain/generation_run_test.go
+++ b/pkg/bichat/domain/generation_run_test.go
@@ -49,3 +49,86 @@ func TestGenerationRun_Transitions(t *testing.T) {
 	_, err = completed.Cancel(time.Now())
 	require.Error(t, err)
 }
+
+func TestGenerationRun_Fail_OnlyFromStreaming(t *testing.T) {
+	t.Parallel()
+
+	run, err := domain.NewGenerationRun(domain.GenerationRunSpec{
+		SessionID: uuid.New(),
+		TenantID:  uuid.New(),
+		UserID:    17,
+	})
+	require.NoError(t, err)
+
+	failed, err := run.Fail(time.Now())
+	require.NoError(t, err)
+	assert.Equal(t, domain.GenerationRunStatusFailed, failed.Status())
+
+	_, err = failed.Fail(time.Now())
+	require.Error(t, err, "double-failing must be rejected")
+
+	_, err = failed.Cancel(time.Now())
+	require.Error(t, err, "cancel on failed run must be rejected")
+}
+
+func TestGenerationRun_RequestCancel_StaysStreaming(t *testing.T) {
+	t.Parallel()
+
+	run, err := domain.NewGenerationRun(domain.GenerationRunSpec{
+		SessionID: uuid.New(),
+		TenantID:  uuid.New(),
+		UserID:    17,
+	})
+	require.NoError(t, err)
+	require.False(t, run.CancelRequested(), "new run must start without a cancel request")
+
+	requested, err := run.RequestCancel(time.Now())
+	require.NoError(t, err)
+	assert.True(t, requested.CancelRequested())
+	assert.Equal(t, domain.GenerationRunStatusStreaming, requested.Status(),
+		"RequestCancel must not change status; the worker drives Cancel")
+
+	// Request again: idempotent, no error.
+	again, err := requested.RequestCancel(time.Now())
+	require.NoError(t, err)
+	assert.True(t, again.CancelRequested())
+}
+
+func TestGenerationRun_Heartbeat_RefreshesTimestamp(t *testing.T) {
+	t.Parallel()
+
+	start := time.Now().Add(-time.Minute)
+	run, err := domain.NewGenerationRun(domain.GenerationRunSpec{
+		SessionID: uuid.New(),
+		TenantID:  uuid.New(),
+		UserID:    17,
+		StartedAt: start,
+	})
+	require.NoError(t, err)
+	assert.True(t, run.LastHeartbeatAt().IsZero(), "never-heartbeated runs must report a zero LastHeartbeatAt")
+
+	beat := time.Now()
+	beat1, err := run.Heartbeat(beat)
+	require.NoError(t, err)
+	assert.Equal(t, beat.UTC().Truncate(0), beat1.LastHeartbeatAt().UTC().Truncate(0))
+
+	// Heartbeat on a completed run is rejected.
+	completed, err := beat1.Complete(time.Now())
+	require.NoError(t, err)
+	_, err = completed.Heartbeat(time.Now())
+	require.Error(t, err)
+}
+
+func TestRehydrateGenerationRun_AcceptsFailedStatus(t *testing.T) {
+	t.Parallel()
+
+	run, err := domain.RehydrateGenerationRun(domain.GenerationRunSpec{
+		ID:        uuid.New(),
+		SessionID: uuid.New(),
+		TenantID:  uuid.New(),
+		UserID:    17,
+		Status:    domain.GenerationRunStatusFailed,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, domain.GenerationRunStatusFailed, run.Status())
+}

--- a/pkg/bichat/services/chat_service.go
+++ b/pkg/bichat/services/chat_service.go
@@ -188,6 +188,9 @@ type StreamChunk struct {
 	Snapshot *StreamSnapshot
 	// RunID is set when Type is ChunkTypeStreamStarted so the client can store it for resume.
 	RunID string
+	// TextBlockSeq identifies the assistant text segment ordinal that just ended
+	// (when Type is ChunkTypeTextBlockEnd). Zero-based within a single run.
+	TextBlockSeq int
 }
 
 // ChunkType represents the type of streaming chunk
@@ -207,6 +210,11 @@ const (
 	ChunkTypeSnapshot      ChunkType = "snapshot"
 	ChunkTypeStreamStarted ChunkType = "stream_started"
 	ChunkTypePing          ChunkType = "ping"
+	// ChunkTypeTextBlockEnd marks the boundary of an assistant text segment
+	// inside a turn that contains tool calls. The frontend uses it to render
+	// each text-then-tool sequence as a distinct block instead of merging
+	// every text delta into one paragraph.
+	ChunkTypeTextBlockEnd ChunkType = "text_block_end"
 )
 
 // ToolEvent represents a tool execution event in a streaming chunk.

--- a/pkg/bichat/services/chat_service.go
+++ b/pkg/bichat/services/chat_service.go
@@ -14,6 +14,12 @@ import (
 // ErrRunNotFoundOrFinished is returned by ResumeStream when the run is not active in this process.
 var ErrRunNotFoundOrFinished = errors.New("generation run not found or already finished")
 
+// ErrRunEventLogUnavailable is returned by TailRunEvents when the durable
+// event log is not configured (e.g. REDIS_URL unset in dev). Controllers
+// map this to 501 Not Implemented so clients know to fall back to the
+// legacy in-memory ResumeStream endpoint.
+var ErrRunEventLogUnavailable = errors.New("run event log unavailable")
+
 // SessionCommands manages mutating session actions.
 type SessionCommands interface {
 	CreateSession(ctx context.Context, tenantID uuid.UUID, userID int64, title string) (domain.Session, error)
@@ -81,6 +87,25 @@ type StreamCommands interface {
 	// ResumeStream attaches to an active run: delivers current snapshot then streams subsequent chunks.
 	// Returns ErrRunNotFoundOrFinished if the run is not active in this process.
 	ResumeStream(ctx context.Context, sessionID uuid.UUID, runID uuid.UUID, onChunk func(StreamChunk)) error
+
+	// TailRunEvents reads the durable per-run event log. Events with
+	// stream id > `from` are delivered in order; an empty `from` streams
+	// from the beginning. onEvent is invoked once per event and must be
+	// non-blocking; callers typically forward it as an SSE line. The
+	// call returns when a terminal event is observed, ctx is cancelled,
+	// or the event log TTL has expired. Returns ErrRunEventLogUnavailable
+	// when the backing Redis stream is not configured.
+	TailRunEvents(ctx context.Context, sessionID, runID uuid.UUID, from string, onEvent func(RunEventDelivery)) error
+}
+
+// RunEventDelivery is a single durable event delivered through TailRunEvents.
+// StreamID is the Redis stream id used as the SSE `id:` field for
+// Last-Event-ID reconnect. Payload is the JSON-encoded
+// httpdto.StreamChunkPayload ready to be written verbatim to the SSE body.
+type RunEventDelivery struct {
+	StreamID string
+	Type     string
+	Payload  []byte
 }
 
 // StreamStatus describes an active streaming run for a session.

--- a/pkg/bichat/services/chat_service.go
+++ b/pkg/bichat/services/chat_service.go
@@ -107,7 +107,7 @@ type StreamCommands interface {
 	// TailActiveRuns delivers the tenant's sidebar active-run view:
 	// first a snapshot of current runs, then live status deltas
 	// (streaming / completed / cancelled / failed / queued). Closes
-	// when ctx is cancelled. Returns ErrRunEventLogUnavailable when
+	// when ctx is cancelled. Returns ErrActiveRunIndexUnavailable when
 	// the active-run index is not configured.
 	//
 	// The tenant scope is resolved from context (composables.UseTenantID)

--- a/pkg/bichat/services/chat_service.go
+++ b/pkg/bichat/services/chat_service.go
@@ -15,10 +15,17 @@ import (
 var ErrRunNotFoundOrFinished = errors.New("generation run not found or already finished")
 
 // ErrRunEventLogUnavailable is returned by TailRunEvents when the durable
-// event log is not configured (e.g. REDIS_URL unset in dev). The stream
-// controller reports this via an SSE `error` event on an otherwise-200
+// per-run event log is not configured (e.g. REDIS_URL unset in dev). The
+// stream controller reports this via an SSE `error` event on an otherwise-200
 // stream so clients can display the condition without switching transports.
 var ErrRunEventLogUnavailable = errors.New("run event log unavailable")
+
+// ErrActiveRunIndexUnavailable is returned by TailActiveRuns when the
+// active-run index (per-tenant sidebar Redis hash) is not configured. Like
+// ErrRunEventLogUnavailable, the stream controller surfaces it as an SSE
+// `error` event rather than an HTTP error status so clients remain on the
+// same transport.
+var ErrActiveRunIndexUnavailable = errors.New("active run index unavailable")
 
 // SessionCommands manages mutating session actions.
 type SessionCommands interface {

--- a/pkg/bichat/services/chat_service.go
+++ b/pkg/bichat/services/chat_service.go
@@ -178,6 +178,13 @@ type SendMessageRequest struct {
 	ReasoningEffort *string
 	// Model overrides the default model for this request. Must match a registered model name.
 	Model *string
+	// RequestID is the client-supplied idempotency key. When set, two
+	// sends sharing a RequestID within the dedupe TTL window (~30 min)
+	// converge on the same run: one server-side run executes, both
+	// clients see the same stream. Nil means no dedupe — duplicate
+	// sends race normally and the session's active-run lock decides
+	// which wins. See RunJobQueue.ClaimRequest for the mechanism.
+	RequestID *uuid.UUID
 }
 
 // SendMessageResponse contains the result of sending a message

--- a/pkg/bichat/services/chat_service.go
+++ b/pkg/bichat/services/chat_service.go
@@ -15,9 +15,9 @@ import (
 var ErrRunNotFoundOrFinished = errors.New("generation run not found or already finished")
 
 // ErrRunEventLogUnavailable is returned by TailRunEvents when the durable
-// event log is not configured (e.g. REDIS_URL unset in dev). Controllers
-// map this to 501 Not Implemented so clients know to fall back to the
-// legacy in-memory ResumeStream endpoint.
+// event log is not configured (e.g. REDIS_URL unset in dev). The stream
+// controller reports this via an SSE `error` event on an otherwise-200
+// stream so clients can display the condition without switching transports.
 var ErrRunEventLogUnavailable = errors.New("run event log unavailable")
 
 // SessionCommands manages mutating session actions.
@@ -116,7 +116,7 @@ type StreamCommands interface {
 // pubsub deltas, so the client can render differently (one-shot vs
 // mutation).
 type ActiveRunDelivery struct {
-	Event     string    // "snapshot" | "update"
+	Event     string // "snapshot" | "update"
 	SessionID uuid.UUID
 	RunID     uuid.UUID
 	Status    string

--- a/pkg/bichat/services/chat_service.go
+++ b/pkg/bichat/services/chat_service.go
@@ -96,6 +96,31 @@ type StreamCommands interface {
 	// or the event log TTL has expired. Returns ErrRunEventLogUnavailable
 	// when the backing Redis stream is not configured.
 	TailRunEvents(ctx context.Context, sessionID, runID uuid.UUID, from string, onEvent func(RunEventDelivery)) error
+
+	// TailActiveRuns delivers the tenant's sidebar active-run view:
+	// first a snapshot of current runs, then live status deltas
+	// (streaming / completed / cancelled / failed / queued). Closes
+	// when ctx is cancelled. Returns ErrRunEventLogUnavailable when
+	// the active-run index is not configured.
+	//
+	// The tenant scope is resolved from context (composables.UseTenantID)
+	// so the transport layer doesn't need to pass it explicitly — the
+	// HTTP middleware has already authenticated the user and set the
+	// tenant header on the request ctx.
+	TailActiveRuns(ctx context.Context, onEvent func(ActiveRunDelivery)) error
+}
+
+// ActiveRunDelivery is a single sidebar update — either a snapshot row
+// on connect or a live delta afterwards. `Event` is "snapshot" for
+// rows delivered during initial HGETALL and "update" for subsequent
+// pubsub deltas, so the client can render differently (one-shot vs
+// mutation).
+type ActiveRunDelivery struct {
+	Event     string    // "snapshot" | "update"
+	SessionID uuid.UUID
+	RunID     uuid.UUID
+	Status    string
+	UpdatedAt int64 // UnixMilli for wire compactness
 }
 
 // RunEventDelivery is a single durable event delivered through TailRunEvents.

--- a/pkg/httpdto/stream_chunk_payload.go
+++ b/pkg/httpdto/stream_chunk_payload.go
@@ -36,6 +36,12 @@ type InterruptEventPayload struct {
 }
 
 // StreamSnapshotPayload is the partial state sent when resuming a stream.
+//
+// PartialMetadata may include a "text_block_offsets" key whose value is
+// []int. Each entry is a UTF-16 code unit count into PartialContent marking
+// the end of a completed assistant text segment (seq 0, seq 1, …). The
+// applet can use these with str.slice() directly — they are NOT Go byte
+// offsets.
 type StreamSnapshotPayload struct {
 	PartialContent  string         `json:"partialContent,omitempty"`
 	PartialMetadata map[string]any `json:"partialMetadata,omitempty"`

--- a/pkg/httpdto/stream_chunk_payload.go
+++ b/pkg/httpdto/stream_chunk_payload.go
@@ -53,4 +53,10 @@ type StreamChunkPayload struct {
 	Timestamp    int64                  `json:"timestamp,omitempty"`
 	Snapshot     *StreamSnapshotPayload `json:"snapshot,omitempty"`
 	RunID        string                 `json:"runId,omitempty"`
+	// TextBlockSeq is set when Type == "text_block_end". It is the zero-based
+	// ordinal of the assistant text segment that just ended within a single
+	// run, allowing clients to render text/tool/text/tool sequences as
+	// distinct blocks instead of one merged paragraph. Pointer so the JSON
+	// `0` value is preserved while remaining absent for unrelated chunks.
+	TextBlockSeq *int `json:"textBlockSeq,omitempty"`
 }

--- a/pkg/httpdto/stream_events.go
+++ b/pkg/httpdto/stream_events.go
@@ -1,0 +1,48 @@
+// Package httpdto provides wire DTO types shared between the backend and the
+// TypeScript applet.
+package httpdto
+
+// StreamEventType is the name of an SSE event the bichat stream emits.
+// These names are the source of truth for both the backend (which writes
+// them into the event-log + the SSE `event:` line) and the TS applet
+// (which registers EventSource listeners by these names).
+type StreamEventType string
+
+const (
+	StreamEventChunk         StreamEventType = "chunk"
+	StreamEventContent       StreamEventType = "content"
+	StreamEventThinking      StreamEventType = "thinking"
+	StreamEventToolStart     StreamEventType = "tool_start"
+	StreamEventToolEnd       StreamEventType = "tool_end"
+	StreamEventTextBlockEnd  StreamEventType = "text_block_end"
+	StreamEventSnapshot      StreamEventType = "snapshot"
+	StreamEventInterrupt     StreamEventType = "interrupt"
+	StreamEventCitation      StreamEventType = "citation"
+	StreamEventUsage         StreamEventType = "usage"
+	StreamEventPing          StreamEventType = "ping"
+	StreamEventStreamStarted StreamEventType = "stream_started"
+	StreamEventDone          StreamEventType = "done"
+	StreamEventCancelled     StreamEventType = "cancelled"
+	StreamEventError         StreamEventType = "error"
+	StreamEventFailed        StreamEventType = "failed"
+)
+
+// IsTerminal reports whether an event type ends the run. Tailing consumers
+// (both server-side and applet-side) MUST settle on any of these.
+func IsTerminal(t StreamEventType) bool {
+	switch t {
+	case StreamEventDone, StreamEventCancelled, StreamEventError, StreamEventFailed:
+		return true
+	}
+	return false
+}
+
+// AllStreamEventTypes enumerates every wire event name. Keep in sync with
+// the applet's utils/eventNames.ts (there is a drift-guard test there).
+var AllStreamEventTypes = []StreamEventType{
+	StreamEventChunk, StreamEventContent, StreamEventThinking,
+	StreamEventToolStart, StreamEventToolEnd, StreamEventTextBlockEnd,
+	StreamEventSnapshot, StreamEventInterrupt, StreamEventCitation,
+	StreamEventUsage, StreamEventPing, StreamEventStreamStarted,
+	StreamEventDone, StreamEventCancelled, StreamEventError, StreamEventFailed,
+}

--- a/pkg/httpdto/stream_events.go
+++ b/pkg/httpdto/stream_events.go
@@ -30,11 +30,12 @@ const (
 // IsTerminal reports whether an event type ends the run. Tailing consumers
 // (both server-side and applet-side) MUST settle on any of these.
 func IsTerminal(t StreamEventType) bool {
-	switch t {
+	switch t { //nolint:exhaustive // only terminal types need explicit cases; all non-terminal types return false via default
 	case StreamEventDone, StreamEventCancelled, StreamEventError, StreamEventFailed:
 		return true
+	default:
+		return false
 	}
-	return false
 }
 
 // allStreamEventTypes is the authoritative list of every wire event name.

--- a/pkg/httpdto/stream_events.go
+++ b/pkg/httpdto/stream_events.go
@@ -37,12 +37,20 @@ func IsTerminal(t StreamEventType) bool {
 	return false
 }
 
-// AllStreamEventTypes enumerates every wire event name. Keep in sync with
-// the applet's utils/eventNames.ts (there is a drift-guard test there).
-var AllStreamEventTypes = []StreamEventType{
+// allStreamEventTypes is the authoritative list of every wire event name.
+// Keep in sync with the applet's utils/eventNames.ts (there is a
+// drift-guard test there).
+var allStreamEventTypes = []StreamEventType{
 	StreamEventChunk, StreamEventContent, StreamEventThinking,
 	StreamEventToolStart, StreamEventToolEnd, StreamEventTextBlockEnd,
 	StreamEventSnapshot, StreamEventInterrupt, StreamEventCitation,
 	StreamEventUsage, StreamEventPing, StreamEventStreamStarted,
 	StreamEventDone, StreamEventCancelled, StreamEventError, StreamEventFailed,
+}
+
+// AllStreamEventTypes returns a defensive copy of every wire event name so
+// callers cannot mutate the authoritative list. Use slices.Clone when you
+// need to iterate in a mutation-prone context.
+func AllStreamEventTypes() []StreamEventType {
+	return append([]StreamEventType(nil), allStreamEventTypes...)
 }

--- a/pkg/httpdto/stream_events_test.go
+++ b/pkg/httpdto/stream_events_test.go
@@ -16,7 +16,7 @@ func TestIsTerminal(t *testing.T) {
 		httpdto.StreamEventFailed:    true,
 	}
 
-	for _, et := range httpdto.AllStreamEventTypes {
+	for _, et := range httpdto.AllStreamEventTypes() {
 		want := terminal[et]
 		got := httpdto.IsTerminal(et)
 		if got != want {
@@ -37,7 +37,7 @@ func TestIsTerminal_AllValuesAccountedFor(t *testing.T) {
 	}
 
 	all := make(map[httpdto.StreamEventType]bool)
-	for _, et := range httpdto.AllStreamEventTypes {
+	for _, et := range httpdto.AllStreamEventTypes() {
 		all[et] = true
 	}
 

--- a/pkg/httpdto/stream_events_test.go
+++ b/pkg/httpdto/stream_events_test.go
@@ -1,0 +1,49 @@
+package httpdto_test
+
+import (
+	"testing"
+
+	"github.com/iota-uz/iota-sdk/pkg/httpdto"
+)
+
+func TestIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	terminal := map[httpdto.StreamEventType]bool{
+		httpdto.StreamEventDone:      true,
+		httpdto.StreamEventCancelled: true,
+		httpdto.StreamEventError:     true,
+		httpdto.StreamEventFailed:    true,
+	}
+
+	for _, et := range httpdto.AllStreamEventTypes {
+		want := terminal[et]
+		got := httpdto.IsTerminal(et)
+		if got != want {
+			t.Errorf("IsTerminal(%q) = %v, want %v", et, got, want)
+		}
+	}
+}
+
+func TestIsTerminal_AllValuesAccountedFor(t *testing.T) {
+	t.Parallel()
+
+	// Every terminal event type must be in AllStreamEventTypes.
+	terminalTypes := []httpdto.StreamEventType{
+		httpdto.StreamEventDone,
+		httpdto.StreamEventCancelled,
+		httpdto.StreamEventError,
+		httpdto.StreamEventFailed,
+	}
+
+	all := make(map[httpdto.StreamEventType]bool)
+	for _, et := range httpdto.AllStreamEventTypes {
+		all[et] = true
+	}
+
+	for _, tt := range terminalTypes {
+		if !all[tt] {
+			t.Errorf("terminal event type %q missing from AllStreamEventTypes", tt)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Complete backend implementation of iota-uz/iota-sdk#732 — Redis-backed resilience layer for bichat generation runs. Ten commits land every primitive in the plan plus integration into the live streaming path; zero behaviour change when `REDIS_URL` is unset (dev/CI falls back to the pre-PR in-memory path).

### Commits

1. **M1 `text_block_end`** `f73a1579` — Executor emits a boundary marker before the first `tool_start` of an iteration, so the frontend renders text+tool+text sequences as distinct blocks instead of one merged paragraph. `TextBlockSeq` flows through `ChunkType` → `httpdto.StreamChunkPayload` → SSE.
2. **M2.1 `RunJobQueue`** `7d692cfe` — Redis stream `bichat:run:jobs` + `bichat:run:request:{request_id}` SetNX dedupe.
3. **M2.2 `RunEventLog`** `5a9ceb56` — Per-run Redis stream with `Append`/`Replay`/`Tail`/`DropAfterTerminal`.
4. **M2.3 state** `225af772` — `failed` status, `CancelRequested`, `LastHeartbeatAt` on domain + store + manager.
5. **Mirror wiring** `07e36a48` — `ActiveRun.SetMirror` + `stream_event_codec.go`; every broadcast chunk is dual-written into the event log.
6. **Cancel + heartbeat** `f4c05d66` — `runStreamLoop` refreshes heartbeat + polls cancel flag every snapshot tick; `StopGeneration` writes the persisted flag so cross-process stop works.
7. **M2.4 cursor reader** `6d8731f4` — `TailRunEvents` service method + `GET /bi-chat/stream/events` handler with `Last-Event-ID` support.
8. **M3 sidebar index** `eebd42f9` — `ActiveRunIndex` (per-tenant Redis hash + pubsub) + `TailActiveRuns` + `GET /bi-chat/stream/active-runs`. `PublishAndRemove` is atomic so late snapshots never see a stale streaming entry.
9. **M4 reaper + FIFO** `4a732c43` — `RunReaper` fails runs whose heartbeat has gone silent for > 60s (Lua CAS lock for single-writer across replicas); `RunSessionQueue` per-session FIFO primitive with MaxLen drop-oldest. Reaper boots in the `bichat-runtime` Hook alongside the title worker.
10. **M2.5 request_id dedupe** `5793eecc` — `ClaimRequest`/`ReleaseRequest` on `RunJobQueue` (SetNX without XADD); `SendMessageStream` claims at entry; duplicate sends converge on the same run via `ResumeStream` delegation.

### End-to-end resilience

| Scenario | Status |
| --- | --- |
| Intermediate text blocks between tool calls | ✅ backend ready — applet PR renders the blocks |
| Wifi drop / tab sleep → seamless reconnect with `Last-Event-ID` | ✅ `GET /stream/events` honours the header |
| Tab close + reopen on same device | ✅ `/stream/status` → open EventSource from cursor 0 |
| Phone → laptop transition | ✅ event log is shared; any replica can tail |
| Stop from any tab/device | ✅ `cancel_requested` flag; worker polls every 2s |
| Mirror events for cross-process consumers | ✅ via `ActiveRun.SetMirror` |
| Heartbeats written during streaming | ✅ every 2s on the snapshot tick |
| Worker crash mid-LLM → auto-fail via reaper | ✅ `RunReaper` sweeps every 15s, stale threshold 60s |
| Failed run → sidebar dot transitions + `error` event on log | ✅ `PublishAndRemove` + terminal `XADD` |
| Cross-tab/device send dedupe via `request_id` | ✅ `ClaimRequest` at the top of `SendMessageStream` |
| Sidebar status dot fan-out | ✅ `GET /stream/active-runs` SSE stream |
| Per-session FIFO primitive | ✅ `RunSessionQueue` shipped |

### Deferred (future PR)

- **Extracting `runStreamLoop` into an out-of-process `RunExecutor` + `RunJobWorker`.** The `RunJobQueue` is currently used only for its dedupe side (`ClaimRequest`); nothing XADDs to the job stream yet because execution stays in-process. When the extraction lands, the queue becomes the mechanism for surviving server restarts mid-run.
- **Per-session FIFO integration.** The `RunSessionQueue` primitive is built and tested but `SendMessageStream` does not yet push on `ErrActiveRunExists` nor drain on terminal. The integration is coupled with the worker extraction (need a headless executor to drain queued messages after the current run finishes) and lands with it.
- **Applet UI** (separate `iota-uz/applets` PR). Switch the React chat to native `EventSource` against `/stream/events`, generate a client-side `request_id`, render text blocks, consume `/stream/active-runs` for sidebar dots.

### Scope summary

**New files** (services + tests):
- `run_job_queue.go` + test — queue with dedupe primitives
- `run_event_log.go` + test — per-run Redis stream
- `tail_run_events_test.go` — service integration
- `active_run_index.go` + test — sidebar fan-out
- `run_reaper.go` + test — stale-run detection
- `run_session_queue.go` + test — per-session FIFO
- `stream_event_codec.go` + test — StreamChunk → JSON wire format

**Modified** (integration):
- `pkg/bichat/agents/executor.go` — text_block_end event
- `pkg/bichat/domain/generation_run.go` — failed/cancel/heartbeat
- `pkg/bichat/services/chat_service.go` — new interface methods + types
- `pkg/httpdto/stream_chunk_payload.go` — `TextBlockSeq`
- `modules/bichat/services/generation_run_store.go` — persisted fields + store methods
- `modules/bichat/services/streaming/run_state.go` — manager methods
- `modules/bichat/services/streaming/run_registry.go` — `SetMirror`, `TextBlockOffsets`
- `modules/bichat/services/chat_service_impl.go` — event log wiring, cancel poll, heartbeat, request_id dedupe, active-run publishes, `TailRunEvents`, `TailActiveRuns`
- `modules/bichat/presentation/controllers/stream_controller.go` — `GET /stream/events`, `GET /stream/active-runs`, `requestId` plumb
- `modules/bichat/component.go` — reaper boot hook
- `modules/bichat/config.go` — `NewRunReaper` factory

**Tests:** ~48 new test functions, all using `miniredis` — no Postgres / integration harness needed. CI-safe.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./pkg/bichat/agents/...` — text_block_end paths
- [x] `go test ./pkg/bichat/domain/...` — Fail/RequestCancel/Heartbeat
- [x] `go test ./pkg/bichat/... ./modules/bichat/services/streaming/ ./modules/bichat/presentation/controllers/` — zero failures across all non-Postgres packages
- [x] `go test -run 'RunJob|RunEvent|ActiveRun|TailRunEvents|Reaper|SessionQueue|Encode|ClaimRequest' ./modules/bichat/services/` — all 39 new service-layer tests pass
- [ ] ITF/Postgres tests: rerun locally against a restored DB (blocked on pre-existing PG15→17 data directory mismatch; not caused by this PR)
- [ ] Manual against staging once applet PR lands and eai bumps the SDK commit

## Review notes

- **Backward compatibility.** Every `newConfigured*` helper returns nil when `REDIS_URL` is unset. Mirror, index, event log, queue, reaper are all nil-safe and degrade to the pre-PR in-memory broadcaster path.
- **Wire contract.** Redis stores already-encoded `httpdto.StreamChunkPayload` JSON so `GET /stream/events` forwards payloads verbatim. No double-serialization on the hot path.
- **Single-writer discipline.** `UpdateRunSnapshot`/`Heartbeat` assume one writer per session (the owning `runStreamLoop`); `RequestCancel` is called only from `StopGeneration` and `PublishAndRemove` is atomic via `TxPipeline`. The reaper holds a Lua CAS lock so replicas don't double-reap.
- **Error propagation.** Every Redis side-effect in the hot path swallows errors (logged via serrors) so a Redis blip cannot abort an in-flight agent stream. The reaper + session primitives return typed errors so tests can assert failure modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new streaming endpoints for tailing run events and active-run status updates.
  * Introduced automatic detection and recovery of stale generation runs via periodic monitoring.
  * Enabled request-level idempotency for message submissions.
  * Added text-block segmentation markers to streaming responses for improved client-side rendering.

* **Bug Fixes**
  * Improved cross-process run cancellation and heartbeat tracking for better state consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->