### PR TITLE
periodics: propagate Timeout deadline into task ctx

### DIFF
--- a/pkg/periodics/manager.go
+++ b/pkg/periodics/manager.go
@@ -199,13 +199,10 @@ func (m *manager) buildWrappedExecutor(task PeriodicTask) func() {
 
 	// Create the job that will execute the task
 	job := cron.FuncJob(func() {
-		// TimeoutWrapper cancels the host goroutine after config.Timeout but
-		// cannot share a context through cron's Job.Run() interface. Apply
-		// the same budget directly to the ctx handed to Execute so DB calls,
-		// HTTP requests, and bounded waits inside the task observe the
-		// deadline. Without this, long-running drains (e.g. Spotlight's
-		// WaitPending) fall back to internal per-call defaults and trip
-		// long before the configured Timeout.
+		// cron's Job.Run() has no ctx parameter, so TimeoutWrapper's deadline
+		// cannot reach Execute via the chain. Apply config.Timeout here so
+		// downstream calls observe the budget; TimeoutWrapper still logs and
+		// stops waiting after the deadline, but cannot preempt the goroutine.
 		ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
 		defer cancel()
 

--- a/pkg/periodics/manager.go
+++ b/pkg/periodics/manager.go
@@ -199,8 +199,15 @@ func (m *manager) buildWrappedExecutor(task PeriodicTask) func() {
 
 	// Create the job that will execute the task
 	job := cron.FuncJob(func() {
-		// No context.WithTimeout here — TimeoutWrapper already handles it
-		ctx := context.Background()
+		// TimeoutWrapper cancels the host goroutine after config.Timeout but
+		// cannot share a context through cron's Job.Run() interface. Apply
+		// the same budget directly to the ctx handed to Execute so DB calls,
+		// HTTP requests, and bounded waits inside the task observe the
+		// deadline. Without this, long-running drains (e.g. Spotlight's
+		// WaitPending) fall back to internal per-call defaults and trip
+		// long before the configured Timeout.
+		ctx, cancel := context.WithTimeout(context.Background(), config.Timeout)
+		defer cancel()
 
 		// Add database pool, tenant ID, and logger to context for task execution
 		ctx = composables.WithPool(ctx, m.pool)

--- a/pkg/periodics/manager_test.go
+++ b/pkg/periodics/manager_test.go
@@ -18,9 +18,9 @@ type ctxCapturingTask struct {
 	completed chan struct{}
 }
 
-func (t *ctxCapturingTask) Name() string                   { return t.name }
-func (t *ctxCapturingTask) Schedule() string               { return "@every 1h" }
-func (t *ctxCapturingTask) RunOnStart() bool               { return false }
+func (t *ctxCapturingTask) Name() string     { return t.name }
+func (t *ctxCapturingTask) Schedule() string { return "@every 1h" }
+func (t *ctxCapturingTask) RunOnStart() bool { return false }
 func (t *ctxCapturingTask) Config() TaskConfig {
 	return TaskConfig{
 		Timeout:             t.timeout,

--- a/pkg/periodics/manager_test.go
+++ b/pkg/periodics/manager_test.go
@@ -12,10 +12,12 @@ import (
 )
 
 type ctxCapturingTask struct {
-	name      string
-	timeout   time.Duration
-	gotCtx    context.Context
-	completed chan struct{}
+	name        string
+	timeout     time.Duration
+	gotDeadline time.Time
+	gotHasDL    bool
+	executedAt  time.Time
+	completed   chan struct{}
 }
 
 func (t *ctxCapturingTask) Name() string     { return t.name }
@@ -30,7 +32,11 @@ func (t *ctxCapturingTask) Config() TaskConfig {
 }
 
 func (t *ctxCapturingTask) Execute(ctx context.Context) error {
-	t.gotCtx = ctx
+	// Capture deadline state inside Execute so the delta we measure is
+	// "deadline - executedAt", not "deadline - assertion time". The latter
+	// drifts under GC / scheduler stalls and would flake on a busy CI.
+	t.executedAt = time.Now()
+	t.gotDeadline, t.gotHasDL = ctx.Deadline()
 	close(t.completed)
 	return nil
 }
@@ -63,11 +69,12 @@ func TestBuildWrappedExecutor_PropagatesTimeoutDeadline(t *testing.T) {
 		t.Fatal("task did not execute")
 	}
 
-	require.NotNil(t, task.gotCtx, "Execute must receive a non-nil ctx")
-	deadline, ok := task.gotCtx.Deadline()
-	require.True(t, ok, "Execute ctx must carry the configured timeout as a deadline")
+	require.True(t, task.gotHasDL, "Execute ctx must carry the configured timeout as a deadline")
+	require.False(t, task.executedAt.IsZero(), "expected executedAt to be set inside Execute")
 
-	remaining := time.Until(deadline)
-	assert.InDelta(t, timeout.Seconds(), remaining.Seconds(), 5,
-		"ctx deadline should be ~config.Timeout from now")
+	// Span between ctx creation in buildWrappedExecutor and Execute entry is
+	// microseconds in practice; 1s tolerance trivially absorbs scheduler jitter.
+	budget := task.gotDeadline.Sub(task.executedAt)
+	assert.InDelta(t, timeout.Seconds(), budget.Seconds(), 1,
+		"ctx deadline should be ~config.Timeout from the moment Execute runs")
 }

--- a/pkg/periodics/manager_test.go
+++ b/pkg/periodics/manager_test.go
@@ -1,0 +1,73 @@
+package periodics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type ctxCapturingTask struct {
+	name      string
+	timeout   time.Duration
+	gotCtx    context.Context
+	completed chan struct{}
+}
+
+func (t *ctxCapturingTask) Name() string                   { return t.name }
+func (t *ctxCapturingTask) Schedule() string               { return "@every 1h" }
+func (t *ctxCapturingTask) RunOnStart() bool               { return false }
+func (t *ctxCapturingTask) Config() TaskConfig {
+	return TaskConfig{
+		Timeout:             t.timeout,
+		MaxRetries:          IntPtr(1),
+		EnableSkipIfRunning: BoolPtr(false),
+	}
+}
+
+func (t *ctxCapturingTask) Execute(ctx context.Context) error {
+	t.gotCtx = ctx
+	close(t.completed)
+	return nil
+}
+
+// TestBuildWrappedExecutor_PropagatesTimeoutDeadline guards against a
+// regression where Execute received a bare context.Background() with no
+// deadline. The fix injects config.Timeout into ctx so downstream calls
+// (DB queries, drains) observe the budget.
+func TestBuildWrappedExecutor_PropagatesTimeoutDeadline(t *testing.T) {
+	t.Parallel()
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+	mgr := NewManager(logger, nil, uuid.Nil).(*manager)
+
+	timeout := 7 * time.Minute
+	task := &ctxCapturingTask{
+		name:      "ctx-deadline-task",
+		timeout:   timeout,
+		completed: make(chan struct{}),
+	}
+	require.NoError(t, mgr.AddTask(task))
+
+	executor := mgr.buildWrappedExecutor(task)
+	executor()
+
+	select {
+	case <-task.completed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("task did not execute")
+	}
+
+	require.NotNil(t, task.gotCtx, "Execute must receive a non-nil ctx")
+	deadline, ok := task.gotCtx.Deadline()
+	require.True(t, ok, "Execute ctx must carry the configured timeout as a deadline")
+
+	remaining := time.Until(deadline)
+	assert.InDelta(t, timeout.Seconds(), remaining.Seconds(), 5,
+		"ctx deadline should be ~config.Timeout from now")
+}


### PR DESCRIPTION
## Summary

`TimeoutWrapper` cancels the host goroutine after `config.Timeout` but cannot share its `ctx` through cron's `Job.Run()` interface, so `task.Execute(ctx)` received a bare `context.Background()` with **no deadline**. Downstream code (DB calls, drains, HTTP) had no way to observe the configured budget and fell back to its own per-call defaults.

## Why this surfaced now

Spotlight's `WaitPending` exposes the latent bug at scale. With no parent deadline, `drainTaskCtx` applies its 5-minute floor per task — and a 1.3 M-doc Meili commit batch trips it long before the 30-minute `Timeout` configured on the periodic. End result on preprod: the periodic reindex consistently fails at exactly `wait_ms ≈ 300000`, leaving an orphan build index that traps every subsequent tick into `StartRebuild: context deadline exceeded`.

## Change

Apply `context.WithTimeout(config.Timeout)` directly inside the `FuncJob` in `manager.buildWrappedExecutor` so `Execute` and everything downstream observe the deadline. `TimeoutWrapper` stays in the chain as a defense-in-depth goroutine kill switch — both layers are needed because cron's job interface has no `ctx` parameter to share.

## Regression test

`TestBuildWrappedExecutor_PropagatesTimeoutDeadline` exercises `buildWrappedExecutor` directly and asserts that `Execute` receives a `ctx` whose `Deadline()` matches `config.Timeout`. Confirmed it fails against the pre-fix code:

```
manager_test.go:68: Execute ctx must carry the configured timeout as a deadline
--- FAIL: TestBuildWrappedExecutor_PropagatesTimeoutDeadline (0.00s)
```

## Behavior change for existing tasks

Tasks that respect their `ctx` will now cancel cleanly at `Timeout` instead of running to completion and getting their goroutine killed. Tasks that ignore `ctx` are unchanged — `TimeoutWrapper` still kills the goroutine. Net effect: existing tasks become more responsive to their configured budget; no task observes a *smaller* effective timeout than before.

## Test plan

- [x] `go test ./pkg/periodics/... -count=1`
- [x] `go test ./pkg/spotlight/... -count=1`
- [x] `go vet ./pkg/periodics/... ./pkg/spotlight/...`
- [ ] After merge: bump `back/go.mod` in `iota-uz/eai`, redeploy preprod, verify a `*/20` reindex tick completes the full 1.3 M-doc commit without `WaitPending` deadline-exceeded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Periodic tasks now enforce configured timeouts so database calls, HTTP requests, and other operations observe the intended deadlines, improving reliability.
* **Tests**
  * Added a regression test ensuring wrapped executors pass a context with a real deadline into task execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iota-uz/iota-sdk/pull/778?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->