### PR TITLE
feat(upload-input): support drag-and-drop on the dropzone

### DIFF
--- a/components/upload_input.templ
+++ b/components/upload_input.templ
@@ -115,10 +115,30 @@ templ UploadTarget(p *UploadInputProps) {
 	<div class="w-full space-y-2">
 		for i, upload := range p.Uploads {
 			{{ rowID := fmt.Sprintf("uploaded-file-%s-%d", p.ID, i) }}
+			{{ name := uploadDisplayName(upload) }}
+			{{ previewURL := strings.TrimSpace(upload.URL) }}
 			<div id={ rowID } class="rounded-md border border-primary bg-surface-100 p-2">
 				<div class="flex items-start justify-between gap-3">
 					<div class="min-w-0">
-						<div class="truncate text-xs font-medium text-100">{ uploadDisplayName(upload) }</div>
+						if previewURL != "" {
+							// Open the uploaded file in a new tab so the user
+							// can verify what was actually attached. rel=noopener+
+							// noreferrer is required whenever target=_blank
+							// crosses an origin boundary.
+							<a
+								href={ templ.SafeURL(previewURL) }
+								target="_blank"
+								rel="noopener noreferrer"
+								class="block truncate text-xs font-medium text-primary hover:underline"
+								title={ name }
+							>
+								{ name }
+							</a>
+						} else {
+							<div class="truncate text-xs font-medium text-100" title={ name }>
+								{ name }
+							</div>
+						}
 						<div class="truncate text-[11px] text-text-300">{ uploadDisplayMeta(upload) }</div>
 					</div>
 					<button
@@ -131,8 +151,10 @@ templ UploadTarget(p *UploadInputProps) {
 						@icons.X(icons.Props{Size: "14"})
 					</button>
 				</div>
-				if upload.URL != "" && strings.HasPrefix(strings.ToLower(strings.TrimSpace(upload.Mimetype)), "image/") {
-					<img class="mt-2 h-16 w-16 rounded-md object-contain" src={ upload.URL } alt={ uploadDisplayName(upload) }/>
+				if previewURL != "" && strings.HasPrefix(strings.ToLower(strings.TrimSpace(upload.Mimetype)), "image/") {
+					<a href={ templ.SafeURL(previewURL) } target="_blank" rel="noopener noreferrer">
+						<img class="mt-2 h-16 w-16 rounded-md object-contain" src={ previewURL } alt={ name }/>
+					</a>
 				}
 				if p.Form != "" {
 					<input type="hidden" name={ p.Name } value={ upload.ID } form={ p.Form }/>
@@ -386,6 +408,13 @@ script removeUploadedFile(rowID string) {
 func uploadDisplayName(upload *viewmodels.Upload) string {
 	if upload == nil {
 		return "Uploaded file"
+	}
+	// Prefer the original filename (Name) so the user sees "scan.pdf"
+	// instead of the storage hash. Slug is a filesystem-safe identifier
+	// that defaults to the hash when no name was provided, so it is a
+	// fallback rather than a primary display.
+	if value := strings.TrimSpace(upload.Name); value != "" {
+		return value
 	}
 	if value := strings.TrimSpace(upload.Slug); value != "" {
 		return value

--- a/components/upload_input.templ
+++ b/components/upload_input.templ
@@ -70,7 +70,10 @@ templ UploadTarget(p *UploadInputProps) {
 }
 
 templ (p *UploadInputProps) render() {
-	<div class={ "border border-gray-400 border-dashed rounded-md p-4 flex flex-col items-center", p.Class }>
+	<div
+		class={ "border border-gray-400 border-dashed rounded-md p-4 flex flex-col items-center transition-colors", p.Class }
+		{ uploadDropAttrs(p.ID)... }
+	>
 		<div class="flex flex-col items-center">
 			<div id={ fmt.Sprintf("upload-form-%s", p.ID) }>
 				<input
@@ -116,6 +119,29 @@ templ (p *UploadInputProps) render() {
 			}
 		</div>
 	</div>
+}
+
+// uploadDropAttrs builds the dragover/dragenter/dragleave/drop handlers that
+// route a dropped FileList into the hidden <input type=file> and dispatch
+// `change` so the existing HTMX hx-trigger="change" picks the upload up.
+// The DataTransfer fallback covers older WebKit builds where input.files is
+// read-only.
+func uploadDropAttrs(id string) templ.Attributes {
+	drop := fmt.Sprintf(
+		`event.preventDefault(); event.stopPropagation(); this.classList.remove('border-primary');`+
+			` var inp=document.getElementById(%q);`+
+			` if(!inp||!event.dataTransfer||!event.dataTransfer.files||!event.dataTransfer.files.length){return;}`+
+			` try{inp.files=event.dataTransfer.files;}`+
+			` catch(e){var dt=new DataTransfer(); for(var i=0;i<event.dataTransfer.files.length;i++){dt.items.add(event.dataTransfer.files[i]);} inp.files=dt.files;}`+
+			` inp.dispatchEvent(new Event('change',{bubbles:true}));`,
+		id,
+	)
+	return templ.Attributes{
+		"ondragover":  "event.preventDefault(); event.stopPropagation();",
+		"ondragenter": "event.preventDefault(); event.stopPropagation(); this.classList.add('border-primary');",
+		"ondragleave": "if(event.target===this){this.classList.remove('border-primary');}",
+		"ondrop":      drop,
+	}
 }
 
 // UploadInput renders a file upload input with preview capability.

--- a/components/upload_input.templ
+++ b/components/upload_input.templ
@@ -105,6 +105,7 @@ templ (p *UploadInputProps) render() {
 					name="file"
 					multiple?={ p.Multiple }
 					hx-on::after-request="this.value = ''"
+					{ uploadErrorAttrs(p.ID)... }
 				/>
 			</div>
 			<div id={ fmt.Sprintf("target-%s", p.ID) }>
@@ -126,6 +127,14 @@ templ (p *UploadInputProps) render() {
 			<p class="text-xs">
 				{ p.Placeholder }
 			</p>
+			// Inline error slot populated by the response-error / send-error
+			// handlers above. Hidden until a request fails.
+			<p
+				id={ fmt.Sprintf("error-%s", p.ID) }
+				class="text-red-500 text-xs mt-2 hidden"
+				role="alert"
+				aria-live="polite"
+			></p>
 			if p.Error != "" {
 				<p class="text-red-500 text-xs mt-2">
 					{ p.Error }
@@ -133,6 +142,34 @@ templ (p *UploadInputProps) render() {
 			}
 		</div>
 	</div>
+}
+
+// uploadErrorAttrs builds the HTMX failure-event handlers for the hidden file
+// input. On a server error (4xx/5xx) it surfaces the response body; on a
+// pre-flight failure (network/CORS/offline) it shows a generic retry message.
+// Both render an inline error inside the dropzone and dispatch a `notify`
+// toast event so users actually see what went wrong instead of the spinner
+// silently disappearing. `hx-on::before-request` clears any prior error so a
+// fresh upload starts clean.
+func uploadErrorAttrs(id string) templ.Attributes {
+	clearSlot := fmt.Sprintf(
+		`var slot = document.getElementById('error-%s'); if (slot) { slot.textContent = ''; slot.classList.add('hidden'); }`,
+		id,
+	)
+	render := func(read string) string {
+		return fmt.Sprintf(
+			`%s var slot = document.getElementById('error-%s'); if (slot) { slot.textContent = msg; slot.classList.remove('hidden'); }`+
+				` window.dispatchEvent(new CustomEvent('notify', {detail: {variant: 'error', message: msg}}));`,
+			read, id,
+		)
+	}
+	respErr := render(`var msg = (event.detail && event.detail.xhr && event.detail.xhr.responseText) ? event.detail.xhr.responseText : ''; if (!msg) { msg = 'Upload failed'; } if (msg.length > 200) { msg = msg.slice(0, 200) + '…'; }`)
+	netErr := render(`var msg = 'Network error — please retry';`)
+	return templ.Attributes{
+		"hx-on::before-request":  clearSlot,
+		"hx-on::response-error":  respErr,
+		"hx-on::send-error":      netErr,
+	}
 }
 
 // uploadDropAttrs builds the dragover/dragenter/dragleave/drop handlers that

--- a/components/upload_input.templ
+++ b/components/upload_input.templ
@@ -146,7 +146,7 @@ func uploadDropAttrs(id string) templ.Attributes {
 			` var inp=document.getElementById(%q);`+
 			` if(!inp||!event.dataTransfer||!event.dataTransfer.files||!event.dataTransfer.files.length){return;}`+
 			` try{inp.files=event.dataTransfer.files;}`+
-			` catch(e){var dt=new DataTransfer(); for(var i=0;i<event.dataTransfer.files.length;i++){dt.items.add(event.dataTransfer.files[i]);} inp.files=dt.files;}`+
+			` catch(e){if(typeof DataTransfer==='function'){var dt=new DataTransfer(); for(var i=0;i<event.dataTransfer.files.length;i++){dt.items.add(event.dataTransfer.files[i]);} inp.files=dt.files;}}`+
 			` inp.dispatchEvent(new Event('change',{bubbles:true}));`,
 		id,
 	)

--- a/components/upload_input.templ
+++ b/components/upload_input.templ
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -13,40 +14,36 @@ import (
 )
 
 // UploadInputProps defines the properties for the UploadInput component.
-// It provides configuration options for the file upload interface.
 type UploadInputProps struct {
-	ID          string               // Unique identifier for the input
-	Label       string               // Text label for the upload button
-	Placeholder string               // Placeholder text shown below the button
-	Uploads     []*viewmodels.Upload // List of already uploaded files
-	Error       string               // Error message to display
-	Accept      string               // File types to accept (e.g., "image/*")
-	Name        string               // Name attribute for the form field
-	Form        string               // ID of the form this input belongs to
-	Class       string               // Additional CSS classes
-	Multiple    bool                 // Whether multiple file uploads are allowed
+	ID          string
+	Label       string
+	Placeholder string
+	Uploads     []*viewmodels.Upload
+	Error       string
+	Accept      string
+	Name        string
+	Form        string
+	Class       string
+	Multiple    bool
 
-	// MaxSize is the per-file size limit in bytes enforced client-side before
-	// upload. 0 means no client-side limit (server may still reject).
+	// MaxSize is the per-file size limit in bytes enforced client-side
+	// before upload. 0 = no client-side limit (server may still reject).
 	MaxSize int64
 
-	// Labels override default English copy used in async error feedback. Each
-	// field is optional; empty values fall back to a built-in default.
+	// Labels override default English copy for async error feedback. Use
+	// {name}, {size}, {limit} placeholders in TypeRejected/SizeRejected;
+	// they are replaced with the rejected file's name and megabyte values.
 	Labels UploadInputLabels
 }
 
-// UploadInputLabels holds the user-facing strings rendered by the component
-// at runtime. Use {name}, {size} and {limit} placeholders in messages where
-// applicable — they are replaced with the rejected file's name, megabyte
-// size and configured limit respectively.
 type UploadInputLabels struct {
-	GenericError    string // generic 4xx/5xx fallback, default "Upload failed"
-	NetworkError    string // pre-flight failure, default "Network error — please retry"
-	TypeRejected    string // unsupported extension, default `File "{name}" — unsupported format`
-	SizeRejected    string // oversized file, default `File "{name}" is too large ({size}MB > {limit}MB)`
-	TooLargeStatus  string // 413 fallback, default "File too large"
-	UnsupportedType string // 415 fallback, default "Unsupported file type"
-	ServerError     string // 5xx fallback, default "Server error — please retry later"
+	GenericError    string `json:"genericError"`
+	NetworkError    string `json:"networkError"`
+	TypeRejected    string `json:"typeRejected"`
+	SizeRejected    string `json:"sizeRejected"`
+	TooLargeStatus  string `json:"tooLargeStatus"`
+	UnsupportedType string `json:"unsupportedType"`
+	ServerError     string `json:"serverError"`
 }
 
 func newUploadInput(props *UploadInputProps) *UploadInputProps {
@@ -81,6 +78,36 @@ func applyLabelDefaults(l *UploadInputLabels) {
 	}
 	if l.ServerError == "" {
 		l.ServerError = "Server error — please retry later"
+	}
+}
+
+// uploadInputDropAttrs returns the drag-and-drop event handlers for the
+// outer wrapper. Defined as a Go helper because templ's attribute parser
+// treats `on*=` literals as templ.ComponentScript when the value is an
+// expression — a bare templ.Attributes spread sidesteps that and keeps
+// the JS handlers as plain strings.
+func uploadInputDropAttrs(id string) templ.Attributes {
+	return templ.Attributes{
+		"ondragenter": "__upload.dragenter(this, event)",
+		"ondragover":  "__upload.dragover(event)",
+		"ondragleave": "__upload.dragleave(this, event)",
+		"ondrop":      fmt.Sprintf("__upload.drop(this, event, %q)", id),
+	}
+}
+
+// uploadInputDataAttrs serialises the per-instance config (size limit,
+// accept list, error/status labels, error-slot id) as JSON-in-data-*
+// attributes that the runtime helpers in `uploadInputScript` read at the
+// moment of an event. Keeping the inline `hx-on::*` and `ondrop="..."`
+// handlers as one-liners (e.g. `__upload.drop(this, event, '<id>')`)
+// instead of multi-line JS-in-Go strings.
+func uploadInputDataAttrs(p *UploadInputProps) templ.Attributes {
+	labels, _ := json.Marshal(p.Labels)
+	return templ.Attributes{
+		"data-upload-max-size": fmt.Sprintf("%d", p.MaxSize),
+		"data-upload-accept":   p.Accept,
+		"data-upload-slot":     fmt.Sprintf("error-%s", p.ID),
+		"data-upload-labels":   string(labels),
 	}
 }
 
@@ -120,14 +147,8 @@ templ UploadTarget(p *UploadInputProps) {
 templ (p *UploadInputProps) render() {
 	<div
 		class={ "relative border border-gray-400 border-dashed rounded-md p-4 flex flex-col items-center transition-colors", p.Class }
-		{ uploadDropAttrs(p.ID)... }
+		{ uploadInputDropAttrs(p.ID)... }
 	>
-		// Loading overlay shown while a file is being uploaded. The
-		// `htmx-indicator` class is toggled by HTMX via `hx-indicator` on the
-		// hidden file input below; `pointer-events-none` keeps the overlay
-		// click-through when invisible. `hx-sync="this:drop"` on the input
-		// already prevents concurrent uploads, so the overlay's visual block
-		// during a request is enough.
 		<div
 			id={ fmt.Sprintf("spinner-%s", p.ID) }
 			class="htmx-indicator pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-md bg-surface-100/80"
@@ -156,8 +177,10 @@ templ (p *UploadInputProps) render() {
 					name="file"
 					multiple?={ p.Multiple }
 					hx-on::after-request="this.value = ''"
-					{ uploadValidationAttrs(p)... }
-					{ uploadErrorAttrs(p)... }
+					hx-on::before-request="__upload.beforeRequest(this, event)"
+					hx-on::response-error="__upload.onResponseError(this, event)"
+					hx-on::send-error="__upload.onSendError(this, event)"
+					{ uploadInputDataAttrs(p)... }
 				/>
 			</div>
 			<div id={ fmt.Sprintf("target-%s", p.ID) }>
@@ -179,8 +202,6 @@ templ (p *UploadInputProps) render() {
 			<p class="text-xs">
 				{ p.Placeholder }
 			</p>
-			// Inline error slot populated by the validation/response/send-error
-			// handlers above. Hidden until a request fails or files are rejected.
 			<p
 				id={ fmt.Sprintf("error-%s", p.ID) }
 				class="text-red-500 text-xs mt-2 hidden"
@@ -196,137 +217,163 @@ templ (p *UploadInputProps) render() {
 	</div>
 }
 
-// uploadValidationAttrs builds the `hx-on::before-request` handler that
-// rejects files exceeding `MaxSize` or whose extension/mimetype does not
-// match `Accept` before the upload fires. The browser already enforces
-// `accept` on click-picked files, but drop events bypass it — so we filter
-// in JS to keep the behaviour consistent.
-//
-// On rejection: render an inline error in the dropzone, dispatch a `notify`
-// toast, clear the input value (so the same file can be retried), and call
-// `event.preventDefault()` to abort the request. On success: clear any
-// stale error and let HTMX continue.
-func uploadValidationAttrs(p *UploadInputProps) templ.Attributes {
-	js := fmt.Sprintf(
-		`var inp = this; var slot = document.getElementById('error-%s');`+
-			` if (slot) { slot.textContent = ''; slot.classList.add('hidden'); }`+
-			` var maxSize = %d; var accept = %q;`+
-			` var sizeTpl = %q; var typeTpl = %q;`+
-			` var errs = []; var files = inp.files || [];`+
-			` for (var i = 0; i < files.length; i++) {`+
-			`   var f = files[i];`+
-			`   if (maxSize > 0 && f.size > maxSize) {`+
-			`     errs.push(sizeTpl.replace('{name}', f.name).replace('{size}', (f.size/1048576).toFixed(1)).replace('{limit}', (maxSize/1048576).toFixed(1)));`+
-			`     continue;`+
-			`   }`+
-			`   if (accept && !__uploadAcceptMatches(f, accept)) {`+
-			`     errs.push(typeTpl.replace('{name}', f.name));`+
-			`   }`+
-			` }`+
-			` if (errs.length) {`+
-			`   var msg = errs.join('; ');`+
-			`   if (slot) { slot.textContent = msg; slot.classList.remove('hidden'); }`+
-			`   window.dispatchEvent(new CustomEvent('notify', {detail: {variant: 'error', message: msg}}));`+
-			`   inp.value = ''; event.preventDefault();`+
-			` }`,
-		p.ID, p.MaxSize, p.Accept, p.Labels.SizeRejected, p.Labels.TypeRejected,
-	)
-	return templ.Attributes{
-		"hx-on::before-request": js,
-	}
-}
-
-// uploadErrorAttrs builds the HTMX failure-event handlers for the hidden file
-// input. Server errors (4xx/5xx) get pretty-mapped by status code; only
-// fall back to the raw response body when no status-specific label fits.
-// Pre-flight failures (network/CORS/offline) get the network label.
-//
-// Both render an inline error inside the dropzone and dispatch a `notify`
-// toast event.
-func uploadErrorAttrs(p *UploadInputProps) templ.Attributes {
-	render := func(read string) string {
-		return fmt.Sprintf(
-			`%s var slot = document.getElementById('error-%s'); if (slot) { slot.textContent = msg; slot.classList.remove('hidden'); }`+
-				` window.dispatchEvent(new CustomEvent('notify', {detail: {variant: 'error', message: msg}}));`,
-			read, p.ID,
-		)
-	}
-	respErr := render(fmt.Sprintf(
-		`var xhr = event.detail && event.detail.xhr; var status = xhr ? xhr.status : 0; var body = xhr ? (xhr.responseText || '') : '';`+
-			` var msg = '';`+
-			` if (status === 413) { msg = %q; }`+
-			` else if (status === 415) { msg = %q; }`+
-			` else if (status >= 500) { msg = %q; }`+
-			` else if (body && body.length < 200 && body.indexOf('<') === -1) { msg = body; }`+
-			` else { msg = %q; }`,
-		p.Labels.TooLargeStatus, p.Labels.UnsupportedType, p.Labels.ServerError, p.Labels.GenericError,
-	))
-	netErr := fmt.Sprintf(`var msg = %q;`, p.Labels.NetworkError)
-	netErr = render(netErr)
-	return templ.Attributes{
-		"hx-on::response-error": respErr,
-		"hx-on::send-error":     netErr,
-	}
-}
-
-// uploadDropAttrs builds the dragover/dragenter/dragleave/drop handlers that
-// route a dropped FileList into the hidden <input type=file> and dispatch
-// `change` so the existing HTMX hx-trigger="change" picks the upload up.
-// The DataTransfer fallback covers older WebKit builds where input.files is
-// read-only.
-func uploadDropAttrs(id string) templ.Attributes {
-	drop := fmt.Sprintf(
-		`event.preventDefault(); event.stopPropagation(); this.classList.remove('border-primary');`+
-			` var inp=document.getElementById(%q);`+
-			` if(!inp||!event.dataTransfer||!event.dataTransfer.files||!event.dataTransfer.files.length){return;}`+
-			` try{inp.files=event.dataTransfer.files;}`+
-			` catch(e){if(typeof DataTransfer==='function'){var dt=new DataTransfer(); for(var i=0;i<event.dataTransfer.files.length;i++){dt.items.add(event.dataTransfer.files[i]);} inp.files=dt.files;}}`+
-			` inp.dispatchEvent(new Event('change',{bubbles:true}));`,
-		id,
-	)
-	return templ.Attributes{
-		"ondragover":  "event.preventDefault(); event.stopPropagation();",
-		"ondragenter": "event.preventDefault(); event.stopPropagation(); this.classList.add('border-primary');",
-		"ondragleave": "if(event.target===this){this.classList.remove('border-primary');}",
-		"ondrop":      drop,
-	}
-}
-
-// UploadInput renders a file upload input with preview capability.
-// It displays existing uploads and allows selecting new files.
-templ UploadInput(props *UploadInputProps) {
-	@newUploadInput(props).render()
-	@uploadAcceptHelper()
-}
-
-// uploadAcceptHelper emits the global `__uploadAcceptMatches` JS function
-// once per page (idempotent via existence check) so multiple UploadInputs
-// share a single implementation. Matches files against the same syntax the
-// browser uses for `accept`: comma-separated extensions (`.pdf`),
-// MIME types (`image/png`), or wildcards (`image/*`).
-templ uploadAcceptHelper() {
+// UploadHelpersScript emits the runtime helpers shared by every upload
+// dropzone on the page (this SDK's `UploadInput` and any consumer that
+// wants to reuse the `__upload` namespace, e.g. the EAI claim
+// `UploadSection`). Idempotent via a `__upload` existence check so
+// rendering N dropzones only registers the helpers once. Centralising the
+// logic here keeps templates declarative — call sites only emit
+// `__upload.fn(this, event)` callbacks plus per-instance config in
+// data-* attributes.
+templ UploadHelpersScript() {
 	<script>
-		if (typeof window.__uploadAcceptMatches !== 'function') {
-			window.__uploadAcceptMatches = function (file, accept) {
-				if (!accept) return true;
-				var name = (file.name || '').toLowerCase();
-				var type = (file.type || '').toLowerCase();
-				var tokens = accept.split(',').map(function (s) { return s.trim().toLowerCase(); }).filter(Boolean);
-				for (var i = 0; i < tokens.length; i++) {
-					var t = tokens[i];
-					if (t.indexOf('.') === 0) {
-						if (name.endsWith(t)) return true;
-					} else if (t.indexOf('/*') === t.length - 2) {
-						var prefix = t.slice(0, t.length - 1);
-						if (type.indexOf(prefix) === 0) return true;
-					} else if (type === t) {
-						return true;
+		if (typeof window.__upload === 'undefined') {
+			window.__upload = (function () {
+				function acceptMatches(file, accept) {
+					if (!accept) return true;
+					var name = (file.name || '').toLowerCase();
+					var type = (file.type || '').toLowerCase();
+					var tokens = accept.split(',').map(function (s) { return s.trim().toLowerCase(); }).filter(Boolean);
+					return tokens.some(function (t) {
+						if (t.charAt(0) === '.') return name.endsWith(t);
+						if (t.endsWith('/*')) return type.indexOf(t.slice(0, -1)) === 0;
+						return type === t;
+					});
+				}
+
+				function readConfig(input) {
+					return {
+						maxSize: parseInt(input.dataset.uploadMaxSize, 10) || 0,
+						accept: input.dataset.uploadAccept || '',
+						slot: input.dataset.uploadSlot || '',
+						labels: parseLabels(input.dataset.uploadLabels),
+					};
+				}
+
+				function parseLabels(raw) {
+					try { return raw ? JSON.parse(raw) : {}; } catch (e) { return {}; }
+				}
+
+				function setError(slotId, msg) {
+					var slot = slotId && document.getElementById(slotId);
+					if (slot) {
+						slot.textContent = msg;
+						slot.classList.remove('hidden');
+					}
+					window.dispatchEvent(new CustomEvent('notify', { detail: { variant: 'error', message: msg } }));
+				}
+
+				function clearError(slotId) {
+					var slot = slotId && document.getElementById(slotId);
+					if (slot) {
+						slot.textContent = '';
+						slot.classList.add('hidden');
 					}
 				}
-				return false;
-			};
+
+				function dragover(event) {
+					event.preventDefault();
+					event.stopPropagation();
+				}
+
+				function dragenter(el, event) {
+					event.preventDefault();
+					event.stopPropagation();
+					el.classList.add('border-primary');
+				}
+
+				function dragleave(el, event) {
+					if (event.target === el) el.classList.remove('border-primary');
+				}
+
+				function drop(el, event, inputId) {
+					event.preventDefault();
+					event.stopPropagation();
+					el.classList.remove('border-primary');
+					var inp = document.getElementById(inputId);
+					if (!inp || !event.dataTransfer || !event.dataTransfer.files || !event.dataTransfer.files.length) return;
+					try {
+						inp.files = event.dataTransfer.files;
+					} catch (e) {
+						if (typeof DataTransfer !== 'function') return;
+						var dt = new DataTransfer();
+						for (var i = 0; i < event.dataTransfer.files.length; i++) {
+							dt.items.add(event.dataTransfer.files[i]);
+						}
+						inp.files = dt.files;
+					}
+					inp.dispatchEvent(new Event('change', { bubbles: true }));
+				}
+
+				function beforeRequest(input, event) {
+					var cfg = readConfig(input);
+					clearError(cfg.slot);
+					var errs = [];
+					var files = input.files || [];
+					for (var i = 0; i < files.length; i++) {
+						var f = files[i];
+						if (cfg.maxSize > 0 && f.size > cfg.maxSize) {
+							errs.push((cfg.labels.sizeRejected || '{name} is too large')
+								.replace('{name}', f.name)
+								.replace('{size}', (f.size / 1048576).toFixed(1))
+								.replace('{limit}', (cfg.maxSize / 1048576).toFixed(1)));
+							continue;
+						}
+						if (cfg.accept && !acceptMatches(f, cfg.accept)) {
+							errs.push((cfg.labels.typeRejected || '{name} unsupported').replace('{name}', f.name));
+						}
+					}
+					if (errs.length) {
+						setError(cfg.slot, errs.join('; '));
+						input.value = '';
+						event.preventDefault();
+					}
+				}
+
+				function pickResponseMessage(xhr, labels) {
+					var status = xhr ? xhr.status : 0;
+					var body = xhr ? (xhr.responseText || '') : '';
+					if (status === 413) return labels.tooLargeStatus || 'File too large';
+					if (status === 415) return labels.unsupportedType || 'Unsupported file type';
+					if (status >= 500) return labels.serverError || 'Server error';
+					if (body && body.length < 200 && body.indexOf('<') === -1) return body.trim();
+					return labels.genericError || 'Upload failed';
+				}
+
+				function onResponseError(input, event) {
+					var cfg = readConfig(input);
+					var xhr = event && event.detail && event.detail.xhr;
+					setError(cfg.slot, pickResponseMessage(xhr, cfg.labels));
+				}
+
+				function onSendError(input) {
+					var cfg = readConfig(input);
+					setError(cfg.slot, cfg.labels.networkError || 'Network error');
+				}
+
+				return {
+					acceptMatches: acceptMatches,
+					dragover: dragover,
+					dragenter: dragenter,
+					dragleave: dragleave,
+					drop: drop,
+					beforeRequest: beforeRequest,
+					onResponseError: onResponseError,
+					onSendError: onSendError,
+					setError: setError,
+					clearError: clearError,
+				};
+			})();
 		}
 	</script>
+}
+
+// UploadInput renders a file upload input with preview capability. Drop
+// support, client-side validation and async error feedback are powered by
+// the shared `__upload` helpers in `UploadHelpersScript`.
+templ UploadInput(props *UploadInputProps) {
+	@newUploadInput(props).render()
+	@UploadHelpersScript()
 }
 
 script removeUploadedFile(rowID string) {

--- a/components/upload_input.templ
+++ b/components/upload_input.templ
@@ -7,6 +7,7 @@ import (
 
 	icons "github.com/iota-uz/icons/phosphor"
 	"github.com/iota-uz/iota-sdk/components/base/button"
+	"github.com/iota-uz/iota-sdk/components/loaders"
 	"github.com/iota-uz/iota-sdk/modules/core/presentation/viewmodels"
 	"github.com/iota-uz/utils/random"
 )
@@ -71,9 +72,21 @@ templ UploadTarget(p *UploadInputProps) {
 
 templ (p *UploadInputProps) render() {
 	<div
-		class={ "border border-gray-400 border-dashed rounded-md p-4 flex flex-col items-center transition-colors", p.Class }
+		class={ "relative border border-gray-400 border-dashed rounded-md p-4 flex flex-col items-center transition-colors", p.Class }
 		{ uploadDropAttrs(p.ID)... }
 	>
+		// Loading overlay shown while a file is being uploaded. The
+		// `htmx-indicator` class is toggled by HTMX via `hx-indicator` on the
+		// hidden file input below.
+		<div
+			id={ fmt.Sprintf("spinner-%s", p.ID) }
+			class="htmx-indicator absolute inset-0 z-10 flex items-center justify-center rounded-md bg-white/70"
+			aria-hidden="true"
+		>
+			@loaders.Spinner(loaders.SpinnerProps{
+				SpinnerClass: templ.Classes("w-6 h-6"),
+			})
+		</div>
 		<div class="flex flex-col items-center">
 			<div id={ fmt.Sprintf("upload-form-%s", p.ID) }>
 				<input
@@ -85,6 +98,7 @@ templ (p *UploadInputProps) render() {
 					accept={ p.Accept }
 					hx-trigger="change"
 					hx-target={ fmt.Sprintf("#target-%s", p.ID) }
+					hx-indicator={ fmt.Sprintf("#spinner-%s", p.ID) }
 					hx-post="/uploads"
 					hx-encoding="multipart/form-data"
 					hx-vals={ fmt.Sprintf(`{"_id": "%s", "_formName": "%s", "_name": "%s", "_multiple": "%t"}`, p.ID, p.Form, p.Name, p.Multiple) }

--- a/components/upload_input.templ
+++ b/components/upload_input.templ
@@ -25,6 +25,28 @@ type UploadInputProps struct {
 	Form        string               // ID of the form this input belongs to
 	Class       string               // Additional CSS classes
 	Multiple    bool                 // Whether multiple file uploads are allowed
+
+	// MaxSize is the per-file size limit in bytes enforced client-side before
+	// upload. 0 means no client-side limit (server may still reject).
+	MaxSize int64
+
+	// Labels override default English copy used in async error feedback. Each
+	// field is optional; empty values fall back to a built-in default.
+	Labels UploadInputLabels
+}
+
+// UploadInputLabels holds the user-facing strings rendered by the component
+// at runtime. Use {name}, {size} and {limit} placeholders in messages where
+// applicable — they are replaced with the rejected file's name, megabyte
+// size and configured limit respectively.
+type UploadInputLabels struct {
+	GenericError    string // generic 4xx/5xx fallback, default "Upload failed"
+	NetworkError    string // pre-flight failure, default "Network error — please retry"
+	TypeRejected    string // unsupported extension, default `File "{name}" — unsupported format`
+	SizeRejected    string // oversized file, default `File "{name}" is too large ({size}MB > {limit}MB)`
+	TooLargeStatus  string // 413 fallback, default "File too large"
+	UnsupportedType string // 415 fallback, default "Unsupported file type"
+	ServerError     string // 5xx fallback, default "Server error — please retry later"
 }
 
 func newUploadInput(props *UploadInputProps) *UploadInputProps {
@@ -34,7 +56,32 @@ func newUploadInput(props *UploadInputProps) *UploadInputProps {
 	if props.Accept == "" {
 		props.Accept = "image/*"
 	}
+	applyLabelDefaults(&props.Labels)
 	return props
+}
+
+func applyLabelDefaults(l *UploadInputLabels) {
+	if l.GenericError == "" {
+		l.GenericError = "Upload failed"
+	}
+	if l.NetworkError == "" {
+		l.NetworkError = "Network error — please retry"
+	}
+	if l.TypeRejected == "" {
+		l.TypeRejected = `File "{name}" — unsupported format`
+	}
+	if l.SizeRejected == "" {
+		l.SizeRejected = `File "{name}" is too large ({size}MB > {limit}MB)`
+	}
+	if l.TooLargeStatus == "" {
+		l.TooLargeStatus = "File too large"
+	}
+	if l.UnsupportedType == "" {
+		l.UnsupportedType = "Unsupported file type"
+	}
+	if l.ServerError == "" {
+		l.ServerError = "Server error — please retry later"
+	}
 }
 
 templ UploadTarget(p *UploadInputProps) {
@@ -77,10 +124,13 @@ templ (p *UploadInputProps) render() {
 	>
 		// Loading overlay shown while a file is being uploaded. The
 		// `htmx-indicator` class is toggled by HTMX via `hx-indicator` on the
-		// hidden file input below.
+		// hidden file input below; `pointer-events-none` keeps the overlay
+		// click-through when invisible. `hx-sync="this:drop"` on the input
+		// already prevents concurrent uploads, so the overlay's visual block
+		// during a request is enough.
 		<div
 			id={ fmt.Sprintf("spinner-%s", p.ID) }
-			class="htmx-indicator absolute inset-0 z-10 flex items-center justify-center rounded-md bg-white/70"
+			class="htmx-indicator pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-md bg-surface-100/80"
 			aria-hidden="true"
 		>
 			@loaders.Spinner(loaders.SpinnerProps{
@@ -102,10 +152,12 @@ templ (p *UploadInputProps) render() {
 					hx-post="/uploads"
 					hx-encoding="multipart/form-data"
 					hx-vals={ fmt.Sprintf(`{"_id": "%s", "_formName": "%s", "_name": "%s", "_multiple": "%t"}`, p.ID, p.Form, p.Name, p.Multiple) }
+					hx-sync="this:drop"
 					name="file"
 					multiple?={ p.Multiple }
 					hx-on::after-request="this.value = ''"
-					{ uploadErrorAttrs(p.ID)... }
+					{ uploadValidationAttrs(p)... }
+					{ uploadErrorAttrs(p)... }
 				/>
 			</div>
 			<div id={ fmt.Sprintf("target-%s", p.ID) }>
@@ -127,8 +179,8 @@ templ (p *UploadInputProps) render() {
 			<p class="text-xs">
 				{ p.Placeholder }
 			</p>
-			// Inline error slot populated by the response-error / send-error
-			// handlers above. Hidden until a request fails.
+			// Inline error slot populated by the validation/response/send-error
+			// handlers above. Hidden until a request fails or files are rejected.
 			<p
 				id={ fmt.Sprintf("error-%s", p.ID) }
 				class="text-red-500 text-xs mt-2 hidden"
@@ -144,31 +196,76 @@ templ (p *UploadInputProps) render() {
 	</div>
 }
 
-// uploadErrorAttrs builds the HTMX failure-event handlers for the hidden file
-// input. On a server error (4xx/5xx) it surfaces the response body; on a
-// pre-flight failure (network/CORS/offline) it shows a generic retry message.
-// Both render an inline error inside the dropzone and dispatch a `notify`
-// toast event so users actually see what went wrong instead of the spinner
-// silently disappearing. `hx-on::before-request` clears any prior error so a
-// fresh upload starts clean.
-func uploadErrorAttrs(id string) templ.Attributes {
-	clearSlot := fmt.Sprintf(
-		`var slot = document.getElementById('error-%s'); if (slot) { slot.textContent = ''; slot.classList.add('hidden'); }`,
-		id,
+// uploadValidationAttrs builds the `hx-on::before-request` handler that
+// rejects files exceeding `MaxSize` or whose extension/mimetype does not
+// match `Accept` before the upload fires. The browser already enforces
+// `accept` on click-picked files, but drop events bypass it — so we filter
+// in JS to keep the behaviour consistent.
+//
+// On rejection: render an inline error in the dropzone, dispatch a `notify`
+// toast, clear the input value (so the same file can be retried), and call
+// `event.preventDefault()` to abort the request. On success: clear any
+// stale error and let HTMX continue.
+func uploadValidationAttrs(p *UploadInputProps) templ.Attributes {
+	js := fmt.Sprintf(
+		`var inp = this; var slot = document.getElementById('error-%s');`+
+			` if (slot) { slot.textContent = ''; slot.classList.add('hidden'); }`+
+			` var maxSize = %d; var accept = %q;`+
+			` var sizeTpl = %q; var typeTpl = %q;`+
+			` var errs = []; var files = inp.files || [];`+
+			` for (var i = 0; i < files.length; i++) {`+
+			`   var f = files[i];`+
+			`   if (maxSize > 0 && f.size > maxSize) {`+
+			`     errs.push(sizeTpl.replace('{name}', f.name).replace('{size}', (f.size/1048576).toFixed(1)).replace('{limit}', (maxSize/1048576).toFixed(1)));`+
+			`     continue;`+
+			`   }`+
+			`   if (accept && !__uploadAcceptMatches(f, accept)) {`+
+			`     errs.push(typeTpl.replace('{name}', f.name));`+
+			`   }`+
+			` }`+
+			` if (errs.length) {`+
+			`   var msg = errs.join('; ');`+
+			`   if (slot) { slot.textContent = msg; slot.classList.remove('hidden'); }`+
+			`   window.dispatchEvent(new CustomEvent('notify', {detail: {variant: 'error', message: msg}}));`+
+			`   inp.value = ''; event.preventDefault();`+
+			` }`,
+		p.ID, p.MaxSize, p.Accept, p.Labels.SizeRejected, p.Labels.TypeRejected,
 	)
+	return templ.Attributes{
+		"hx-on::before-request": js,
+	}
+}
+
+// uploadErrorAttrs builds the HTMX failure-event handlers for the hidden file
+// input. Server errors (4xx/5xx) get pretty-mapped by status code; only
+// fall back to the raw response body when no status-specific label fits.
+// Pre-flight failures (network/CORS/offline) get the network label.
+//
+// Both render an inline error inside the dropzone and dispatch a `notify`
+// toast event.
+func uploadErrorAttrs(p *UploadInputProps) templ.Attributes {
 	render := func(read string) string {
 		return fmt.Sprintf(
 			`%s var slot = document.getElementById('error-%s'); if (slot) { slot.textContent = msg; slot.classList.remove('hidden'); }`+
 				` window.dispatchEvent(new CustomEvent('notify', {detail: {variant: 'error', message: msg}}));`,
-			read, id,
+			read, p.ID,
 		)
 	}
-	respErr := render(`var msg = (event.detail && event.detail.xhr && event.detail.xhr.responseText) ? event.detail.xhr.responseText : ''; if (!msg) { msg = 'Upload failed'; } if (msg.length > 200) { msg = msg.slice(0, 200) + '…'; }`)
-	netErr := render(`var msg = 'Network error — please retry';`)
+	respErr := render(fmt.Sprintf(
+		`var xhr = event.detail && event.detail.xhr; var status = xhr ? xhr.status : 0; var body = xhr ? (xhr.responseText || '') : '';`+
+			` var msg = '';`+
+			` if (status === 413) { msg = %q; }`+
+			` else if (status === 415) { msg = %q; }`+
+			` else if (status >= 500) { msg = %q; }`+
+			` else if (body && body.length < 200 && body.indexOf('<') === -1) { msg = body; }`+
+			` else { msg = %q; }`,
+		p.Labels.TooLargeStatus, p.Labels.UnsupportedType, p.Labels.ServerError, p.Labels.GenericError,
+	))
+	netErr := fmt.Sprintf(`var msg = %q;`, p.Labels.NetworkError)
+	netErr = render(netErr)
 	return templ.Attributes{
-		"hx-on::before-request":  clearSlot,
-		"hx-on::response-error":  respErr,
-		"hx-on::send-error":      netErr,
+		"hx-on::response-error": respErr,
+		"hx-on::send-error":     netErr,
 	}
 }
 
@@ -199,6 +296,37 @@ func uploadDropAttrs(id string) templ.Attributes {
 // It displays existing uploads and allows selecting new files.
 templ UploadInput(props *UploadInputProps) {
 	@newUploadInput(props).render()
+	@uploadAcceptHelper()
+}
+
+// uploadAcceptHelper emits the global `__uploadAcceptMatches` JS function
+// once per page (idempotent via existence check) so multiple UploadInputs
+// share a single implementation. Matches files against the same syntax the
+// browser uses for `accept`: comma-separated extensions (`.pdf`),
+// MIME types (`image/png`), or wildcards (`image/*`).
+templ uploadAcceptHelper() {
+	<script>
+		if (typeof window.__uploadAcceptMatches !== 'function') {
+			window.__uploadAcceptMatches = function (file, accept) {
+				if (!accept) return true;
+				var name = (file.name || '').toLowerCase();
+				var type = (file.type || '').toLowerCase();
+				var tokens = accept.split(',').map(function (s) { return s.trim().toLowerCase(); }).filter(Boolean);
+				for (var i = 0; i < tokens.length; i++) {
+					var t = tokens[i];
+					if (t.indexOf('.') === 0) {
+						if (name.endsWith(t)) return true;
+					} else if (t.indexOf('/*') === t.length - 2) {
+						var prefix = t.slice(0, t.length - 1);
+						if (type.indexOf(prefix) === 0) return true;
+					} else if (type === t) {
+						return true;
+					}
+				}
+				return false;
+			};
+		}
+	</script>
 }
 
 script removeUploadedFile(rowID string) {

--- a/components/upload_input_templ.go
+++ b/components/upload_input_templ.go
@@ -15,6 +15,7 @@ import (
 
 	icons "github.com/iota-uz/icons/phosphor"
 	"github.com/iota-uz/iota-sdk/components/base/button"
+	"github.com/iota-uz/iota-sdk/components/loaders"
 	"github.com/iota-uz/iota-sdk/modules/core/presentation/viewmodels"
 	"github.com/iota-uz/utils/random"
 )
@@ -78,7 +79,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 			var templ_7745c5c3_Var2 string
 			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(rowID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 43, Col: 18}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 44, Col: 18}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
@@ -91,7 +92,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(uploadDisplayName(upload))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 46, Col: 84}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 47, Col: 84}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -104,7 +105,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(uploadDisplayMeta(upload))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 47, Col: 81}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 48, Col: 81}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -147,7 +148,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 				var templ_7745c5c3_Var6 string
 				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(upload.URL)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 60, Col: 75}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 61, Col: 75}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 				if templ_7745c5c3_Err != nil {
@@ -160,7 +161,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 				var templ_7745c5c3_Var7 string
 				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(uploadDisplayName(upload))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 60, Col: 109}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 61, Col: 109}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 				if templ_7745c5c3_Err != nil {
@@ -179,7 +180,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 				var templ_7745c5c3_Var8 string
 				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(p.Name)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 63, Col: 39}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 64, Col: 39}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 				if templ_7745c5c3_Err != nil {
@@ -192,7 +193,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 				var templ_7745c5c3_Var9 string
 				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(upload.ID)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 63, Col: 59}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 64, Col: 59}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 				if templ_7745c5c3_Err != nil {
@@ -205,7 +206,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 				var templ_7745c5c3_Var10 string
 				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(p.Form)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 63, Col: 75}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 64, Col: 75}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 				if templ_7745c5c3_Err != nil {
@@ -223,7 +224,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 				var templ_7745c5c3_Var11 string
 				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(p.Name)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 65, Col: 39}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 66, Col: 39}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 				if templ_7745c5c3_Err != nil {
@@ -236,7 +237,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 				var templ_7745c5c3_Var12 string
 				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(upload.ID)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 65, Col: 59}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 66, Col: 59}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 				if templ_7745c5c3_Err != nil {
@@ -281,7 +282,7 @@ func (p *UploadInputProps) render() templ.Component {
 			templ_7745c5c3_Var13 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		var templ_7745c5c3_Var14 = []any{"border border-gray-400 border-dashed rounded-md p-4 flex flex-col items-center transition-colors", p.Class}
+		var templ_7745c5c3_Var14 = []any{"relative border border-gray-400 border-dashed rounded-md p-4 flex flex-col items-center transition-colors", p.Class}
 		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var14...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -307,95 +308,131 @@ func (p *UploadInputProps) render() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "><div class=\"flex flex-col items-center\"><div id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "><div id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var16 string
-		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("upload-form-%s", p.ID))
+		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("spinner-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 78, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 82, Col: 39}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\"><input id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\" class=\"htmx-indicator absolute inset-0 z-10 flex items-center justify-center rounded-md bg-white/70\" aria-hidden=\"true\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = loaders.Spinner(loaders.SpinnerProps{
+			SpinnerClass: templ.Classes("w-6 h-6"),
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</div><div class=\"flex flex-col items-center\"><div id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var17 string
-		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(p.ID)
+		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("upload-form-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 80, Col: 14}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 91, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\" type=\"file\" class=\"sr-only\" aria-hidden=\"true\" tabindex=\"-1\" accept=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\"><input id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var18 string
-		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(p.Accept)
+		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(p.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 85, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 93, Col: 14}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\" hx-trigger=\"change\" hx-target=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "\" type=\"file\" class=\"sr-only\" aria-hidden=\"true\" tabindex=\"-1\" accept=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var19 string
-		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("#target-%s", p.ID))
+		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(p.Accept)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 87, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 98, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "\" hx-post=\"/uploads\" hx-encoding=\"multipart/form-data\" hx-vals=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\" hx-trigger=\"change\" hx-target=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var20 string
-		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf(`{"_id": "%s", "_formName": "%s", "_name": "%s", "_multiple": "%t"}`, p.ID, p.Form, p.Name, p.Multiple))
+		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("#target-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 90, Col: 130}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 100, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\" name=\"file\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		if p.Multiple {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, " multiple")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, " hx-on::after-request=\"this.value = &#39;&#39;\"></div><div id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\" hx-indicator=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var21 string
-		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("target-%s", p.ID))
+		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("#spinner-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 96, Col: 43}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 101, Col: 52}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\" hx-post=\"/uploads\" hx-encoding=\"multipart/form-data\" hx-vals=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var22 string
+		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf(`{"_id": "%s", "_formName": "%s", "_name": "%s", "_multiple": "%t"}`, p.ID, p.Form, p.Name, p.Multiple))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 104, Col: 130}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\" name=\"file\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if p.Multiple {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, " multiple")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, " hx-on::after-request=\"this.value = &#39;&#39;\"></div><div id=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var23 string
+		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("target-%s", p.ID))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 110, Col: 43}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -403,11 +440,11 @@ func (p *UploadInputProps) render() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</div><div class=\"flex gap-1 items-center mt-4 mb-1.5\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</div><div class=\"flex gap-1 items-center mt-4 mb-1.5\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var22 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var24 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -419,12 +456,12 @@ func (p *UploadInputProps) render() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			var templ_7745c5c3_Var23 string
-			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(p.Label)
+			var templ_7745c5c3_Var25 string
+			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(p.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 109, Col: 14}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 123, Col: 14}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -438,47 +475,47 @@ func (p *UploadInputProps) render() templ.Component {
 				"title":      p.Label,
 				"onclick":    fmt.Sprintf("document.getElementById('%s')?.click()", p.ID),
 			},
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var22), templ_7745c5c3_Buffer)
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var24), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</div><p class=\"text-xs\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "</div><p class=\"text-xs\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var24 string
-		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(p.Placeholder)
+		var templ_7745c5c3_Var26 string
+		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(p.Placeholder)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 113, Col: 19}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 127, Col: 19}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</p>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if p.Error != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "<p class=\"text-red-500 text-xs mt-2\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "<p class=\"text-red-500 text-xs mt-2\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var25 string
-			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(p.Error)
+			var templ_7745c5c3_Var27 string
+			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(p.Error)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 117, Col: 14}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 131, Col: 14}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -527,9 +564,9 @@ func UploadInput(props *UploadInputProps) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var26 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var26 == nil {
-			templ_7745c5c3_Var26 = templ.NopComponent
+		templ_7745c5c3_Var28 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var28 == nil {
+			templ_7745c5c3_Var28 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = newUploadInput(props).render().Render(ctx, templ_7745c5c3_Buffer)

--- a/components/upload_input_templ.go
+++ b/components/upload_input_templ.go
@@ -281,7 +281,7 @@ func (p *UploadInputProps) render() templ.Component {
 			templ_7745c5c3_Var13 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		var templ_7745c5c3_Var14 = []any{"border border-gray-400 border-dashed rounded-md p-4 flex flex-col items-center", p.Class}
+		var templ_7745c5c3_Var14 = []any{"border border-gray-400 border-dashed rounded-md p-4 flex flex-col items-center transition-colors", p.Class}
 		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var14...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -299,95 +299,103 @@ func (p *UploadInputProps) render() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "\"><div class=\"flex flex-col items-center\"><div id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, uploadDropAttrs(p.ID))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "><div class=\"flex flex-col items-center\"><div id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var16 string
 		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("upload-form-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 75, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 78, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\"><input id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\"><input id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var17 string
 		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(p.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 77, Col: 14}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 80, Col: 14}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\" type=\"file\" class=\"sr-only\" aria-hidden=\"true\" tabindex=\"-1\" accept=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\" type=\"file\" class=\"sr-only\" aria-hidden=\"true\" tabindex=\"-1\" accept=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var18 string
 		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(p.Accept)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 82, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 85, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\" hx-trigger=\"change\" hx-target=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\" hx-trigger=\"change\" hx-target=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var19 string
 		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("#target-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 84, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 87, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\" hx-post=\"/uploads\" hx-encoding=\"multipart/form-data\" hx-vals=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "\" hx-post=\"/uploads\" hx-encoding=\"multipart/form-data\" hx-vals=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var20 string
 		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf(`{"_id": "%s", "_formName": "%s", "_name": "%s", "_multiple": "%t"}`, p.ID, p.Form, p.Name, p.Multiple))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 87, Col: 130}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 90, Col: 130}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "\" name=\"file\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\" name=\"file\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if p.Multiple {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, " multiple")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, " multiple")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, " hx-on::after-request=\"this.value = &#39;&#39;\"></div><div id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, " hx-on::after-request=\"this.value = &#39;&#39;\"></div><div id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var21 string
 		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("target-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 93, Col: 43}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 96, Col: 43}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -395,7 +403,7 @@ func (p *UploadInputProps) render() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</div><div class=\"flex gap-1 items-center mt-4 mb-1.5\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</div><div class=\"flex gap-1 items-center mt-4 mb-1.5\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -414,7 +422,7 @@ func (p *UploadInputProps) render() templ.Component {
 			var templ_7745c5c3_Var23 string
 			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(p.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 106, Col: 14}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 109, Col: 14}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 			if templ_7745c5c3_Err != nil {
@@ -434,48 +442,71 @@ func (p *UploadInputProps) render() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</div><p class=\"text-xs\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</div><p class=\"text-xs\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var24 string
 		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(p.Placeholder)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 110, Col: 19}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 113, Col: 19}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</p>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if p.Error != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<p class=\"text-red-500 text-xs mt-2\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "<p class=\"text-red-500 text-xs mt-2\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var25 string
 			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(p.Error)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 114, Col: 14}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 117, Col: 14}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		return nil
 	})
+}
+
+// uploadDropAttrs builds the dragover/dragenter/dragleave/drop handlers that
+// route a dropped FileList into the hidden <input type=file> and dispatch
+// `change` so the existing HTMX hx-trigger="change" picks the upload up.
+// The DataTransfer fallback covers older WebKit builds where input.files is
+// read-only.
+func uploadDropAttrs(id string) templ.Attributes {
+	drop := fmt.Sprintf(
+		`event.preventDefault(); event.stopPropagation(); this.classList.remove('border-primary');`+
+			` var inp=document.getElementById(%q);`+
+			` if(!inp||!event.dataTransfer||!event.dataTransfer.files||!event.dataTransfer.files.length){return;}`+
+			` try{inp.files=event.dataTransfer.files;}`+
+			` catch(e){var dt=new DataTransfer(); for(var i=0;i<event.dataTransfer.files.length;i++){dt.items.add(event.dataTransfer.files[i]);} inp.files=dt.files;}`+
+			` inp.dispatchEvent(new Event('change',{bubbles:true}));`,
+		id,
+	)
+	return templ.Attributes{
+		"ondragover":  "event.preventDefault(); event.stopPropagation();",
+		"ondragenter": "event.preventDefault(); event.stopPropagation(); this.classList.add('border-primary');",
+		"ondragleave": "if(event.target===this){this.classList.remove('border-primary');}",
+		"ondrop":      drop,
+	}
 }
 
 // UploadInput renders a file upload input with preview capability.

--- a/components/upload_input_templ.go
+++ b/components/upload_input_templ.go
@@ -146,6 +146,8 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 		}
 		for i, upload := range p.Uploads {
 			rowID := fmt.Sprintf("uploaded-file-%s-%d", p.ID, i)
+			name := uploadDisplayName(upload)
+			previewURL := strings.TrimSpace(upload.URL)
 			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -153,39 +155,102 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 			var templ_7745c5c3_Var2 string
 			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(rowID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 118, Col: 18}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 120, Col: 18}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\" class=\"rounded-md border border-primary bg-surface-100 p-2\"><div class=\"flex items-start justify-between gap-3\"><div class=\"min-w-0\"><div class=\"truncate text-xs font-medium text-100\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\" class=\"rounded-md border border-primary bg-surface-100 p-2\"><div class=\"flex items-start justify-between gap-3\"><div class=\"min-w-0\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var3 string
-			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(uploadDisplayName(upload))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 121, Col: 84}
+			if previewURL != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "    <a href=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var3 templ.SafeURL = templ.SafeURL(previewURL)
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var3)))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"block truncate text-xs font-medium text-primary hover:underline\" title=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var4 string
+				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(name)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 133, Col: 20}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var5 string
+				templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(name)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 135, Col: 14}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</a>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			} else {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div class=\"truncate text-xs font-medium text-100\" title=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var6 string
+				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(name)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 138, Col: 70}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var7 string
+				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(name)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 139, Col: 14}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div class=\"truncate text-[11px] text-text-300\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</div><div class=\"truncate text-[11px] text-text-300\">")
+			var templ_7745c5c3_Var8 string
+			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(uploadDisplayMeta(upload))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 142, Col: 81}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var4 string
-			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(uploadDisplayMeta(upload))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 122, Col: 81}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -193,16 +258,16 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<button type=\"button\" class=\"text-red-500 hover:text-red-700 text-xs\" title=\"Remove file\" aria-label=\"Remove file\" onclick=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<button type=\"button\" class=\"text-red-500 hover:text-red-700 text-xs\" title=\"Remove file\" aria-label=\"Remove file\" onclick=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var5 templ.ComponentScript = removeUploadedFile(rowID)
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var5.Call)
+			var templ_7745c5c3_Var9 templ.ComponentScript = removeUploadedFile(rowID)
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var9.Call)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -210,124 +275,133 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</button></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</button></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if upload.URL != "" && strings.HasPrefix(strings.ToLower(strings.TrimSpace(upload.Mimetype)), "image/") {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<img class=\"mt-2 h-16 w-16 rounded-md object-contain\" src=\"")
+			if previewURL != "" && strings.HasPrefix(strings.ToLower(strings.TrimSpace(upload.Mimetype)), "image/") {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<a href=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var6 string
-				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(upload.URL)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 135, Col: 75}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+				var templ_7745c5c3_Var10 templ.SafeURL = templ.SafeURL(previewURL)
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var10)))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\" alt=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var7 string
-				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(uploadDisplayName(upload))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 135, Col: 109}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\"> ")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			if p.Form != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<input type=\"hidden\" name=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var8 string
-				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(p.Name)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 138, Col: 39}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\" value=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var9 string
-				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(upload.ID)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 138, Col: 59}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\" form=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var10 string
-				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(p.Form)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 138, Col: 75}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<input type=\"hidden\" name=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\" target=\"_blank\" rel=\"noopener noreferrer\"><img class=\"mt-2 h-16 w-16 rounded-md object-contain\" src=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var11 string
-				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(p.Name)
+				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(previewURL)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 140, Col: 39}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 156, Col: 76}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\" value=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\" alt=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var12 string
-				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(upload.ID)
+				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(name)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 140, Col: 59}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 156, Col: 89}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\"></a> ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div>")
+			if p.Form != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<input type=\"hidden\" name=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var13 string
+				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(p.Name)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 160, Col: 39}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "\" value=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var14 string
+				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(upload.ID)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 160, Col: 59}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "\" form=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var15 string
+				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(p.Form)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 160, Col: 75}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			} else {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<input type=\"hidden\" name=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var16 string
+				templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(p.Name)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 162, Col: 39}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\" value=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var17 string
+				templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(upload.ID)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 162, Col: 59}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -351,30 +425,30 @@ func (p *UploadInputProps) render() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var13 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var13 == nil {
-			templ_7745c5c3_Var13 = templ.NopComponent
+		templ_7745c5c3_Var18 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var18 == nil {
+			templ_7745c5c3_Var18 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		var templ_7745c5c3_Var14 = []any{"relative border border-gray-400 border-dashed rounded-md p-4 flex flex-col items-center transition-colors", p.Class}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var14...)
+		var templ_7745c5c3_Var19 = []any{"relative border border-gray-400 border-dashed rounded-md p-4 flex flex-col items-center transition-colors", p.Class}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var19...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<div class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<div class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var15 string
-		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var14).String())
+		var templ_7745c5c3_Var20 string
+		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var19).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -382,20 +456,20 @@ func (p *UploadInputProps) render() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "><div id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "><div id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var16 string
-		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("spinner-%s", p.ID))
+		var templ_7745c5c3_Var21 string
+		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("spinner-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 153, Col: 39}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 175, Col: 39}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\" class=\"htmx-indicator pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-md bg-surface-100/80\" aria-hidden=\"true\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\" class=\"htmx-indicator pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-md bg-surface-100/80\" aria-hidden=\"true\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -405,95 +479,95 @@ func (p *UploadInputProps) render() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</div><div class=\"flex flex-col items-center\"><div id=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var17 string
-		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("upload-form-%s", p.ID))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 162, Col: 48}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\"><input id=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var18 string
-		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(p.ID)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 164, Col: 14}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "\" type=\"file\" class=\"sr-only\" aria-hidden=\"true\" tabindex=\"-1\" accept=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var19 string
-		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(p.Accept)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 169, Col: 22}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\" hx-trigger=\"change\" hx-target=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var20 string
-		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("#target-%s", p.ID))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 171, Col: 48}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\" hx-indicator=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var21 string
-		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("#spinner-%s", p.ID))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 172, Col: 52}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\" hx-post=\"/uploads\" hx-encoding=\"multipart/form-data\" hx-vals=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</div><div class=\"flex flex-col items-center\"><div id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var22 string
-		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf(`{"_id": "%s", "_formName": "%s", "_name": "%s", "_multiple": "%t"}`, p.ID, p.Form, p.Name, p.Multiple))
+		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("upload-form-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 175, Col: 130}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 184, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\" hx-sync=\"this:drop\" name=\"file\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "\"><input id=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var23 string
+		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(p.ID)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 186, Col: 14}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "\" type=\"file\" class=\"sr-only\" aria-hidden=\"true\" tabindex=\"-1\" accept=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var24 string
+		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(p.Accept)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 191, Col: 22}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "\" hx-trigger=\"change\" hx-target=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var25 string
+		templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("#target-%s", p.ID))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 193, Col: 48}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "\" hx-indicator=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var26 string
+		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("#spinner-%s", p.ID))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 194, Col: 52}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "\" hx-post=\"/uploads\" hx-encoding=\"multipart/form-data\" hx-vals=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var27 string
+		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf(`{"_id": "%s", "_formName": "%s", "_name": "%s", "_multiple": "%t"}`, p.ID, p.Form, p.Name, p.Multiple))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 197, Col: 130}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "\" hx-sync=\"this:drop\" name=\"file\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if p.Multiple {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, " multiple")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, " multiple")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, " hx-on::after-request=\"this.value = &#39;&#39;\" hx-on::before-request=\"__upload.beforeRequest(this, event)\" hx-on::response-error=\"__upload.onResponseError(this, event)\" hx-on::send-error=\"__upload.onSendError(this, event)\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, " hx-on::after-request=\"this.value = &#39;&#39;\" hx-on::before-request=\"__upload.beforeRequest(this, event)\" hx-on::response-error=\"__upload.onResponseError(this, event)\" hx-on::send-error=\"__upload.onSendError(this, event)\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -501,20 +575,20 @@ func (p *UploadInputProps) render() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "></div><div id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "></div><div id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var23 string
-		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("target-%s", p.ID))
+		var templ_7745c5c3_Var28 string
+		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("target-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 186, Col: 43}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 208, Col: 43}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -522,11 +596,11 @@ func (p *UploadInputProps) render() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "</div><div class=\"flex gap-1 items-center mt-4 mb-1.5\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "</div><div class=\"flex gap-1 items-center mt-4 mb-1.5\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var24 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var29 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -538,12 +612,12 @@ func (p *UploadInputProps) render() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			var templ_7745c5c3_Var25 string
-			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(p.Label)
+			var templ_7745c5c3_Var30 string
+			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(p.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 199, Col: 14}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 221, Col: 14}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -557,60 +631,60 @@ func (p *UploadInputProps) render() templ.Component {
 				"title":      p.Label,
 				"onclick":    fmt.Sprintf("document.getElementById('%s')?.click()", p.ID),
 			},
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var24), templ_7745c5c3_Buffer)
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var29), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</div><p class=\"text-xs\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</div><p class=\"text-xs\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var26 string
-		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(p.Placeholder)
+		var templ_7745c5c3_Var31 string
+		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(p.Placeholder)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 203, Col: 19}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 225, Col: 19}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</p><p id=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var27 string
-		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("error-%s", p.ID))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 206, Col: 38}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</p><p id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "\" class=\"text-red-500 text-xs mt-2 hidden\" role=\"alert\" aria-live=\"polite\"></p>")
+		var templ_7745c5c3_Var32 string
+		templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("error-%s", p.ID))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 228, Col: 38}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "\" class=\"text-red-500 text-xs mt-2 hidden\" role=\"alert\" aria-live=\"polite\"></p>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if p.Error != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "<p class=\"text-red-500 text-xs mt-2\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "<p class=\"text-red-500 text-xs mt-2\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var28 string
-			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(p.Error)
+			var templ_7745c5c3_Var33 string
+			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(p.Error)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 213, Col: 14}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 235, Col: 14}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -642,12 +716,12 @@ func UploadHelpersScript() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var29 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var29 == nil {
-			templ_7745c5c3_Var29 = templ.NopComponent
+		templ_7745c5c3_Var34 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var34 == nil {
+			templ_7745c5c3_Var34 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<script>\n\t\tif (typeof window.__upload === 'undefined') {\n\t\t\twindow.__upload = (function () {\n\t\t\t\tfunction acceptMatches(file, accept) {\n\t\t\t\t\tif (!accept) return true;\n\t\t\t\t\tvar name = (file.name || '').toLowerCase();\n\t\t\t\t\tvar type = (file.type || '').toLowerCase();\n\t\t\t\t\tvar tokens = accept.split(',').map(function (s) { return s.trim().toLowerCase(); }).filter(Boolean);\n\t\t\t\t\treturn tokens.some(function (t) {\n\t\t\t\t\t\tif (t.charAt(0) === '.') return name.endsWith(t);\n\t\t\t\t\t\tif (t.endsWith('/*')) return type.indexOf(t.slice(0, -1)) === 0;\n\t\t\t\t\t\treturn type === t;\n\t\t\t\t\t});\n\t\t\t\t}\n\n\t\t\t\tfunction readConfig(input) {\n\t\t\t\t\treturn {\n\t\t\t\t\t\tmaxSize: parseInt(input.dataset.uploadMaxSize, 10) || 0,\n\t\t\t\t\t\taccept: input.dataset.uploadAccept || '',\n\t\t\t\t\t\tslot: input.dataset.uploadSlot || '',\n\t\t\t\t\t\tlabels: parseLabels(input.dataset.uploadLabels),\n\t\t\t\t\t};\n\t\t\t\t}\n\n\t\t\t\tfunction parseLabels(raw) {\n\t\t\t\t\ttry { return raw ? JSON.parse(raw) : {}; } catch (e) { return {}; }\n\t\t\t\t}\n\n\t\t\t\tfunction setError(slotId, msg) {\n\t\t\t\t\tvar slot = slotId && document.getElementById(slotId);\n\t\t\t\t\tif (slot) {\n\t\t\t\t\t\tslot.textContent = msg;\n\t\t\t\t\t\tslot.classList.remove('hidden');\n\t\t\t\t\t}\n\t\t\t\t\twindow.dispatchEvent(new CustomEvent('notify', { detail: { variant: 'error', message: msg } }));\n\t\t\t\t}\n\n\t\t\t\tfunction clearError(slotId) {\n\t\t\t\t\tvar slot = slotId && document.getElementById(slotId);\n\t\t\t\t\tif (slot) {\n\t\t\t\t\t\tslot.textContent = '';\n\t\t\t\t\t\tslot.classList.add('hidden');\n\t\t\t\t\t}\n\t\t\t\t}\n\n\t\t\t\tfunction dragover(event) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tevent.stopPropagation();\n\t\t\t\t}\n\n\t\t\t\tfunction dragenter(el, event) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tevent.stopPropagation();\n\t\t\t\t\tel.classList.add('border-primary');\n\t\t\t\t}\n\n\t\t\t\tfunction dragleave(el, event) {\n\t\t\t\t\tif (event.target === el) el.classList.remove('border-primary');\n\t\t\t\t}\n\n\t\t\t\tfunction drop(el, event, inputId) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tevent.stopPropagation();\n\t\t\t\t\tel.classList.remove('border-primary');\n\t\t\t\t\tvar inp = document.getElementById(inputId);\n\t\t\t\t\tif (!inp || !event.dataTransfer || !event.dataTransfer.files || !event.dataTransfer.files.length) return;\n\t\t\t\t\ttry {\n\t\t\t\t\t\tinp.files = event.dataTransfer.files;\n\t\t\t\t\t} catch (e) {\n\t\t\t\t\t\tif (typeof DataTransfer !== 'function') return;\n\t\t\t\t\t\tvar dt = new DataTransfer();\n\t\t\t\t\t\tfor (var i = 0; i < event.dataTransfer.files.length; i++) {\n\t\t\t\t\t\t\tdt.items.add(event.dataTransfer.files[i]);\n\t\t\t\t\t\t}\n\t\t\t\t\t\tinp.files = dt.files;\n\t\t\t\t\t}\n\t\t\t\t\tinp.dispatchEvent(new Event('change', { bubbles: true }));\n\t\t\t\t}\n\n\t\t\t\tfunction beforeRequest(input, event) {\n\t\t\t\t\tvar cfg = readConfig(input);\n\t\t\t\t\tclearError(cfg.slot);\n\t\t\t\t\tvar errs = [];\n\t\t\t\t\tvar files = input.files || [];\n\t\t\t\t\tfor (var i = 0; i < files.length; i++) {\n\t\t\t\t\t\tvar f = files[i];\n\t\t\t\t\t\tif (cfg.maxSize > 0 && f.size > cfg.maxSize) {\n\t\t\t\t\t\t\terrs.push((cfg.labels.sizeRejected || '{name} is too large')\n\t\t\t\t\t\t\t\t.replace('{name}', f.name)\n\t\t\t\t\t\t\t\t.replace('{size}', (f.size / 1048576).toFixed(1))\n\t\t\t\t\t\t\t\t.replace('{limit}', (cfg.maxSize / 1048576).toFixed(1)));\n\t\t\t\t\t\t\tcontinue;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tif (cfg.accept && !acceptMatches(f, cfg.accept)) {\n\t\t\t\t\t\t\terrs.push((cfg.labels.typeRejected || '{name} unsupported').replace('{name}', f.name));\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t\tif (errs.length) {\n\t\t\t\t\t\tsetError(cfg.slot, errs.join('; '));\n\t\t\t\t\t\tinput.value = '';\n\t\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\t}\n\t\t\t\t}\n\n\t\t\t\tfunction pickResponseMessage(xhr, labels) {\n\t\t\t\t\tvar status = xhr ? xhr.status : 0;\n\t\t\t\t\tvar body = xhr ? (xhr.responseText || '') : '';\n\t\t\t\t\tif (status === 413) return labels.tooLargeStatus || 'File too large';\n\t\t\t\t\tif (status === 415) return labels.unsupportedType || 'Unsupported file type';\n\t\t\t\t\tif (status >= 500) return labels.serverError || 'Server error';\n\t\t\t\t\tif (body && body.length < 200 && body.indexOf('<') === -1) return body.trim();\n\t\t\t\t\treturn labels.genericError || 'Upload failed';\n\t\t\t\t}\n\n\t\t\t\tfunction onResponseError(input, event) {\n\t\t\t\t\tvar cfg = readConfig(input);\n\t\t\t\t\tvar xhr = event && event.detail && event.detail.xhr;\n\t\t\t\t\tsetError(cfg.slot, pickResponseMessage(xhr, cfg.labels));\n\t\t\t\t}\n\n\t\t\t\tfunction onSendError(input) {\n\t\t\t\t\tvar cfg = readConfig(input);\n\t\t\t\t\tsetError(cfg.slot, cfg.labels.networkError || 'Network error');\n\t\t\t\t}\n\n\t\t\t\treturn {\n\t\t\t\t\tacceptMatches: acceptMatches,\n\t\t\t\t\tdragover: dragover,\n\t\t\t\t\tdragenter: dragenter,\n\t\t\t\t\tdragleave: dragleave,\n\t\t\t\t\tdrop: drop,\n\t\t\t\t\tbeforeRequest: beforeRequest,\n\t\t\t\t\tonResponseError: onResponseError,\n\t\t\t\t\tonSendError: onSendError,\n\t\t\t\t\tsetError: setError,\n\t\t\t\t\tclearError: clearError,\n\t\t\t\t};\n\t\t\t})();\n\t\t}\n\t</script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<script>\n\t\tif (typeof window.__upload === 'undefined') {\n\t\t\twindow.__upload = (function () {\n\t\t\t\tfunction acceptMatches(file, accept) {\n\t\t\t\t\tif (!accept) return true;\n\t\t\t\t\tvar name = (file.name || '').toLowerCase();\n\t\t\t\t\tvar type = (file.type || '').toLowerCase();\n\t\t\t\t\tvar tokens = accept.split(',').map(function (s) { return s.trim().toLowerCase(); }).filter(Boolean);\n\t\t\t\t\treturn tokens.some(function (t) {\n\t\t\t\t\t\tif (t.charAt(0) === '.') return name.endsWith(t);\n\t\t\t\t\t\tif (t.endsWith('/*')) return type.indexOf(t.slice(0, -1)) === 0;\n\t\t\t\t\t\treturn type === t;\n\t\t\t\t\t});\n\t\t\t\t}\n\n\t\t\t\tfunction readConfig(input) {\n\t\t\t\t\treturn {\n\t\t\t\t\t\tmaxSize: parseInt(input.dataset.uploadMaxSize, 10) || 0,\n\t\t\t\t\t\taccept: input.dataset.uploadAccept || '',\n\t\t\t\t\t\tslot: input.dataset.uploadSlot || '',\n\t\t\t\t\t\tlabels: parseLabels(input.dataset.uploadLabels),\n\t\t\t\t\t};\n\t\t\t\t}\n\n\t\t\t\tfunction parseLabels(raw) {\n\t\t\t\t\ttry { return raw ? JSON.parse(raw) : {}; } catch (e) { return {}; }\n\t\t\t\t}\n\n\t\t\t\tfunction setError(slotId, msg) {\n\t\t\t\t\tvar slot = slotId && document.getElementById(slotId);\n\t\t\t\t\tif (slot) {\n\t\t\t\t\t\tslot.textContent = msg;\n\t\t\t\t\t\tslot.classList.remove('hidden');\n\t\t\t\t\t}\n\t\t\t\t\twindow.dispatchEvent(new CustomEvent('notify', { detail: { variant: 'error', message: msg } }));\n\t\t\t\t}\n\n\t\t\t\tfunction clearError(slotId) {\n\t\t\t\t\tvar slot = slotId && document.getElementById(slotId);\n\t\t\t\t\tif (slot) {\n\t\t\t\t\t\tslot.textContent = '';\n\t\t\t\t\t\tslot.classList.add('hidden');\n\t\t\t\t\t}\n\t\t\t\t}\n\n\t\t\t\tfunction dragover(event) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tevent.stopPropagation();\n\t\t\t\t}\n\n\t\t\t\tfunction dragenter(el, event) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tevent.stopPropagation();\n\t\t\t\t\tel.classList.add('border-primary');\n\t\t\t\t}\n\n\t\t\t\tfunction dragleave(el, event) {\n\t\t\t\t\tif (event.target === el) el.classList.remove('border-primary');\n\t\t\t\t}\n\n\t\t\t\tfunction drop(el, event, inputId) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tevent.stopPropagation();\n\t\t\t\t\tel.classList.remove('border-primary');\n\t\t\t\t\tvar inp = document.getElementById(inputId);\n\t\t\t\t\tif (!inp || !event.dataTransfer || !event.dataTransfer.files || !event.dataTransfer.files.length) return;\n\t\t\t\t\ttry {\n\t\t\t\t\t\tinp.files = event.dataTransfer.files;\n\t\t\t\t\t} catch (e) {\n\t\t\t\t\t\tif (typeof DataTransfer !== 'function') return;\n\t\t\t\t\t\tvar dt = new DataTransfer();\n\t\t\t\t\t\tfor (var i = 0; i < event.dataTransfer.files.length; i++) {\n\t\t\t\t\t\t\tdt.items.add(event.dataTransfer.files[i]);\n\t\t\t\t\t\t}\n\t\t\t\t\t\tinp.files = dt.files;\n\t\t\t\t\t}\n\t\t\t\t\tinp.dispatchEvent(new Event('change', { bubbles: true }));\n\t\t\t\t}\n\n\t\t\t\tfunction beforeRequest(input, event) {\n\t\t\t\t\tvar cfg = readConfig(input);\n\t\t\t\t\tclearError(cfg.slot);\n\t\t\t\t\tvar errs = [];\n\t\t\t\t\tvar files = input.files || [];\n\t\t\t\t\tfor (var i = 0; i < files.length; i++) {\n\t\t\t\t\t\tvar f = files[i];\n\t\t\t\t\t\tif (cfg.maxSize > 0 && f.size > cfg.maxSize) {\n\t\t\t\t\t\t\terrs.push((cfg.labels.sizeRejected || '{name} is too large')\n\t\t\t\t\t\t\t\t.replace('{name}', f.name)\n\t\t\t\t\t\t\t\t.replace('{size}', (f.size / 1048576).toFixed(1))\n\t\t\t\t\t\t\t\t.replace('{limit}', (cfg.maxSize / 1048576).toFixed(1)));\n\t\t\t\t\t\t\tcontinue;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tif (cfg.accept && !acceptMatches(f, cfg.accept)) {\n\t\t\t\t\t\t\terrs.push((cfg.labels.typeRejected || '{name} unsupported').replace('{name}', f.name));\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t\tif (errs.length) {\n\t\t\t\t\t\tsetError(cfg.slot, errs.join('; '));\n\t\t\t\t\t\tinput.value = '';\n\t\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\t}\n\t\t\t\t}\n\n\t\t\t\tfunction pickResponseMessage(xhr, labels) {\n\t\t\t\t\tvar status = xhr ? xhr.status : 0;\n\t\t\t\t\tvar body = xhr ? (xhr.responseText || '') : '';\n\t\t\t\t\tif (status === 413) return labels.tooLargeStatus || 'File too large';\n\t\t\t\t\tif (status === 415) return labels.unsupportedType || 'Unsupported file type';\n\t\t\t\t\tif (status >= 500) return labels.serverError || 'Server error';\n\t\t\t\t\tif (body && body.length < 200 && body.indexOf('<') === -1) return body.trim();\n\t\t\t\t\treturn labels.genericError || 'Upload failed';\n\t\t\t\t}\n\n\t\t\t\tfunction onResponseError(input, event) {\n\t\t\t\t\tvar cfg = readConfig(input);\n\t\t\t\t\tvar xhr = event && event.detail && event.detail.xhr;\n\t\t\t\t\tsetError(cfg.slot, pickResponseMessage(xhr, cfg.labels));\n\t\t\t\t}\n\n\t\t\t\tfunction onSendError(input) {\n\t\t\t\t\tvar cfg = readConfig(input);\n\t\t\t\t\tsetError(cfg.slot, cfg.labels.networkError || 'Network error');\n\t\t\t\t}\n\n\t\t\t\treturn {\n\t\t\t\t\tacceptMatches: acceptMatches,\n\t\t\t\t\tdragover: dragover,\n\t\t\t\t\tdragenter: dragenter,\n\t\t\t\t\tdragleave: dragleave,\n\t\t\t\t\tdrop: drop,\n\t\t\t\t\tbeforeRequest: beforeRequest,\n\t\t\t\t\tonResponseError: onResponseError,\n\t\t\t\t\tonSendError: onSendError,\n\t\t\t\t\tsetError: setError,\n\t\t\t\t\tclearError: clearError,\n\t\t\t\t};\n\t\t\t})();\n\t\t}\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -674,9 +748,9 @@ func UploadInput(props *UploadInputProps) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var30 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var30 == nil {
-			templ_7745c5c3_Var30 = templ.NopComponent
+		templ_7745c5c3_Var35 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var35 == nil {
+			templ_7745c5c3_Var35 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = newUploadInput(props).render().Render(ctx, templ_7745c5c3_Buffer)
@@ -707,6 +781,13 @@ func removeUploadedFile(rowID string) templ.ComponentScript {
 func uploadDisplayName(upload *viewmodels.Upload) string {
 	if upload == nil {
 		return "Uploaded file"
+	}
+	// Prefer the original filename (Name) so the user sees "scan.pdf"
+	// instead of the storage hash. Slug is a filesystem-safe identifier
+	// that defaults to the hash when no name was provided, so it is a
+	// fallback rather than a primary display.
+	if value := strings.TrimSpace(upload.Name); value != "" {
+		return value
 	}
 	if value := strings.TrimSpace(upload.Slug); value != "" {
 		return value

--- a/components/upload_input_templ.go
+++ b/components/upload_input_templ.go
@@ -618,13 +618,15 @@ func (p *UploadInputProps) render() templ.Component {
 	})
 }
 
-// uploadInputScript emits the runtime helpers shared by every UploadInput
-// instance on the page. Idempotent via a `__upload` existence check so
-// rendering N inputs only registers the helpers once. Centralising the
-// logic here keeps the Go side declarative — templates only emit
+// UploadHelpersScript emits the runtime helpers shared by every upload
+// dropzone on the page (this SDK's `UploadInput` and any consumer that
+// wants to reuse the `__upload` namespace, e.g. the EAI claim
+// `UploadSection`). Idempotent via a `__upload` existence check so
+// rendering N dropzones only registers the helpers once. Centralising the
+// logic here keeps templates declarative — call sites only emit
 // `__upload.fn(this, event)` callbacks plus per-instance config in
 // data-* attributes.
-func uploadInputScript() templ.Component {
+func UploadHelpersScript() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -655,7 +657,7 @@ func uploadInputScript() templ.Component {
 
 // UploadInput renders a file upload input with preview capability. Drop
 // support, client-side validation and async error feedback are powered by
-// the shared `__upload` helpers in `uploadInputScript`.
+// the shared `__upload` helpers in `UploadHelpersScript`.
 func UploadInput(props *UploadInputProps) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -681,7 +683,7 @@ func UploadInput(props *UploadInputProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = uploadInputScript().Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = UploadHelpersScript().Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/components/upload_input_templ.go
+++ b/components/upload_input_templ.go
@@ -419,20 +419,28 @@ func (p *UploadInputProps) render() templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, " hx-on::after-request=\"this.value = &#39;&#39;\"></div><div id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, " hx-on::after-request=\"this.value = &#39;&#39;\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, uploadErrorAttrs(p.ID))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "></div><div id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var23 string
 		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("target-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 110, Col: 43}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 111, Col: 43}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -440,7 +448,7 @@ func (p *UploadInputProps) render() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</div><div class=\"flex gap-1 items-center mt-4 mb-1.5\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "</div><div class=\"flex gap-1 items-center mt-4 mb-1.5\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -459,7 +467,7 @@ func (p *UploadInputProps) render() templ.Component {
 			var templ_7745c5c3_Var25 string
 			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(p.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 123, Col: 14}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 124, Col: 14}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {
@@ -479,48 +487,89 @@ func (p *UploadInputProps) render() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "</div><p class=\"text-xs\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</div><p class=\"text-xs\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var26 string
 		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(p.Placeholder)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 127, Col: 19}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 128, Col: 19}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</p><p id=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var27 string
+		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("error-%s", p.ID))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 133, Col: 38}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "\" class=\"text-red-500 text-xs mt-2 hidden\" role=\"alert\" aria-live=\"polite\"></p>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if p.Error != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "<p class=\"text-red-500 text-xs mt-2\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "<p class=\"text-red-500 text-xs mt-2\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var27 string
-			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(p.Error)
+			var templ_7745c5c3_Var28 string
+			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(p.Error)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 131, Col: 14}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 140, Col: 14}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		return nil
 	})
+}
+
+// uploadErrorAttrs builds the HTMX failure-event handlers for the hidden file
+// input. On a server error (4xx/5xx) it surfaces the response body; on a
+// pre-flight failure (network/CORS/offline) it shows a generic retry message.
+// Both render an inline error inside the dropzone and dispatch a `notify`
+// toast event so users actually see what went wrong instead of the spinner
+// silently disappearing. `hx-on::before-request` clears any prior error so a
+// fresh upload starts clean.
+func uploadErrorAttrs(id string) templ.Attributes {
+	clearSlot := fmt.Sprintf(
+		`var slot = document.getElementById('error-%s'); if (slot) { slot.textContent = ''; slot.classList.add('hidden'); }`,
+		id,
+	)
+	render := func(read string) string {
+		return fmt.Sprintf(
+			`%s var slot = document.getElementById('error-%s'); if (slot) { slot.textContent = msg; slot.classList.remove('hidden'); }`+
+				` window.dispatchEvent(new CustomEvent('notify', {detail: {variant: 'error', message: msg}}));`,
+			read, id,
+		)
+	}
+	respErr := render(`var msg = (event.detail && event.detail.xhr && event.detail.xhr.responseText) ? event.detail.xhr.responseText : ''; if (!msg) { msg = 'Upload failed'; } if (msg.length > 200) { msg = msg.slice(0, 200) + '…'; }`)
+	netErr := render(`var msg = 'Network error — please retry';`)
+	return templ.Attributes{
+		"hx-on::before-request": clearSlot,
+		"hx-on::response-error": respErr,
+		"hx-on::send-error":     netErr,
+	}
 }
 
 // uploadDropAttrs builds the dragover/dragenter/dragleave/drop handlers that
