### PR TITLE
periodics: drop misleading envDefault on BaseTaskConfig.Timeout

### DIFF
--- a/pkg/periodics/config.go
+++ b/pkg/periodics/config.go
@@ -22,8 +22,12 @@ type BaseTaskConfig struct {
 	// RetryDelay is the initial delay between retries (will be exponentially increased)
 	RetryDelay time.Duration `env:"RETRY_DELAY" envDefault:"1s"`
 
-	// Timeout is the maximum time the task can run before being cancelled
-	Timeout time.Duration `env:"TIMEOUT" envDefault:"5m"`
+	// Timeout is the maximum time the task can run before being cancelled.
+	// No envDefault: caarlos0/env applies envDefault unconditionally when the
+	// env var is unset, which silently overwrites a value pre-populated by the
+	// caller's NewDefaultConfig(). mergeWithDefaults() falls back to the
+	// DefaultTaskConfig().Timeout (5m) at task registration if this stays zero.
+	Timeout time.Duration `env:"TIMEOUT"`
 
 	// EnableSkipIfRunning skips execution if previous instance is still running
 	EnableSkipIfRunning bool `env:"ENABLE_SKIP_IF_RUNNING" envDefault:"true"`

--- a/pkg/periodics/config.go
+++ b/pkg/periodics/config.go
@@ -13,7 +13,8 @@ import "time"
 //	}
 type BaseTaskConfig struct {
 	// Schedule is the cron expression for when to run the task.
-	// No envDefault — each module sets its own default via NewDefaultConfig().
+	// No envDefault: callers may pre-populate task-specific defaults before
+	// env.Parse runs.
 	Schedule string `env:"SCHEDULE"`
 
 	// MaxRetries is the maximum number of retry attempts on failure
@@ -24,9 +25,9 @@ type BaseTaskConfig struct {
 
 	// Timeout is the maximum time the task can run before being cancelled.
 	// No envDefault: caarlos0/env applies envDefault unconditionally when the
-	// env var is unset, which silently overwrites a value pre-populated by the
-	// caller's NewDefaultConfig(). mergeWithDefaults() falls back to the
-	// DefaultTaskConfig().Timeout (5m) at task registration if this stays zero.
+	// env var is unset, which silently overwrites caller-provided default config
+	// values. mergeWithDefaults() falls back to DefaultTaskConfig().Timeout (5m)
+	// when building the scheduled task executor if this stays zero.
 	Timeout time.Duration `env:"TIMEOUT"`
 
 	// EnableSkipIfRunning skips execution if previous instance is still running

--- a/pkg/periodics/manager_test.go
+++ b/pkg/periodics/manager_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/caarlos0/env/v11"
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -77,4 +78,25 @@ func TestBuildWrappedExecutor_PropagatesTimeoutDeadline(t *testing.T) {
 	budget := task.gotDeadline.Sub(task.executedAt)
 	assert.InDelta(t, timeout.Seconds(), budget.Seconds(), 1,
 		"ctx deadline should be ~config.Timeout from the moment Execute runs")
+}
+
+type envTestConfig struct {
+	BaseTaskConfig `envPrefix:"PERIODIC_ENVTEST_"`
+}
+
+// TestBaseTaskConfig_TimeoutSurvivesEnvParse guards against a regression
+// where BaseTaskConfig.Timeout carried `envDefault:"5m"`. caarlos0/env applies
+// envDefault unconditionally when the env var is unset, which silently
+// overwrote consumer-set values like EAI's 30m Spotlight reindex timeout.
+func TestBaseTaskConfig_TimeoutSurvivesEnvParse(t *testing.T) {
+	t.Setenv("PERIODIC_ENVTEST_ENABLED", "true")
+
+	cfg := &envTestConfig{
+		BaseTaskConfig: BaseTaskConfig{
+			Timeout: 30 * time.Minute,
+		},
+	}
+	require.NoError(t, env.Parse(cfg))
+	assert.Equal(t, 30*time.Minute, cfg.Timeout,
+		"struct-set Timeout must survive env.Parse when no TIMEOUT env var is set")
 }


### PR DESCRIPTION
## Summary

`caarlos0/env` applies `envDefault` unconditionally when the corresponding env var is unset, which silently overwrites a value pre-populated by the caller's `NewDefaultConfig()`. Verified empirically:

```go
type Inner struct {
    NoDefault   time.Duration \`env:\"TEST_NO_DEFAULT\"\`
    WithDefault time.Duration \`env:\"TEST_WITH_DEFAULT\" envDefault:\"5m\"\`
}

c := &Inner{NoDefault: 30 * time.Minute, WithDefault: 30 * time.Minute}
env.Parse(c)
// NoDefault   (struct=30m, no env): 30m0s   ✓
// WithDefault (struct=30m, no env): 5m0s    ✗ — pre-set 30m discarded
```

End result on preprod: EAI's `SpotlightReindexConfig.Timeout = 30 * time.Minute` was clobbered back to 5m at every boot. The periodic Spotlight reindex got a 5-minute ctx deadline (after #778 propagated it to Execute), which is too short for the 1.3M-doc Meili commit and `StartRebuild` against a queue-backlog drain.

## Change

Remove `envDefault:\"5m\"` from `BaseTaskConfig.Timeout`. `mergeWithDefaults()` in `interface.go` already provides the 5-minute fallback at task registration when the field stays zero, so the behavior for tasks that don't set a custom timeout is preserved.

Other `BaseTaskConfig` fields (`MaxRetries`, `RetryDelay`, `EnableSkipIfRunning`, `Enabled`, `RunOnStart`) carry the same latent bug, but no consumer in the repo overrides them today — leaving those alone to keep this change surgical. Filing a follow-up to redesign the whole struct's default story.

## Regression test

`TestBaseTaskConfig_TimeoutSurvivesEnvParse` pins a struct-set 30m Timeout through `env.Parse` without a `TIMEOUT` env var. Fails on `main`, passes here.

## Test plan

- [x] `go test ./pkg/periodics/... -count=1` — green (new test + existing pass)
- [x] `go vet ./pkg/periodics/...`
- [x] `gofmt -l pkg/periodics/`
- [ ] After merge: bump `back/go.mod` in `iota-uz/eai` (combined with stack-file env-var pin) → preprod reindex completes the full 1.3M-doc commit within the configured 30-min budget

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted internal timeout configuration so default values are applied later in the config merge flow, reducing unintended overrides.

* **Tests**
  * Added test coverage to ensure an explicitly set timeout value is preserved during environment-based config parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iota-uz/iota-sdk/pull/779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->