### PR TITLE
feat(itf): add WithCapabilities option to control composition compile

### DIFF
--- a/pkg/itf/builder.go
+++ b/pkg/itf/builder.go
@@ -13,10 +13,11 @@ import (
 
 // SuiteBuilder provides a fluent API for building test suites with minimal boilerplate
 type SuiteBuilder struct {
-	t          testing.TB
-	components []composition.Component
-	user       user.User
-	dbName     string
+	t            testing.TB
+	components   []composition.Component
+	capabilities []composition.Capability
+	user         user.User
+	dbName       string
 }
 
 // NewSuiteBuilder creates a new SuiteBuilder for HTTP controller testing
@@ -30,6 +31,18 @@ func NewSuiteBuilder(tb testing.TB) *SuiteBuilder {
 // WithComponents adds composition components to the test suite.
 func (sb *SuiteBuilder) WithComponents(components ...composition.Component) *SuiteBuilder {
 	sb.components = append(sb.components, components...)
+	return sb
+}
+
+// WithCapabilities sets the composition capabilities used when compiling the
+// suite container. When unset (the default), Build / BuildWithOptions compile
+// with [CapabilityAPI, CapabilityWorker] — preserving the historical
+// behaviour. Pass a narrower set (for example, just composition.CapabilityAPI)
+// to verify that worker-only contributions stay inactive — useful for testing
+// CLI / API-only compositions that must not materialize NATS consumers,
+// periodic-task managers, file-locked indices, etc.
+func (sb *SuiteBuilder) WithCapabilities(caps ...composition.Capability) *SuiteBuilder {
+	sb.capabilities = append(sb.capabilities[:0], caps...)
 	return sb
 }
 
@@ -91,6 +104,13 @@ func (sb *SuiteBuilder) AsAnonymous() *SuiteBuilder {
 func (sb *SuiteBuilder) Build() *Suite {
 	sb.t.Helper()
 
+	// When capabilities are explicitly set, route through BuildWithOptions to
+	// pass them down via the Option pipeline. Otherwise fall back to the
+	// original NewSuite path for full backward compatibility.
+	if len(sb.capabilities) > 0 {
+		return sb.BuildWithOptions()
+	}
+
 	// Create the base suite with modules
 	suite := NewSuite(sb.t, sb.components...)
 
@@ -107,9 +127,12 @@ func (sb *SuiteBuilder) BuildWithOptions(opts ...Option) *Suite {
 	sb.t.Helper()
 
 	// Build options array
-	options := make([]Option, 0, len(opts)+2)
+	options := make([]Option, 0, len(opts)+4)
 	if len(sb.components) > 0 {
 		options = append(options, WithComponents(sb.components...))
+	}
+	if len(sb.capabilities) > 0 {
+		options = append(options, WithCapabilities(sb.capabilities...))
 	}
 	if sb.user != nil {
 		options = append(options, WithUser(sb.user))

--- a/pkg/itf/context.go
+++ b/pkg/itf/context.go
@@ -20,14 +20,15 @@ type controllerCloser interface {
 
 // TestContext provides a fluent API for building test contexts
 type TestContext struct {
-	ctx        context.Context
-	pool       *pgxpool.Pool
-	tx         pgx.Tx
-	app        application.Application
-	tenant     *composables.Tenant
-	user       user.User
-	components []composition.Component
-	dbName     string
+	ctx          context.Context
+	pool         *pgxpool.Pool
+	tx           pgx.Tx
+	app          application.Application
+	tenant       *composables.Tenant
+	user         user.User
+	components   []composition.Component
+	capabilities []composition.Capability
+	dbName       string
 }
 
 // newTestContext creates a new internal TestContext builder.
@@ -71,8 +72,9 @@ func (tc *TestContext) Build(tb testing.TB) *TestEnvironment {
 		tc.dbName = tb.Name() + "_" + uniqueSuffix
 	}
 	h := NewHarness(tb, HarnessConfig{
-		Name:       tc.dbName,
-		Components: tc.components,
+		Name:         tc.dbName,
+		Components:   tc.components,
+		Capabilities: tc.capabilities,
 		Database: DatabaseConfig{
 			Provisioning: ProvisioningPerTestDatabase,
 			Cleanup:      CleanupDropOnExit,

--- a/pkg/itf/harness.go
+++ b/pkg/itf/harness.go
@@ -119,11 +119,19 @@ type ContextConfig struct {
 type HarnessConfig struct {
 	Name       string
 	Components []composition.Component
-	Database   DatabaseConfig
-	Migration  MigrationConfig
-	Isolation  IsolationConfig
-	Seed       SeedConfig
-	Context    ContextConfig
+	// Capabilities controls which composition capabilities are active when
+	// the harness compiles its container. Empty defaults to the historical
+	// behaviour of [CapabilityAPI, CapabilityWorker]. Set to a narrower
+	// subset (e.g. just CapabilityAPI) to test capability gating — useful
+	// for verifying that worker-only contributions (NATS consumers,
+	// periodic-task managers, file-locked indices, etc.) stay inactive in
+	// API-only contexts.
+	Capabilities []composition.Capability
+	Database     DatabaseConfig
+	Migration    MigrationConfig
+	Isolation    IsolationConfig
+	Seed         SeedConfig
+	Context      ContextConfig
 }
 
 type Scope struct {
@@ -437,7 +445,7 @@ func createHarnessState(key string, cfg HarnessConfig, isPerTest bool) (*harness
 		return nil, serrors.E(opCreatePool, err, "create pool")
 	}
 
-	app, container, err := SetupApplication(pool, cfg.Components)
+	app, container, err := SetupApplication(pool, cfg.Components, cfg.Capabilities...)
 	if err != nil {
 		pool.Close()
 		_ = DropDBE(dbName)

--- a/pkg/itf/itf.go
+++ b/pkg/itf/itf.go
@@ -92,6 +92,18 @@ func WithUser(u user.User) Option {
 	}
 }
 
+// WithCapabilities sets the composition capabilities used when compiling the
+// test container. When unset (the default) the harness compiles with the
+// historical [CapabilityAPI, CapabilityWorker] pair. Pass a narrower subset
+// to verify capability gating — for example, compile with CapabilityAPI only
+// to assert that worker-only contributions (NATS consumers, periodic tasks,
+// file-locked indices, etc.) stay inactive in API/CLI contexts.
+func WithCapabilities(caps ...composition.Capability) Option {
+	return func(tc *TestContext) {
+		tc.capabilities = append(tc.capabilities[:0], caps...)
+	}
+}
+
 // applyOptions applies all options to the test context
 func (tc *TestContext) applyOptions(opts ...Option) *TestContext {
 	for _, opt := range opts {

--- a/pkg/itf/utils.go
+++ b/pkg/itf/utils.go
@@ -379,10 +379,25 @@ func DBOpts(name string) string {
 	)
 }
 
+// SetupApplication wires a test application + composition container against
+// `pool` using the provided components.
+//
+// `capabilities` controls which capability set is passed to `engine.Compile`.
+// When empty (the default for backward compatibility), it expands to
+// `[CapabilityAPI, CapabilityWorker]` — same behaviour as before this option
+// was added. Pass an explicit, narrower set (for example, just
+// `composition.CapabilityAPI`) to verify that worker-only contributions stay
+// inactive in API-only contexts. This is the same shape the EAI CLI uses to
+// avoid materializing NATS subscribers, periodic tasks, MSSQL pools, and
+// Bleve file-locks at compile time.
 func SetupApplication(
 	pool *pgxpool.Pool,
 	components []composition.Component,
+	capabilities ...composition.Capability,
 ) (application.Application, *composition.Container, error) {
+	if len(capabilities) == 0 {
+		capabilities = []composition.Capability{composition.CapabilityAPI, composition.CapabilityWorker}
+	}
 	conf := configuration.Use()
 	bundle := application.LoadBundle()
 	app, err := application.New(&application.ApplicationOptions{
@@ -403,8 +418,7 @@ func SetupApplication(
 		}
 		container, err = engine.Compile(
 			composition.NewBuildContext(app, conf),
-			composition.CapabilityAPI,
-			composition.CapabilityWorker,
+			capabilities...,
 		)
 		if err != nil {
 			return nil, nil, serrors.E(serrors.Op("itf.SetupApplication"), err, "compile components")


### PR DESCRIPTION
## Summary

Adds an opt-in \`WithCapabilities(...)\` knob across \`itf.SetupApplication\`, \`itf.HarnessConfig\`, the \`itf.Option\` system, and \`SuiteBuilder\`. Lets test authors compile the test container with a narrower set than the historical \`[CapabilityAPI, CapabilityWorker]\` pair — for example just \`composition.CapabilityAPI\` to verify worker-only contributions stay inactive.

## Why

Worker-only contributions registered at composition Build time (NATS subscribers, periodic task manager wiring, file-locked Bleve indices, MSSQL pools dialed via \`db.Ping\`) are a real source of CLI hangs and resource leaks downstream. EAI's \`fix/cli-jetbus-hang\` PR ([eai#2416](https://github.com/iota-uz/eai/pull/2416)) introduced per-module \`HasCapability(CapabilityWorker)\` guards to fix this, but couldn't add a behavioural ITF test (compile with API only → assert hook list shrinks) because \`SetupApplication\`/\`HarnessConfig\` hard-coded both capabilities. This change unblocks that test.

## Changes

- \`pkg/itf/utils.go\` — \`SetupApplication\` accepts variadic \`...composition.Capability\`. Empty defaults to \`[CapabilityAPI, CapabilityWorker]\` (historical behaviour).
- \`pkg/itf/harness.go\` — new \`Capabilities []composition.Capability\` field on \`HarnessConfig\`. Piped to \`SetupApplication\`.
- \`pkg/itf/itf.go\` — new \`WithCapabilities(...)\` \`Option\` (works with \`Setup(...)\` and \`SuiteBuilder.BuildWithOptions(...)\`).
- \`pkg/itf/builder.go\` — fluent \`SuiteBuilder.WithCapabilities(...)\` method. \`Build()\` routes to \`BuildWithOptions\` when capabilities are explicitly set so the option pipeline is honoured.
- \`pkg/itf/context.go\` — internal \`TestContext\` carries the capability set through to \`HarnessConfig\`.

## Backward compatibility

All existing call sites continue to see \`[CapabilityAPI, CapabilityWorker]\`. The new field on \`HarnessConfig\` defaults to nil, the variadic on \`SetupApplication\` defaults to empty, and \`SuiteBuilder.Build()\` only routes through the new path when callers opt in via \`WithCapabilities(...)\`.

## Test plan

- [x] \`go vet ./pkg/itf/...\` clean.
- [x] \`go test ./pkg/itf/...\` passes.
- [ ] Downstream EAI behavioural test will land in a follow-up commit on [eai#2416](https://github.com/iota-uz/eai/pull/2416) once this PR is merged and the SDK pin bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Test harnesses now support configurable capability selection. Developers can specify which capabilities activate during test environment setup via new configuration options. Default behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->