### PR TITLE
feat(billing): add Transfer (bank transfer) gateway

### DIFF
--- a/modules/billing/domain/aggregates/billing/billing_provider.go
+++ b/modules/billing/domain/aggregates/billing/billing_provider.go
@@ -12,6 +12,7 @@ const (
 	Octo       Gateway = "octo"
 	Stripe     Gateway = "stripe"
 	Cash       Gateway = "cash"
+	Transfer   Gateway = "transfer"
 	Integrator Gateway = "integrator"
 )
 

--- a/modules/billing/domain/aggregates/details/details.go
+++ b/modules/billing/domain/aggregates/details/details.go
@@ -239,6 +239,18 @@ type CashDetails interface {
 	Set(key string, value any) CashDetails
 }
 
+type TransferDetails interface {
+	Details
+
+	Data() map[string]any
+	SetData(data map[string]any) TransferDetails
+	Get(key string) any
+	Set(key string, value any) TransferDetails
+
+	Comment() string
+	SetComment(comment string) TransferDetails
+}
+
 type IntegratorDetails interface {
 	Details
 

--- a/modules/billing/domain/aggregates/details/transfer_details_impl.go
+++ b/modules/billing/domain/aggregates/details/transfer_details_impl.go
@@ -1,0 +1,72 @@
+// Package details provides this package.
+package details
+
+type TransferOption func(d *transferDetails)
+
+func TransferWithData(data map[string]any) TransferOption {
+	return func(d *transferDetails) {
+		d.data = data
+	}
+}
+
+func TransferWithComment(comment string) TransferOption {
+	return func(d *transferDetails) {
+		d.comment = comment
+	}
+}
+
+// ---- Implementation ----
+
+func NewTransferDetails(opts ...TransferOption) TransferDetails {
+	d := &transferDetails{
+		data: make(map[string]any),
+	}
+
+	for _, opt := range opts {
+		opt(d)
+	}
+
+	return d
+}
+
+type transferDetails struct {
+	data    map[string]any
+	comment string
+}
+
+func (d *transferDetails) Data() map[string]any {
+	return d.data
+}
+
+func (d *transferDetails) SetData(data map[string]any) TransferDetails {
+	result := *d
+	result.data = data
+	return &result
+}
+
+func (d *transferDetails) Get(key string) any {
+	if d.data == nil {
+		return nil
+	}
+	return d.data[key]
+}
+
+func (d *transferDetails) Set(key string, value any) TransferDetails {
+	result := *d
+	result.data = make(map[string]any, len(d.data)+1)
+	for k, v := range d.data {
+		result.data[k] = v
+	}
+	result.data[key] = value
+	return &result
+}
+
+func (d *transferDetails) Comment() string {
+	return d.comment
+}
+
+func (d *transferDetails) SetComment(comment string) TransferDetails {
+	result := *d
+	result.comment = comment
+	return &result
+}

--- a/modules/billing/domain/aggregates/details/transfer_details_impl.go
+++ b/modules/billing/domain/aggregates/details/transfer_details_impl.go
@@ -19,7 +19,8 @@ func TransferWithComment(comment string) TransferOption {
 
 func NewTransferDetails(opts ...TransferOption) TransferDetails {
 	d := &transferDetails{
-		data: make(map[string]any),
+		data:    make(map[string]any),
+		comment: "",
 	}
 
 	for _, opt := range opts {

--- a/modules/billing/infrastructure/persistence/billing_mappers.go
+++ b/modules/billing/infrastructure/persistence/billing_mappers.go
@@ -205,6 +205,17 @@ func ToDomainDetails(gateway billing.Gateway, data json.RawMessage) (details.Det
 		cashDetails := details.NewCashDetails(details.CashWithData(d.Data))
 		return cashDetails, nil
 
+	case billing.Transfer:
+		var d models.TransferDetails
+		if err := json.Unmarshal(data, &d); err != nil {
+			return nil, err
+		}
+		transferDetails := details.NewTransferDetails(
+			details.TransferWithData(d.Data),
+			details.TransferWithComment(d.Comment),
+		)
+		return transferDetails, nil
+
 	case billing.Integrator:
 		var d models.IntegratorDetails
 		if err := json.Unmarshal(data, &d); err != nil {
@@ -324,6 +335,12 @@ func ToDBDetails(data details.Details) (json.RawMessage, error) {
 	case details.CashDetails:
 		return json.Marshal(&models.CashDetails{
 			Data: d.Data(),
+		})
+
+	case details.TransferDetails:
+		return json.Marshal(&models.TransferDetails{
+			Data:    d.Data(),
+			Comment: d.Comment(),
 		})
 
 	case details.IntegratorDetails:

--- a/modules/billing/infrastructure/persistence/models/models.go
+++ b/modules/billing/infrastructure/persistence/models/models.go
@@ -122,6 +122,11 @@ type CashDetails struct {
 	Data map[string]any `json:"data"`
 }
 
+type TransferDetails struct {
+	Data    map[string]any `json:"data"`
+	Comment string         `json:"comment"`
+}
+
 type IntegratorDetails struct {
 	Data      map[string]any `json:"data"`
 	ErrorCode int32          `json:"error_code"`


### PR DESCRIPTION
## Summary
- Introduces a new billing gateway `Transfer` alongside `Cash`
- New `TransferDetails` aggregate carries an operator `Comment` plus the existing free-form data map
- DB model (`models.TransferDetails`) + JSON mappers (`ToDomainDetails` / `ToDBDetails`) wired so transactions roundtrip through `billing_transactions.details`

The gateway behaves identically to `Cash` from the SDK's perspective (synchronous, single-phase). The dedicated `Comment` field lets downstream apps persist bank-transfer particulars (payer, date, payment-order number, etc.) without abusing the data map, and keeps the comment available to UIs without JSON probing.

## Why
EAI needs a separate "Перечисление" (bank transfer) payment method on the policy payment page that requires an operator comment. Reusing `Cash` would conflate the two methods in reports and gateway badges; reusing `Integrator` would collide with already-routed integrator flows. A first-class `Transfer` gateway keeps both ends clean.

## Test plan
- [ ] `go vet ./modules/billing/...`
- [ ] `go test ./modules/billing/...`
- [ ] Marshal/unmarshal a `TransferDetails` end-to-end via `ToDBDetails` → `ToDomainDetails`
- [ ] Confirm existing Cash/Click/Payme/Octo paths are untouched

## EAI counterpart
The consumer-side wiring (Pay/ConfirmPay UI, admissions column, comment textarea, translations) lives in the EAI back PR: https://github.com/iota-uz/eai/pull/<TBD>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transfer payment method is now available as a billing gateway option
  * Supports storing custom transaction data and comments with transfer payments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->