### PR TITLE
fix(lens): bottom-place metric info tooltip + combobox chip overflow

### DIFF
--- a/components/base/combobox.templ
+++ b/components/base/combobox.templ
@@ -62,10 +62,10 @@ templ DropdownIndicator() {
 templ SelectedValues() {
 	<ul class="contents">
 		<template x-for="item in Array.from(selectedValues.values())" :key="item.value">
-			<li class="flex items-center gap-1.5 px-1.5 py-1 rounded-md bg-surface-100 whitespace-nowrap">
-				<span class="whitespace-nowrap" x-text="item.label"></span>
+			<li class="flex min-w-0 items-center gap-1.5 px-1.5 py-1 rounded-md bg-surface-100">
+				<span class="block max-w-48 truncate" x-text="item.label" :title="item.label"></span>
 				<button
-					class="text-brand-500 cursor-pointer"
+					class="text-brand-500 cursor-pointer flex-shrink-0"
 					type="button"
 					@click="removeSelectedValue(item.value)"
 				>
@@ -210,16 +210,19 @@ templ Combobox(props ComboboxProps) {
 					Placeholder: props.Placeholder,
 					WrapperProps: templ.Attributes{
 						"x-ref": "trigger",
+						"class": "flex-wrap gap-1 py-1",
 					},
 					AddonLeft: &input.Addon{
 						Component: SelectedValues(),
 						Attrs: templ.Attributes{
 							"x-show": "selectedValues.size > 0",
 						},
+						Class: "contents",
 					},
 					Attrs: searchInputAttrs,
 					AddonRight: &input.Addon{
 						Component: DropdownIndicator(),
+						Class:     "ml-auto",
 					},
 				})
 			} else {

--- a/components/base/combobox_templ.go
+++ b/components/base/combobox_templ.go
@@ -164,7 +164,7 @@ func SelectedValues() templ.Component {
 			templ_7745c5c3_Var5 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<ul class=\"contents\"><template x-for=\"item in Array.from(selectedValues.values())\" :key=\"item.value\"><li class=\"flex items-center gap-1.5 px-1.5 py-1 rounded-md bg-surface-100 whitespace-nowrap\"><span class=\"whitespace-nowrap\" x-text=\"item.label\"></span> <button class=\"text-brand-500 cursor-pointer\" type=\"button\" @click=\"removeSelectedValue(item.value)\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<ul class=\"contents\"><template x-for=\"item in Array.from(selectedValues.values())\" :key=\"item.value\"><li class=\"flex min-w-0 items-center gap-1.5 px-1.5 py-1 rounded-md bg-surface-100\"><span class=\"block max-w-48 truncate\" x-text=\"item.label\" :title=\"item.label\"></span> <button class=\"text-brand-500 cursor-pointer flex-shrink-0\" type=\"button\" @click=\"removeSelectedValue(item.value)\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -467,16 +467,19 @@ func Combobox(props ComboboxProps) templ.Component {
 				Placeholder: props.Placeholder,
 				WrapperProps: templ.Attributes{
 					"x-ref": "trigger",
+					"class": "flex-wrap gap-1 py-1",
 				},
 				AddonLeft: &input.Addon{
 					Component: SelectedValues(),
 					Attrs: templ.Attributes{
 						"x-show": "selectedValues.size > 0",
 					},
+					Class: "contents",
 				},
 				Attrs: searchInputAttrs,
 				AddonRight: &input.Addon{
 					Component: DropdownIndicator(),
+					Class:     "ml-auto",
 				},
 			}).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
@@ -559,7 +562,7 @@ func Combobox(props ComboboxProps) templ.Component {
 		var templ_7745c5c3_Var17 string
 		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("options.length == 0 && %t", props.CanCreateNew))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/combobox.templ`, Line: 290, Col: 98}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/combobox.templ`, Line: 293, Col: 98}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
@@ -580,7 +583,7 @@ func Combobox(props ComboboxProps) templ.Component {
 		var templ_7745c5c3_Var18 string
 		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("options.length == 0 && %t", !props.CanCreateNew))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/combobox.templ`, Line: 294, Col: 78}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/combobox.templ`, Line: 297, Col: 78}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 		if templ_7745c5c3_Err != nil {
@@ -593,7 +596,7 @@ func Combobox(props ComboboxProps) templ.Component {
 		var templ_7745c5c3_Var19 string
 		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(props.NotFoundText)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/combobox.templ`, Line: 295, Col: 25}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/combobox.templ`, Line: 298, Col: 25}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 		if templ_7745c5c3_Err != nil {

--- a/pkg/lens/render/templ/dashboard.templ
+++ b/pkg/lens/render/templ/dashboard.templ
@@ -554,7 +554,7 @@ templ MetricInfoButtonWithText(infoText, class string) {
 	<button
 		type="button"
 		class={ "inline-flex h-7 w-7 items-center justify-center rounded-full text-slate-300 transition hover:text-slate-500 focus:outline-none cursor-pointer", class }
-		x-tooltip.interactive.theme.light.html.raw={ metricInfoTooltipHTML(ctx, infoText) }
+		x-tooltip.placement.bottom-start.interactive.theme.light.html.raw={ metricInfoTooltipHTML(ctx, infoText) }
 		@click.stop=""
 		aria-label={ chartText.MetricInfo }
 	>

--- a/pkg/lens/render/templ/dashboard_templ.go
+++ b/pkg/lens/render/templ/dashboard_templ.go
@@ -2306,14 +2306,14 @@ func MetricInfoButtonWithText(infoText, class string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 167, "\" x-tooltip.interactive.theme.light.html.raw=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 167, "\" x-tooltip.placement.bottom-start.interactive.theme.light.html.raw=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var110 string
 		templ_7745c5c3_Var110, templ_7745c5c3_Err = templ.JoinStringErrs(metricInfoTooltipHTML(ctx, infoText))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `pkg/lens/render/templ/dashboard.templ`, Line: 557, Col: 83}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `pkg/lens/render/templ/dashboard.templ`, Line: 557, Col: 106}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var110))
 		if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
## Summary
- `pkg/lens/render/templ/dashboard.templ`: place the metric info tooltip with `.placement.bottom-start` so it doesn't get clipped by the card it anchors to.
- `components/base/combobox.templ`: stop selected-value chips from overflowing the trigger — wrap the chip list (`flex-wrap gap-1`), truncate long labels to `max-w-48` with `title` for the full text, and let the search input flex-shrink instead of pushing chips off the row.

## Test plan
- [ ] Open any Lens dashboard with `panel.Spec.Info` set → hovering the info icon shows the popover below-left, fully visible (no clipping by the card).
- [ ] Multi-select combobox with several long-label options → chips wrap onto multiple rows, each chip truncates with an ellipsis and shows full label on hover; the trigger height grows but does not overflow horizontally.
- [ ] Single-line searchable combobox with short labels still renders as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Selected values in combobox now truncate with full text visible on hover
  * Enhanced search input layout and spacing in combobox interface
  * Improved tooltip positioning for metric information buttons

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iota-uz/iota-sdk/pull/772)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->