### PR TITLE
perf(commands): remove app boot from check_tr_keys

### DIFF
--- a/modules/bichat/component.go
+++ b/modules/bichat/component.go
@@ -134,6 +134,10 @@ func (c *component) Descriptor() composition.Descriptor {
 	return composition.Descriptor{Name: "bichat"}
 }
 
+func (c *component) LocaleFS() []*embed.FS {
+	return []*embed.FS{&LocaleFiles}
+}
+
 // bichatBundle is the lazily-built BiChat runtime graph. Held as a single
 // provider so buildModuleConfig is invoked at most once per container.
 type bichatBundle struct {

--- a/modules/billing/component.go
+++ b/modules/billing/component.go
@@ -54,6 +54,10 @@ func (c *component) Descriptor() composition.Descriptor {
 	}
 }
 
+func (c *component) LocaleFS() []*embed.FS {
+	return []*embed.FS{&LocaleFiles}
+}
+
 func (c *component) Build(builder *composition.Builder) error {
 	composition.AddLocales(builder, &LocaleFiles)
 

--- a/modules/core/component.go
+++ b/modules/core/component.go
@@ -72,6 +72,10 @@ func (c *component) Descriptor() composition.Descriptor {
 	return composition.Descriptor{Name: "core"}
 }
 
+func (c *component) LocaleFS() []*embed.FS {
+	return []*embed.FS{&LocaleFiles}
+}
+
 func (c *component) Build(builder *composition.Builder) error {
 	const op serrors.Op = "core.component.Build"
 

--- a/modules/crm/component.go
+++ b/modules/crm/component.go
@@ -35,6 +35,10 @@ func (c *component) Descriptor() composition.Descriptor {
 	return composition.Descriptor{Name: "crm"}
 }
 
+func (c *component) LocaleFS() []*embed.FS {
+	return []*embed.FS{&LocaleFiles}
+}
+
 func (c *component) Build(builder *composition.Builder) error {
 	composition.AddLocales(builder, &LocaleFiles)
 	composition.AddNavItems(builder, NavItems...)

--- a/modules/finance/component.go
+++ b/modules/finance/component.go
@@ -30,6 +30,10 @@ func (c *component) Descriptor() composition.Descriptor {
 	}
 }
 
+func (c *component) LocaleFS() []*embed.FS {
+	return []*embed.FS{&localeFiles}
+}
+
 func (c *component) Build(builder *composition.Builder) error {
 	composition.AddLocales(builder, &localeFiles)
 	composition.AddNavItems(builder, NavItems...)

--- a/modules/hrm/component.go
+++ b/modules/hrm/component.go
@@ -27,6 +27,10 @@ func (c *component) Descriptor() composition.Descriptor {
 	}
 }
 
+func (c *component) LocaleFS() []*embed.FS {
+	return []*embed.FS{&LocaleFiles}
+}
+
 func (c *component) Build(builder *composition.Builder) error {
 	composition.AddLocales(builder, &LocaleFiles)
 	composition.AddNavItems(builder, NavItems...)

--- a/modules/logging/component.go
+++ b/modules/logging/component.go
@@ -20,6 +20,10 @@ func (c *component) Descriptor() composition.Descriptor {
 	return composition.Descriptor{Name: "logging"}
 }
 
+func (c *component) LocaleFS() []*embed.FS {
+	return []*embed.FS{&localeFiles}
+}
+
 func (c *component) Build(builder *composition.Builder) error {
 	composition.AddLocales(builder, &localeFiles)
 	return nil

--- a/modules/oidc/component.go
+++ b/modules/oidc/component.go
@@ -47,6 +47,10 @@ func (c *component) Descriptor() composition.Descriptor {
 	}
 }
 
+func (c *component) LocaleFS() []*embed.FS {
+	return []*embed.FS{&LocaleFiles}
+}
+
 func (c *component) Build(builder *composition.Builder) error {
 	composition.AddLocales(builder, &LocaleFiles)
 

--- a/modules/projects/component.go
+++ b/modules/projects/component.go
@@ -27,6 +27,10 @@ func (c *component) Descriptor() composition.Descriptor {
 	}
 }
 
+func (c *component) LocaleFS() []*embed.FS {
+	return []*embed.FS{&localeFiles}
+}
+
 func (c *component) Build(builder *composition.Builder) error {
 	composition.AddLocales(builder, &localeFiles)
 	composition.AddNavItems(builder, NavItems...)

--- a/modules/superadmin/component.go
+++ b/modules/superadmin/component.go
@@ -38,6 +38,10 @@ func (c *component) Descriptor() composition.Descriptor {
 	}
 }
 
+func (c *component) LocaleFS() []*embed.FS {
+	return []*embed.FS{&LocaleFiles}
+}
+
 func (c *component) Build(builder *composition.Builder) error {
 	composition.AddLocales(builder, &LocaleFiles)
 	composition.AddNavItems(builder, NavItems...)

--- a/modules/warehouse/component.go
+++ b/modules/warehouse/component.go
@@ -35,6 +35,10 @@ func (c *component) Descriptor() composition.Descriptor {
 	}
 }
 
+func (c *component) LocaleFS() []*embed.FS {
+	return []*embed.FS{&localeFiles}
+}
+
 func (c *component) Build(builder *composition.Builder) error {
 	composition.AddLocales(builder, &localeFiles)
 	composition.AddNavItems(builder, NavItems...)

--- a/modules/website/component.go
+++ b/modules/website/component.go
@@ -31,6 +31,10 @@ func (c *component) Descriptor() composition.Descriptor {
 	}
 }
 
+func (c *component) LocaleFS() []*embed.FS {
+	return []*embed.FS{&LocaleFiles}
+}
+
 func (c *component) Build(builder *composition.Builder) error {
 	composition.AddLocales(builder, &LocaleFiles)
 	composition.AddNavItems(builder, NavItems...)

--- a/pkg/commands/check_tr_keys.go
+++ b/pkg/commands/check_tr_keys.go
@@ -134,9 +134,6 @@ func componentName(comp composition.Component) string {
 }
 
 func parseAllowedLanguages(allowed []string, messages map[language.Tag]map[string]*i18n.MessageTemplate) (map[string]language.Tag, error) {
-	if len(allowed) == 0 {
-		return nil, nil
-	}
 	out := make(map[string]language.Tag, len(allowed))
 	for _, code := range allowed {
 		tag, err := language.Parse(code)

--- a/pkg/commands/check_tr_keys.go
+++ b/pkg/commands/check_tr_keys.go
@@ -3,71 +3,169 @@ package commands
 
 import (
 	"bufio"
+	"embed"
 	"encoding/json"
 	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
 
+	"github.com/BurntSushi/toml"
+	"github.com/iota-uz/go-i18n/v2/i18n"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/text/language"
 
-	"github.com/iota-uz/iota-sdk/pkg/commands/common"
 	"github.com/iota-uz/iota-sdk/pkg/composition"
-	"github.com/iota-uz/iota-sdk/pkg/configuration"
 )
 
+// CheckTrKeys validates translation key consistency across the locale files
+// shipped by the given components. It does NOT boot the application — no
+// database, Redis, NATS, S3 or DI container is initialized — so it is safe
+// to run as a fast pre-commit / CI check.
+//
+// Locale files are discovered through the optional composition.LocaleSource
+// interface on each component. Components that do not implement it are
+// skipped silently (they ship no locales for this check to validate).
+//
+// The check performs three things:
+//  1. Parses every embedded locale file. The underlying go-i18n parser
+//     surfaces an error if a TOML/JSON table mixes reserved plural keys
+//     (one/other/description/hash/…) with regular sub-keys.
+//  2. Reports keys that exist in some locales but are missing from others.
+//  3. Walks the current working directory for T()/TSafe() call sites and
+//     reports any translation key that is used in code but never defined
+//     in a locale file.
 func CheckTrKeys(allowedLanguages []string, components ...composition.Component) error {
-	conf := configuration.Use()
-	app, pool, err := common.NewApplicationWithDefaults(components...)
+	logger := newDefaultLogger()
+
+	bundle := i18n.NewBundle(language.Russian)
+	bundle.RegisterUnmarshalFunc("json", json.Unmarshal)
+	bundle.RegisterUnmarshalFunc("toml", toml.Unmarshal)
+
+	if err := loadComponentLocales(bundle, components); err != nil {
+		return err
+	}
+
+	messages := bundle.Messages()
+	if len(messages) == 0 {
+		return fmt.Errorf("no locale files were discovered from the supplied components — ensure each component implements composition.LocaleSource")
+	}
+
+	allowedLocales, err := parseAllowedLanguages(allowedLanguages, messages)
 	if err != nil {
-		return fmt.Errorf("failed to initialize application: %w", err)
-	}
-	defer pool.Close()
-
-	messages := app.Bundle().Messages()
-
-	// If allowedLanguages is provided, create a whitelist map for validation
-	var allowedLocales map[string]language.Tag
-	if len(allowedLanguages) > 0 {
-		allowedLocales = make(map[string]language.Tag)
-		for _, code := range allowedLanguages {
-			// Parse language code to tag
-			tag, err := language.Parse(code)
-			if err != nil {
-				return fmt.Errorf("invalid language code in whitelist: %s: %w", code, err)
-			}
-			allowedLocales[code] = tag
-		}
-
-		// Validate that all allowed languages exist in the bundle
-		for code, tag := range allowedLocales {
-			if messages[tag] == nil {
-				return fmt.Errorf("language %s (%s) is in whitelist but not found in bundle", code, tag)
-			}
-		}
+		return err
 	}
 
-	// Store all keys for each locale
+	allKeys, locales := collectKeys(messages, allowedLocales)
+	if len(locales) == 0 {
+		return fmt.Errorf("no locales found in the application bundle")
+	}
+
+	if missing := reportMissingKeys(logger, allKeys, locales); missing {
+		return fmt.Errorf("some translation keys are not consistent across all locales, see logs for details")
+	}
+
+	logger.WithFields(logrus.Fields{
+		"locale_count": len(locales),
+		"key_count":    len(allKeys),
+	}).Info("All translation keys are consistent across all locales")
+
+	if err := checkForUndefinedKeys(allKeys, logger); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// loadComponentLocales parses every locale file contributed by the
+// LocaleSource components into the supplied bundle. Each component's locale
+// files are loaded in registration order; duplicate filenames across
+// components are tolerated (go-i18n merges them into the same locale).
+func loadComponentLocales(bundle *i18n.Bundle, components []composition.Component) error {
+	for _, comp := range components {
+		src, ok := comp.(composition.LocaleSource)
+		if !ok {
+			continue
+		}
+		for _, embedFS := range src.LocaleFS() {
+			if embedFS == nil {
+				continue
+			}
+			if err := loadEmbedFSIntoBundle(bundle, embedFS); err != nil {
+				return fmt.Errorf("component %q: %w", componentName(comp), err)
+			}
+		}
+	}
+	return nil
+}
+
+func loadEmbedFSIntoBundle(bundle *i18n.Bundle, embedFS *embed.FS) error {
+	return fs.WalkDir(embedFS, ".", func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		if ext != ".toml" && ext != ".json" {
+			return nil
+		}
+		data, err := embedFS.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", path, err)
+		}
+		if _, err := bundle.ParseMessageFileBytes(data, filepath.Base(path)); err != nil {
+			return fmt.Errorf("parse %s: %w", path, err)
+		}
+		return nil
+	})
+}
+
+func componentName(comp composition.Component) string {
+	defer func() { _ = recover() }()
+	return comp.Descriptor().Name
+}
+
+func parseAllowedLanguages(allowed []string, messages map[language.Tag]map[string]*i18n.MessageTemplate) (map[string]language.Tag, error) {
+	if len(allowed) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]language.Tag, len(allowed))
+	for _, code := range allowed {
+		tag, err := language.Parse(code)
+		if err != nil {
+			return nil, fmt.Errorf("invalid language code in whitelist: %s: %w", code, err)
+		}
+		if messages[tag] == nil {
+			return nil, fmt.Errorf("language %s (%s) is in whitelist but not found in bundle", code, tag)
+		}
+		out[code] = tag
+	}
+	return out, nil
+}
+
+func collectKeys(
+	messages map[language.Tag]map[string]*i18n.MessageTemplate,
+	allowedLocales map[string]language.Tag,
+) (map[string]map[language.Tag]bool, []language.Tag) {
 	allKeys := make(map[string]map[language.Tag]bool)
 	locales := make([]language.Tag, 0)
 
-	// First pass: collect all keys from locales (filtered by allowedLanguages if provided)
 	for locale, message := range messages {
 		if message == nil {
 			continue
 		}
-
-		// If allowedLanguages is specified, only process those locales
 		if len(allowedLocales) > 0 {
 			isAllowed := false
-			for _, allowedTag := range allowedLocales {
-				if locale == allowedTag {
+			for _, tag := range allowedLocales {
+				if locale == tag {
 					isAllowed = true
 					break
 				}
@@ -78,8 +176,6 @@ func CheckTrKeys(allowedLanguages []string, components ...composition.Component)
 		}
 
 		locales = append(locales, locale)
-
-		// Process keys in this locale
 		for key := range message {
 			if allKeys[key] == nil {
 				allKeys[key] = make(map[language.Tag]bool)
@@ -87,100 +183,78 @@ func CheckTrKeys(allowedLanguages []string, components ...composition.Component)
 			allKeys[key][locale] = true
 		}
 	}
+	return allKeys, locales
+}
 
-	// No locales found
-	if len(locales) == 0 {
-		return fmt.Errorf("no locales found in the application bundle")
-	}
-
-	// Second pass: check for missing keys
-	missingKeys := false
+func reportMissingKeys(logger *logrus.Logger, allKeys map[string]map[language.Tag]bool, locales []language.Tag) bool {
+	missing := false
 	for key, localeMap := range allKeys {
-		// If the key is not present in all locales
-		if len(localeMap) != len(locales) {
-			missingKeys = true
-
-			// Find which locales have the key
-			present := make([]string, 0)
-			missing := make([]string, 0)
-
-			for _, locale := range locales {
-				if localeMap[locale] {
-					present = append(present, locale.String())
-				} else {
-					missing = append(missing, locale.String())
-				}
-			}
-
-			// Log detailed error about the missing key using WithFields
-			conf.Logger().WithFields(logrus.Fields{
-				"key":          key,
-				"present_in":   strings.Join(present, ", "),
-				"missing_from": strings.Join(missing, ", "),
-			}).Error("Translation key mismatch")
+		if len(localeMap) == len(locales) {
+			continue
 		}
+		missing = true
+		present := make([]string, 0, len(locales))
+		absent := make([]string, 0, len(locales))
+		for _, locale := range locales {
+			if localeMap[locale] {
+				present = append(present, locale.String())
+			} else {
+				absent = append(absent, locale.String())
+			}
+		}
+		logger.WithFields(logrus.Fields{
+			"key":          key,
+			"present_in":   strings.Join(present, ", "),
+			"missing_from": strings.Join(absent, ", "),
+		}).Error("Translation key mismatch")
 	}
+	return missing
+}
 
-	if missingKeys {
-		return fmt.Errorf("some translation keys are not consistent across all locales, see logs for details")
-	}
-
-	conf.Logger().WithFields(logrus.Fields{
-		"locale_count": len(locales),
-		"key_count":    len(allKeys),
-	}).Info("All translation keys are consistent across all locales")
-
-	if err := checkForUndefinedKeys(allKeys, conf.Logger()); err != nil {
-		return err
-	}
-
-	return nil
+// newDefaultLogger returns a stdout logger so the command does not depend on
+// configuration.Use() (which loads .env and validates rate-limit / 2FA
+// settings — neither relevant to a static key-parity check).
+func newDefaultLogger() *logrus.Logger {
+	l := logrus.New()
+	l.SetOutput(os.Stdout)
+	l.SetFormatter(&logrus.TextFormatter{
+		FullTimestamp: false,
+		DisableQuote:  true,
+	})
+	return l
 }
 
 func extractKeysFromGoFile(path string, rootPath string, fset *token.FileSet) (map[string][]string, error) {
 	keysWithLocations := make(map[string][]string)
 
-	// Parse the Go file
 	node, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse %s: %w", path, err)
 	}
 
-	// Visit all nodes in the AST
 	ast.Inspect(node, func(n ast.Node) bool {
-		// Look for function calls
 		call, ok := n.(*ast.CallExpr)
 		if !ok {
 			return true
 		}
-
-		// Check if it's a method call (selector expression)
 		sel, ok := call.Fun.(*ast.SelectorExpr)
 		if !ok {
 			return true
 		}
-
-		// Check if method name is T or TSafe
 		methodName := sel.Sel.Name
 		if methodName != "T" && methodName != "TSafe" {
 			return true
 		}
-
-		// Extract the first argument (the translation key)
 		if len(call.Args) == 0 {
 			return true
 		}
-
-		// Check if first argument is a string literal
 		if lit, ok := call.Args[0].(*ast.BasicLit); ok && lit.Kind == token.STRING {
-			// Remove quotes from string literal
 			key := strings.Trim(lit.Value, `"`)
 			relPath, _ := filepath.Rel(rootPath, path)
 			position := fset.Position(call.Pos())
 			location := fmt.Sprintf("%s:%d", relPath, position.Line)
 			keysWithLocations[key] = append(keysWithLocations[key], location)
 		}
-
 		return true
 	})
 
@@ -198,8 +272,6 @@ func extractKeysFromTemplFile(path string, rootPath string) (map[string][]string
 		_ = file.Close()
 	}()
 
-	// Regex to match .T("key") or .TSafe("key") calls
-	// Matches both single and double quotes
 	tCallRegex := regexp.MustCompile(`\.T(?:Safe)?\s*\(\s*["']([^"']+)["']`)
 
 	scanner := bufio.NewScanner(file)
@@ -207,8 +279,6 @@ func extractKeysFromTemplFile(path string, rootPath string) (map[string][]string
 	for scanner.Scan() {
 		lineNum++
 		line := scanner.Text()
-
-		// Find all matches in this line
 		matches := tCallRegex.FindAllStringSubmatch(line, -1)
 		for _, match := range matches {
 			if len(match) >= 2 {
@@ -219,11 +289,9 @@ func extractKeysFromTemplFile(path string, rootPath string) (map[string][]string
 			}
 		}
 	}
-
 	if err := scanner.Err(); err != nil {
 		return nil, err
 	}
-
 	return keysWithLocations, nil
 }
 
@@ -235,8 +303,6 @@ func extractTranslationKeys(rootPath string) (map[string][]string, error) {
 		if err != nil {
 			return err
 		}
-
-		// Skip non-relevant directories
 		if info.IsDir() {
 			name := info.Name()
 			if name == "vendor" || name == "node_modules" || name == ".git" || name == "dist" || name == "build" {
@@ -248,11 +314,9 @@ func extractTranslationKeys(rootPath string) (map[string][]string, error) {
 		var fileKeys map[string][]string
 		var fileErr error
 
-		// Process Go files (excluding tests)
 		if strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go") {
 			fileKeys, fileErr = extractKeysFromGoFile(path, rootPath, fset)
 		} else if strings.HasSuffix(path, ".templ") {
-			// Process templ files
 			fileKeys, fileErr = extractKeysFromTemplFile(path, rootPath)
 		} else {
 			return nil
@@ -261,12 +325,9 @@ func extractTranslationKeys(rootPath string) (map[string][]string, error) {
 		if fileErr != nil {
 			return fileErr
 		}
-
-		// Merge keys from this file
 		for key, locations := range fileKeys {
 			keysWithLocations[key] = append(keysWithLocations[key], locations...)
 		}
-
 		return nil
 	})
 
@@ -283,7 +344,6 @@ func WriteRequiredKeysFile(projectRoot, outputPath string) error {
 	}
 	keys := make([]string, 0, len(keysWithLocations))
 	for key := range keysWithLocations {
-		// Skip dynamic key suffixes (e.g. "Countries.") same as checkForUndefinedKeys
 		if strings.HasSuffix(key, ".") {
 			continue
 		}
@@ -303,7 +363,6 @@ func WriteRequiredKeysFile(projectRoot, outputPath string) error {
 func checkForUndefinedKeys(allKeys map[string]map[language.Tag]bool, logger *logrus.Logger) error {
 	logger.Info("Scanning codebase for T() and TSafe() calls...")
 
-	// Get current working directory as root path for scanning
 	rootPath, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get working directory: %w", err)
@@ -314,15 +373,11 @@ func checkForUndefinedKeys(allKeys map[string]map[language.Tag]bool, logger *log
 		return fmt.Errorf("failed to extract translation keys from codebase: %w", err)
 	}
 
-	// Check for keys used in code but not in any locale
 	undefinedKeys := false
 	for key, locations := range usedKeys {
-		// Skip keys that end with "." - these are likely dynamic keys built with string concatenation
-		// Example: pageCtx.T("Countries." + countryCode) will be detected as "Countries."
 		if strings.HasSuffix(key, ".") {
 			continue
 		}
-
 		if _, exists := allKeys[key]; !exists {
 			undefinedKeys = true
 			logger.WithFields(logrus.Fields{

--- a/pkg/composition/locale_source.go
+++ b/pkg/composition/locale_source.go
@@ -1,0 +1,14 @@
+package composition
+
+import "embed"
+
+// LocaleSource is an optional interface for Components that ship locale TOML/JSON
+// files. Tooling that only needs to read locales (such as the check_tr_keys
+// validator) can extract them without booting the application or running
+// Build — which is important for fast, dependency-free CLI checks.
+//
+// Implementations should return a stable slice of the package-level embed.FS
+// values that hold `presentation/locales/*.{toml,json}` files.
+type LocaleSource interface {
+	LocaleFS() []*embed.FS
+}


### PR DESCRIPTION
## Summary

`check_tr_keys` was booting the full application (DB, Redis, NATS, S3) just to read locale TOML/JSON files for a static parity check. On machines without those services the command hung indefinitely; even when they were up the boot path added ~30 s before the actual check.

This PR:

- Adds `composition.LocaleSource` — an optional interface components implement to expose their package-level `embed.FS`.
- Implements `LocaleFS()` on every SDK module that ships locales (12 components).
- Rewrites `CheckTrKeys` so it builds a fresh `i18n.Bundle` from each component's `LocaleSource`, skipping `NewApplicationWithDefaults` entirely. Parity check + undefined-key check are preserved.
- Uses a local `logrus.Logger` instead of `configuration.Use().Logger()` so the command no longer parses `.env` or validates rate-limit / 2FA settings unrelated to the check.

The go-i18n parser already surfaces mixed reserved/unreserved key errors (`one/other/description/hash/…`) at parse time, so the reserved-key footgun stays covered.

## Numbers

Wall time on a pre-built `eai` binary, EAI workspace:

| | before | after |
|---|---|---|
| cold | 1–3 min (or hang without services) | ~3 s |
| warm | ~30 s | ~3 s |

The remaining wall time is dominated by the codebase walk that detects `T()` / `TSafe()` call sites; locale loading itself is sub-second.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./pkg/commands/... ./pkg/composition/...`
- [x] End-to-end run from EAI workspace: `eai check_tr_keys` prints `All translation keys are consistent across all locales` with `locale_count=4 key_count=8901` and exits 0 in ~3 s
- [ ] Reviewer to confirm no other consumers of the old behavior

## Related

Pairs with iota-uz/eai PR (`perf/check-tr-keys-no-boot`) which adds `LocaleFS()` to the EAI modules and bumps the SDK pointer. Resolves iota-uz/eai#2715.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized locale resource exposure across modules, allowing tools and framework wiring to read embedded translation files.

* **Refactor**
  * Translation key validation tool refactored to run without full app initialization and to better extract/validate keys across locales.

* **Chores**
  * Module components updated to expose embedded locale assets for localization workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iota-uz/iota-sdk/pull/774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->