### PR TITLE
fix(core/upload): nil-safe Mimetype in ToDBUpload mapper

### DIFF
--- a/modules/core/infrastructure/persistence/core_mappers.go
+++ b/modules/core/infrastructure/persistence/core_mappers.go
@@ -237,6 +237,10 @@ func ToDomainTin(s sql.NullString, c country.Country) (tax.Tin, error) {
 }
 
 func ToDBUpload(upload upload.Upload) *models.Upload {
+	mimetypeStr := ""
+	if mime := upload.Mimetype(); mime != nil {
+		mimetypeStr = mime.String()
+	}
 	model := &models.Upload{
 		ID:        upload.ID(),
 		TenantID:  upload.TenantID().String(),
@@ -246,7 +250,7 @@ func ToDBUpload(upload upload.Upload) *models.Upload {
 		Name:      upload.Name(),
 		Size:      upload.Size().Bytes(),
 		Type:      upload.Type().String(),
-		Mimetype:  upload.Mimetype().String(),
+		Mimetype:  mimetypeStr,
 		CreatedAt: upload.CreatedAt(),
 		UpdatedAt: upload.UpdatedAt(),
 		GeoPoint:  &models.Point{X: 0, Y: 0},


### PR DESCRIPTION
## Summary
- `ToDomainUpload` returns a domain upload with nil `Mimetype` when the DB column is empty (core_mappers.go:264-268).
- A subsequent round-trip through `ToDBUpload` panicked at line 249 on `upload.Mimetype().String()` — nil pointer dereference.
- Guard the nil pointer and serialize it as an empty string.

## Repro
Triggered from EAI: https://erp.eai.uz/p/{uuid}/view?custom after its slug-cache short-circuit was removed (iota-uz/eai#2422). With cache removed, `UploadService.Create` hits the update/swap branches (`upload_service.go:92`, `:94`, `:109`) on pre-existing uploads. An upload row with empty `mimetype` crashed the handler.

## Test plan
- [ ] Run the EAI travel policy PDF download flow on staging and verify no panic + fresh PDF returned.
- [ ] Unit-cover `ToDBUpload` with nil-mimetype input (can follow up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of upload handling when MIME type information is unavailable, preventing potential errors and ensuring proper storage of upload metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->