### PR TITLE
fix(billing): bump click to accept integer amount strings in sign validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/gotd/td v0.115.0
 	github.com/henomis/langfuse-go v0.0.3
 	github.com/iota-uz/applets v0.4.30
-	github.com/iota-uz/click v1.0.5-0.20260429082959-aba6c3284bf9
+	github.com/iota-uz/click v1.0.5-0.20260429132149-cf24863b0f7e
 	github.com/iota-uz/eskiz v0.0.0-20250711174003-e4a8dcdb7049
 	github.com/iota-uz/go-i18n/v2 v2.6.1
 	github.com/iota-uz/icons v0.0.3

--- a/go.sum
+++ b/go.sum
@@ -295,6 +295,8 @@ github.com/iota-uz/click v1.0.5-0.20260429080350-2c5e7aa8f4f1 h1:qPK5fiPjBIiZsYP
 github.com/iota-uz/click v1.0.5-0.20260429080350-2c5e7aa8f4f1/go.mod h1:WamcxWiFXli4WMWiPQgeNHX/hU4Ac/Xmx1N1ok6vbkQ=
 github.com/iota-uz/click v1.0.5-0.20260429082959-aba6c3284bf9 h1:+SmxU7RJaP5XpL37PD5Ktu9fyQwgY+64Bv1cimCsVAg=
 github.com/iota-uz/click v1.0.5-0.20260429082959-aba6c3284bf9/go.mod h1:WamcxWiFXli4WMWiPQgeNHX/hU4Ac/Xmx1N1ok6vbkQ=
+github.com/iota-uz/click v1.0.5-0.20260429132149-cf24863b0f7e h1:837CEXuzIT0a2l7Ll55Lyau6k4S1i+xIXy8lOfGakPU=
+github.com/iota-uz/click v1.0.5-0.20260429132149-cf24863b0f7e/go.mod h1:WamcxWiFXli4WMWiPQgeNHX/hU4Ac/Xmx1N1ok6vbkQ=
 github.com/iota-uz/eskiz v0.0.0-20250711174003-e4a8dcdb7049 h1:rcV6DDYg68P/PAn1oshQGHQsFoZcRquMeN8+OvHshyQ=
 github.com/iota-uz/eskiz v0.0.0-20250711174003-e4a8dcdb7049/go.mod h1:AQhBUxkNnq/mVuJQY+WTt1KfHaM/UoRV4m1sFxadUr0=
 github.com/iota-uz/go-i18n/v2 v2.6.1 h1:TqeZQAjlc7jSOuCgvulH9HvNXjeaKrbEXxXicx9Sfv8=


### PR DESCRIPTION
## Summary

- Bump `github.com/iota-uz/click` to pick up [iota-uz/click#2](https://github.com/iota-uz/click/pull/2).
- The validator now accepts both `38400` and `38400.00` (and other reasonable representations) for the `amount` segment of `sign_string`.

## Why

After #762 the click validator always reformatted the amount as `%.2f`. Legacy merchant URLs that hit Click as `amount=38400` (integer, no decimals) started failing in production with:

```
POST /billing/click/prepare  click_trans_id=3647911201&service_id=73438&...&amount=38400&action=0&sign_time=2026-04-29+18%3A02%3A18&error=0&error_note=Success&sign_string=10ad9d868217e201f48bd29c727c7c7f Invalid signature
```

`iota-uz/click#2` validates the signature against several amount string candidates and returns true if any match — restores the integer-amount flow without breaking the kopeck-preserving one.

## Test plan

- [x] `go vet ./modules/billing/...`
- [x] `go test ./modules/billing/presentation/controllers/...` — pass
- [ ] After merge: bump in `iota-uz/eai`, then retry a stuck Click `prepare`/`complete` callback in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)