@@ -564,9 +613,9 @@ func UploadInput(props *UploadInputProps) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var28 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var28 == nil {
-			templ_7745c5c3_Var28 = templ.NopComponent
+		templ_7745c5c3_Var29 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var29 == nil {
+			templ_7745c5c3_Var29 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = newUploadInput(props).render().Render(ctx, templ_7745c5c3_Buffer)

--- a/components/upload_input_templ.go
+++ b/components/upload_input_templ.go
@@ -33,6 +33,28 @@ type UploadInputProps struct {
 	Form        string               // ID of the form this input belongs to
 	Class       string               // Additional CSS classes
 	Multiple    bool                 // Whether multiple file uploads are allowed
+
+	// MaxSize is the per-file size limit in bytes enforced client-side before
+	// upload. 0 means no client-side limit (server may still reject).
+	MaxSize int64
+
+	// Labels override default English copy used in async error feedback. Each
+	// field is optional; empty values fall back to a built-in default.
+	Labels UploadInputLabels
+}
+
+// UploadInputLabels holds the user-facing strings rendered by the component
+// at runtime. Use {name}, {size} and {limit} placeholders in messages where
+// applicable — they are replaced with the rejected file's name, megabyte
+// size and configured limit respectively.
+type UploadInputLabels struct {
+	GenericError    string // generic 4xx/5xx fallback, default "Upload failed"
+	NetworkError    string // pre-flight failure, default "Network error — please retry"
+	TypeRejected    string // unsupported extension, default `File "{name}" — unsupported format`
+	SizeRejected    string // oversized file, default `File "{name}" is too large ({size}MB > {limit}MB)`
+	TooLargeStatus  string // 413 fallback, default "File too large"
+	UnsupportedType string // 415 fallback, default "Unsupported file type"
+	ServerError     string // 5xx fallback, default "Server error — please retry later"
 }
 
 func newUploadInput(props *UploadInputProps) *UploadInputProps {
@@ -42,7 +64,32 @@ func newUploadInput(props *UploadInputProps) *UploadInputProps {
 	if props.Accept == "" {
 		props.Accept = "image/*"
 	}
+	applyLabelDefaults(&props.Labels)
 	return props
+}
+
+func applyLabelDefaults(l *UploadInputLabels) {
+	if l.GenericError == "" {
+		l.GenericError = "Upload failed"
+	}
+	if l.NetworkError == "" {
+		l.NetworkError = "Network error — please retry"
+	}
+	if l.TypeRejected == "" {
+		l.TypeRejected = `File "{name}" — unsupported format`
+	}
+	if l.SizeRejected == "" {
+		l.SizeRejected = `File "{name}" is too large ({size}MB > {limit}MB)`
+	}
+	if l.TooLargeStatus == "" {
+		l.TooLargeStatus = "File too large"
+	}
+	if l.UnsupportedType == "" {
+		l.UnsupportedType = "Unsupported file type"
+	}
+	if l.ServerError == "" {
+		l.ServerError = "Server error — please retry later"
+	}
 }
 
 func UploadTarget(p *UploadInputProps) templ.Component {
@@ -79,7 +126,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 			var templ_7745c5c3_Var2 string
 			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(rowID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 44, Col: 18}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 91, Col: 18}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
@@ -92,7 +139,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(uploadDisplayName(upload))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 47, Col: 84}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 94, Col: 84}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -105,7 +152,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(uploadDisplayMeta(upload))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 48, Col: 81}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 95, Col: 81}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -148,7 +195,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 				var templ_7745c5c3_Var6 string
 				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(upload.URL)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 61, Col: 75}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 108, Col: 75}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 				if templ_7745c5c3_Err != nil {
@@ -161,7 +208,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 				var templ_7745c5c3_Var7 string
 				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(uploadDisplayName(upload))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 61, Col: 109}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 108, Col: 109}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 				if templ_7745c5c3_Err != nil {
@@ -180,7 +227,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 				var templ_7745c5c3_Var8 string
 				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(p.Name)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 64, Col: 39}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 111, Col: 39}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 				if templ_7745c5c3_Err != nil {
@@ -193,7 +240,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 				var templ_7745c5c3_Var9 string
 				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(upload.ID)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 64, Col: 59}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 111, Col: 59}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 				if templ_7745c5c3_Err != nil {
@@ -206,7 +253,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 				var templ_7745c5c3_Var10 string
 				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(p.Form)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 64, Col: 75}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 111, Col: 75}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 				if templ_7745c5c3_Err != nil {
@@ -224,7 +271,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 				var templ_7745c5c3_Var11 string
 				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(p.Name)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 66, Col: 39}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 113, Col: 39}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 				if templ_7745c5c3_Err != nil {
@@ -237,7 +284,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 				var templ_7745c5c3_Var12 string
 				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(upload.ID)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 66, Col: 59}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 113, Col: 59}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 				if templ_7745c5c3_Err != nil {
@@ -315,13 +362,13 @@ func (p *UploadInputProps) render() templ.Component {
 		var templ_7745c5c3_Var16 string
 		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("spinner-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 82, Col: 39}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 132, Col: 39}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\" class=\"htmx-indicator absolute inset-0 z-10 flex items-center justify-center rounded-md bg-white/70\" aria-hidden=\"true\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\" class=\"htmx-indicator pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-md bg-surface-100/80\" aria-hidden=\"true\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -338,7 +385,7 @@ func (p *UploadInputProps) render() templ.Component {
 		var templ_7745c5c3_Var17 string
 		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("upload-form-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 91, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 141, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
@@ -351,7 +398,7 @@ func (p *UploadInputProps) render() templ.Component {
 		var templ_7745c5c3_Var18 string
 		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(p.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 93, Col: 14}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 143, Col: 14}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 		if templ_7745c5c3_Err != nil {
@@ -364,7 +411,7 @@ func (p *UploadInputProps) render() templ.Component {
 		var templ_7745c5c3_Var19 string
 		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(p.Accept)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 98, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 148, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 		if templ_7745c5c3_Err != nil {
@@ -377,7 +424,7 @@ func (p *UploadInputProps) render() templ.Component {
 		var templ_7745c5c3_Var20 string
 		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("#target-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 100, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 150, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 		if templ_7745c5c3_Err != nil {
@@ -390,7 +437,7 @@ func (p *UploadInputProps) render() templ.Component {
 		var templ_7745c5c3_Var21 string
 		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("#spinner-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 101, Col: 52}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 151, Col: 52}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 		if templ_7745c5c3_Err != nil {
@@ -403,13 +450,13 @@ func (p *UploadInputProps) render() templ.Component {
 		var templ_7745c5c3_Var22 string
 		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf(`{"_id": "%s", "_formName": "%s", "_name": "%s", "_multiple": "%t"}`, p.ID, p.Form, p.Name, p.Multiple))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 104, Col: 130}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 154, Col: 130}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\" name=\"file\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\" hx-sync=\"this:drop\" name=\"file\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -423,7 +470,11 @@ func (p *UploadInputProps) render() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, uploadErrorAttrs(p.ID))
+		templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, uploadValidationAttrs(p))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, uploadErrorAttrs(p))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -434,7 +485,7 @@ func (p *UploadInputProps) render() templ.Component {
 		var templ_7745c5c3_Var23 string
 		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("target-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 111, Col: 43}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 163, Col: 43}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 		if templ_7745c5c3_Err != nil {
@@ -467,7 +518,7 @@ func (p *UploadInputProps) render() templ.Component {
 			var templ_7745c5c3_Var25 string
 			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(p.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 124, Col: 14}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 176, Col: 14}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {
@@ -494,7 +545,7 @@ func (p *UploadInputProps) render() templ.Component {
 		var templ_7745c5c3_Var26 string
 		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(p.Placeholder)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 128, Col: 19}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 180, Col: 19}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 		if templ_7745c5c3_Err != nil {
@@ -507,7 +558,7 @@ func (p *UploadInputProps) render() templ.Component {
 		var templ_7745c5c3_Var27 string
 		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("error-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 133, Col: 38}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 185, Col: 38}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 		if templ_7745c5c3_Err != nil {
@@ -525,7 +576,7 @@ func (p *UploadInputProps) render() templ.Component {
 			var templ_7745c5c3_Var28 string
 			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(p.Error)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 140, Col: 14}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 192, Col: 14}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 			if templ_7745c5c3_Err != nil {
@@ -544,29 +595,74 @@ func (p *UploadInputProps) render() templ.Component {
 	})
 }
 
-// uploadErrorAttrs builds the HTMX failure-event handlers for the hidden file
-// input. On a server error (4xx/5xx) it surfaces the response body; on a
-// pre-flight failure (network/CORS/offline) it shows a generic retry message.
-// Both render an inline error inside the dropzone and dispatch a `notify`
-// toast event so users actually see what went wrong instead of the spinner
-// silently disappearing. `hx-on::before-request` clears any prior error so a
-// fresh upload starts clean.
-func uploadErrorAttrs(id string) templ.Attributes {
-	clearSlot := fmt.Sprintf(
-		`var slot = document.getElementById('error-%s'); if (slot) { slot.textContent = ''; slot.classList.add('hidden'); }`,
-		id,
+// uploadValidationAttrs builds the `hx-on::before-request` handler that
+// rejects files exceeding `MaxSize` or whose extension/mimetype does not
+// match `Accept` before the upload fires. The browser already enforces
+// `accept` on click-picked files, but drop events bypass it — so we filter
+// in JS to keep the behaviour consistent.
+//
+// On rejection: render an inline error in the dropzone, dispatch a `notify`
+// toast, clear the input value (so the same file can be retried), and call
+// `event.preventDefault()` to abort the request. On success: clear any
+// stale error and let HTMX continue.
+func uploadValidationAttrs(p *UploadInputProps) templ.Attributes {
+	js := fmt.Sprintf(
+		`var inp = this; var slot = document.getElementById('error-%s');`+
+			` if (slot) { slot.textContent = ''; slot.classList.add('hidden'); }`+
+			` var maxSize = %d; var accept = %q;`+
+			` var sizeTpl = %q; var typeTpl = %q;`+
+			` var errs = []; var files = inp.files || [];`+
+			` for (var i = 0; i < files.length; i++) {`+
+			`   var f = files[i];`+
+			`   if (maxSize > 0 && f.size > maxSize) {`+
+			`     errs.push(sizeTpl.replace('{name}', f.name).replace('{size}', (f.size/1048576).toFixed(1)).replace('{limit}', (maxSize/1048576).toFixed(1)));`+
+			`     continue;`+
+			`   }`+
+			`   if (accept && !__uploadAcceptMatches(f, accept)) {`+
+			`     errs.push(typeTpl.replace('{name}', f.name));`+
+			`   }`+
+			` }`+
+			` if (errs.length) {`+
+			`   var msg = errs.join('; ');`+
+			`   if (slot) { slot.textContent = msg; slot.classList.remove('hidden'); }`+
+			`   window.dispatchEvent(new CustomEvent('notify', {detail: {variant: 'error', message: msg}}));`+
+			`   inp.value = ''; event.preventDefault();`+
+			` }`,
+		p.ID, p.MaxSize, p.Accept, p.Labels.SizeRejected, p.Labels.TypeRejected,
 	)
+	return templ.Attributes{
+		"hx-on::before-request": js,
+	}
+}
+
+// uploadErrorAttrs builds the HTMX failure-event handlers for the hidden file
+// input. Server errors (4xx/5xx) get pretty-mapped by status code; only
+// fall back to the raw response body when no status-specific label fits.
+// Pre-flight failures (network/CORS/offline) get the network label.
+//
+// Both render an inline error inside the dropzone and dispatch a `notify`
+// toast event.
+func uploadErrorAttrs(p *UploadInputProps) templ.Attributes {
 	render := func(read string) string {
 		return fmt.Sprintf(
 			`%s var slot = document.getElementById('error-%s'); if (slot) { slot.textContent = msg; slot.classList.remove('hidden'); }`+
 				` window.dispatchEvent(new CustomEvent('notify', {detail: {variant: 'error', message: msg}}));`,
-			read, id,
+			read, p.ID,
 		)
 	}
-	respErr := render(`var msg = (event.detail && event.detail.xhr && event.detail.xhr.responseText) ? event.detail.xhr.responseText : ''; if (!msg) { msg = 'Upload failed'; } if (msg.length > 200) { msg = msg.slice(0, 200) + '…'; }`)
-	netErr := render(`var msg = 'Network error — please retry';`)
+	respErr := render(fmt.Sprintf(
+		`var xhr = event.detail && event.detail.xhr; var status = xhr ? xhr.status : 0; var body = xhr ? (xhr.responseText || '') : '';`+
+			` var msg = '';`+
+			` if (status === 413) { msg = %q; }`+
+			` else if (status === 415) { msg = %q; }`+
+			` else if (status >= 500) { msg = %q; }`+
+			` else if (body && body.length < 200 && body.indexOf('<') === -1) { msg = body; }`+
+			` else { msg = %q; }`,
+		p.Labels.TooLargeStatus, p.Labels.UnsupportedType, p.Labels.ServerError, p.Labels.GenericError,
+	))
+	netErr := fmt.Sprintf(`var msg = %q;`, p.Labels.NetworkError)
+	netErr = render(netErr)
 	return templ.Attributes{
-		"hx-on::before-request": clearSlot,
 		"hx-on::response-error": respErr,
 		"hx-on::send-error":     netErr,
 	}
@@ -619,6 +715,44 @@ func UploadInput(props *UploadInputProps) templ.Component {
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = newUploadInput(props).render().Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = uploadAcceptHelper().Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// uploadAcceptHelper emits the global `__uploadAcceptMatches` JS function
+// once per page (idempotent via existence check) so multiple UploadInputs
+// share a single implementation. Matches files against the same syntax the
+// browser uses for `accept`: comma-separated extensions (`.pdf`),
+// MIME types (`image/png`), or wildcards (`image/*`).
+func uploadAcceptHelper() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var30 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var30 == nil {
+			templ_7745c5c3_Var30 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<script>\n\t\tif (typeof window.__uploadAcceptMatches !== 'function') {\n\t\t\twindow.__uploadAcceptMatches = function (file, accept) {\n\t\t\t\tif (!accept) return true;\n\t\t\t\tvar name = (file.name || '').toLowerCase();\n\t\t\t\tvar type = (file.type || '').toLowerCase();\n\t\t\t\tvar tokens = accept.split(',').map(function (s) { return s.trim().toLowerCase(); }).filter(Boolean);\n\t\t\t\tfor (var i = 0; i < tokens.length; i++) {\n\t\t\t\t\tvar t = tokens[i];\n\t\t\t\t\tif (t.indexOf('.') === 0) {\n\t\t\t\t\t\tif (name.endsWith(t)) return true;\n\t\t\t\t\t} else if (t.indexOf('/*') === t.length - 2) {\n\t\t\t\t\t\tvar prefix = t.slice(0, t.length - 1);\n\t\t\t\t\t\tif (type.indexOf(prefix) === 0) return true;\n\t\t\t\t\t} else if (type === t) {\n\t\t\t\t\t\treturn true;\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\treturn false;\n\t\t\t};\n\t\t}\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/components/upload_input_templ.go
+++ b/components/upload_input_templ.go
@@ -9,6 +9,7 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -21,40 +22,36 @@ import (
 )
 
 // UploadInputProps defines the properties for the UploadInput component.
-// It provides configuration options for the file upload interface.
 type UploadInputProps struct {
-	ID          string               // Unique identifier for the input
-	Label       string               // Text label for the upload button
-	Placeholder string               // Placeholder text shown below the button
-	Uploads     []*viewmodels.Upload // List of already uploaded files
-	Error       string               // Error message to display
-	Accept      string               // File types to accept (e.g., "image/*")
-	Name        string               // Name attribute for the form field
-	Form        string               // ID of the form this input belongs to
-	Class       string               // Additional CSS classes
-	Multiple    bool                 // Whether multiple file uploads are allowed
+	ID          string
+	Label       string
+	Placeholder string
+	Uploads     []*viewmodels.Upload
+	Error       string
+	Accept      string
+	Name        string
+	Form        string
+	Class       string
+	Multiple    bool
 
-	// MaxSize is the per-file size limit in bytes enforced client-side before
-	// upload. 0 means no client-side limit (server may still reject).
+	// MaxSize is the per-file size limit in bytes enforced client-side
+	// before upload. 0 = no client-side limit (server may still reject).
 	MaxSize int64
 
-	// Labels override default English copy used in async error feedback. Each
-	// field is optional; empty values fall back to a built-in default.
+	// Labels override default English copy for async error feedback. Use
+	// {name}, {size}, {limit} placeholders in TypeRejected/SizeRejected;
+	// they are replaced with the rejected file's name and megabyte values.
 	Labels UploadInputLabels
 }
 
-// UploadInputLabels holds the user-facing strings rendered by the component
-// at runtime. Use {name}, {size} and {limit} placeholders in messages where
-// applicable — they are replaced with the rejected file's name, megabyte
-// size and configured limit respectively.
 type UploadInputLabels struct {
-	GenericError    string // generic 4xx/5xx fallback, default "Upload failed"
-	NetworkError    string // pre-flight failure, default "Network error — please retry"
-	TypeRejected    string // unsupported extension, default `File "{name}" — unsupported format`
-	SizeRejected    string // oversized file, default `File "{name}" is too large ({size}MB > {limit}MB)`
-	TooLargeStatus  string // 413 fallback, default "File too large"
-	UnsupportedType string // 415 fallback, default "Unsupported file type"
-	ServerError     string // 5xx fallback, default "Server error — please retry later"
+	GenericError    string `json:"genericError"`
+	NetworkError    string `json:"networkError"`
+	TypeRejected    string `json:"typeRejected"`
+	SizeRejected    string `json:"sizeRejected"`
+	TooLargeStatus  string `json:"tooLargeStatus"`
+	UnsupportedType string `json:"unsupportedType"`
+	ServerError     string `json:"serverError"`
 }
 
 func newUploadInput(props *UploadInputProps) *UploadInputProps {
@@ -92,6 +89,36 @@ func applyLabelDefaults(l *UploadInputLabels) {
 	}
 }
 
+// uploadInputDropAttrs returns the drag-and-drop event handlers for the
+// outer wrapper. Defined as a Go helper because templ's attribute parser
+// treats `on*=` literals as templ.ComponentScript when the value is an
+// expression — a bare templ.Attributes spread sidesteps that and keeps
+// the JS handlers as plain strings.
+func uploadInputDropAttrs(id string) templ.Attributes {
+	return templ.Attributes{
+		"ondragenter": "__upload.dragenter(this, event)",
+		"ondragover":  "__upload.dragover(event)",
+		"ondragleave": "__upload.dragleave(this, event)",
+		"ondrop":      fmt.Sprintf("__upload.drop(this, event, %q)", id),
+	}
+}
+
+// uploadInputDataAttrs serialises the per-instance config (size limit,
+// accept list, error/status labels, error-slot id) as JSON-in-data-*
+// attributes that the runtime helpers in `uploadInputScript` read at the
+// moment of an event. Keeping the inline `hx-on::*` and `ondrop="..."`
+// handlers as one-liners (e.g. `__upload.drop(this, event, '<id>')`)
+// instead of multi-line JS-in-Go strings.
+func uploadInputDataAttrs(p *UploadInputProps) templ.Attributes {
+	labels, _ := json.Marshal(p.Labels)
+	return templ.Attributes{
+		"data-upload-max-size": fmt.Sprintf("%d", p.MaxSize),
+		"data-upload-accept":   p.Accept,
+		"data-upload-slot":     fmt.Sprintf("error-%s", p.ID),
+		"data-upload-labels":   string(labels),
+	}
+}
+
 func UploadTarget(p *UploadInputProps) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
@@ -126,7 +153,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 			var templ_7745c5c3_Var2 string
 			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(rowID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 91, Col: 18}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 118, Col: 18}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
@@ -139,7 +166,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(uploadDisplayName(upload))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 94, Col: 84}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 121, Col: 84}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 			if templ_7745c5c3_Err != nil {
@@ -152,7 +179,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(uploadDisplayMeta(upload))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 95, Col: 81}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 122, Col: 81}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
@@ -195,7 +222,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 				var templ_7745c5c3_Var6 string
 				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(upload.URL)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 108, Col: 75}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 135, Col: 75}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 				if templ_7745c5c3_Err != nil {
@@ -208,7 +235,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 				var templ_7745c5c3_Var7 string
 				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(uploadDisplayName(upload))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 108, Col: 109}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 135, Col: 109}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 				if templ_7745c5c3_Err != nil {
@@ -227,7 +254,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 				var templ_7745c5c3_Var8 string
 				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(p.Name)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 111, Col: 39}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 138, Col: 39}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 				if templ_7745c5c3_Err != nil {
@@ -240,7 +267,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 				var templ_7745c5c3_Var9 string
 				templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(upload.ID)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 111, Col: 59}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 138, Col: 59}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 				if templ_7745c5c3_Err != nil {
@@ -253,7 +280,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 				var templ_7745c5c3_Var10 string
 				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(p.Form)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 111, Col: 75}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 138, Col: 75}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 				if templ_7745c5c3_Err != nil {
@@ -271,7 +298,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 				var templ_7745c5c3_Var11 string
 				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(p.Name)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 113, Col: 39}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 140, Col: 39}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 				if templ_7745c5c3_Err != nil {
@@ -284,7 +311,7 @@ func UploadTarget(p *UploadInputProps) templ.Component {
 				var templ_7745c5c3_Var12 string
 				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(upload.ID)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 113, Col: 59}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 140, Col: 59}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 				if templ_7745c5c3_Err != nil {
@@ -351,7 +378,7 @@ func (p *UploadInputProps) render() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, uploadDropAttrs(p.ID))
+		templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, uploadInputDropAttrs(p.ID))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -362,7 +389,7 @@ func (p *UploadInputProps) render() templ.Component {
 		var templ_7745c5c3_Var16 string
 		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("spinner-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 132, Col: 39}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 153, Col: 39}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 		if templ_7745c5c3_Err != nil {
@@ -385,7 +412,7 @@ func (p *UploadInputProps) render() templ.Component {
 		var templ_7745c5c3_Var17 string
 		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("upload-form-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 141, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 162, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
@@ -398,7 +425,7 @@ func (p *UploadInputProps) render() templ.Component {
 		var templ_7745c5c3_Var18 string
 		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(p.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 143, Col: 14}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 164, Col: 14}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 		if templ_7745c5c3_Err != nil {
@@ -411,7 +438,7 @@ func (p *UploadInputProps) render() templ.Component {
 		var templ_7745c5c3_Var19 string
 		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(p.Accept)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 148, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 169, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 		if templ_7745c5c3_Err != nil {
@@ -424,7 +451,7 @@ func (p *UploadInputProps) render() templ.Component {
 		var templ_7745c5c3_Var20 string
 		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("#target-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 150, Col: 48}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 171, Col: 48}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 		if templ_7745c5c3_Err != nil {
@@ -437,7 +464,7 @@ func (p *UploadInputProps) render() templ.Component {
 		var templ_7745c5c3_Var21 string
 		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("#spinner-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 151, Col: 52}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 172, Col: 52}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 		if templ_7745c5c3_Err != nil {
@@ -450,7 +477,7 @@ func (p *UploadInputProps) render() templ.Component {
 		var templ_7745c5c3_Var22 string
 		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf(`{"_id": "%s", "_formName": "%s", "_name": "%s", "_multiple": "%t"}`, p.ID, p.Form, p.Name, p.Multiple))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 154, Col: 130}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 175, Col: 130}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 		if templ_7745c5c3_Err != nil {
@@ -466,15 +493,11 @@ func (p *UploadInputProps) render() templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, " hx-on::after-request=\"this.value = &#39;&#39;\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, " hx-on::after-request=\"this.value = &#39;&#39;\" hx-on::before-request=\"__upload.beforeRequest(this, event)\" hx-on::response-error=\"__upload.onResponseError(this, event)\" hx-on::send-error=\"__upload.onSendError(this, event)\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, uploadValidationAttrs(p))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, uploadErrorAttrs(p))
+		templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, uploadInputDataAttrs(p))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -485,7 +508,7 @@ func (p *UploadInputProps) render() templ.Component {
 		var templ_7745c5c3_Var23 string
 		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("target-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 163, Col: 43}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 186, Col: 43}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 		if templ_7745c5c3_Err != nil {
@@ -518,7 +541,7 @@ func (p *UploadInputProps) render() templ.Component {
 			var templ_7745c5c3_Var25 string
 			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(p.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 176, Col: 14}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 199, Col: 14}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {
@@ -545,7 +568,7 @@ func (p *UploadInputProps) render() templ.Component {
 		var templ_7745c5c3_Var26 string
 		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(p.Placeholder)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 180, Col: 19}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 203, Col: 19}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 		if templ_7745c5c3_Err != nil {
@@ -558,7 +581,7 @@ func (p *UploadInputProps) render() templ.Component {
 		var templ_7745c5c3_Var27 string
 		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("error-%s", p.ID))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 185, Col: 38}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 206, Col: 38}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 		if templ_7745c5c3_Err != nil {
@@ -576,7 +599,7 @@ func (p *UploadInputProps) render() templ.Component {
 			var templ_7745c5c3_Var28 string
 			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(p.Error)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 192, Col: 14}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/upload_input.templ`, Line: 213, Col: 14}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 			if templ_7745c5c3_Err != nil {
@@ -595,105 +618,13 @@ func (p *UploadInputProps) render() templ.Component {
 	})
 }
 
-// uploadValidationAttrs builds the `hx-on::before-request` handler that
-// rejects files exceeding `MaxSize` or whose extension/mimetype does not
-// match `Accept` before the upload fires. The browser already enforces
-// `accept` on click-picked files, but drop events bypass it — so we filter
-// in JS to keep the behaviour consistent.
-//
-// On rejection: render an inline error in the dropzone, dispatch a `notify`
-// toast, clear the input value (so the same file can be retried), and call
-// `event.preventDefault()` to abort the request. On success: clear any
-// stale error and let HTMX continue.
-func uploadValidationAttrs(p *UploadInputProps) templ.Attributes {
-	js := fmt.Sprintf(
-		`var inp = this; var slot = document.getElementById('error-%s');`+
-			` if (slot) { slot.textContent = ''; slot.classList.add('hidden'); }`+
-			` var maxSize = %d; var accept = %q;`+
-			` var sizeTpl = %q; var typeTpl = %q;`+
-			` var errs = []; var files = inp.files || [];`+
-			` for (var i = 0; i < files.length; i++) {`+
-			`   var f = files[i];`+
-			`   if (maxSize > 0 && f.size > maxSize) {`+
-			`     errs.push(sizeTpl.replace('{name}', f.name).replace('{size}', (f.size/1048576).toFixed(1)).replace('{limit}', (maxSize/1048576).toFixed(1)));`+
-			`     continue;`+
-			`   }`+
-			`   if (accept && !__uploadAcceptMatches(f, accept)) {`+
-			`     errs.push(typeTpl.replace('{name}', f.name));`+
-			`   }`+
-			` }`+
-			` if (errs.length) {`+
-			`   var msg = errs.join('; ');`+
-			`   if (slot) { slot.textContent = msg; slot.classList.remove('hidden'); }`+
-			`   window.dispatchEvent(new CustomEvent('notify', {detail: {variant: 'error', message: msg}}));`+
-			`   inp.value = ''; event.preventDefault();`+
-			` }`,
-		p.ID, p.MaxSize, p.Accept, p.Labels.SizeRejected, p.Labels.TypeRejected,
-	)
-	return templ.Attributes{
-		"hx-on::before-request": js,
-	}
-}
-
-// uploadErrorAttrs builds the HTMX failure-event handlers for the hidden file
-// input. Server errors (4xx/5xx) get pretty-mapped by status code; only
-// fall back to the raw response body when no status-specific label fits.
-// Pre-flight failures (network/CORS/offline) get the network label.
-//
-// Both render an inline error inside the dropzone and dispatch a `notify`
-// toast event.
-func uploadErrorAttrs(p *UploadInputProps) templ.Attributes {
-	render := func(read string) string {
-		return fmt.Sprintf(
-			`%s var slot = document.getElementById('error-%s'); if (slot) { slot.textContent = msg; slot.classList.remove('hidden'); }`+
-				` window.dispatchEvent(new CustomEvent('notify', {detail: {variant: 'error', message: msg}}));`,
-			read, p.ID,
-		)
-	}
-	respErr := render(fmt.Sprintf(
-		`var xhr = event.detail && event.detail.xhr; var status = xhr ? xhr.status : 0; var body = xhr ? (xhr.responseText || '') : '';`+
-			` var msg = '';`+
-			` if (status === 413) { msg = %q; }`+
-			` else if (status === 415) { msg = %q; }`+
-			` else if (status >= 500) { msg = %q; }`+
-			` else if (body && body.length < 200 && body.indexOf('<') === -1) { msg = body; }`+
-			` else { msg = %q; }`,
-		p.Labels.TooLargeStatus, p.Labels.UnsupportedType, p.Labels.ServerError, p.Labels.GenericError,
-	))
-	netErr := fmt.Sprintf(`var msg = %q;`, p.Labels.NetworkError)
-	netErr = render(netErr)
-	return templ.Attributes{
-		"hx-on::response-error": respErr,
-		"hx-on::send-error":     netErr,
-	}
-}
-
-// uploadDropAttrs builds the dragover/dragenter/dragleave/drop handlers that
-// route a dropped FileList into the hidden <input type=file> and dispatch
-// `change` so the existing HTMX hx-trigger="change" picks the upload up.
-// The DataTransfer fallback covers older WebKit builds where input.files is
-// read-only.
-func uploadDropAttrs(id string) templ.Attributes {
-	drop := fmt.Sprintf(
-		`event.preventDefault(); event.stopPropagation(); this.classList.remove('border-primary');`+
-			` var inp=document.getElementById(%q);`+
-			` if(!inp||!event.dataTransfer||!event.dataTransfer.files||!event.dataTransfer.files.length){return;}`+
-			` try{inp.files=event.dataTransfer.files;}`+
-			` catch(e){if(typeof DataTransfer==='function'){var dt=new DataTransfer(); for(var i=0;i<event.dataTransfer.files.length;i++){dt.items.add(event.dataTransfer.files[i]);} inp.files=dt.files;}}`+
-			` inp.dispatchEvent(new Event('change',{bubbles:true}));`,
-		id,
-	)
-	return templ.Attributes{
-		"ondragover":  "event.preventDefault(); event.stopPropagation();",
-		"ondragenter": "event.preventDefault(); event.stopPropagation(); this.classList.add('border-primary');",
-		"ondragleave": "if(event.target===this){this.classList.remove('border-primary');}",
-		"ondrop":      drop,
-	}
-}
-
-// UploadInput renders a file upload input with preview capability.
-// It displays existing uploads and allows selecting new files.
-func UploadInput(props *UploadInputProps) templ.Component {
+// uploadInputScript emits the runtime helpers shared by every UploadInput
+// instance on the page. Idempotent via a `__upload` existence check so
+// rendering N inputs only registers the helpers once. Centralising the
+// logic here keeps the Go side declarative — templates only emit
+// `__upload.fn(this, event)` callbacks plus per-instance config in
+// data-* attributes.
+func uploadInputScript() templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -714,11 +645,7 @@ func UploadInput(props *UploadInputProps) templ.Component {
 			templ_7745c5c3_Var29 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = newUploadInput(props).render().Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = uploadAcceptHelper().Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<script>\n\t\tif (typeof window.__upload === 'undefined') {\n\t\t\twindow.__upload = (function () {\n\t\t\t\tfunction acceptMatches(file, accept) {\n\t\t\t\t\tif (!accept) return true;\n\t\t\t\t\tvar name = (file.name || '').toLowerCase();\n\t\t\t\t\tvar type = (file.type || '').toLowerCase();\n\t\t\t\t\tvar tokens = accept.split(',').map(function (s) { return s.trim().toLowerCase(); }).filter(Boolean);\n\t\t\t\t\treturn tokens.some(function (t) {\n\t\t\t\t\t\tif (t.charAt(0) === '.') return name.endsWith(t);\n\t\t\t\t\t\tif (t.endsWith('/*')) return type.indexOf(t.slice(0, -1)) === 0;\n\t\t\t\t\t\treturn type === t;\n\t\t\t\t\t});\n\t\t\t\t}\n\n\t\t\t\tfunction readConfig(input) {\n\t\t\t\t\treturn {\n\t\t\t\t\t\tmaxSize: parseInt(input.dataset.uploadMaxSize, 10) || 0,\n\t\t\t\t\t\taccept: input.dataset.uploadAccept || '',\n\t\t\t\t\t\tslot: input.dataset.uploadSlot || '',\n\t\t\t\t\t\tlabels: parseLabels(input.dataset.uploadLabels),\n\t\t\t\t\t};\n\t\t\t\t}\n\n\t\t\t\tfunction parseLabels(raw) {\n\t\t\t\t\ttry { return raw ? JSON.parse(raw) : {}; } catch (e) { return {}; }\n\t\t\t\t}\n\n\t\t\t\tfunction setError(slotId, msg) {\n\t\t\t\t\tvar slot = slotId && document.getElementById(slotId);\n\t\t\t\t\tif (slot) {\n\t\t\t\t\t\tslot.textContent = msg;\n\t\t\t\t\t\tslot.classList.remove('hidden');\n\t\t\t\t\t}\n\t\t\t\t\twindow.dispatchEvent(new CustomEvent('notify', { detail: { variant: 'error', message: msg } }));\n\t\t\t\t}\n\n\t\t\t\tfunction clearError(slotId) {\n\t\t\t\t\tvar slot = slotId && document.getElementById(slotId);\n\t\t\t\t\tif (slot) {\n\t\t\t\t\t\tslot.textContent = '';\n\t\t\t\t\t\tslot.classList.add('hidden');\n\t\t\t\t\t}\n\t\t\t\t}\n\n\t\t\t\tfunction dragover(event) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tevent.stopPropagation();\n\t\t\t\t}\n\n\t\t\t\tfunction dragenter(el, event) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tevent.stopPropagation();\n\t\t\t\t\tel.classList.add('border-primary');\n\t\t\t\t}\n\n\t\t\t\tfunction dragleave(el, event) {\n\t\t\t\t\tif (event.target === el) el.classList.remove('border-primary');\n\t\t\t\t}\n\n\t\t\t\tfunction drop(el, event, inputId) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\tevent.stopPropagation();\n\t\t\t\t\tel.classList.remove('border-primary');\n\t\t\t\t\tvar inp = document.getElementById(inputId);\n\t\t\t\t\tif (!inp || !event.dataTransfer || !event.dataTransfer.files || !event.dataTransfer.files.length) return;\n\t\t\t\t\ttry {\n\t\t\t\t\t\tinp.files = event.dataTransfer.files;\n\t\t\t\t\t} catch (e) {\n\t\t\t\t\t\tif (typeof DataTransfer !== 'function') return;\n\t\t\t\t\t\tvar dt = new DataTransfer();\n\t\t\t\t\t\tfor (var i = 0; i < event.dataTransfer.files.length; i++) {\n\t\t\t\t\t\t\tdt.items.add(event.dataTransfer.files[i]);\n\t\t\t\t\t\t}\n\t\t\t\t\t\tinp.files = dt.files;\n\t\t\t\t\t}\n\t\t\t\t\tinp.dispatchEvent(new Event('change', { bubbles: true }));\n\t\t\t\t}\n\n\t\t\t\tfunction beforeRequest(input, event) {\n\t\t\t\t\tvar cfg = readConfig(input);\n\t\t\t\t\tclearError(cfg.slot);\n\t\t\t\t\tvar errs = [];\n\t\t\t\t\tvar files = input.files || [];\n\t\t\t\t\tfor (var i = 0; i < files.length; i++) {\n\t\t\t\t\t\tvar f = files[i];\n\t\t\t\t\t\tif (cfg.maxSize > 0 && f.size > cfg.maxSize) {\n\t\t\t\t\t\t\terrs.push((cfg.labels.sizeRejected || '{name} is too large')\n\t\t\t\t\t\t\t\t.replace('{name}', f.name)\n\t\t\t\t\t\t\t\t.replace('{size}', (f.size / 1048576).toFixed(1))\n\t\t\t\t\t\t\t\t.replace('{limit}', (cfg.maxSize / 1048576).toFixed(1)));\n\t\t\t\t\t\t\tcontinue;\n\t\t\t\t\t\t}\n\t\t\t\t\t\tif (cfg.accept && !acceptMatches(f, cfg.accept)) {\n\t\t\t\t\t\t\terrs.push((cfg.labels.typeRejected || '{name} unsupported').replace('{name}', f.name));\n\t\t\t\t\t\t}\n\t\t\t\t\t}\n\t\t\t\t\tif (errs.length) {\n\t\t\t\t\t\tsetError(cfg.slot, errs.join('; '));\n\t\t\t\t\t\tinput.value = '';\n\t\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\t}\n\t\t\t\t}\n\n\t\t\t\tfunction pickResponseMessage(xhr, labels) {\n\t\t\t\t\tvar status = xhr ? xhr.status : 0;\n\t\t\t\t\tvar body = xhr ? (xhr.responseText || '') : '';\n\t\t\t\t\tif (status === 413) return labels.tooLargeStatus || 'File too large';\n\t\t\t\t\tif (status === 415) return labels.unsupportedType || 'Unsupported file type';\n\t\t\t\t\tif (status >= 500) return labels.serverError || 'Server error';\n\t\t\t\t\tif (body && body.length < 200 && body.indexOf('<') === -1) return body.trim();\n\t\t\t\t\treturn labels.genericError || 'Upload failed';\n\t\t\t\t}\n\n\t\t\t\tfunction onResponseError(input, event) {\n\t\t\t\t\tvar cfg = readConfig(input);\n\t\t\t\t\tvar xhr = event && event.detail && event.detail.xhr;\n\t\t\t\t\tsetError(cfg.slot, pickResponseMessage(xhr, cfg.labels));\n\t\t\t\t}\n\n\t\t\t\tfunction onSendError(input) {\n\t\t\t\t\tvar cfg = readConfig(input);\n\t\t\t\t\tsetError(cfg.slot, cfg.labels.networkError || 'Network error');\n\t\t\t\t}\n\n\t\t\t\treturn {\n\t\t\t\t\tacceptMatches: acceptMatches,\n\t\t\t\t\tdragover: dragover,\n\t\t\t\t\tdragenter: dragenter,\n\t\t\t\t\tdragleave: dragleave,\n\t\t\t\t\tdrop: drop,\n\t\t\t\t\tbeforeRequest: beforeRequest,\n\t\t\t\t\tonResponseError: onResponseError,\n\t\t\t\t\tonSendError: onSendError,\n\t\t\t\t\tsetError: setError,\n\t\t\t\t\tclearError: clearError,\n\t\t\t\t};\n\t\t\t})();\n\t\t}\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -726,12 +653,10 @@ func UploadInput(props *UploadInputProps) templ.Component {
 	})
 }
 
-// uploadAcceptHelper emits the global `__uploadAcceptMatches` JS function
-// once per page (idempotent via existence check) so multiple UploadInputs
-// share a single implementation. Matches files against the same syntax the
-// browser uses for `accept`: comma-separated extensions (`.pdf`),
-// MIME types (`image/png`), or wildcards (`image/*`).
-func uploadAcceptHelper() templ.Component {
+// UploadInput renders a file upload input with preview capability. Drop
+// support, client-side validation and async error feedback are powered by
+// the shared `__upload` helpers in `uploadInputScript`.
+func UploadInput(props *UploadInputProps) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -752,7 +677,11 @@ func uploadAcceptHelper() templ.Component {
 			templ_7745c5c3_Var30 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<script>\n\t\tif (typeof window.__uploadAcceptMatches !== 'function') {\n\t\t\twindow.__uploadAcceptMatches = function (file, accept) {\n\t\t\t\tif (!accept) return true;\n\t\t\t\tvar name = (file.name || '').toLowerCase();\n\t\t\t\tvar type = (file.type || '').toLowerCase();\n\t\t\t\tvar tokens = accept.split(',').map(function (s) { return s.trim().toLowerCase(); }).filter(Boolean);\n\t\t\t\tfor (var i = 0; i < tokens.length; i++) {\n\t\t\t\t\tvar t = tokens[i];\n\t\t\t\t\tif (t.indexOf('.') === 0) {\n\t\t\t\t\t\tif (name.endsWith(t)) return true;\n\t\t\t\t\t} else if (t.indexOf('/*') === t.length - 2) {\n\t\t\t\t\t\tvar prefix = t.slice(0, t.length - 1);\n\t\t\t\t\t\tif (type.indexOf(prefix) === 0) return true;\n\t\t\t\t\t} else if (type === t) {\n\t\t\t\t\t\treturn true;\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t\treturn false;\n\t\t\t};\n\t\t}\n\t</script>")
+		templ_7745c5c3_Err = newUploadInput(props).render().Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = uploadInputScript().Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/components/upload_input_templ.go
+++ b/components/upload_input_templ.go
@@ -583,7 +583,7 @@ func uploadDropAttrs(id string) templ.Attributes {
 			` var inp=document.getElementById(%q);`+
 			` if(!inp||!event.dataTransfer||!event.dataTransfer.files||!event.dataTransfer.files.length){return;}`+
 			` try{inp.files=event.dataTransfer.files;}`+
-			` catch(e){var dt=new DataTransfer(); for(var i=0;i<event.dataTransfer.files.length;i++){dt.items.add(event.dataTransfer.files[i]);} inp.files=dt.files;}`+
+			` catch(e){if(typeof DataTransfer==='function'){var dt=new DataTransfer(); for(var i=0;i<event.dataTransfer.files.length;i++){dt.items.add(event.dataTransfer.files[i]);} inp.files=dt.files;}}`+
 			` inp.dispatchEvent(new Event('change',{bubbles:true}));`,
 		id,
 	)

--- a/modules/core/presentation/mappers/mappers.go
+++ b/modules/core/presentation/mappers/mappers.go
@@ -82,6 +82,7 @@ func UploadToViewModel(entity upload.Upload) *viewmodels.Upload {
 		ID:        strconv.FormatUint(uint64(entity.ID()), 10),
 		Hash:      entity.Hash(),
 		Slug:      entity.Slug(),
+		Name:      entity.Name(),
 		URL:       entity.PreviewURL(),
 		Mimetype:  "",
 		Size:      entity.Size().String(),

--- a/modules/core/presentation/viewmodels/models.go
+++ b/modules/core/presentation/viewmodels/models.go
@@ -10,7 +10,8 @@ type Currency struct {
 type Upload struct {
 	ID        string
 	Hash      string
-	Slug      string
+	Slug      string // Filesystem-safe storage slug (defaults to Hash if no original name).
+	Name      string // Original filename as uploaded by the user, e.g. "scan.pdf".
 	URL       string
 	Mimetype  string
 	Size      string


### PR DESCRIPTION
The component already advertised drag-and-drop behaviour visually (the dashed-border zone) but only worked on click — the hidden input had no drop handlers. Wire ondragover/dragenter/dragleave/drop on the wrapper: on drop we copy the FileList into the hidden input and dispatch a `change` event so the existing HTMX hx-trigger picks the upload up. The DataTransfer fallback covers older WebKit builds where input.files is read-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop file uploads with visual highlight, automatic trigger, and configurable client-side validation (per-file max size and accepted types).
  * Configurable inline error labels and a hidden per-upload error slot for async error feedback.
  * Loading spinner overlay shown during uploads.

* **Bug Fixes**
  * Prevents uploads when client validation fails and maps server/network errors to user-friendly messages and toast notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->