### PR TITLE
fix(billing): allow 'transfer' gateway in billing_transactions check

### DIFF
--- a/migrations/changes-1778050688.sql
+++ b/migrations/changes-1778050688.sql
@@ -1,0 +1,20 @@
+-- Migration: Add 'transfer' payment gateway to billing_transactions
+-- Date: 2026-05-06
+-- Purpose: Extend billing_transactions.gateway CHECK constraint to allow the
+-- new bank-transfer gateway introduced alongside the TransferDetails aggregate.
+
+-- +migrate Up
+ALTER TABLE billing_transactions
+DROP CONSTRAINT IF EXISTS billing_transactions_gateway_check;
+
+ALTER TABLE billing_transactions
+ADD CONSTRAINT billing_transactions_gateway_check
+CHECK (gateway IN ('click', 'payme', 'octo', 'stripe', 'cash', 'integrator', 'transfer'));
+
+-- +migrate Down
+ALTER TABLE billing_transactions
+DROP CONSTRAINT IF EXISTS billing_transactions_gateway_check;
+
+ALTER TABLE billing_transactions
+ADD CONSTRAINT billing_transactions_gateway_check
+CHECK (gateway IN ('click', 'payme', 'octo', 'stripe', 'cash', 'integrator'));


### PR DESCRIPTION
## Summary
- Adds the migration that PR #770 forgot: extends the `billing_transactions_gateway_check` CHECK constraint to allow the new `'transfer'` value alongside the existing six gateways.

## Problem
After deploying PR #770 to EAI staging, attempting to record a Transfer payment fails:

```
ContractController.ConfirmPay: createPaymentHandler.Handle:
failed to insert transaction: ERROR: new row for relation "billing_transactions"
violates check constraint "billing_transactions_gateway_check" (SQLSTATE 23514)
```

The Go-side gateway constant + `TransferDetails` shipped, but the DB whitelist still only includes `click | payme | octo | stripe | cash | integrator`.

## Fix
`migrations/changes-1778050688.sql` drops + recreates the CHECK with `'transfer'` added, mirroring `changes-1761729594.sql` (the previous cash/integrator extension). Includes a symmetric `Down` that restores the previous list.

## Test plan
- [ ] `just db migrate up` in dev — verify the constraint now accepts `'transfer'`
- [ ] Insert a billing transaction with gateway `'transfer'` — should succeed
- [ ] `just db migrate down` — confirm reversal
- [ ] Re-run the EAI staging payment flow — Transfer payments record successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)