### PR TITLE
fix(billing): bump click for decimal-preserving sign validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/gotd/td v0.115.0
 	github.com/henomis/langfuse-go v0.0.3
 	github.com/iota-uz/applets v0.4.28
-	github.com/iota-uz/click v1.0.4
+	github.com/iota-uz/click v1.0.5-0.20260429080350-2c5e7aa8f4f1
 	github.com/iota-uz/eskiz v0.0.0-20250711174003-e4a8dcdb7049
 	github.com/iota-uz/go-i18n/v2 v2.6.1
 	github.com/iota-uz/icons v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -289,8 +289,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/iota-uz/applets v0.4.28 h1:CzebwpCIGOaWRvNkDj8ok+tr9xzoTAVvxTaY5GVr9Zo=
 github.com/iota-uz/applets v0.4.28/go.mod h1:PnaI9UI+C+cnx9HaV8kTMzozO7h+ycBvQUn1hFHIARY=
-github.com/iota-uz/click v1.0.4 h1:XOiUWByPWpCEbGnuEV2kyOrf2UuXUYFqbXnBOjwOn6M=
-github.com/iota-uz/click v1.0.4/go.mod h1:WamcxWiFXli4WMWiPQgeNHX/hU4Ac/Xmx1N1ok6vbkQ=
+github.com/iota-uz/click v1.0.5-0.20260429080350-2c5e7aa8f4f1 h1:qPK5fiPjBIiZsYP0ti/SQyXeaNeI0LQDJEr6Qzo+4AA=
+github.com/iota-uz/click v1.0.5-0.20260429080350-2c5e7aa8f4f1/go.mod h1:WamcxWiFXli4WMWiPQgeNHX/hU4Ac/Xmx1N1ok6vbkQ=
 github.com/iota-uz/eskiz v0.0.0-20250711174003-e4a8dcdb7049 h1:rcV6DDYg68P/PAn1oshQGHQsFoZcRquMeN8+OvHshyQ=
 github.com/iota-uz/eskiz v0.0.0-20250711174003-e4a8dcdb7049/go.mod h1:AQhBUxkNnq/mVuJQY+WTt1KfHaM/UoRV4m1sFxadUr0=
 github.com/iota-uz/go-i18n/v2 v2.6.1 h1:TqeZQAjlc7jSOuCgvulH9HvNXjeaKrbEXxXicx9Sfv8=


### PR DESCRIPTION
## Summary
- Bump `github.com/iota-uz/click` to a commit that uses `%.2f` (instead of `%.0f`) when reconstructing the md5 sign string for Prepare/Complete callbacks.

## Why
With `%.0f`, any payment whose amount has kopecks (e.g. `33139.73`) was hashed as `33140` on our side while Click signs the literal `33139.73`. Every fractional-amount callback failed with `Invalid signature` and the policy was never moved to Pending. The pay URL we generate already uses `%.2f`, so this restores symmetry.

## Linked
- iota-uz/click#1

## Test plan
- [x] `go vet ./modules/billing/...`
- [x] `go test ./modules/billing/presentation/controllers/...`
- [ ] Smoke-test a real Click `/prepare` callback with a fractional amount once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)