### PR TITLE
feat(core): organizational model — departments + user positions

### DIFF
--- a/migrations/changes-1779808179.sql
+++ b/migrations/changes-1779808179.sql
@@ -1,0 +1,47 @@
+-- Migration: Add core organizational model (departments + user positions)
+-- Date: 2026-05-26
+-- Purpose: Introduce reusable, tenant-scoped department hierarchy and user
+--   position aggregates in the core module. Foundation for EAI's EDO granular
+--   permissions epic. Names/titles are multilingual jsonb (MultiLang).
+
+-- +migrate Up
+CREATE SCHEMA IF NOT EXISTS core;
+
+CREATE TABLE core.departments (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
+    tenant_id uuid NOT NULL REFERENCES tenants (id) ON DELETE CASCADE,
+    parent_id uuid NULL REFERENCES core.departments (id) ON DELETE SET NULL,
+    code varchar NOT NULL,
+    name jsonb NOT NULL,
+    "order" int NOT NULL DEFAULT 0,
+    status varchar NOT NULL DEFAULT 'active',
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now(),
+    UNIQUE (tenant_id, code)
+);
+
+CREATE INDEX departments_tenant_id_idx ON core.departments (tenant_id);
+
+CREATE INDEX departments_tenant_id_parent_id_idx ON core.departments (tenant_id, parent_id);
+
+CREATE TABLE core.user_positions (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
+    tenant_id uuid NOT NULL REFERENCES tenants (id) ON DELETE CASCADE,
+    user_id integer NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    department_id uuid NOT NULL REFERENCES core.departments (id) ON DELETE CASCADE,
+    title jsonb NOT NULL,
+    is_manager boolean NOT NULL DEFAULT FALSE,
+    is_primary boolean NOT NULL DEFAULT FALSE,
+    status varchar NOT NULL DEFAULT 'active',
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now()
+);
+
+CREATE INDEX user_positions_tenant_id_user_id_idx ON core.user_positions (tenant_id, user_id);
+
+CREATE INDEX user_positions_tenant_id_department_id_idx ON core.user_positions (tenant_id, department_id);
+
+-- +migrate Down
+DROP TABLE IF EXISTS core.user_positions;
+
+DROP TABLE IF EXISTS core.departments;

--- a/migrations/changes-1779808179.sql
+++ b/migrations/changes-1779808179.sql
@@ -31,9 +31,11 @@ CREATE TABLE core.departments (
     -- Tenant-qualified self-reference target for the parent FK below.
     CONSTRAINT departments_tenant_id_id_key UNIQUE (tenant_id, id),
     -- A parent department must live in the same tenant; cross-tenant parents
-    -- are rejected by the database, not only the application.
+    -- are rejected by the database, not only the application. On parent delete
+    -- only parent_id is nulled (column-specific SET NULL, PG15+); tenant_id is
+    -- NOT NULL and must be preserved, so children orphan to the tenant root.
     CONSTRAINT departments_parent_tenant_fkey FOREIGN KEY (tenant_id, parent_id)
-        REFERENCES core.departments (tenant_id, id) ON DELETE SET NULL
+        REFERENCES core.departments (tenant_id, id) ON DELETE SET NULL (parent_id)
 );
 
 CREATE INDEX departments_tenant_id_idx ON core.departments (tenant_id);

--- a/migrations/changes-1779808179.sql
+++ b/migrations/changes-1779808179.sql
@@ -3,21 +3,37 @@
 -- Purpose: Introduce reusable, tenant-scoped department hierarchy and user
 --   position aggregates in the core module. Foundation for EAI's EDO granular
 --   permissions epic. Names/titles are multilingual jsonb (MultiLang).
+--
+-- Cross-tenant integrity is enforced at the database level: foreign keys are
+-- tenant-qualified (they reference the composite (tenant_id, id) of the parent
+-- table) so a row can never link to another tenant's row, regardless of the
+-- application path that wrote it.
 
 -- +migrate Up
 CREATE SCHEMA IF NOT EXISTS core;
 
+-- Tenant-qualified FK target: a position references both the user's id and
+-- tenant, so a position can never point at a user in another tenant.
+ALTER TABLE users
+    ADD CONSTRAINT users_tenant_id_id_key UNIQUE (tenant_id, id);
+
 CREATE TABLE core.departments (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
     tenant_id uuid NOT NULL REFERENCES tenants (id) ON DELETE CASCADE,
-    parent_id uuid NULL REFERENCES core.departments (id) ON DELETE SET NULL,
+    parent_id uuid NULL,
     code varchar NOT NULL,
     name jsonb NOT NULL,
     "order" int NOT NULL DEFAULT 0,
     status varchar NOT NULL DEFAULT 'active',
     created_at timestamp with time zone DEFAULT now(),
     updated_at timestamp with time zone DEFAULT now(),
-    UNIQUE (tenant_id, code)
+    UNIQUE (tenant_id, code),
+    -- Tenant-qualified self-reference target for the parent FK below.
+    CONSTRAINT departments_tenant_id_id_key UNIQUE (tenant_id, id),
+    -- A parent department must live in the same tenant; cross-tenant parents
+    -- are rejected by the database, not only the application.
+    CONSTRAINT departments_parent_tenant_fkey FOREIGN KEY (tenant_id, parent_id)
+        REFERENCES core.departments (tenant_id, id) ON DELETE SET NULL
 );
 
 CREATE INDEX departments_tenant_id_idx ON core.departments (tenant_id);
@@ -27,14 +43,19 @@ CREATE INDEX departments_tenant_id_parent_id_idx ON core.departments (tenant_id,
 CREATE TABLE core.user_positions (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
     tenant_id uuid NOT NULL REFERENCES tenants (id) ON DELETE CASCADE,
-    user_id integer NOT NULL REFERENCES users (id) ON DELETE CASCADE,
-    department_id uuid NOT NULL REFERENCES core.departments (id) ON DELETE CASCADE,
+    user_id integer NOT NULL,
+    department_id uuid NOT NULL,
     title jsonb NOT NULL,
     is_manager boolean NOT NULL DEFAULT FALSE,
     is_primary boolean NOT NULL DEFAULT FALSE,
     status varchar NOT NULL DEFAULT 'active',
     created_at timestamp with time zone DEFAULT now(),
-    updated_at timestamp with time zone DEFAULT now()
+    updated_at timestamp with time zone DEFAULT now(),
+    -- Both references are tenant-qualified so a position cannot bridge tenants.
+    CONSTRAINT user_positions_department_tenant_fkey FOREIGN KEY (tenant_id, department_id)
+        REFERENCES core.departments (tenant_id, id) ON DELETE CASCADE,
+    CONSTRAINT user_positions_user_tenant_fkey FOREIGN KEY (tenant_id, user_id)
+        REFERENCES users (tenant_id, id) ON DELETE CASCADE
 );
 
 CREATE INDEX user_positions_tenant_id_user_id_idx ON core.user_positions (tenant_id, user_id);
@@ -45,3 +66,6 @@ CREATE INDEX user_positions_tenant_id_department_id_idx ON core.user_positions (
 DROP TABLE IF EXISTS core.user_positions;
 
 DROP TABLE IF EXISTS core.departments;
+
+ALTER TABLE users
+    DROP CONSTRAINT IF EXISTS users_tenant_id_id_key;

--- a/modules/core/component.go
+++ b/modules/core/component.go
@@ -117,9 +117,12 @@ func (c *component) Build(builder *composition.Builder) error {
 	composition.ProvideFunc(builder, persistence.NewRecoveryCodeRepository)
 	composition.ProvideFunc(builder, persistence.NewGroupRepository)
 	composition.ProvideFunc(builder, persistence.NewCurrencyRepository)
+	composition.ProvideFunc(builder, persistence.NewDepartmentRepository)
+	composition.ProvideFunc(builder, persistence.NewUserPositionRepository)
 	composition.ProvideFunc(builder, query.NewPgUserQueryRepository)
 	composition.ProvideFunc(builder, query.NewPgGroupQueryRepository)
 	composition.ProvideFunc(builder, query.NewPgRoleQueryRepository)
+	composition.ProvideFunc(builder, query.NewPgOrgQueryRepository)
 
 	// ----- Services -----
 	composition.ProvideFunc(builder, services.NewTenantService)
@@ -136,6 +139,9 @@ func (c *component) Build(builder *composition.Builder) error {
 	composition.ProvideFunc(builder, services.NewRoleService)
 	composition.ProvideFunc(builder, services.NewPermissionService)
 	composition.ProvideFunc(builder, services.NewGroupService)
+	composition.ProvideFunc(builder, services.NewDepartmentService)
+	composition.ProvideFunc(builder, services.NewUserPositionService)
+	composition.ProvideFunc(builder, services.NewOrgQueryService)
 	composition.ProvideFunc(builder, newCoreTwoFactorService)
 
 	// ----- Event handlers -----

--- a/modules/core/domain/aggregates/department/department.go
+++ b/modules/core/domain/aggregates/department/department.go
@@ -61,9 +61,20 @@ func WithTenantID(tenantID uuid.UUID) Option {
 	}
 }
 
+// copyUUIDPtr returns a defensive copy of a *uuid.UUID so a caller that retains
+// the original pointer cannot mutate the aggregate's parent reference after
+// construction (the aggregate is immutable).
+func copyUUIDPtr(id *uuid.UUID) *uuid.UUID {
+	if id == nil {
+		return nil
+	}
+	v := *id
+	return &v
+}
+
 func WithParentID(parentID *uuid.UUID) Option {
 	return func(d *department) {
-		d.parentID = parentID
+		d.parentID = copyUUIDPtr(parentID)
 	}
 }
 
@@ -191,7 +202,7 @@ func (d *department) SetName(name models.MultiLang) Department {
 
 func (d *department) SetParentID(parentID *uuid.UUID) Department {
 	r := *d
-	r.parentID = parentID
+	r.parentID = copyUUIDPtr(parentID)
 	r.updatedAt = time.Now()
 	return &r
 }

--- a/modules/core/domain/aggregates/department/department.go
+++ b/modules/core/domain/aggregates/department/department.go
@@ -135,7 +135,13 @@ func (d *department) TenantID() uuid.UUID {
 }
 
 func (d *department) ParentID() *uuid.UUID {
-	return d.parentID
+	if d.parentID == nil {
+		return nil
+	}
+	// Return a fresh copy so callers cannot mutate the aggregate's internal
+	// parent pointer through the returned reference.
+	parentID := *d.parentID
+	return &parentID
 }
 
 func (d *department) Code() string {

--- a/modules/core/domain/aggregates/department/department.go
+++ b/modules/core/domain/aggregates/department/department.go
@@ -1,0 +1,212 @@
+// Package department provides the department aggregate: a tenant-scoped,
+// self-referential organizational unit with a multilingual name.
+package department
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/pkg/crud/models"
+)
+
+// Status enumerates the lifecycle states a department can be in.
+type Status string
+
+const (
+	StatusActive   Status = "active"
+	StatusInactive Status = "inactive"
+)
+
+type Option func(d *department)
+
+// ---- Interface ----
+
+// Department is a tenant-scoped organizational unit. Names are stored as a
+// MultiLang jsonb value so each tenant can localise them independently.
+// Departments may form a hierarchy through ParentID.
+type Department interface {
+	ID() uuid.UUID
+	TenantID() uuid.UUID
+	ParentID() *uuid.UUID
+	Code() string
+	// Name resolves the department name in the requested locale, falling back
+	// to the MultiLang default when the locale is missing.
+	Name(locale string) string
+	// NameI18n returns the full multilingual name value.
+	NameI18n() models.MultiLang
+	Order() int
+	Status() Status
+	CreatedAt() time.Time
+	UpdatedAt() time.Time
+
+	SetCode(code string) Department
+	SetName(name models.MultiLang) Department
+	SetParentID(parentID *uuid.UUID) Department
+	SetOrder(order int) Department
+	SetStatus(status Status) Department
+	SetTenantID(tenantID uuid.UUID) Department
+}
+
+// ---- Options ----
+
+func WithID(id uuid.UUID) Option {
+	return func(d *department) {
+		d.id = id
+	}
+}
+
+func WithTenantID(tenantID uuid.UUID) Option {
+	return func(d *department) {
+		d.tenantID = tenantID
+	}
+}
+
+func WithParentID(parentID *uuid.UUID) Option {
+	return func(d *department) {
+		d.parentID = parentID
+	}
+}
+
+func WithOrder(order int) Option {
+	return func(d *department) {
+		d.order = order
+	}
+}
+
+func WithStatus(status Status) Option {
+	return func(d *department) {
+		d.status = status
+	}
+}
+
+func WithCreatedAt(t time.Time) Option {
+	return func(d *department) {
+		d.createdAt = t
+	}
+}
+
+func WithUpdatedAt(t time.Time) Option {
+	return func(d *department) {
+		d.updatedAt = t
+	}
+}
+
+// New constructs a Department. code is the tenant-unique identifier and name is
+// the multilingual display name.
+func New(code string, name models.MultiLang, opts ...Option) Department {
+	d := &department{
+		id:        uuid.New(),
+		tenantID:  uuid.Nil,
+		parentID:  nil,
+		code:      code,
+		name:      name,
+		order:     0,
+		status:    StatusActive,
+		createdAt: time.Now(),
+		updatedAt: time.Now(),
+	}
+
+	for _, opt := range opts {
+		opt(d)
+	}
+	return d
+}
+
+// ---- Implementation ----
+
+type department struct {
+	id        uuid.UUID
+	tenantID  uuid.UUID
+	parentID  *uuid.UUID
+	code      string
+	name      models.MultiLang
+	order     int
+	status    Status
+	createdAt time.Time
+	updatedAt time.Time
+}
+
+func (d *department) ID() uuid.UUID {
+	return d.id
+}
+
+func (d *department) TenantID() uuid.UUID {
+	return d.tenantID
+}
+
+func (d *department) ParentID() *uuid.UUID {
+	return d.parentID
+}
+
+func (d *department) Code() string {
+	return d.code
+}
+
+func (d *department) Name(locale string) string {
+	if d.name == nil {
+		return ""
+	}
+	return d.name.GetWithFallback(locale)
+}
+
+func (d *department) NameI18n() models.MultiLang {
+	return d.name
+}
+
+func (d *department) Order() int {
+	return d.order
+}
+
+func (d *department) Status() Status {
+	return d.status
+}
+
+func (d *department) CreatedAt() time.Time {
+	return d.createdAt
+}
+
+func (d *department) UpdatedAt() time.Time {
+	return d.updatedAt
+}
+
+func (d *department) SetCode(code string) Department {
+	r := *d
+	r.code = code
+	r.updatedAt = time.Now()
+	return &r
+}
+
+func (d *department) SetName(name models.MultiLang) Department {
+	r := *d
+	r.name = name
+	r.updatedAt = time.Now()
+	return &r
+}
+
+func (d *department) SetParentID(parentID *uuid.UUID) Department {
+	r := *d
+	r.parentID = parentID
+	r.updatedAt = time.Now()
+	return &r
+}
+
+func (d *department) SetOrder(order int) Department {
+	r := *d
+	r.order = order
+	r.updatedAt = time.Now()
+	return &r
+}
+
+func (d *department) SetStatus(status Status) Department {
+	r := *d
+	r.status = status
+	r.updatedAt = time.Now()
+	return &r
+}
+
+func (d *department) SetTenantID(tenantID uuid.UUID) Department {
+	r := *d
+	r.tenantID = tenantID
+	r.updatedAt = time.Now()
+	return &r
+}

--- a/modules/core/domain/aggregates/department/department_events.go
+++ b/modules/core/domain/aggregates/department/department_events.go
@@ -1,0 +1,52 @@
+// Package department provides this package.
+package department
+
+import (
+	"time"
+
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/user"
+)
+
+type CreatedEvent struct {
+	Department Department
+	Timestamp  time.Time
+	Actor      user.User
+}
+
+func NewCreatedEvent(department Department, actor user.User) *CreatedEvent {
+	return &CreatedEvent{
+		Department: department,
+		Timestamp:  time.Now(),
+		Actor:      actor,
+	}
+}
+
+type UpdatedEvent struct {
+	Department    Department
+	OldDepartment Department
+	Timestamp     time.Time
+	Actor         user.User
+}
+
+func NewUpdatedEvent(oldDepartment, newDepartment Department, actor user.User) *UpdatedEvent {
+	return &UpdatedEvent{
+		Department:    newDepartment,
+		OldDepartment: oldDepartment,
+		Timestamp:     time.Now(),
+		Actor:         actor,
+	}
+}
+
+type DeletedEvent struct {
+	Department Department
+	Timestamp  time.Time
+	Actor      user.User
+}
+
+func NewDeletedEvent(department Department, actor user.User) *DeletedEvent {
+	return &DeletedEvent{
+		Department: department,
+		Timestamp:  time.Now(),
+		Actor:      actor,
+	}
+}

--- a/modules/core/domain/aggregates/department/department_repository.go
+++ b/modules/core/domain/aggregates/department/department_repository.go
@@ -33,6 +33,10 @@ type FindParams struct {
 
 func (f *FindParams) FilterBy(field Field, filter repo.Filter) *FindParams {
 	res := *f
+	// Deep-copy Filters so the shallow struct copy does not share the backing
+	// array with the receiver (appending below could otherwise mutate it).
+	res.Filters = make([]Filter, len(f.Filters), len(f.Filters)+1)
+	copy(res.Filters, f.Filters)
 	res.Filters = append(res.Filters, Filter{
 		Column: field,
 		Filter: filter,

--- a/modules/core/domain/aggregates/department/department_repository.go
+++ b/modules/core/domain/aggregates/department/department_repository.go
@@ -1,0 +1,50 @@
+// Package department provides this package.
+package department
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/pkg/repo"
+)
+
+type Field = int
+
+const (
+	CreatedAtField Field = iota
+	UpdatedAtField
+	TenantIDField
+	CodeField
+	ParentIDField
+	OrderField
+	StatusField
+)
+
+type SortBy = repo.SortBy[Field]
+type Filter = repo.FieldFilter[Field]
+
+type FindParams struct {
+	Limit   int
+	Offset  int
+	SortBy  SortBy
+	Search  string
+	Filters []Filter
+}
+
+func (f *FindParams) FilterBy(field Field, filter repo.Filter) *FindParams {
+	res := *f
+	res.Filters = append(res.Filters, Filter{
+		Column: field,
+		Filter: filter,
+	})
+	return &res
+}
+
+type Repository interface {
+	Count(ctx context.Context, params *FindParams) (int64, error)
+	GetPaginated(ctx context.Context, params *FindParams) ([]Department, error)
+	GetByID(ctx context.Context, id uuid.UUID) (Department, error)
+	Save(ctx context.Context, department Department) (Department, error)
+	Exists(ctx context.Context, id uuid.UUID) (bool, error)
+	Delete(ctx context.Context, id uuid.UUID) error
+}

--- a/modules/core/domain/aggregates/userposition/user_position.go
+++ b/modules/core/domain/aggregates/userposition/user_position.go
@@ -1,0 +1,219 @@
+// Package userposition provides the user position aggregate: a tenant-scoped
+// assignment of a user to a department with a multilingual title.
+package userposition
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/pkg/crud/models"
+)
+
+// Status enumerates the lifecycle states a user position can be in.
+type Status string
+
+const (
+	StatusActive   Status = "active"
+	StatusInactive Status = "inactive"
+)
+
+type Option func(p *userPosition)
+
+// ---- Interface ----
+
+// UserPosition assigns a user to a department within a tenant. A user may hold
+// several positions; IsManager marks the position as a department head and
+// IsPrimary marks the user's primary placement. Titles are multilingual.
+type UserPosition interface {
+	ID() uuid.UUID
+	TenantID() uuid.UUID
+	UserID() uint
+	DepartmentID() uuid.UUID
+	// Title resolves the position title in the requested locale, falling back
+	// to the MultiLang default when the locale is missing.
+	Title(locale string) string
+	// TitleI18n returns the full multilingual title value.
+	TitleI18n() models.MultiLang
+	IsManager() bool
+	IsPrimary() bool
+	Status() Status
+	CreatedAt() time.Time
+	UpdatedAt() time.Time
+
+	SetTitle(title models.MultiLang) UserPosition
+	SetDepartmentID(departmentID uuid.UUID) UserPosition
+	SetIsManager(isManager bool) UserPosition
+	SetIsPrimary(isPrimary bool) UserPosition
+	SetStatus(status Status) UserPosition
+	SetTenantID(tenantID uuid.UUID) UserPosition
+}
+
+// ---- Options ----
+
+func WithID(id uuid.UUID) Option {
+	return func(p *userPosition) {
+		p.id = id
+	}
+}
+
+func WithTenantID(tenantID uuid.UUID) Option {
+	return func(p *userPosition) {
+		p.tenantID = tenantID
+	}
+}
+
+func WithIsManager(isManager bool) Option {
+	return func(p *userPosition) {
+		p.isManager = isManager
+	}
+}
+
+func WithIsPrimary(isPrimary bool) Option {
+	return func(p *userPosition) {
+		p.isPrimary = isPrimary
+	}
+}
+
+func WithStatus(status Status) Option {
+	return func(p *userPosition) {
+		p.status = status
+	}
+}
+
+func WithCreatedAt(t time.Time) Option {
+	return func(p *userPosition) {
+		p.createdAt = t
+	}
+}
+
+func WithUpdatedAt(t time.Time) Option {
+	return func(p *userPosition) {
+		p.updatedAt = t
+	}
+}
+
+// New constructs a UserPosition placing userID into departmentID with the given
+// multilingual title.
+func New(userID uint, departmentID uuid.UUID, title models.MultiLang, opts ...Option) UserPosition {
+	p := &userPosition{
+		id:           uuid.New(),
+		tenantID:     uuid.Nil,
+		userID:       userID,
+		departmentID: departmentID,
+		title:        title,
+		isManager:    false,
+		isPrimary:    false,
+		status:       StatusActive,
+		createdAt:    time.Now(),
+		updatedAt:    time.Now(),
+	}
+
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// ---- Implementation ----
+
+type userPosition struct {
+	id           uuid.UUID
+	tenantID     uuid.UUID
+	userID       uint
+	departmentID uuid.UUID
+	title        models.MultiLang
+	isManager    bool
+	isPrimary    bool
+	status       Status
+	createdAt    time.Time
+	updatedAt    time.Time
+}
+
+func (p *userPosition) ID() uuid.UUID {
+	return p.id
+}
+
+func (p *userPosition) TenantID() uuid.UUID {
+	return p.tenantID
+}
+
+func (p *userPosition) UserID() uint {
+	return p.userID
+}
+
+func (p *userPosition) DepartmentID() uuid.UUID {
+	return p.departmentID
+}
+
+func (p *userPosition) Title(locale string) string {
+	if p.title == nil {
+		return ""
+	}
+	return p.title.GetWithFallback(locale)
+}
+
+func (p *userPosition) TitleI18n() models.MultiLang {
+	return p.title
+}
+
+func (p *userPosition) IsManager() bool {
+	return p.isManager
+}
+
+func (p *userPosition) IsPrimary() bool {
+	return p.isPrimary
+}
+
+func (p *userPosition) Status() Status {
+	return p.status
+}
+
+func (p *userPosition) CreatedAt() time.Time {
+	return p.createdAt
+}
+
+func (p *userPosition) UpdatedAt() time.Time {
+	return p.updatedAt
+}
+
+func (p *userPosition) SetTitle(title models.MultiLang) UserPosition {
+	r := *p
+	r.title = title
+	r.updatedAt = time.Now()
+	return &r
+}
+
+func (p *userPosition) SetDepartmentID(departmentID uuid.UUID) UserPosition {
+	r := *p
+	r.departmentID = departmentID
+	r.updatedAt = time.Now()
+	return &r
+}
+
+func (p *userPosition) SetIsManager(isManager bool) UserPosition {
+	r := *p
+	r.isManager = isManager
+	r.updatedAt = time.Now()
+	return &r
+}
+
+func (p *userPosition) SetIsPrimary(isPrimary bool) UserPosition {
+	r := *p
+	r.isPrimary = isPrimary
+	r.updatedAt = time.Now()
+	return &r
+}
+
+func (p *userPosition) SetStatus(status Status) UserPosition {
+	r := *p
+	r.status = status
+	r.updatedAt = time.Now()
+	return &r
+}
+
+func (p *userPosition) SetTenantID(tenantID uuid.UUID) UserPosition {
+	r := *p
+	r.tenantID = tenantID
+	r.updatedAt = time.Now()
+	return &r
+}

--- a/modules/core/domain/aggregates/userposition/user_position_events.go
+++ b/modules/core/domain/aggregates/userposition/user_position_events.go
@@ -1,0 +1,52 @@
+// Package userposition provides this package.
+package userposition
+
+import (
+	"time"
+
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/user"
+)
+
+type CreatedEvent struct {
+	Position  UserPosition
+	Timestamp time.Time
+	Actor     user.User
+}
+
+func NewCreatedEvent(position UserPosition, actor user.User) *CreatedEvent {
+	return &CreatedEvent{
+		Position:  position,
+		Timestamp: time.Now(),
+		Actor:     actor,
+	}
+}
+
+type UpdatedEvent struct {
+	Position    UserPosition
+	OldPosition UserPosition
+	Timestamp   time.Time
+	Actor       user.User
+}
+
+func NewUpdatedEvent(oldPosition, newPosition UserPosition, actor user.User) *UpdatedEvent {
+	return &UpdatedEvent{
+		Position:    newPosition,
+		OldPosition: oldPosition,
+		Timestamp:   time.Now(),
+		Actor:       actor,
+	}
+}
+
+type DeletedEvent struct {
+	Position  UserPosition
+	Timestamp time.Time
+	Actor     user.User
+}
+
+func NewDeletedEvent(position UserPosition, actor user.User) *DeletedEvent {
+	return &DeletedEvent{
+		Position:  position,
+		Timestamp: time.Now(),
+		Actor:     actor,
+	}
+}

--- a/modules/core/domain/aggregates/userposition/user_position_repository.go
+++ b/modules/core/domain/aggregates/userposition/user_position_repository.go
@@ -34,6 +34,10 @@ type FindParams struct {
 
 func (f *FindParams) FilterBy(field Field, filter repo.Filter) *FindParams {
 	res := *f
+	// Deep-copy Filters so the shallow struct copy does not share the backing
+	// array with the receiver (appending below could otherwise mutate it).
+	res.Filters = make([]Filter, len(f.Filters), len(f.Filters)+1)
+	copy(res.Filters, f.Filters)
 	res.Filters = append(res.Filters, Filter{
 		Column: field,
 		Filter: filter,

--- a/modules/core/domain/aggregates/userposition/user_position_repository.go
+++ b/modules/core/domain/aggregates/userposition/user_position_repository.go
@@ -1,0 +1,51 @@
+// Package userposition provides this package.
+package userposition
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/pkg/repo"
+)
+
+type Field = int
+
+const (
+	CreatedAtField Field = iota
+	UpdatedAtField
+	TenantIDField
+	UserIDField
+	DepartmentIDField
+	IsManagerField
+	IsPrimaryField
+	StatusField
+)
+
+type SortBy = repo.SortBy[Field]
+type Filter = repo.FieldFilter[Field]
+
+type FindParams struct {
+	Limit   int
+	Offset  int
+	SortBy  SortBy
+	Search  string
+	Filters []Filter
+}
+
+func (f *FindParams) FilterBy(field Field, filter repo.Filter) *FindParams {
+	res := *f
+	res.Filters = append(res.Filters, Filter{
+		Column: field,
+		Filter: filter,
+	})
+	return &res
+}
+
+type Repository interface {
+	Count(ctx context.Context, params *FindParams) (int64, error)
+	GetPaginated(ctx context.Context, params *FindParams) ([]UserPosition, error)
+	GetByID(ctx context.Context, id uuid.UUID) (UserPosition, error)
+	Save(ctx context.Context, position UserPosition) (UserPosition, error)
+	Exists(ctx context.Context, id uuid.UUID) (bool, error)
+	Delete(ctx context.Context, id uuid.UUID) error
+}

--- a/modules/core/infrastructure/persistence/core_mappers.go
+++ b/modules/core/infrastructure/persistence/core_mappers.go
@@ -10,9 +10,11 @@ import (
 	"github.com/go-faster/errors"
 	"github.com/google/uuid"
 
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/department"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/group"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/role"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/user"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/userposition"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/authlog"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/currency"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/passport"
@@ -26,6 +28,7 @@ import (
 	"github.com/iota-uz/iota-sdk/modules/core/domain/value_objects/phone"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/value_objects/tax"
 	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence/models"
+	crudmodels "github.com/iota-uz/iota-sdk/pkg/crud/models"
 	"github.com/iota-uz/iota-sdk/pkg/mapping"
 	"github.com/iota-uz/iota-sdk/pkg/twofactor"
 )
@@ -566,4 +569,118 @@ func ToDBGroup(g group.Group) *models.Group {
 		CreatedAt:   g.CreatedAt(),
 		UpdatedAt:   g.UpdatedAt(),
 	}
+}
+
+func ToDomainDepartment(dbDepartment *models.Department) (department.Department, error) {
+	id, err := uuid.Parse(dbDepartment.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	tenantID, err := uuid.Parse(dbDepartment.TenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	name, err := crudmodels.MultiLangFromJSON(dbDepartment.Name)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse department name jsonb")
+	}
+
+	opts := []department.Option{
+		department.WithID(id),
+		department.WithTenantID(tenantID),
+		department.WithOrder(dbDepartment.Order),
+		department.WithStatus(department.Status(dbDepartment.Status)),
+		department.WithCreatedAt(dbDepartment.CreatedAt),
+		department.WithUpdatedAt(dbDepartment.UpdatedAt),
+	}
+
+	if dbDepartment.ParentID.Valid && dbDepartment.ParentID.String != "" {
+		parentID, err := uuid.Parse(dbDepartment.ParentID.String)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, department.WithParentID(&parentID))
+	}
+
+	return department.New(dbDepartment.Code, name, opts...), nil
+}
+
+func ToDBDepartment(d department.Department) (*models.Department, error) {
+	name, err := d.NameI18n().ToJSON()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to serialize department name to jsonb")
+	}
+
+	var parentID sql.NullString
+	if d.ParentID() != nil {
+		parentID = mapping.ValueToSQLNullString(d.ParentID().String())
+	}
+
+	return &models.Department{
+		ID:        d.ID().String(),
+		TenantID:  d.TenantID().String(),
+		ParentID:  parentID,
+		Code:      d.Code(),
+		Name:      name,
+		Order:     d.Order(),
+		Status:    string(d.Status()),
+		CreatedAt: d.CreatedAt(),
+		UpdatedAt: d.UpdatedAt(),
+	}, nil
+}
+
+func ToDomainUserPosition(dbPosition *models.UserPosition) (userposition.UserPosition, error) {
+	id, err := uuid.Parse(dbPosition.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	tenantID, err := uuid.Parse(dbPosition.TenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	departmentID, err := uuid.Parse(dbPosition.DepartmentID)
+	if err != nil {
+		return nil, err
+	}
+
+	title, err := crudmodels.MultiLangFromJSON(dbPosition.Title)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse user position title jsonb")
+	}
+
+	opts := []userposition.Option{
+		userposition.WithID(id),
+		userposition.WithTenantID(tenantID),
+		userposition.WithIsManager(dbPosition.IsManager),
+		userposition.WithIsPrimary(dbPosition.IsPrimary),
+		userposition.WithStatus(userposition.Status(dbPosition.Status)),
+		userposition.WithCreatedAt(dbPosition.CreatedAt),
+		userposition.WithUpdatedAt(dbPosition.UpdatedAt),
+	}
+
+	return userposition.New(dbPosition.UserID, departmentID, title, opts...), nil
+}
+
+func ToDBUserPosition(p userposition.UserPosition) (*models.UserPosition, error) {
+	title, err := p.TitleI18n().ToJSON()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to serialize user position title to jsonb")
+	}
+
+	return &models.UserPosition{
+		ID:           p.ID().String(),
+		TenantID:     p.TenantID().String(),
+		UserID:       p.UserID(),
+		DepartmentID: p.DepartmentID().String(),
+		Title:        title,
+		IsManager:    p.IsManager(),
+		IsPrimary:    p.IsPrimary(),
+		Status:       string(p.Status()),
+		CreatedAt:    p.CreatedAt(),
+		UpdatedAt:    p.UpdatedAt(),
+	}, nil
 }

--- a/modules/core/infrastructure/persistence/core_mappers.go
+++ b/modules/core/infrastructure/persistence/core_mappers.go
@@ -30,6 +30,7 @@ import (
 	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence/models"
 	crudmodels "github.com/iota-uz/iota-sdk/pkg/crud/models"
 	"github.com/iota-uz/iota-sdk/pkg/mapping"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
 	"github.com/iota-uz/iota-sdk/pkg/twofactor"
 )
 
@@ -572,45 +573,33 @@ func ToDBGroup(g group.Group) *models.Group {
 }
 
 func ToDomainDepartment(dbDepartment *models.Department) (department.Department, error) {
-	id, err := uuid.Parse(dbDepartment.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	tenantID, err := uuid.Parse(dbDepartment.TenantID)
-	if err != nil {
-		return nil, err
-	}
-
+	const op serrors.Op = "ToDomainDepartment"
 	name, err := crudmodels.MultiLangFromJSON(dbDepartment.Name)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse department name jsonb")
+		return nil, serrors.E(op, err)
 	}
 
 	opts := []department.Option{
-		department.WithID(id),
-		department.WithTenantID(tenantID),
+		department.WithID(dbDepartment.ParsedID()),
+		department.WithTenantID(dbDepartment.ParsedTenantID()),
 		department.WithOrder(dbDepartment.Order),
 		department.WithStatus(department.Status(dbDepartment.Status)),
 		department.WithCreatedAt(dbDepartment.CreatedAt),
 		department.WithUpdatedAt(dbDepartment.UpdatedAt),
 	}
 
-	if dbDepartment.ParentID.Valid && dbDepartment.ParentID.String != "" {
-		parentID, err := uuid.Parse(dbDepartment.ParentID.String)
-		if err != nil {
-			return nil, err
-		}
-		opts = append(opts, department.WithParentID(&parentID))
+	if parentID := dbDepartment.ParsedParentID(); parentID != nil {
+		opts = append(opts, department.WithParentID(parentID))
 	}
 
 	return department.New(dbDepartment.Code, name, opts...), nil
 }
 
 func ToDBDepartment(d department.Department) (*models.Department, error) {
+	const op serrors.Op = "ToDBDepartment"
 	name, err := d.NameI18n().ToJSON()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to serialize department name to jsonb")
+		return nil, serrors.E(op, err)
 	}
 
 	var parentID sql.NullString
@@ -632,29 +621,15 @@ func ToDBDepartment(d department.Department) (*models.Department, error) {
 }
 
 func ToDomainUserPosition(dbPosition *models.UserPosition) (userposition.UserPosition, error) {
-	id, err := uuid.Parse(dbPosition.ID)
-	if err != nil {
-		return nil, err
-	}
-
-	tenantID, err := uuid.Parse(dbPosition.TenantID)
-	if err != nil {
-		return nil, err
-	}
-
-	departmentID, err := uuid.Parse(dbPosition.DepartmentID)
-	if err != nil {
-		return nil, err
-	}
-
+	const op serrors.Op = "ToDomainUserPosition"
 	title, err := crudmodels.MultiLangFromJSON(dbPosition.Title)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse user position title jsonb")
+		return nil, serrors.E(op, err)
 	}
 
 	opts := []userposition.Option{
-		userposition.WithID(id),
-		userposition.WithTenantID(tenantID),
+		userposition.WithID(dbPosition.ParsedID()),
+		userposition.WithTenantID(dbPosition.ParsedTenantID()),
 		userposition.WithIsManager(dbPosition.IsManager),
 		userposition.WithIsPrimary(dbPosition.IsPrimary),
 		userposition.WithStatus(userposition.Status(dbPosition.Status)),
@@ -662,13 +637,14 @@ func ToDomainUserPosition(dbPosition *models.UserPosition) (userposition.UserPos
 		userposition.WithUpdatedAt(dbPosition.UpdatedAt),
 	}
 
-	return userposition.New(dbPosition.UserID, departmentID, title, opts...), nil
+	return userposition.New(dbPosition.UserID, dbPosition.ParsedDepartmentID(), title, opts...), nil
 }
 
 func ToDBUserPosition(p userposition.UserPosition) (*models.UserPosition, error) {
+	const op serrors.Op = "ToDBUserPosition"
 	title, err := p.TitleI18n().ToJSON()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to serialize user position title to jsonb")
+		return nil, serrors.E(op, err)
 	}
 
 	return &models.UserPosition{

--- a/modules/core/infrastructure/persistence/department_repository.go
+++ b/modules/core/infrastructure/persistence/department_repository.go
@@ -325,8 +325,12 @@ func (r *PgDepartmentRepository) Delete(ctx context.Context, id uuid.UUID) error
 		return serrors.E(op, err)
 	}
 
-	if _, err := tx.Exec(ctx, departmentDeleteQuery, id.String(), tenantID.String()); err != nil {
+	tag, err := tx.Exec(ctx, departmentDeleteQuery, id.String(), tenantID.String())
+	if err != nil {
 		return serrors.E(op, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return serrors.E(op, serrors.NotFound, ErrDepartmentNotFound)
 	}
 	return nil
 }

--- a/modules/core/infrastructure/persistence/department_repository.go
+++ b/modules/core/infrastructure/persistence/department_repository.go
@@ -3,14 +3,15 @@ package persistence
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/go-faster/errors"
 	"github.com/google/uuid"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/department"
 	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence/models"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
 	"github.com/iota-uz/iota-sdk/pkg/repo"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
 )
 
 var (
@@ -58,9 +59,10 @@ func (r *PgDepartmentRepository) buildFilters(
 	ctx context.Context,
 	params *department.FindParams,
 ) ([]string, []interface{}, error) {
+	const op serrors.Op = "PgDepartmentRepository.buildFilters"
 	tenantID, err := composables.UseTenantID(ctx)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to get tenant from context")
+		return nil, nil, serrors.E(op, err)
 	}
 
 	where := []string{"d.tenant_id = $1"}
@@ -69,7 +71,7 @@ func (r *PgDepartmentRepository) buildFilters(
 	for _, filter := range params.Filters {
 		column, ok := r.fieldMap[filter.Column]
 		if !ok {
-			return nil, nil, errors.Wrap(fmt.Errorf("unknown filter field: %v", filter.Column), "invalid filter")
+			return nil, nil, serrors.E(op, fmt.Errorf("unknown filter field: %v", filter.Column))
 		}
 		where = append(where, filter.Filter.String(column, len(args)+1))
 		args = append(args, filter.Filter.Value()...)
@@ -88,9 +90,14 @@ func (r *PgDepartmentRepository) GetPaginated(
 	ctx context.Context,
 	params *department.FindParams,
 ) ([]department.Department, error) {
+	const op serrors.Op = "PgDepartmentRepository.GetPaginated"
+	if params == nil {
+		params = &department.FindParams{}
+	}
+
 	where, args, err := r.buildFilters(ctx, params)
 	if err != nil {
-		return nil, err
+		return nil, serrors.E(op, err)
 	}
 
 	query := repo.Join(
@@ -102,20 +109,25 @@ func (r *PgDepartmentRepository) GetPaginated(
 
 	departments, err := r.queryDepartments(ctx, query, args...)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get paginated departments")
+		return nil, serrors.E(op, err)
 	}
 	return departments, nil
 }
 
 func (r *PgDepartmentRepository) Count(ctx context.Context, params *department.FindParams) (int64, error) {
+	const op serrors.Op = "PgDepartmentRepository.Count"
+	if params == nil {
+		params = &department.FindParams{}
+	}
+
 	tx, err := composables.UseTx(ctx)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to get transaction")
+		return 0, serrors.E(op, err)
 	}
 
 	where, args, err := r.buildFilters(ctx, params)
 	if err != nil {
-		return 0, err
+		return 0, serrors.E(op, err)
 	}
 
 	query := repo.Join(
@@ -125,50 +137,53 @@ func (r *PgDepartmentRepository) Count(ctx context.Context, params *department.F
 
 	var count int64
 	if err := tx.QueryRow(ctx, query, args...).Scan(&count); err != nil {
-		return 0, errors.Wrap(err, "failed to count departments")
+		return 0, serrors.E(op, err)
 	}
 	return count, nil
 }
 
 func (r *PgDepartmentRepository) GetByID(ctx context.Context, id uuid.UUID) (department.Department, error) {
+	const op serrors.Op = "PgDepartmentRepository.GetByID"
 	tenantID, err := composables.UseTenantID(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get tenant from context")
+		return nil, serrors.E(op, err)
 	}
 
 	q := repo.Join(departmentFindQuery, "WHERE d.id = $1 AND d.tenant_id = $2")
 	departments, err := r.queryDepartments(ctx, q, id.String(), tenantID.String())
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to query department with id: %s", id.String()))
+		return nil, serrors.E(op, err)
 	}
 	if len(departments) == 0 {
-		return nil, errors.Wrap(ErrDepartmentNotFound, fmt.Sprintf("id: %s", id.String()))
+		return nil, serrors.E(op, serrors.NotFound, ErrDepartmentNotFound)
 	}
 	return departments[0], nil
 }
 
 func (r *PgDepartmentRepository) Exists(ctx context.Context, id uuid.UUID) (bool, error) {
+	const op serrors.Op = "PgDepartmentRepository.Exists"
 	tx, err := composables.UseTx(ctx)
 	if err != nil {
-		return false, errors.Wrap(err, "failed to get transaction")
+		return false, serrors.E(op, err)
 	}
 
 	tenantID, err := composables.UseTenantID(ctx)
 	if err != nil {
-		return false, errors.Wrap(err, "failed to get tenant from context")
+		return false, serrors.E(op, err)
 	}
 
 	var exists bool
 	if err := tx.QueryRow(ctx, departmentExistsQuery, id.String(), tenantID.String()).Scan(&exists); err != nil {
-		return false, errors.Wrap(err, "failed to check if department exists")
+		return false, serrors.E(op, err)
 	}
 	return exists, nil
 }
 
 func (r *PgDepartmentRepository) Save(ctx context.Context, entity department.Department) (department.Department, error) {
+	const op serrors.Op = "PgDepartmentRepository.Save"
 	exists, err := r.Exists(ctx, entity.ID())
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to check if department exists")
+		return nil, serrors.E(op, err)
 	}
 
 	if exists {
@@ -181,15 +196,24 @@ func (r *PgDepartmentRepository) create(
 	ctx context.Context,
 	entity department.Department,
 ) (department.Department, error) {
+	const op serrors.Op = "PgDepartmentRepository.create"
 	tx, err := composables.UseTx(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get transaction")
+		return nil, serrors.E(op, err)
+	}
+
+	// Tenant ownership comes from the request context, never the entity
+	// payload, so a mismatched-entity tenant cannot insert into another tenant.
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return nil, serrors.E(op, err)
 	}
 
 	dbDepartment, err := ToDBDepartment(entity)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to map department to db model")
+		return nil, serrors.E(op, err)
 	}
+	dbDepartment.TenantID = tenantID.String()
 	if entity.ID() == uuid.Nil {
 		dbDepartment.ID = uuid.New().String()
 	}
@@ -219,12 +243,12 @@ func (r *PgDepartmentRepository) create(
 	}
 
 	if _, err := tx.Exec(ctx, repo.Insert("core.departments", fields), values...); err != nil {
-		return nil, errors.Wrap(err, "failed to insert department")
+		return nil, serrors.E(op, err)
 	}
 
 	id, err := uuid.Parse(dbDepartment.ID)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse UUID")
+		return nil, serrors.E(op, err)
 	}
 	return r.GetByID(ctx, id)
 }
@@ -233,15 +257,24 @@ func (r *PgDepartmentRepository) update(
 	ctx context.Context,
 	entity department.Department,
 ) (department.Department, error) {
+	const op serrors.Op = "PgDepartmentRepository.update"
 	tx, err := composables.UseTx(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get transaction")
+		return nil, serrors.E(op, err)
+	}
+
+	// Tenant ownership comes from the request context, never the entity
+	// payload, so the update can only ever target the caller's own tenant row.
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return nil, serrors.E(op, err)
 	}
 
 	dbDepartment, err := ToDBDepartment(entity)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to map department to db model")
+		return nil, serrors.E(op, err)
 	}
+	dbDepartment.TenantID = tenantID.String()
 
 	fields := []string{
 		"parent_id",
@@ -270,29 +303,30 @@ func (r *PgDepartmentRepository) update(
 		fmt.Sprintf("tenant_id = $%d", len(values)),
 	)
 	if _, err := tx.Exec(ctx, query, values...); err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to update department with ID: %s", dbDepartment.ID))
+		return nil, serrors.E(op, err)
 	}
 
 	id, err := uuid.Parse(dbDepartment.ID)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse UUID")
+		return nil, serrors.E(op, err)
 	}
 	return r.GetByID(ctx, id)
 }
 
 func (r *PgDepartmentRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	const op serrors.Op = "PgDepartmentRepository.Delete"
 	tx, err := composables.UseTx(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to get transaction")
+		return serrors.E(op, err)
 	}
 
 	tenantID, err := composables.UseTenantID(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to get tenant from context")
+		return serrors.E(op, err)
 	}
 
 	if _, err := tx.Exec(ctx, departmentDeleteQuery, id.String(), tenantID.String()); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to delete department with ID: %s", id.String()))
+		return serrors.E(op, err)
 	}
 	return nil
 }
@@ -302,14 +336,15 @@ func (r *PgDepartmentRepository) queryDepartments(
 	query string,
 	args ...interface{},
 ) ([]department.Department, error) {
+	const op serrors.Op = "PgDepartmentRepository.queryDepartments"
 	tx, err := composables.UseTx(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get transaction")
+		return nil, serrors.E(op, err)
 	}
 
 	rows, err := tx.Query(ctx, query, args...)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to execute query")
+		return nil, serrors.E(op, err)
 	}
 	defer rows.Close()
 
@@ -327,20 +362,20 @@ func (r *PgDepartmentRepository) queryDepartments(
 			&dbDepartment.CreatedAt,
 			&dbDepartment.UpdatedAt,
 		); err != nil {
-			return nil, errors.Wrap(err, "failed to scan department row")
+			return nil, serrors.E(op, err)
 		}
 		dbDepartments = append(dbDepartments, &dbDepartment)
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, errors.Wrap(err, "row iteration error")
+		return nil, serrors.E(op, err)
 	}
 
 	entities := make([]department.Department, 0, len(dbDepartments))
 	for _, dbDepartment := range dbDepartments {
 		domainDepartment, err := ToDomainDepartment(dbDepartment)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("failed to convert department ID: %s to domain entity", dbDepartment.ID))
+			return nil, serrors.E(op, err)
 		}
 		entities = append(entities, domainDepartment)
 	}

--- a/modules/core/infrastructure/persistence/department_repository.go
+++ b/modules/core/infrastructure/persistence/department_repository.go
@@ -1,0 +1,349 @@
+// Package persistence provides this package.
+package persistence
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-faster/errors"
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/department"
+	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence/models"
+	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"github.com/iota-uz/iota-sdk/pkg/repo"
+)
+
+var (
+	ErrDepartmentNotFound = errors.New("department not found")
+)
+
+const (
+	departmentFindQuery = `
+		SELECT
+			d.id,
+			d.tenant_id,
+			d.parent_id,
+			d.code,
+			d.name,
+			d."order",
+			d.status,
+			d.created_at,
+			d.updated_at
+		FROM core.departments d`
+
+	departmentCountQuery  = `SELECT COUNT(d.id) FROM core.departments d`
+	departmentExistsQuery = `SELECT EXISTS(SELECT 1 FROM core.departments WHERE id = $1 AND tenant_id = $2)`
+	departmentDeleteQuery = `DELETE FROM core.departments WHERE id = $1 AND tenant_id = $2`
+)
+
+type PgDepartmentRepository struct {
+	fieldMap map[department.Field]string
+}
+
+func NewDepartmentRepository() department.Repository {
+	return &PgDepartmentRepository{
+		fieldMap: map[department.Field]string{
+			department.CreatedAtField: "d.created_at",
+			department.UpdatedAtField: "d.updated_at",
+			department.TenantIDField:  "d.tenant_id",
+			department.CodeField:      "d.code",
+			department.ParentIDField:  "d.parent_id",
+			department.OrderField:     `d."order"`,
+			department.StatusField:    "d.status",
+		},
+	}
+}
+
+func (r *PgDepartmentRepository) buildFilters(
+	ctx context.Context,
+	params *department.FindParams,
+) ([]string, []interface{}, error) {
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to get tenant from context")
+	}
+
+	where := []string{"d.tenant_id = $1"}
+	args := []interface{}{tenantID.String()}
+
+	for _, filter := range params.Filters {
+		column, ok := r.fieldMap[filter.Column]
+		if !ok {
+			return nil, nil, errors.Wrap(fmt.Errorf("unknown filter field: %v", filter.Column), "invalid filter")
+		}
+		where = append(where, filter.Filter.String(column, len(args)+1))
+		args = append(args, filter.Filter.Value()...)
+	}
+
+	if params.Search != "" {
+		index := len(args) + 1
+		where = append(where, fmt.Sprintf("(d.code ILIKE $%d OR d.name::text ILIKE $%d)", index, index))
+		args = append(args, "%"+params.Search+"%")
+	}
+
+	return where, args, nil
+}
+
+func (r *PgDepartmentRepository) GetPaginated(
+	ctx context.Context,
+	params *department.FindParams,
+) ([]department.Department, error) {
+	where, args, err := r.buildFilters(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	query := repo.Join(
+		departmentFindQuery,
+		repo.JoinWhere(where...),
+		params.SortBy.ToSQL(r.fieldMap),
+		repo.FormatLimitOffset(params.Limit, params.Offset),
+	)
+
+	departments, err := r.queryDepartments(ctx, query, args...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get paginated departments")
+	}
+	return departments, nil
+}
+
+func (r *PgDepartmentRepository) Count(ctx context.Context, params *department.FindParams) (int64, error) {
+	tx, err := composables.UseTx(ctx)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to get transaction")
+	}
+
+	where, args, err := r.buildFilters(ctx, params)
+	if err != nil {
+		return 0, err
+	}
+
+	query := repo.Join(
+		departmentCountQuery,
+		repo.JoinWhere(where...),
+	)
+
+	var count int64
+	if err := tx.QueryRow(ctx, query, args...).Scan(&count); err != nil {
+		return 0, errors.Wrap(err, "failed to count departments")
+	}
+	return count, nil
+}
+
+func (r *PgDepartmentRepository) GetByID(ctx context.Context, id uuid.UUID) (department.Department, error) {
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get tenant from context")
+	}
+
+	q := repo.Join(departmentFindQuery, "WHERE d.id = $1 AND d.tenant_id = $2")
+	departments, err := r.queryDepartments(ctx, q, id.String(), tenantID.String())
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to query department with id: %s", id.String()))
+	}
+	if len(departments) == 0 {
+		return nil, errors.Wrap(ErrDepartmentNotFound, fmt.Sprintf("id: %s", id.String()))
+	}
+	return departments[0], nil
+}
+
+func (r *PgDepartmentRepository) Exists(ctx context.Context, id uuid.UUID) (bool, error) {
+	tx, err := composables.UseTx(ctx)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to get transaction")
+	}
+
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to get tenant from context")
+	}
+
+	var exists bool
+	if err := tx.QueryRow(ctx, departmentExistsQuery, id.String(), tenantID.String()).Scan(&exists); err != nil {
+		return false, errors.Wrap(err, "failed to check if department exists")
+	}
+	return exists, nil
+}
+
+func (r *PgDepartmentRepository) Save(ctx context.Context, entity department.Department) (department.Department, error) {
+	exists, err := r.Exists(ctx, entity.ID())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to check if department exists")
+	}
+
+	if exists {
+		return r.update(ctx, entity)
+	}
+	return r.create(ctx, entity)
+}
+
+func (r *PgDepartmentRepository) create(
+	ctx context.Context,
+	entity department.Department,
+) (department.Department, error) {
+	tx, err := composables.UseTx(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get transaction")
+	}
+
+	dbDepartment, err := ToDBDepartment(entity)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to map department to db model")
+	}
+	if entity.ID() == uuid.Nil {
+		dbDepartment.ID = uuid.New().String()
+	}
+
+	fields := []string{
+		"id",
+		"tenant_id",
+		"parent_id",
+		"code",
+		"name",
+		`"order"`,
+		"status",
+		"created_at",
+		"updated_at",
+	}
+
+	values := []interface{}{
+		dbDepartment.ID,
+		dbDepartment.TenantID,
+		dbDepartment.ParentID,
+		dbDepartment.Code,
+		dbDepartment.Name,
+		dbDepartment.Order,
+		dbDepartment.Status,
+		dbDepartment.CreatedAt,
+		dbDepartment.UpdatedAt,
+	}
+
+	if _, err := tx.Exec(ctx, repo.Insert("core.departments", fields), values...); err != nil {
+		return nil, errors.Wrap(err, "failed to insert department")
+	}
+
+	id, err := uuid.Parse(dbDepartment.ID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse UUID")
+	}
+	return r.GetByID(ctx, id)
+}
+
+func (r *PgDepartmentRepository) update(
+	ctx context.Context,
+	entity department.Department,
+) (department.Department, error) {
+	tx, err := composables.UseTx(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get transaction")
+	}
+
+	dbDepartment, err := ToDBDepartment(entity)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to map department to db model")
+	}
+
+	fields := []string{
+		"parent_id",
+		"code",
+		"name",
+		`"order"`,
+		"status",
+		"updated_at",
+	}
+
+	values := []interface{}{
+		dbDepartment.ParentID,
+		dbDepartment.Code,
+		dbDepartment.Name,
+		dbDepartment.Order,
+		dbDepartment.Status,
+		dbDepartment.UpdatedAt,
+		dbDepartment.ID,
+		dbDepartment.TenantID,
+	}
+
+	query := repo.Update(
+		"core.departments",
+		fields,
+		fmt.Sprintf("id = $%d", len(values)-1),
+		fmt.Sprintf("tenant_id = $%d", len(values)),
+	)
+	if _, err := tx.Exec(ctx, query, values...); err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to update department with ID: %s", dbDepartment.ID))
+	}
+
+	id, err := uuid.Parse(dbDepartment.ID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse UUID")
+	}
+	return r.GetByID(ctx, id)
+}
+
+func (r *PgDepartmentRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	tx, err := composables.UseTx(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get transaction")
+	}
+
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get tenant from context")
+	}
+
+	if _, err := tx.Exec(ctx, departmentDeleteQuery, id.String(), tenantID.String()); err != nil {
+		return errors.Wrap(err, fmt.Sprintf("failed to delete department with ID: %s", id.String()))
+	}
+	return nil
+}
+
+func (r *PgDepartmentRepository) queryDepartments(
+	ctx context.Context,
+	query string,
+	args ...interface{},
+) ([]department.Department, error) {
+	tx, err := composables.UseTx(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get transaction")
+	}
+
+	rows, err := tx.Query(ctx, query, args...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to execute query")
+	}
+	defer rows.Close()
+
+	var dbDepartments []*models.Department
+	for rows.Next() {
+		var dbDepartment models.Department
+		if err := rows.Scan(
+			&dbDepartment.ID,
+			&dbDepartment.TenantID,
+			&dbDepartment.ParentID,
+			&dbDepartment.Code,
+			&dbDepartment.Name,
+			&dbDepartment.Order,
+			&dbDepartment.Status,
+			&dbDepartment.CreatedAt,
+			&dbDepartment.UpdatedAt,
+		); err != nil {
+			return nil, errors.Wrap(err, "failed to scan department row")
+		}
+		dbDepartments = append(dbDepartments, &dbDepartment)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "row iteration error")
+	}
+
+	entities := make([]department.Department, 0, len(dbDepartments))
+	for _, dbDepartment := range dbDepartments {
+		domainDepartment, err := ToDomainDepartment(dbDepartment)
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("failed to convert department ID: %s to domain entity", dbDepartment.ID))
+		}
+		entities = append(entities, domainDepartment)
+	}
+
+	return entities, nil
+}

--- a/modules/core/infrastructure/persistence/department_repository_test.go
+++ b/modules/core/infrastructure/persistence/department_repository_test.go
@@ -1,0 +1,225 @@
+package persistence_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/department"
+	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence"
+	"github.com/iota-uz/iota-sdk/pkg/composables"
+	crudmodels "github.com/iota-uz/iota-sdk/pkg/crud/models"
+	"github.com/iota-uz/iota-sdk/pkg/itf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func orgName(t *testing.T, base string) crudmodels.MultiLang {
+	t.Helper()
+	ml, err := crudmodels.NewMultiLangFromMap(map[string]string{
+		"en":      base + " EN",
+		"ru":      base + " RU",
+		"uz":      base + " UZ",
+		"uz-Cyrl": base + " UZ-CYRL",
+	})
+	require.NoError(t, err)
+	return ml
+}
+
+func TestPgDepartmentRepository_CRUD(t *testing.T) {
+	t.Parallel()
+	f := setupTest(t)
+
+	departmentRepository := persistence.NewDepartmentRepository()
+
+	tenant, err := composables.UseTenantID(f.Ctx)
+	require.NoError(t, err)
+
+	t.Run("CreateAndGet", func(t *testing.T) {
+		id := uuid.New()
+		entity := department.New(
+			"ENG",
+			orgName(t, "Engineering"),
+			department.WithID(id),
+			department.WithTenantID(tenant),
+			department.WithOrder(1),
+		)
+
+		saved, err := departmentRepository.Save(f.Ctx, entity)
+		require.NoError(t, err)
+		assert.Equal(t, id, saved.ID())
+		assert.Equal(t, "ENG", saved.Code())
+		assert.Equal(t, "Engineering EN", saved.Name("en"))
+		assert.Equal(t, "Engineering RU", saved.Name("ru"))
+		assert.Equal(t, "Engineering UZ-CYRL", saved.Name("uz-Cyrl"))
+		assert.Equal(t, 1, saved.Order())
+		assert.Equal(t, department.StatusActive, saved.Status())
+		assert.Nil(t, saved.ParentID())
+
+		retrieved, err := departmentRepository.GetByID(f.Ctx, id)
+		require.NoError(t, err)
+		assert.Equal(t, id, retrieved.ID())
+		assert.Equal(t, "Engineering UZ", retrieved.Name("uz"))
+
+		// Non-existent
+		_, err = departmentRepository.GetByID(f.Ctx, uuid.New())
+		require.ErrorIs(t, err, persistence.ErrDepartmentNotFound)
+	})
+
+	t.Run("Hierarchy", func(t *testing.T) {
+		parentID := uuid.New()
+		parent := department.New(
+			"PARENT",
+			orgName(t, "Parent"),
+			department.WithID(parentID),
+			department.WithTenantID(tenant),
+		)
+		_, err := departmentRepository.Save(f.Ctx, parent)
+		require.NoError(t, err)
+
+		childID := uuid.New()
+		child := department.New(
+			"CHILD",
+			orgName(t, "Child"),
+			department.WithID(childID),
+			department.WithTenantID(tenant),
+			department.WithParentID(&parentID),
+		)
+		savedChild, err := departmentRepository.Save(f.Ctx, child)
+		require.NoError(t, err)
+		require.NotNil(t, savedChild.ParentID())
+		assert.Equal(t, parentID, *savedChild.ParentID())
+
+		retrieved, err := departmentRepository.GetByID(f.Ctx, childID)
+		require.NoError(t, err)
+		require.NotNil(t, retrieved.ParentID())
+		assert.Equal(t, parentID, *retrieved.ParentID())
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		id := uuid.New()
+		entity := department.New(
+			"UPD",
+			orgName(t, "Original"),
+			department.WithID(id),
+			department.WithTenantID(tenant),
+		)
+		saved, err := departmentRepository.Save(f.Ctx, entity)
+		require.NoError(t, err)
+
+		updated := saved.
+			SetName(orgName(t, "Updated")).
+			SetOrder(5).
+			SetStatus(department.StatusInactive)
+		savedUpdated, err := departmentRepository.Save(f.Ctx, updated)
+		require.NoError(t, err)
+		assert.Equal(t, "Updated EN", savedUpdated.Name("en"))
+		assert.Equal(t, 5, savedUpdated.Order())
+		assert.Equal(t, department.StatusInactive, savedUpdated.Status())
+	})
+
+	t.Run("ExistsAndDelete", func(t *testing.T) {
+		id := uuid.New()
+		entity := department.New(
+			"DEL",
+			orgName(t, "ToDelete"),
+			department.WithID(id),
+			department.WithTenantID(tenant),
+		)
+		_, err := departmentRepository.Save(f.Ctx, entity)
+		require.NoError(t, err)
+
+		exists, err := departmentRepository.Exists(f.Ctx, id)
+		require.NoError(t, err)
+		assert.True(t, exists)
+
+		require.NoError(t, departmentRepository.Delete(f.Ctx, id))
+
+		exists, err = departmentRepository.Exists(f.Ctx, id)
+		require.NoError(t, err)
+		assert.False(t, exists)
+
+		_, err = departmentRepository.GetByID(f.Ctx, id)
+		require.ErrorIs(t, err, persistence.ErrDepartmentNotFound)
+	})
+
+	t.Run("CountAndPaginate", func(t *testing.T) {
+		count, err := departmentRepository.Count(f.Ctx, &department.FindParams{})
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, count, int64(1))
+
+		list, err := departmentRepository.GetPaginated(f.Ctx, &department.FindParams{Limit: 100})
+		require.NoError(t, err)
+		assert.GreaterOrEqual(t, len(list), 1)
+	})
+}
+
+func TestPgDepartmentRepository_TenantIsolation(t *testing.T) {
+	t.Parallel()
+	f := setupTest(t)
+
+	departmentRepository := persistence.NewDepartmentRepository()
+
+	tenantA, err := composables.UseTenantID(f.Ctx)
+	require.NoError(t, err)
+
+	secondTenant, err := itf.CreateTestTenant(f.Ctx, f.Pool)
+	require.NoError(t, err)
+	ctxB := composables.WithTenantID(f.Ctx, secondTenant.ID)
+
+	// One department per tenant; identical code to prove isolation is by tenant.
+	idA := uuid.New()
+	_, err = departmentRepository.Save(f.Ctx, department.New(
+		"ISO", orgName(t, "Dept A"),
+		department.WithID(idA), department.WithTenantID(tenantA),
+	))
+	require.NoError(t, err)
+
+	idB := uuid.New()
+	_, err = departmentRepository.Save(ctxB, department.New(
+		"ISO", orgName(t, "Dept B"),
+		department.WithID(idB), department.WithTenantID(secondTenant.ID),
+	))
+	require.NoError(t, err)
+
+	t.Run("GetByID does not cross tenants", func(t *testing.T) {
+		// Tenant A cannot read tenant B's department and vice versa.
+		_, err := departmentRepository.GetByID(f.Ctx, idB)
+		require.ErrorIs(t, err, persistence.ErrDepartmentNotFound)
+
+		_, err = departmentRepository.GetByID(ctxB, idA)
+		require.ErrorIs(t, err, persistence.ErrDepartmentNotFound)
+
+		// Each tenant reads its own row fine.
+		gotA, err := departmentRepository.GetByID(f.Ctx, idA)
+		require.NoError(t, err)
+		assert.Equal(t, tenantA, gotA.TenantID())
+
+		gotB, err := departmentRepository.GetByID(ctxB, idB)
+		require.NoError(t, err)
+		assert.Equal(t, secondTenant.ID, gotB.TenantID())
+	})
+
+	t.Run("Exists is tenant scoped", func(t *testing.T) {
+		exists, err := departmentRepository.Exists(f.Ctx, idB)
+		require.NoError(t, err)
+		assert.False(t, exists, "tenant A must not see tenant B's department")
+
+		exists, err = departmentRepository.Exists(ctxB, idB)
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("GetPaginated excludes other tenant rows", func(t *testing.T) {
+		listA, err := departmentRepository.GetPaginated(f.Ctx, &department.FindParams{Limit: 1000})
+		require.NoError(t, err)
+		for _, d := range listA {
+			assert.Equal(t, tenantA, d.TenantID(), "tenant A list must not contain tenant B rows")
+			assert.NotEqual(t, idB, d.ID())
+		}
+
+		listB, err := departmentRepository.GetPaginated(ctxB, &department.FindParams{Limit: 1000})
+		require.NoError(t, err)
+		require.Len(t, listB, 1)
+		assert.Equal(t, idB, listB[0].ID())
+	})
+}

--- a/modules/core/infrastructure/persistence/models/models.go
+++ b/modules/core/infrastructure/persistence/models/models.go
@@ -208,6 +208,37 @@ type Department struct {
 	UpdatedAt time.Time
 }
 
+// ParsedID parses the ID string to a UUID, returning uuid.Nil on failure.
+func (d *Department) ParsedID() uuid.UUID {
+	id, err := uuid.Parse(d.ID)
+	if err != nil {
+		id = uuid.Nil
+	}
+	return id
+}
+
+// ParsedTenantID parses the TenantID string to a UUID, returning uuid.Nil on failure.
+func (d *Department) ParsedTenantID() uuid.UUID {
+	tenantID, err := uuid.Parse(d.TenantID)
+	if err != nil {
+		tenantID = uuid.Nil
+	}
+	return tenantID
+}
+
+// ParsedParentID parses the nullable ParentID string to a *UUID. It returns nil
+// when the parent is NULL/empty or unparsable.
+func (d *Department) ParsedParentID() *uuid.UUID {
+	if !d.ParentID.Valid || d.ParentID.String == "" {
+		return nil
+	}
+	parentID, err := uuid.Parse(d.ParentID.String)
+	if err != nil {
+		return nil
+	}
+	return &parentID
+}
+
 type UserPosition struct {
 	ID           string
 	TenantID     string
@@ -219,6 +250,33 @@ type UserPosition struct {
 	Status       string
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
+}
+
+// ParsedID parses the ID string to a UUID, returning uuid.Nil on failure.
+func (p *UserPosition) ParsedID() uuid.UUID {
+	id, err := uuid.Parse(p.ID)
+	if err != nil {
+		id = uuid.Nil
+	}
+	return id
+}
+
+// ParsedTenantID parses the TenantID string to a UUID, returning uuid.Nil on failure.
+func (p *UserPosition) ParsedTenantID() uuid.UUID {
+	tenantID, err := uuid.Parse(p.TenantID)
+	if err != nil {
+		tenantID = uuid.Nil
+	}
+	return tenantID
+}
+
+// ParsedDepartmentID parses the DepartmentID string to a UUID, returning uuid.Nil on failure.
+func (p *UserPosition) ParsedDepartmentID() uuid.UUID {
+	departmentID, err := uuid.Parse(p.DepartmentID)
+	if err != nil {
+		departmentID = uuid.Nil
+	}
+	return departmentID
 }
 
 type Point struct {

--- a/modules/core/infrastructure/persistence/models/models.go
+++ b/modules/core/infrastructure/persistence/models/models.go
@@ -196,6 +196,31 @@ type GroupRole struct {
 	CreatedAt time.Time
 }
 
+type Department struct {
+	ID        string
+	TenantID  string
+	ParentID  sql.NullString
+	Code      string
+	Name      []byte // MultiLang jsonb
+	Order     int
+	Status    string
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+type UserPosition struct {
+	ID           string
+	TenantID     string
+	UserID       uint
+	DepartmentID string
+	Title        []byte // MultiLang jsonb
+	IsManager    bool
+	IsPrimary    bool
+	Status       string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
 type Point struct {
 	X float64
 	Y float64

--- a/modules/core/infrastructure/persistence/schema/core-schema.sql
+++ b/modules/core/infrastructure/persistence/schema/core-schema.sql
@@ -103,7 +103,10 @@ CREATE TABLE users (
     created_at timestamp with time zone NOT NULL DEFAULT now(),
     updated_at timestamp with time zone NOT NULL DEFAULT now(),
     UNIQUE (tenant_id, email),
-    UNIQUE (tenant_id, phone)
+    UNIQUE (tenant_id, phone),
+    -- Tenant-qualified FK target so core.user_positions can reference a user by
+    -- (tenant_id, id) and never bridge tenants.
+    CONSTRAINT users_tenant_id_id_key UNIQUE (tenant_id, id)
 );
 
 CREATE TABLE user_roles (
@@ -209,14 +212,17 @@ CREATE SCHEMA IF NOT EXISTS core;
 CREATE TABLE core.departments (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
     tenant_id uuid NOT NULL REFERENCES tenants (id) ON DELETE CASCADE,
-    parent_id uuid NULL REFERENCES core.departments (id) ON DELETE SET NULL,
+    parent_id uuid NULL,
     code varchar NOT NULL,
     name jsonb NOT NULL,
     "order" int NOT NULL DEFAULT 0,
     status varchar NOT NULL DEFAULT 'active',
     created_at timestamp with time zone DEFAULT now(),
     updated_at timestamp with time zone DEFAULT now(),
-    UNIQUE (tenant_id, code)
+    UNIQUE (tenant_id, code),
+    CONSTRAINT departments_tenant_id_id_key UNIQUE (tenant_id, id),
+    CONSTRAINT departments_parent_tenant_fkey FOREIGN KEY (tenant_id, parent_id)
+        REFERENCES core.departments (tenant_id, id) ON DELETE SET NULL
 );
 
 CREATE INDEX departments_tenant_id_idx ON core.departments (tenant_id);
@@ -226,14 +232,18 @@ CREATE INDEX departments_tenant_id_parent_id_idx ON core.departments (tenant_id,
 CREATE TABLE core.user_positions (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
     tenant_id uuid NOT NULL REFERENCES tenants (id) ON DELETE CASCADE,
-    user_id integer NOT NULL REFERENCES users (id) ON DELETE CASCADE,
-    department_id uuid NOT NULL REFERENCES core.departments (id) ON DELETE CASCADE,
+    user_id integer NOT NULL,
+    department_id uuid NOT NULL,
     title jsonb NOT NULL,
     is_manager boolean NOT NULL DEFAULT FALSE,
     is_primary boolean NOT NULL DEFAULT FALSE,
     status varchar NOT NULL DEFAULT 'active',
     created_at timestamp with time zone DEFAULT now(),
-    updated_at timestamp with time zone DEFAULT now()
+    updated_at timestamp with time zone DEFAULT now(),
+    CONSTRAINT user_positions_department_tenant_fkey FOREIGN KEY (tenant_id, department_id)
+        REFERENCES core.departments (tenant_id, id) ON DELETE CASCADE,
+    CONSTRAINT user_positions_user_tenant_fkey FOREIGN KEY (tenant_id, user_id)
+        REFERENCES users (tenant_id, id) ON DELETE CASCADE
 );
 
 CREATE INDEX user_positions_tenant_id_user_id_idx ON core.user_positions (tenant_id, user_id);

--- a/modules/core/infrastructure/persistence/schema/core-schema.sql
+++ b/modules/core/infrastructure/persistence/schema/core-schema.sql
@@ -221,8 +221,7 @@ CREATE TABLE core.departments (
     updated_at timestamp with time zone DEFAULT now(),
     UNIQUE (tenant_id, code),
     CONSTRAINT departments_tenant_id_id_key UNIQUE (tenant_id, id),
-    CONSTRAINT departments_parent_tenant_fkey FOREIGN KEY (tenant_id, parent_id)
-        REFERENCES core.departments (tenant_id, id) ON DELETE SET NULL
+    CONSTRAINT departments_parent_tenant_fkey FOREIGN KEY (tenant_id, parent_id) REFERENCES core.departments (tenant_id, id) ON DELETE SET NULL
 );
 
 CREATE INDEX departments_tenant_id_idx ON core.departments (tenant_id);
@@ -240,10 +239,8 @@ CREATE TABLE core.user_positions (
     status varchar NOT NULL DEFAULT 'active',
     created_at timestamp with time zone DEFAULT now(),
     updated_at timestamp with time zone DEFAULT now(),
-    CONSTRAINT user_positions_department_tenant_fkey FOREIGN KEY (tenant_id, department_id)
-        REFERENCES core.departments (tenant_id, id) ON DELETE CASCADE,
-    CONSTRAINT user_positions_user_tenant_fkey FOREIGN KEY (tenant_id, user_id)
-        REFERENCES users (tenant_id, id) ON DELETE CASCADE
+    CONSTRAINT user_positions_department_tenant_fkey FOREIGN KEY (tenant_id, department_id) REFERENCES core.departments (tenant_id, id) ON DELETE CASCADE,
+    CONSTRAINT user_positions_user_tenant_fkey FOREIGN KEY (tenant_id, user_id) REFERENCES users (tenant_id, id) ON DELETE CASCADE
 );
 
 CREATE INDEX user_positions_tenant_id_user_id_idx ON core.user_positions (tenant_id, user_id);

--- a/modules/core/infrastructure/persistence/schema/core-schema.sql
+++ b/modules/core/infrastructure/persistence/schema/core-schema.sql
@@ -221,7 +221,7 @@ CREATE TABLE core.departments (
     updated_at timestamp with time zone DEFAULT now(),
     UNIQUE (tenant_id, code),
     CONSTRAINT departments_tenant_id_id_key UNIQUE (tenant_id, id),
-    CONSTRAINT departments_parent_tenant_fkey FOREIGN KEY (tenant_id, parent_id) REFERENCES core.departments (tenant_id, id) ON DELETE SET NULL
+    CONSTRAINT departments_parent_tenant_fkey FOREIGN KEY (tenant_id, parent_id) REFERENCES core.departments (tenant_id, id) ON DELETE SET NULL (parent_id)
 );
 
 CREATE INDEX departments_tenant_id_idx ON core.departments (tenant_id);

--- a/modules/core/infrastructure/persistence/schema/core-schema.sql
+++ b/modules/core/infrastructure/persistence/schema/core-schema.sql
@@ -204,3 +204,39 @@ CREATE INDEX roles_tenant_id_idx ON roles (tenant_id);
 
 CREATE INDEX user_groups_tenant_id_idx ON user_groups (tenant_id);
 
+CREATE SCHEMA IF NOT EXISTS core;
+
+CREATE TABLE core.departments (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
+    tenant_id uuid NOT NULL REFERENCES tenants (id) ON DELETE CASCADE,
+    parent_id uuid NULL REFERENCES core.departments (id) ON DELETE SET NULL,
+    code varchar NOT NULL,
+    name jsonb NOT NULL,
+    "order" int NOT NULL DEFAULT 0,
+    status varchar NOT NULL DEFAULT 'active',
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now(),
+    UNIQUE (tenant_id, code)
+);
+
+CREATE INDEX departments_tenant_id_idx ON core.departments (tenant_id);
+
+CREATE INDEX departments_tenant_id_parent_id_idx ON core.departments (tenant_id, parent_id);
+
+CREATE TABLE core.user_positions (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
+    tenant_id uuid NOT NULL REFERENCES tenants (id) ON DELETE CASCADE,
+    user_id integer NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    department_id uuid NOT NULL REFERENCES core.departments (id) ON DELETE CASCADE,
+    title jsonb NOT NULL,
+    is_manager boolean NOT NULL DEFAULT FALSE,
+    is_primary boolean NOT NULL DEFAULT FALSE,
+    status varchar NOT NULL DEFAULT 'active',
+    created_at timestamp with time zone DEFAULT now(),
+    updated_at timestamp with time zone DEFAULT now()
+);
+
+CREATE INDEX user_positions_tenant_id_user_id_idx ON core.user_positions (tenant_id, user_id);
+
+CREATE INDEX user_positions_tenant_id_department_id_idx ON core.user_positions (tenant_id, department_id);
+

--- a/modules/core/infrastructure/persistence/user_position_repository.go
+++ b/modules/core/infrastructure/persistence/user_position_repository.go
@@ -3,14 +3,15 @@ package persistence
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/go-faster/errors"
 	"github.com/google/uuid"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/userposition"
 	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence/models"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
 	"github.com/iota-uz/iota-sdk/pkg/repo"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
 )
 
 var (
@@ -60,9 +61,10 @@ func (r *PgUserPositionRepository) buildFilters(
 	ctx context.Context,
 	params *userposition.FindParams,
 ) ([]string, []interface{}, error) {
+	const op serrors.Op = "PgUserPositionRepository.buildFilters"
 	tenantID, err := composables.UseTenantID(ctx)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to get tenant from context")
+		return nil, nil, serrors.E(op, err)
 	}
 
 	where := []string{"p.tenant_id = $1"}
@@ -71,7 +73,7 @@ func (r *PgUserPositionRepository) buildFilters(
 	for _, filter := range params.Filters {
 		column, ok := r.fieldMap[filter.Column]
 		if !ok {
-			return nil, nil, errors.Wrap(fmt.Errorf("unknown filter field: %v", filter.Column), "invalid filter")
+			return nil, nil, serrors.E(op, fmt.Errorf("unknown filter field: %v", filter.Column))
 		}
 		where = append(where, filter.Filter.String(column, len(args)+1))
 		args = append(args, filter.Filter.Value()...)
@@ -90,9 +92,14 @@ func (r *PgUserPositionRepository) GetPaginated(
 	ctx context.Context,
 	params *userposition.FindParams,
 ) ([]userposition.UserPosition, error) {
+	const op serrors.Op = "PgUserPositionRepository.GetPaginated"
+	if params == nil {
+		params = &userposition.FindParams{}
+	}
+
 	where, args, err := r.buildFilters(ctx, params)
 	if err != nil {
-		return nil, err
+		return nil, serrors.E(op, err)
 	}
 
 	query := repo.Join(
@@ -104,20 +111,25 @@ func (r *PgUserPositionRepository) GetPaginated(
 
 	positions, err := r.queryPositions(ctx, query, args...)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get paginated user positions")
+		return nil, serrors.E(op, err)
 	}
 	return positions, nil
 }
 
 func (r *PgUserPositionRepository) Count(ctx context.Context, params *userposition.FindParams) (int64, error) {
+	const op serrors.Op = "PgUserPositionRepository.Count"
+	if params == nil {
+		params = &userposition.FindParams{}
+	}
+
 	tx, err := composables.UseTx(ctx)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to get transaction")
+		return 0, serrors.E(op, err)
 	}
 
 	where, args, err := r.buildFilters(ctx, params)
 	if err != nil {
-		return 0, err
+		return 0, serrors.E(op, err)
 	}
 
 	query := repo.Join(
@@ -127,42 +139,44 @@ func (r *PgUserPositionRepository) Count(ctx context.Context, params *userpositi
 
 	var count int64
 	if err := tx.QueryRow(ctx, query, args...).Scan(&count); err != nil {
-		return 0, errors.Wrap(err, "failed to count user positions")
+		return 0, serrors.E(op, err)
 	}
 	return count, nil
 }
 
 func (r *PgUserPositionRepository) GetByID(ctx context.Context, id uuid.UUID) (userposition.UserPosition, error) {
+	const op serrors.Op = "PgUserPositionRepository.GetByID"
 	tenantID, err := composables.UseTenantID(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get tenant from context")
+		return nil, serrors.E(op, err)
 	}
 
 	q := repo.Join(userPositionFindQuery, "WHERE p.id = $1 AND p.tenant_id = $2")
 	positions, err := r.queryPositions(ctx, q, id.String(), tenantID.String())
 	if err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to query user position with id: %s", id.String()))
+		return nil, serrors.E(op, err)
 	}
 	if len(positions) == 0 {
-		return nil, errors.Wrap(ErrUserPositionNotFound, fmt.Sprintf("id: %s", id.String()))
+		return nil, serrors.E(op, serrors.NotFound, ErrUserPositionNotFound)
 	}
 	return positions[0], nil
 }
 
 func (r *PgUserPositionRepository) Exists(ctx context.Context, id uuid.UUID) (bool, error) {
+	const op serrors.Op = "PgUserPositionRepository.Exists"
 	tx, err := composables.UseTx(ctx)
 	if err != nil {
-		return false, errors.Wrap(err, "failed to get transaction")
+		return false, serrors.E(op, err)
 	}
 
 	tenantID, err := composables.UseTenantID(ctx)
 	if err != nil {
-		return false, errors.Wrap(err, "failed to get tenant from context")
+		return false, serrors.E(op, err)
 	}
 
 	var exists bool
 	if err := tx.QueryRow(ctx, userPositionExistsQuery, id.String(), tenantID.String()).Scan(&exists); err != nil {
-		return false, errors.Wrap(err, "failed to check if user position exists")
+		return false, serrors.E(op, err)
 	}
 	return exists, nil
 }
@@ -171,9 +185,10 @@ func (r *PgUserPositionRepository) Save(
 	ctx context.Context,
 	entity userposition.UserPosition,
 ) (userposition.UserPosition, error) {
+	const op serrors.Op = "PgUserPositionRepository.Save"
 	exists, err := r.Exists(ctx, entity.ID())
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to check if user position exists")
+		return nil, serrors.E(op, err)
 	}
 
 	if exists {
@@ -186,15 +201,24 @@ func (r *PgUserPositionRepository) create(
 	ctx context.Context,
 	entity userposition.UserPosition,
 ) (userposition.UserPosition, error) {
+	const op serrors.Op = "PgUserPositionRepository.create"
 	tx, err := composables.UseTx(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get transaction")
+		return nil, serrors.E(op, err)
+	}
+
+	// Tenant ownership comes from the request context, never the entity
+	// payload, so a mismatched-entity tenant cannot insert into another tenant.
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return nil, serrors.E(op, err)
 	}
 
 	dbPosition, err := ToDBUserPosition(entity)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to map user position to db model")
+		return nil, serrors.E(op, err)
 	}
+	dbPosition.TenantID = tenantID.String()
 	if entity.ID() == uuid.Nil {
 		dbPosition.ID = uuid.New().String()
 	}
@@ -226,12 +250,12 @@ func (r *PgUserPositionRepository) create(
 	}
 
 	if _, err := tx.Exec(ctx, repo.Insert("core.user_positions", fields), values...); err != nil {
-		return nil, errors.Wrap(err, "failed to insert user position")
+		return nil, serrors.E(op, err)
 	}
 
 	id, err := uuid.Parse(dbPosition.ID)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse UUID")
+		return nil, serrors.E(op, err)
 	}
 	return r.GetByID(ctx, id)
 }
@@ -240,15 +264,24 @@ func (r *PgUserPositionRepository) update(
 	ctx context.Context,
 	entity userposition.UserPosition,
 ) (userposition.UserPosition, error) {
+	const op serrors.Op = "PgUserPositionRepository.update"
 	tx, err := composables.UseTx(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get transaction")
+		return nil, serrors.E(op, err)
+	}
+
+	// Tenant ownership comes from the request context, never the entity
+	// payload, so the update can only ever target the caller's own tenant row.
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return nil, serrors.E(op, err)
 	}
 
 	dbPosition, err := ToDBUserPosition(entity)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to map user position to db model")
+		return nil, serrors.E(op, err)
 	}
+	dbPosition.TenantID = tenantID.String()
 
 	fields := []string{
 		"department_id",
@@ -277,29 +310,30 @@ func (r *PgUserPositionRepository) update(
 		fmt.Sprintf("tenant_id = $%d", len(values)),
 	)
 	if _, err := tx.Exec(ctx, query, values...); err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("failed to update user position with ID: %s", dbPosition.ID))
+		return nil, serrors.E(op, err)
 	}
 
 	id, err := uuid.Parse(dbPosition.ID)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to parse UUID")
+		return nil, serrors.E(op, err)
 	}
 	return r.GetByID(ctx, id)
 }
 
 func (r *PgUserPositionRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	const op serrors.Op = "PgUserPositionRepository.Delete"
 	tx, err := composables.UseTx(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to get transaction")
+		return serrors.E(op, err)
 	}
 
 	tenantID, err := composables.UseTenantID(ctx)
 	if err != nil {
-		return errors.Wrap(err, "failed to get tenant from context")
+		return serrors.E(op, err)
 	}
 
 	if _, err := tx.Exec(ctx, userPositionDeleteQuery, id.String(), tenantID.String()); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to delete user position with ID: %s", id.String()))
+		return serrors.E(op, err)
 	}
 	return nil
 }
@@ -309,14 +343,15 @@ func (r *PgUserPositionRepository) queryPositions(
 	query string,
 	args ...interface{},
 ) ([]userposition.UserPosition, error) {
+	const op serrors.Op = "PgUserPositionRepository.queryPositions"
 	tx, err := composables.UseTx(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get transaction")
+		return nil, serrors.E(op, err)
 	}
 
 	rows, err := tx.Query(ctx, query, args...)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to execute query")
+		return nil, serrors.E(op, err)
 	}
 	defer rows.Close()
 
@@ -335,20 +370,20 @@ func (r *PgUserPositionRepository) queryPositions(
 			&dbPosition.CreatedAt,
 			&dbPosition.UpdatedAt,
 		); err != nil {
-			return nil, errors.Wrap(err, "failed to scan user position row")
+			return nil, serrors.E(op, err)
 		}
 		dbPositions = append(dbPositions, &dbPosition)
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, errors.Wrap(err, "row iteration error")
+		return nil, serrors.E(op, err)
 	}
 
 	entities := make([]userposition.UserPosition, 0, len(dbPositions))
 	for _, dbPosition := range dbPositions {
 		domainPosition, err := ToDomainUserPosition(dbPosition)
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("failed to convert user position ID: %s to domain entity", dbPosition.ID))
+			return nil, serrors.E(op, err)
 		}
 		entities = append(entities, domainPosition)
 	}

--- a/modules/core/infrastructure/persistence/user_position_repository.go
+++ b/modules/core/infrastructure/persistence/user_position_repository.go
@@ -1,0 +1,357 @@
+// Package persistence provides this package.
+package persistence
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-faster/errors"
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/userposition"
+	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence/models"
+	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"github.com/iota-uz/iota-sdk/pkg/repo"
+)
+
+var (
+	ErrUserPositionNotFound = errors.New("user position not found")
+)
+
+const (
+	userPositionFindQuery = `
+		SELECT
+			p.id,
+			p.tenant_id,
+			p.user_id,
+			p.department_id,
+			p.title,
+			p.is_manager,
+			p.is_primary,
+			p.status,
+			p.created_at,
+			p.updated_at
+		FROM core.user_positions p`
+
+	userPositionCountQuery  = `SELECT COUNT(p.id) FROM core.user_positions p`
+	userPositionExistsQuery = `SELECT EXISTS(SELECT 1 FROM core.user_positions WHERE id = $1 AND tenant_id = $2)`
+	userPositionDeleteQuery = `DELETE FROM core.user_positions WHERE id = $1 AND tenant_id = $2`
+)
+
+type PgUserPositionRepository struct {
+	fieldMap map[userposition.Field]string
+}
+
+func NewUserPositionRepository() userposition.Repository {
+	return &PgUserPositionRepository{
+		fieldMap: map[userposition.Field]string{
+			userposition.CreatedAtField:    "p.created_at",
+			userposition.UpdatedAtField:    "p.updated_at",
+			userposition.TenantIDField:     "p.tenant_id",
+			userposition.UserIDField:       "p.user_id",
+			userposition.DepartmentIDField: "p.department_id",
+			userposition.IsManagerField:    "p.is_manager",
+			userposition.IsPrimaryField:    "p.is_primary",
+			userposition.StatusField:       "p.status",
+		},
+	}
+}
+
+func (r *PgUserPositionRepository) buildFilters(
+	ctx context.Context,
+	params *userposition.FindParams,
+) ([]string, []interface{}, error) {
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to get tenant from context")
+	}
+
+	where := []string{"p.tenant_id = $1"}
+	args := []interface{}{tenantID.String()}
+
+	for _, filter := range params.Filters {
+		column, ok := r.fieldMap[filter.Column]
+		if !ok {
+			return nil, nil, errors.Wrap(fmt.Errorf("unknown filter field: %v", filter.Column), "invalid filter")
+		}
+		where = append(where, filter.Filter.String(column, len(args)+1))
+		args = append(args, filter.Filter.Value()...)
+	}
+
+	if params.Search != "" {
+		index := len(args) + 1
+		where = append(where, fmt.Sprintf("(p.title::text ILIKE $%d)", index))
+		args = append(args, "%"+params.Search+"%")
+	}
+
+	return where, args, nil
+}
+
+func (r *PgUserPositionRepository) GetPaginated(
+	ctx context.Context,
+	params *userposition.FindParams,
+) ([]userposition.UserPosition, error) {
+	where, args, err := r.buildFilters(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	query := repo.Join(
+		userPositionFindQuery,
+		repo.JoinWhere(where...),
+		params.SortBy.ToSQL(r.fieldMap),
+		repo.FormatLimitOffset(params.Limit, params.Offset),
+	)
+
+	positions, err := r.queryPositions(ctx, query, args...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get paginated user positions")
+	}
+	return positions, nil
+}
+
+func (r *PgUserPositionRepository) Count(ctx context.Context, params *userposition.FindParams) (int64, error) {
+	tx, err := composables.UseTx(ctx)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to get transaction")
+	}
+
+	where, args, err := r.buildFilters(ctx, params)
+	if err != nil {
+		return 0, err
+	}
+
+	query := repo.Join(
+		userPositionCountQuery,
+		repo.JoinWhere(where...),
+	)
+
+	var count int64
+	if err := tx.QueryRow(ctx, query, args...).Scan(&count); err != nil {
+		return 0, errors.Wrap(err, "failed to count user positions")
+	}
+	return count, nil
+}
+
+func (r *PgUserPositionRepository) GetByID(ctx context.Context, id uuid.UUID) (userposition.UserPosition, error) {
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get tenant from context")
+	}
+
+	q := repo.Join(userPositionFindQuery, "WHERE p.id = $1 AND p.tenant_id = $2")
+	positions, err := r.queryPositions(ctx, q, id.String(), tenantID.String())
+	if err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to query user position with id: %s", id.String()))
+	}
+	if len(positions) == 0 {
+		return nil, errors.Wrap(ErrUserPositionNotFound, fmt.Sprintf("id: %s", id.String()))
+	}
+	return positions[0], nil
+}
+
+func (r *PgUserPositionRepository) Exists(ctx context.Context, id uuid.UUID) (bool, error) {
+	tx, err := composables.UseTx(ctx)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to get transaction")
+	}
+
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to get tenant from context")
+	}
+
+	var exists bool
+	if err := tx.QueryRow(ctx, userPositionExistsQuery, id.String(), tenantID.String()).Scan(&exists); err != nil {
+		return false, errors.Wrap(err, "failed to check if user position exists")
+	}
+	return exists, nil
+}
+
+func (r *PgUserPositionRepository) Save(
+	ctx context.Context,
+	entity userposition.UserPosition,
+) (userposition.UserPosition, error) {
+	exists, err := r.Exists(ctx, entity.ID())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to check if user position exists")
+	}
+
+	if exists {
+		return r.update(ctx, entity)
+	}
+	return r.create(ctx, entity)
+}
+
+func (r *PgUserPositionRepository) create(
+	ctx context.Context,
+	entity userposition.UserPosition,
+) (userposition.UserPosition, error) {
+	tx, err := composables.UseTx(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get transaction")
+	}
+
+	dbPosition, err := ToDBUserPosition(entity)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to map user position to db model")
+	}
+	if entity.ID() == uuid.Nil {
+		dbPosition.ID = uuid.New().String()
+	}
+
+	fields := []string{
+		"id",
+		"tenant_id",
+		"user_id",
+		"department_id",
+		"title",
+		"is_manager",
+		"is_primary",
+		"status",
+		"created_at",
+		"updated_at",
+	}
+
+	values := []interface{}{
+		dbPosition.ID,
+		dbPosition.TenantID,
+		dbPosition.UserID,
+		dbPosition.DepartmentID,
+		dbPosition.Title,
+		dbPosition.IsManager,
+		dbPosition.IsPrimary,
+		dbPosition.Status,
+		dbPosition.CreatedAt,
+		dbPosition.UpdatedAt,
+	}
+
+	if _, err := tx.Exec(ctx, repo.Insert("core.user_positions", fields), values...); err != nil {
+		return nil, errors.Wrap(err, "failed to insert user position")
+	}
+
+	id, err := uuid.Parse(dbPosition.ID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse UUID")
+	}
+	return r.GetByID(ctx, id)
+}
+
+func (r *PgUserPositionRepository) update(
+	ctx context.Context,
+	entity userposition.UserPosition,
+) (userposition.UserPosition, error) {
+	tx, err := composables.UseTx(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get transaction")
+	}
+
+	dbPosition, err := ToDBUserPosition(entity)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to map user position to db model")
+	}
+
+	fields := []string{
+		"department_id",
+		"title",
+		"is_manager",
+		"is_primary",
+		"status",
+		"updated_at",
+	}
+
+	values := []interface{}{
+		dbPosition.DepartmentID,
+		dbPosition.Title,
+		dbPosition.IsManager,
+		dbPosition.IsPrimary,
+		dbPosition.Status,
+		dbPosition.UpdatedAt,
+		dbPosition.ID,
+		dbPosition.TenantID,
+	}
+
+	query := repo.Update(
+		"core.user_positions",
+		fields,
+		fmt.Sprintf("id = $%d", len(values)-1),
+		fmt.Sprintf("tenant_id = $%d", len(values)),
+	)
+	if _, err := tx.Exec(ctx, query, values...); err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to update user position with ID: %s", dbPosition.ID))
+	}
+
+	id, err := uuid.Parse(dbPosition.ID)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse UUID")
+	}
+	return r.GetByID(ctx, id)
+}
+
+func (r *PgUserPositionRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	tx, err := composables.UseTx(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get transaction")
+	}
+
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to get tenant from context")
+	}
+
+	if _, err := tx.Exec(ctx, userPositionDeleteQuery, id.String(), tenantID.String()); err != nil {
+		return errors.Wrap(err, fmt.Sprintf("failed to delete user position with ID: %s", id.String()))
+	}
+	return nil
+}
+
+func (r *PgUserPositionRepository) queryPositions(
+	ctx context.Context,
+	query string,
+	args ...interface{},
+) ([]userposition.UserPosition, error) {
+	tx, err := composables.UseTx(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get transaction")
+	}
+
+	rows, err := tx.Query(ctx, query, args...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to execute query")
+	}
+	defer rows.Close()
+
+	var dbPositions []*models.UserPosition
+	for rows.Next() {
+		var dbPosition models.UserPosition
+		if err := rows.Scan(
+			&dbPosition.ID,
+			&dbPosition.TenantID,
+			&dbPosition.UserID,
+			&dbPosition.DepartmentID,
+			&dbPosition.Title,
+			&dbPosition.IsManager,
+			&dbPosition.IsPrimary,
+			&dbPosition.Status,
+			&dbPosition.CreatedAt,
+			&dbPosition.UpdatedAt,
+		); err != nil {
+			return nil, errors.Wrap(err, "failed to scan user position row")
+		}
+		dbPositions = append(dbPositions, &dbPosition)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "row iteration error")
+	}
+
+	entities := make([]userposition.UserPosition, 0, len(dbPositions))
+	for _, dbPosition := range dbPositions {
+		domainPosition, err := ToDomainUserPosition(dbPosition)
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("failed to convert user position ID: %s to domain entity", dbPosition.ID))
+		}
+		entities = append(entities, domainPosition)
+	}
+
+	return entities, nil
+}

--- a/modules/core/infrastructure/persistence/user_position_repository.go
+++ b/modules/core/infrastructure/persistence/user_position_repository.go
@@ -332,8 +332,12 @@ func (r *PgUserPositionRepository) Delete(ctx context.Context, id uuid.UUID) err
 		return serrors.E(op, err)
 	}
 
-	if _, err := tx.Exec(ctx, userPositionDeleteQuery, id.String(), tenantID.String()); err != nil {
+	tag, err := tx.Exec(ctx, userPositionDeleteQuery, id.String(), tenantID.String())
+	if err != nil {
 		return serrors.E(op, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return serrors.E(op, serrors.NotFound, ErrUserPositionNotFound)
 	}
 	return nil
 }

--- a/modules/core/infrastructure/persistence/user_position_repository_test.go
+++ b/modules/core/infrastructure/persistence/user_position_repository_test.go
@@ -1,0 +1,191 @@
+package persistence_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/department"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/user"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/userposition"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/value_objects/internet"
+	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence"
+	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"github.com/iota-uz/iota-sdk/pkg/itf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPgUserPositionRepository_CRUD(t *testing.T) {
+	t.Parallel()
+	f := setupTest(t)
+
+	uploadRepository := persistence.NewUploadRepository()
+	userRepository := persistence.NewUserRepository(uploadRepository)
+	departmentRepository := persistence.NewDepartmentRepository()
+	positionRepository := persistence.NewUserPositionRepository()
+
+	tenant, err := composables.UseTenantID(f.Ctx)
+	require.NoError(t, err)
+
+	email, err := internet.NewEmail("position-test@gmail.com")
+	require.NoError(t, err)
+	createdUser, err := userRepository.Create(f.Ctx, user.New(
+		"Pos",
+		"Tester",
+		email,
+		user.UILanguageEN,
+		user.WithTenantID(tenant),
+	))
+	require.NoError(t, err)
+
+	deptID := uuid.New()
+	_, err = departmentRepository.Save(f.Ctx, department.New(
+		"POS-DEPT",
+		orgName(t, "Position Department"),
+		department.WithID(deptID),
+		department.WithTenantID(tenant),
+	))
+	require.NoError(t, err)
+
+	t.Run("CreateManagerPosition", func(t *testing.T) {
+		id := uuid.New()
+		entity := userposition.New(
+			createdUser.ID(),
+			deptID,
+			orgName(t, "Head of Department"),
+			userposition.WithID(id),
+			userposition.WithTenantID(tenant),
+			userposition.WithIsManager(true),
+			userposition.WithIsPrimary(true),
+		)
+
+		saved, err := positionRepository.Save(f.Ctx, entity)
+		require.NoError(t, err)
+		assert.Equal(t, id, saved.ID())
+		assert.Equal(t, createdUser.ID(), saved.UserID())
+		assert.Equal(t, deptID, saved.DepartmentID())
+		assert.True(t, saved.IsManager())
+		assert.True(t, saved.IsPrimary())
+		assert.Equal(t, "Head of Department EN", saved.Title("en"))
+		assert.Equal(t, "Head of Department UZ-CYRL", saved.Title("uz-Cyrl"))
+		assert.Equal(t, userposition.StatusActive, saved.Status())
+
+		retrieved, err := positionRepository.GetByID(f.Ctx, id)
+		require.NoError(t, err)
+		assert.True(t, retrieved.IsManager())
+		assert.Equal(t, "Head of Department RU", retrieved.Title("ru"))
+	})
+
+	t.Run("Update", func(t *testing.T) {
+		id := uuid.New()
+		entity := userposition.New(
+			createdUser.ID(),
+			deptID,
+			orgName(t, "Engineer"),
+			userposition.WithID(id),
+			userposition.WithTenantID(tenant),
+		)
+		saved, err := positionRepository.Save(f.Ctx, entity)
+		require.NoError(t, err)
+		assert.False(t, saved.IsManager())
+
+		updated := saved.SetIsManager(true).SetTitle(orgName(t, "Senior Engineer"))
+		savedUpdated, err := positionRepository.Save(f.Ctx, updated)
+		require.NoError(t, err)
+		assert.True(t, savedUpdated.IsManager())
+		assert.Equal(t, "Senior Engineer EN", savedUpdated.Title("en"))
+	})
+
+	t.Run("ExistsAndDelete", func(t *testing.T) {
+		id := uuid.New()
+		entity := userposition.New(
+			createdUser.ID(),
+			deptID,
+			orgName(t, "Temp"),
+			userposition.WithID(id),
+			userposition.WithTenantID(tenant),
+		)
+		_, err := positionRepository.Save(f.Ctx, entity)
+		require.NoError(t, err)
+
+		exists, err := positionRepository.Exists(f.Ctx, id)
+		require.NoError(t, err)
+		assert.True(t, exists)
+
+		require.NoError(t, positionRepository.Delete(f.Ctx, id))
+
+		_, err = positionRepository.GetByID(f.Ctx, id)
+		require.ErrorIs(t, err, persistence.ErrUserPositionNotFound)
+	})
+}
+
+func TestPgUserPositionRepository_TenantIsolation(t *testing.T) {
+	t.Parallel()
+	f := setupTest(t)
+
+	uploadRepository := persistence.NewUploadRepository()
+	userRepository := persistence.NewUserRepository(uploadRepository)
+	departmentRepository := persistence.NewDepartmentRepository()
+	positionRepository := persistence.NewUserPositionRepository()
+
+	tenantA, err := composables.UseTenantID(f.Ctx)
+	require.NoError(t, err)
+	secondTenant, err := itf.CreateTestTenant(f.Ctx, f.Pool)
+	require.NoError(t, err)
+	ctxB := composables.WithTenantID(f.Ctx, secondTenant.ID)
+
+	// Per-tenant user + department + position.
+	mkPosition := func(ctx context.Context, tid uuid.UUID, emailStr, deptCode string) uuid.UUID {
+		email, err := internet.NewEmail(emailStr)
+		require.NoError(t, err)
+		u, err := userRepository.Create(ctx, user.New(
+			"Iso", "User", email, user.UILanguageEN, user.WithTenantID(tid),
+		))
+		require.NoError(t, err)
+
+		deptID := uuid.New()
+		_, err = departmentRepository.Save(ctx, department.New(
+			deptCode, orgName(t, deptCode),
+			department.WithID(deptID), department.WithTenantID(tid),
+		))
+		require.NoError(t, err)
+
+		posID := uuid.New()
+		_, err = positionRepository.Save(ctx, userposition.New(
+			u.ID(), deptID, orgName(t, "Engineer"),
+			userposition.WithID(posID), userposition.WithTenantID(tid),
+		))
+		require.NoError(t, err)
+		return posID
+	}
+
+	posA := mkPosition(f.Ctx, tenantA, "iso-pos-a@gmail.com", "ISO-A")
+	posB := mkPosition(ctxB, secondTenant.ID, "iso-pos-b@gmail.com", "ISO-B")
+
+	t.Run("GetByID does not cross tenants", func(t *testing.T) {
+		_, err := positionRepository.GetByID(f.Ctx, posB)
+		require.ErrorIs(t, err, persistence.ErrUserPositionNotFound)
+
+		_, err = positionRepository.GetByID(ctxB, posA)
+		require.ErrorIs(t, err, persistence.ErrUserPositionNotFound)
+
+		gotA, err := positionRepository.GetByID(f.Ctx, posA)
+		require.NoError(t, err)
+		assert.Equal(t, tenantA, gotA.TenantID())
+	})
+
+	t.Run("GetPaginated excludes other tenant rows", func(t *testing.T) {
+		listA, err := positionRepository.GetPaginated(f.Ctx, &userposition.FindParams{Limit: 1000})
+		require.NoError(t, err)
+		for _, p := range listA {
+			assert.Equal(t, tenantA, p.TenantID())
+			assert.NotEqual(t, posB, p.ID())
+		}
+
+		listB, err := positionRepository.GetPaginated(ctxB, &userposition.FindParams{Limit: 1000})
+		require.NoError(t, err)
+		require.Len(t, listB, 1)
+		assert.Equal(t, posB, listB[0].ID())
+	})
+}

--- a/modules/core/infrastructure/query/org_query_repository.go
+++ b/modules/core/infrastructure/query/org_query_repository.go
@@ -1,0 +1,161 @@
+// Package query provides read-only organizational membership and hierarchy
+// lookups (recursive-CTE subtree walks) for the core module, all tenant-scoped.
+package query
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"github.com/pkg/errors"
+)
+
+// SQL queries for organizational membership/hierarchy lookups.
+//
+// Subtree walks use recursive CTEs (Postgres VIEWs/TRIGGERs are intentionally
+// avoided). Every query is scoped to the caller's tenant.
+const (
+	// userDepartmentsSQL returns the distinct departments a user holds an
+	// active position in.
+	userDepartmentsSQL = `
+		SELECT DISTINCT p.department_id
+		FROM core.user_positions p
+		WHERE p.user_id = $1
+		  AND p.tenant_id = $2
+		  AND p.status = 'active'`
+
+	// userManagedDepartmentsSQL returns the departments where the user holds
+	// an active manager position (no subtree expansion).
+	userManagedDepartmentsSQL = `
+		SELECT DISTINCT p.department_id
+		FROM core.user_positions p
+		WHERE p.user_id = $1
+		  AND p.tenant_id = $2
+		  AND p.is_manager = TRUE
+		  AND p.status = 'active'`
+
+	// userManagedDepartmentsSubtreeSQL expands the manager's departments to
+	// include every descendant department in the tenant.
+	userManagedDepartmentsSubtreeSQL = `
+		WITH RECURSIVE roots AS (
+			SELECT DISTINCT p.department_id AS id
+			FROM core.user_positions p
+			WHERE p.user_id = $1
+			  AND p.tenant_id = $2
+			  AND p.is_manager = TRUE
+			  AND p.status = 'active'
+		),
+		subtree AS (
+			SELECT r.id
+			FROM roots r
+			UNION
+			SELECT d.id
+			FROM core.departments d
+			JOIN subtree s ON d.parent_id = s.id
+			WHERE d.tenant_id = $2
+		)
+		SELECT DISTINCT id FROM subtree`
+
+	// departmentSubtreeSQL returns the department itself plus all of its
+	// descendants within the tenant.
+	departmentSubtreeSQL = `
+		WITH RECURSIVE subtree AS (
+			SELECT d.id
+			FROM core.departments d
+			WHERE d.id = $1 AND d.tenant_id = $2
+			UNION
+			SELECT child.id
+			FROM core.departments child
+			JOIN subtree s ON child.parent_id = s.id
+			WHERE child.tenant_id = $2
+		)
+		SELECT id FROM subtree`
+)
+
+// OrgQueryRepository exposes read-only organizational membership and hierarchy
+// lookups backed by recursive CTEs. All methods are tenant-scoped.
+type OrgQueryRepository interface {
+	// UserDepartments returns the departments the user holds a position in.
+	UserDepartments(ctx context.Context, userID uint) ([]uuid.UUID, error)
+	// UserManagedDepartments returns the departments where the user holds a
+	// manager position. When includeSubtree is true the result also contains
+	// every descendant department.
+	UserManagedDepartments(ctx context.Context, userID uint, includeSubtree bool) ([]uuid.UUID, error)
+	// DepartmentSubtree returns the department and all of its descendants.
+	DepartmentSubtree(ctx context.Context, deptID uuid.UUID) ([]uuid.UUID, error)
+}
+
+type PgOrgQueryRepository struct{}
+
+func NewPgOrgQueryRepository() OrgQueryRepository {
+	return &PgOrgQueryRepository{}
+}
+
+func (r *PgOrgQueryRepository) UserDepartments(ctx context.Context, userID uint) ([]uuid.UUID, error) {
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get tenant from context")
+	}
+	return r.queryDepartmentIDs(ctx, userDepartmentsSQL, userID, tenantID.String())
+}
+
+func (r *PgOrgQueryRepository) UserManagedDepartments(
+	ctx context.Context,
+	userID uint,
+	includeSubtree bool,
+) ([]uuid.UUID, error) {
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get tenant from context")
+	}
+
+	query := userManagedDepartmentsSQL
+	if includeSubtree {
+		query = userManagedDepartmentsSubtreeSQL
+	}
+	return r.queryDepartmentIDs(ctx, query, userID, tenantID.String())
+}
+
+func (r *PgOrgQueryRepository) DepartmentSubtree(ctx context.Context, deptID uuid.UUID) ([]uuid.UUID, error) {
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get tenant from context")
+	}
+	return r.queryDepartmentIDs(ctx, departmentSubtreeSQL, deptID.String(), tenantID.String())
+}
+
+func (r *PgOrgQueryRepository) queryDepartmentIDs(
+	ctx context.Context,
+	query string,
+	args ...interface{},
+) ([]uuid.UUID, error) {
+	tx, err := composables.UseTx(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get transaction")
+	}
+
+	rows, err := tx.Query(ctx, query, args...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to execute org query")
+	}
+	defer rows.Close()
+
+	ids := make([]uuid.UUID, 0)
+	for rows.Next() {
+		var idStr string
+		if err := rows.Scan(&idStr); err != nil {
+			return nil, errors.Wrap(err, "failed to scan department id")
+		}
+		id, err := uuid.Parse(idStr)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to parse department id")
+		}
+		ids = append(ids, id)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, errors.Wrap(err, "row iteration error")
+	}
+
+	return ids, nil
+}

--- a/modules/core/infrastructure/query/org_query_repository.go
+++ b/modules/core/infrastructure/query/org_query_repository.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
-	"github.com/pkg/errors"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
 )
 
 // SQL queries for organizational membership/hierarchy lookups.
@@ -92,9 +92,10 @@ func NewPgOrgQueryRepository() OrgQueryRepository {
 }
 
 func (r *PgOrgQueryRepository) UserDepartments(ctx context.Context, userID uint) ([]uuid.UUID, error) {
+	const op serrors.Op = "PgOrgQueryRepository.UserDepartments"
 	tenantID, err := composables.UseTenantID(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get tenant from context")
+		return nil, serrors.E(op, err)
 	}
 	return r.queryDepartmentIDs(ctx, userDepartmentsSQL, userID, tenantID.String())
 }
@@ -104,9 +105,10 @@ func (r *PgOrgQueryRepository) UserManagedDepartments(
 	userID uint,
 	includeSubtree bool,
 ) ([]uuid.UUID, error) {
+	const op serrors.Op = "PgOrgQueryRepository.UserManagedDepartments"
 	tenantID, err := composables.UseTenantID(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get tenant from context")
+		return nil, serrors.E(op, err)
 	}
 
 	query := userManagedDepartmentsSQL
@@ -117,9 +119,10 @@ func (r *PgOrgQueryRepository) UserManagedDepartments(
 }
 
 func (r *PgOrgQueryRepository) DepartmentSubtree(ctx context.Context, deptID uuid.UUID) ([]uuid.UUID, error) {
+	const op serrors.Op = "PgOrgQueryRepository.DepartmentSubtree"
 	tenantID, err := composables.UseTenantID(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get tenant from context")
+		return nil, serrors.E(op, err)
 	}
 	return r.queryDepartmentIDs(ctx, departmentSubtreeSQL, deptID.String(), tenantID.String())
 }
@@ -129,14 +132,15 @@ func (r *PgOrgQueryRepository) queryDepartmentIDs(
 	query string,
 	args ...interface{},
 ) ([]uuid.UUID, error) {
+	const op serrors.Op = "PgOrgQueryRepository.queryDepartmentIDs"
 	tx, err := composables.UseTx(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get transaction")
+		return nil, serrors.E(op, err)
 	}
 
 	rows, err := tx.Query(ctx, query, args...)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to execute org query")
+		return nil, serrors.E(op, err)
 	}
 	defer rows.Close()
 
@@ -144,17 +148,17 @@ func (r *PgOrgQueryRepository) queryDepartmentIDs(
 	for rows.Next() {
 		var idStr string
 		if err := rows.Scan(&idStr); err != nil {
-			return nil, errors.Wrap(err, "failed to scan department id")
+			return nil, serrors.E(op, err)
 		}
 		id, err := uuid.Parse(idStr)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to parse department id")
+			return nil, serrors.E(op, err)
 		}
 		ids = append(ids, id)
 	}
 
 	if err := rows.Err(); err != nil {
-		return nil, errors.Wrap(err, "row iteration error")
+		return nil, serrors.E(op, err)
 	}
 
 	return ids, nil

--- a/modules/core/infrastructure/query/org_query_repository_test.go
+++ b/modules/core/infrastructure/query/org_query_repository_test.go
@@ -1,0 +1,288 @@
+package query_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/department"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/user"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/userposition"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/value_objects/internet"
+	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence"
+	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/query"
+	"github.com/iota-uz/iota-sdk/pkg/composables"
+	crudmodels "github.com/iota-uz/iota-sdk/pkg/crud/models"
+	"github.com/iota-uz/iota-sdk/pkg/itf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func orgName(t *testing.T, base string) crudmodels.MultiLang {
+	t.Helper()
+	ml, err := crudmodels.NewMultiLangFromMap(map[string]string{
+		"en":      base + " EN",
+		"ru":      base + " RU",
+		"uz":      base + " UZ",
+		"uz-Cyrl": base + " UZ-CYRL",
+	})
+	require.NoError(t, err)
+	return ml
+}
+
+func idSet(ids []uuid.UUID) map[uuid.UUID]struct{} {
+	out := make(map[uuid.UUID]struct{}, len(ids))
+	for _, id := range ids {
+		out[id] = struct{}{}
+	}
+	return out
+}
+
+// secondTenantCtx provisions an additional tenant and returns a context scoped
+// to it, mirroring the cross-tenant pattern used in the persistence tests.
+func secondTenantCtx(t *testing.T, f *itf.TestEnvironment) (context.Context, uuid.UUID) {
+	t.Helper()
+	secondTenant, err := itf.CreateTestTenant(f.Ctx, f.Pool)
+	require.NoError(t, err)
+	return composables.WithTenantID(f.Ctx, secondTenant.ID), secondTenant.ID
+}
+
+func TestPgOrgQueryRepository(t *testing.T) {
+	t.Parallel()
+	f := setupTest(t)
+
+	uploadRepository := persistence.NewUploadRepository()
+	userRepository := persistence.NewUserRepository(uploadRepository)
+	departmentRepository := persistence.NewDepartmentRepository()
+	positionRepository := persistence.NewUserPositionRepository()
+	orgQuery := query.NewPgOrgQueryRepository()
+
+	tenant, err := composables.UseTenantID(f.Ctx)
+	require.NoError(t, err)
+
+	mkDept := func(code string, parent *uuid.UUID) uuid.UUID {
+		id := uuid.New()
+		opts := []department.Option{
+			department.WithID(id),
+			department.WithTenantID(tenant),
+		}
+		if parent != nil {
+			opts = append(opts, department.WithParentID(parent))
+		}
+		_, err := departmentRepository.Save(f.Ctx, department.New(code, orgName(t, code), opts...))
+		require.NoError(t, err)
+		return id
+	}
+
+	// Hierarchy: A -> B -> C ; D is unrelated.
+	deptA := mkDept("ORG-A", nil)
+	deptB := mkDept("ORG-B", &deptA)
+	deptC := mkDept("ORG-C", &deptB)
+	deptD := mkDept("ORG-D", nil)
+
+	email, err := internet.NewEmail("org-query@gmail.com")
+	require.NoError(t, err)
+	managerUser, err := userRepository.Create(f.Ctx, user.New(
+		"Org", "Manager", email, user.UILanguageEN, user.WithTenantID(tenant),
+	))
+	require.NoError(t, err)
+
+	// Manager of A (root), plain member of D.
+	_, err = positionRepository.Save(f.Ctx, userposition.New(
+		managerUser.ID(), deptA, orgName(t, "Director"),
+		userposition.WithID(uuid.New()),
+		userposition.WithTenantID(tenant),
+		userposition.WithIsManager(true),
+		userposition.WithIsPrimary(true),
+	))
+	require.NoError(t, err)
+	_, err = positionRepository.Save(f.Ctx, userposition.New(
+		managerUser.ID(), deptD, orgName(t, "Advisor"),
+		userposition.WithID(uuid.New()),
+		userposition.WithTenantID(tenant),
+		userposition.WithIsManager(false),
+	))
+	require.NoError(t, err)
+
+	t.Run("UserDepartments", func(t *testing.T) {
+		ids, err := orgQuery.UserDepartments(f.Ctx, managerUser.ID())
+		require.NoError(t, err)
+		set := idSet(ids)
+		assert.Len(t, set, 2)
+		assert.Contains(t, set, deptA)
+		assert.Contains(t, set, deptD)
+	})
+
+	t.Run("UserManagedDepartments_NoSubtree", func(t *testing.T) {
+		ids, err := orgQuery.UserManagedDepartments(f.Ctx, managerUser.ID(), false)
+		require.NoError(t, err)
+		set := idSet(ids)
+		assert.Len(t, set, 1)
+		assert.Contains(t, set, deptA)
+		assert.NotContains(t, set, deptB)
+	})
+
+	t.Run("UserManagedDepartments_Subtree", func(t *testing.T) {
+		ids, err := orgQuery.UserManagedDepartments(f.Ctx, managerUser.ID(), true)
+		require.NoError(t, err)
+		set := idSet(ids)
+		// A (managed root) plus descendants B and C. D is unrelated.
+		assert.Len(t, set, 3)
+		assert.Contains(t, set, deptA)
+		assert.Contains(t, set, deptB)
+		assert.Contains(t, set, deptC)
+		assert.NotContains(t, set, deptD)
+	})
+
+	t.Run("DepartmentSubtree", func(t *testing.T) {
+		ids, err := orgQuery.DepartmentSubtree(f.Ctx, deptA)
+		require.NoError(t, err)
+		set := idSet(ids)
+		assert.Len(t, set, 3)
+		assert.Contains(t, set, deptA)
+		assert.Contains(t, set, deptB)
+		assert.Contains(t, set, deptC)
+
+		// Subtree from a mid node.
+		ids, err = orgQuery.DepartmentSubtree(f.Ctx, deptB)
+		require.NoError(t, err)
+		set = idSet(ids)
+		assert.Len(t, set, 2)
+		assert.Contains(t, set, deptB)
+		assert.Contains(t, set, deptC)
+		assert.NotContains(t, set, deptA)
+	})
+}
+
+// TestPgOrgQueryRepository_TenantIsolation builds an identically shaped
+// hierarchy under two tenants (same codes, same depth) and asserts the
+// recursive-CTE walks never bleed across the tenant boundary. This is the
+// central guarantee the org model exists to provide.
+func TestPgOrgQueryRepository_TenantIsolation(t *testing.T) {
+	t.Parallel()
+	f := setupTest(t)
+
+	uploadRepository := persistence.NewUploadRepository()
+	userRepository := persistence.NewUserRepository(uploadRepository)
+	departmentRepository := persistence.NewDepartmentRepository()
+	positionRepository := persistence.NewUserPositionRepository()
+	orgQuery := query.NewPgOrgQueryRepository()
+
+	ctxB, _ := secondTenantCtx(t, f)
+
+	// mkDept creates a department in the given tenant context.
+	mkDept := func(ctx context.Context, code string, parent *uuid.UUID) uuid.UUID {
+		id := uuid.New()
+		tid, err := composables.UseTenantID(ctx)
+		require.NoError(t, err)
+		opts := []department.Option{department.WithID(id), department.WithTenantID(tid)}
+		if parent != nil {
+			opts = append(opts, department.WithParentID(parent))
+		}
+		_, err = departmentRepository.Save(ctx, department.New(code, orgName(t, code), opts...))
+		require.NoError(t, err)
+		return id
+	}
+
+	// Identically shaped hierarchies in both tenants: ROOT -> CHILD -> LEAF.
+	aRoot := mkDept(f.Ctx, "ISO-ROOT", nil)
+	aChild := mkDept(f.Ctx, "ISO-CHILD", &aRoot)
+	aLeaf := mkDept(f.Ctx, "ISO-LEAF", &aChild)
+
+	bRoot := mkDept(ctxB, "ISO-ROOT", nil)
+	bChild := mkDept(ctxB, "ISO-CHILD", &bRoot)
+	bLeaf := mkDept(ctxB, "ISO-LEAF", &bChild)
+
+	// Manager users, one per tenant, each managing their own root.
+	mkManager := func(ctx context.Context, emailStr string, root uuid.UUID) uint {
+		tid, err := composables.UseTenantID(ctx)
+		require.NoError(t, err)
+		email, err := internet.NewEmail(emailStr)
+		require.NoError(t, err)
+		u, err := userRepository.Create(ctx, user.New(
+			"Iso", "Manager", email, user.UILanguageEN, user.WithTenantID(tid),
+		))
+		require.NoError(t, err)
+		_, err = positionRepository.Save(ctx, userposition.New(
+			u.ID(), root, orgName(t, "Director"),
+			userposition.WithID(uuid.New()),
+			userposition.WithTenantID(tid),
+			userposition.WithIsManager(true),
+			userposition.WithIsPrimary(true),
+		))
+		require.NoError(t, err)
+		return u.ID()
+	}
+	managerA := mkManager(f.Ctx, "iso-a@gmail.com", aRoot)
+	managerB := mkManager(ctxB, "iso-b@gmail.com", bRoot)
+
+	t.Run("DepartmentSubtree stays within tenant", func(t *testing.T) {
+		idsA, err := orgQuery.DepartmentSubtree(f.Ctx, aRoot)
+		require.NoError(t, err)
+		setA := idSet(idsA)
+		assert.Len(t, setA, 3)
+		assert.Contains(t, setA, aRoot)
+		assert.Contains(t, setA, aChild)
+		assert.Contains(t, setA, aLeaf)
+		// No tenant-B node leaks in.
+		assert.NotContains(t, setA, bRoot)
+		assert.NotContains(t, setA, bChild)
+		assert.NotContains(t, setA, bLeaf)
+
+		idsB, err := orgQuery.DepartmentSubtree(ctxB, bRoot)
+		require.NoError(t, err)
+		setB := idSet(idsB)
+		assert.Len(t, setB, 3)
+		assert.Contains(t, setB, bRoot)
+		assert.NotContains(t, setB, aRoot)
+		assert.NotContains(t, setB, aChild)
+		assert.NotContains(t, setB, aLeaf)
+	})
+
+	t.Run("DepartmentSubtree of another tenant root returns nothing", func(t *testing.T) {
+		// Asking tenant A's context for tenant B's root must yield an empty set
+		// (the CTE seed `id = $1 AND tenant_id = $2` finds no row).
+		ids, err := orgQuery.DepartmentSubtree(f.Ctx, bRoot)
+		require.NoError(t, err)
+		assert.Empty(t, ids)
+	})
+
+	t.Run("UserManagedDepartments subtree never crosses tenants", func(t *testing.T) {
+		idsA, err := orgQuery.UserManagedDepartments(f.Ctx, managerA, true)
+		require.NoError(t, err)
+		setA := idSet(idsA)
+		assert.Len(t, setA, 3)
+		assert.Contains(t, setA, aRoot)
+		assert.Contains(t, setA, aChild)
+		assert.Contains(t, setA, aLeaf)
+		assert.NotContains(t, setA, bRoot)
+		assert.NotContains(t, setA, bChild)
+		assert.NotContains(t, setA, bLeaf)
+
+		// Manager A queried under tenant B's context resolves nothing: the
+		// position rows are tenant-A scoped.
+		idsCross, err := orgQuery.UserManagedDepartments(ctxB, managerA, true)
+		require.NoError(t, err)
+		assert.Empty(t, idsCross)
+
+		idsB, err := orgQuery.UserManagedDepartments(ctxB, managerB, true)
+		require.NoError(t, err)
+		setB := idSet(idsB)
+		assert.Len(t, setB, 3)
+		assert.Contains(t, setB, bRoot)
+		assert.NotContains(t, setB, aRoot)
+	})
+
+	t.Run("UserDepartments scoped to tenant", func(t *testing.T) {
+		ids, err := orgQuery.UserDepartments(f.Ctx, managerA)
+		require.NoError(t, err)
+		set := idSet(ids)
+		assert.Contains(t, set, aRoot)
+		assert.NotContains(t, set, bRoot)
+
+		// managerA has no positions in tenant B.
+		idsCross, err := orgQuery.UserDepartments(ctxB, managerA)
+		require.NoError(t, err)
+		assert.Empty(t, idsCross)
+	})
+}

--- a/modules/core/permissions/constants.go
+++ b/modules/core/permissions/constants.go
@@ -8,11 +8,13 @@ import (
 )
 
 const (
-	ResourceUser    permission.Resource = "user"
-	ResourceRole    permission.Resource = "role"
-	ResourceGroup   permission.Resource = "group"
-	ResourceUpload  permission.Resource = "upload"
-	ResourceSession permission.Resource = "session"
+	ResourceUser       permission.Resource = "user"
+	ResourceRole       permission.Resource = "role"
+	ResourceGroup      permission.Resource = "group"
+	ResourceUpload     permission.Resource = "upload"
+	ResourceSession    permission.Resource = "session"
+	ResourceDepartment permission.Resource = "department"
+	ResourcePosition   permission.Resource = "position"
 )
 
 var (
@@ -149,6 +151,62 @@ var (
 		permission.ActionDelete,
 		permission.ModifierAll,
 	)
+	DepartmentCreate = permission.MustCreate(
+		uuid.MustParse("773a81ca-1893-420b-a659-d3752d80e99f"),
+		"Department.Create",
+		ResourceDepartment,
+		permission.ActionCreate,
+		permission.ModifierAll,
+	)
+	DepartmentRead = permission.MustCreate(
+		uuid.MustParse("e98757cf-ee24-44bb-83b1-d91a123a9479"),
+		"Department.Read",
+		ResourceDepartment,
+		permission.ActionRead,
+		permission.ModifierAll,
+	)
+	DepartmentUpdate = permission.MustCreate(
+		uuid.MustParse("911da3f7-14ae-4e70-b546-5267f19d087f"),
+		"Department.Update",
+		ResourceDepartment,
+		permission.ActionUpdate,
+		permission.ModifierAll,
+	)
+	DepartmentDelete = permission.MustCreate(
+		uuid.MustParse("c8634512-d87e-452b-b731-e8ef1d0a452d"),
+		"Department.Delete",
+		ResourceDepartment,
+		permission.ActionDelete,
+		permission.ModifierAll,
+	)
+	PositionCreate = permission.MustCreate(
+		uuid.MustParse("3b006eaa-dc10-4f69-85ef-31b5c0afc1f4"),
+		"Position.Create",
+		ResourcePosition,
+		permission.ActionCreate,
+		permission.ModifierAll,
+	)
+	PositionRead = permission.MustCreate(
+		uuid.MustParse("f4d5d8a8-8ed4-4067-9536-d5d5832ca938"),
+		"Position.Read",
+		ResourcePosition,
+		permission.ActionRead,
+		permission.ModifierAll,
+	)
+	PositionUpdate = permission.MustCreate(
+		uuid.MustParse("1619acab-6b1a-4909-b4a8-38fafeee4ed5"),
+		"Position.Update",
+		ResourcePosition,
+		permission.ActionUpdate,
+		permission.ModifierAll,
+	)
+	PositionDelete = permission.MustCreate(
+		uuid.MustParse("17655dc7-b5aa-4c05-83ee-e01be1a17fac"),
+		"Position.Delete",
+		ResourcePosition,
+		permission.ActionDelete,
+		permission.ModifierAll,
+	)
 )
 
 var Permissions = []permission.Permission{
@@ -171,4 +229,12 @@ var Permissions = []permission.Permission{
 	UploadDelete,
 	SessionRead,
 	SessionDelete,
+	DepartmentCreate,
+	DepartmentRead,
+	DepartmentUpdate,
+	DepartmentDelete,
+	PositionCreate,
+	PositionRead,
+	PositionUpdate,
+	PositionDelete,
 }

--- a/modules/core/seed/providers.go
+++ b/modules/core/seed/providers.go
@@ -2,6 +2,7 @@ package seed
 
 import (
 	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence"
+	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/query"
 	"github.com/iota-uz/iota-sdk/pkg/application"
 )
 
@@ -18,5 +19,8 @@ func RegisterProviders(deps *application.SeedDeps) {
 		roleRepository,
 		userRepository,
 		persistence.NewGroupRepository(userRepository, roleRepository),
+		persistence.NewDepartmentRepository(),
+		persistence.NewUserPositionRepository(),
+		query.NewPgOrgQueryRepository(),
 	)
 }

--- a/modules/core/seed/providers_test.go
+++ b/modules/core/seed/providers_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"testing"
 
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/department"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/group"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/role"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/user"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/userposition"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/currency"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/permission"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/tenant"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/upload"
+	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/query"
 	"github.com/iota-uz/iota-sdk/pkg/application"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -37,6 +40,29 @@ func TestRegisterProviders_RegistersCoreRepositories(t *testing.T) {
 		require.NotNil(t, roleRepo)
 		require.NotNil(t, userRepo)
 		require.NotNil(t, groupRepo)
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+// TestRegisterProviders_RegistersOrgRepositories proves the organizational
+// repositories the seeders depend on (department, user position, org query)
+// resolve from the seed provider registry. This guards the seed funcs'
+// dependency-injected signatures, which route seeded rows through the same
+// validation the services enforce.
+func TestRegisterProviders_RegistersOrgRepositories(t *testing.T) {
+	deps := &application.SeedDeps{Logger: logrus.New()}
+	RegisterProviders(deps)
+
+	err := deps.Invoke(context.Background(), func(
+		ctx context.Context,
+		departmentRepo department.Repository,
+		positionRepo userposition.Repository,
+		orgQuery query.OrgQueryRepository,
+	) error {
+		require.NotNil(t, departmentRepo)
+		require.NotNil(t, positionRepo)
+		require.NotNil(t, orgQuery)
 		return nil
 	})
 	require.NoError(t, err)

--- a/modules/core/seed/seed_department.go
+++ b/modules/core/seed/seed_department.go
@@ -1,0 +1,86 @@
+// Package seed provides idempotent seeders for the core organizational model
+// (departments and user positions), routing every seeded row through the same
+// tenant/structural validation the services enforce.
+package seed
+
+import (
+	"context"
+
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/department"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/user"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/userposition"
+	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/query"
+	"github.com/iota-uz/iota-sdk/modules/core/services"
+	"github.com/iota-uz/iota-sdk/pkg/application"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
+	"github.com/sirupsen/logrus"
+)
+
+// DepartmentsSeedFunc returns an idempotent seed function that persists the
+// given departments, skipping any that already exist. Each department is run
+// through the same multilingual + hierarchy validation the service layer
+// enforces, using the row's own tenant as the authoritative tenant.
+func DepartmentsSeedFunc(departments ...department.Department) application.SeedFunc {
+	const op serrors.Op = "seed.DepartmentsSeedFunc"
+	return application.Seed(func(
+		ctx context.Context,
+		departmentRepository department.Repository,
+		orgQuery query.OrgQueryRepository,
+		logger logrus.FieldLogger,
+	) error {
+		for _, d := range departments {
+			if exists, err := departmentRepository.Exists(ctx, d.ID()); err != nil {
+				logger.Errorf("Failed to check if department %s exists: %v", d.Code(), err)
+				return err
+			} else if exists {
+				logger.Infof("Department %s already exists", d.Code())
+				continue
+			}
+			if err := services.ValidateDepartment(ctx, op, d.TenantID(), d, departmentRepository, orgQuery.DepartmentSubtree); err != nil {
+				logger.Errorf("Department %s failed validation: %v", d.Code(), err)
+				return err
+			}
+			if _, err := departmentRepository.Save(ctx, d); err != nil {
+				logger.Errorf("Failed to save department %s: %v", d.Code(), err)
+				return err
+			}
+			logger.Infof("Department %s saved", d.Code())
+		}
+		return nil
+	})
+}
+
+// UserPositionsSeedFunc returns an idempotent seed function that persists the
+// given user positions, skipping any that already exist. Each position is run
+// through the same multilingual + reference validation the service layer
+// enforces, using the row's own tenant as the authoritative tenant.
+func UserPositionsSeedFunc(positions ...userposition.UserPosition) application.SeedFunc {
+	const op serrors.Op = "seed.UserPositionsSeedFunc"
+	return application.Seed(func(
+		ctx context.Context,
+		positionRepository userposition.Repository,
+		departmentRepository department.Repository,
+		userRepository user.Repository,
+		logger logrus.FieldLogger,
+	) error {
+		for _, p := range positions {
+			if exists, err := positionRepository.Exists(ctx, p.ID()); err != nil {
+				logger.Errorf("Failed to check if user position %s exists: %v", p.ID(), err)
+				return err
+			} else if exists {
+				logger.Infof("User position %s already exists", p.ID())
+				continue
+			}
+			if err := services.ValidateUserPosition(ctx, op, p.TenantID(), p, departmentRepository, userRepository); err != nil {
+				logger.Errorf("User position %s failed validation: %v", p.ID(), err)
+				return err
+			}
+			if _, err := positionRepository.Save(ctx, p); err != nil {
+				logger.Errorf("Failed to save user position %s: %v", p.ID(), err)
+				return err
+			}
+			logger.Infof("User position %s saved", p.ID())
+		}
+		return nil
+	})
+}

--- a/modules/core/seed/seed_department_test.go
+++ b/modules/core/seed/seed_department_test.go
@@ -1,0 +1,17 @@
+package seed
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestOrgSeedFuncs_ValidSignatures ensures the department/user-position seed
+// funcs construct without panicking. application.Seed validates the injected
+// signature at construction time and panics on an invalid one, so a successful
+// build proves the dependency-injected parameter shapes (department/user repos,
+// org query) are well-formed.
+func TestOrgSeedFuncs_ValidSignatures(t *testing.T) {
+	require.NotNil(t, DepartmentsSeedFunc())
+	require.NotNil(t, UserPositionsSeedFunc())
+}

--- a/modules/core/services/department_service.go
+++ b/modules/core/services/department_service.go
@@ -1,0 +1,173 @@
+// Package services provides this package.
+package services
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/department"
+	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/query"
+	"github.com/iota-uz/iota-sdk/modules/core/permissions"
+	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"github.com/iota-uz/iota-sdk/pkg/eventbus"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
+)
+
+// DepartmentService provides operations for managing departments.
+type DepartmentService struct {
+	repo      department.Repository
+	orgQuery  query.OrgQueryRepository
+	publisher eventbus.EventBus
+}
+
+// NewDepartmentService creates a new department service instance. orgQuery
+// supplies the recursive subtree walk used for hierarchy cycle detection on
+// write.
+func NewDepartmentService(
+	repo department.Repository,
+	orgQuery query.OrgQueryRepository,
+	publisher eventbus.EventBus,
+) *DepartmentService {
+	return &DepartmentService{
+		repo:      repo,
+		orgQuery:  orgQuery,
+		publisher: publisher,
+	}
+}
+
+// Count returns the total number of departments.
+func (s *DepartmentService) Count(ctx context.Context, params *department.FindParams) (int64, error) {
+	if err := composables.CanUser(ctx, permissions.DepartmentRead); err != nil {
+		return 0, err
+	}
+	return s.repo.Count(ctx, params)
+}
+
+// GetPaginated returns a paginated list of departments.
+func (s *DepartmentService) GetPaginated(
+	ctx context.Context,
+	params *department.FindParams,
+) ([]department.Department, error) {
+	if err := composables.CanUser(ctx, permissions.DepartmentRead); err != nil {
+		return nil, err
+	}
+	return s.repo.GetPaginated(ctx, params)
+}
+
+// GetByID returns a department by its ID.
+func (s *DepartmentService) GetByID(ctx context.Context, id uuid.UUID) (department.Department, error) {
+	if err := composables.CanUser(ctx, permissions.DepartmentRead); err != nil {
+		return nil, err
+	}
+	return s.repo.GetByID(ctx, id)
+}
+
+// GetAll returns all departments.
+func (s *DepartmentService) GetAll(ctx context.Context) ([]department.Department, error) {
+	if err := composables.CanUser(ctx, permissions.DepartmentRead); err != nil {
+		return nil, err
+	}
+	return s.repo.GetPaginated(ctx, &department.FindParams{
+		Limit: 1000,
+	})
+}
+
+// Create creates a new department.
+func (s *DepartmentService) Create(ctx context.Context, d department.Department) (department.Department, error) {
+	const op serrors.Op = "DepartmentService.Create"
+	if err := composables.CanUser(ctx, permissions.DepartmentCreate); err != nil {
+		return nil, err
+	}
+
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return nil, serrors.E(op, err)
+	}
+
+	actor, err := composables.UseUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var saved department.Department
+	err = composables.InTx(ctx, func(txCtx context.Context) error {
+		if err := ValidateDepartment(txCtx, op, tenantID, d, s.repo, s.orgQuery.DepartmentSubtree); err != nil {
+			return err
+		}
+		saved, err = s.repo.Save(txCtx, d)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	s.publisher.Publish(department.NewCreatedEvent(saved, actor))
+	return saved, nil
+}
+
+// Update updates an existing department.
+func (s *DepartmentService) Update(ctx context.Context, d department.Department) (department.Department, error) {
+	const op serrors.Op = "DepartmentService.Update"
+	if err := composables.CanUser(ctx, permissions.DepartmentUpdate); err != nil {
+		return nil, err
+	}
+
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return nil, serrors.E(op, err)
+	}
+
+	actor, err := composables.UseUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var oldDepartment department.Department
+	var updated department.Department
+	err = composables.InTx(ctx, func(txCtx context.Context) error {
+		var err error
+		oldDepartment, err = s.repo.GetByID(txCtx, d.ID())
+		if err != nil {
+			return err
+		}
+		if err := ValidateDepartment(txCtx, op, tenantID, d, s.repo, s.orgQuery.DepartmentSubtree); err != nil {
+			return err
+		}
+		updated, err = s.repo.Save(txCtx, d)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	s.publisher.Publish(department.NewUpdatedEvent(oldDepartment, updated, actor))
+	return updated, nil
+}
+
+// Delete removes a department by its ID.
+func (s *DepartmentService) Delete(ctx context.Context, id uuid.UUID) error {
+	if err := composables.CanUser(ctx, permissions.DepartmentDelete); err != nil {
+		return err
+	}
+
+	actor, err := composables.UseUser(ctx)
+	if err != nil {
+		return err
+	}
+
+	var d department.Department
+	err = composables.InTx(ctx, func(txCtx context.Context) error {
+		var err error
+		d, err = s.repo.GetByID(txCtx, id)
+		if err != nil {
+			return err
+		}
+		return s.repo.Delete(txCtx, id)
+	})
+	if err != nil {
+		return err
+	}
+
+	s.publisher.Publish(department.NewDeletedEvent(d, actor))
+	return nil
+}

--- a/modules/core/services/department_service.go
+++ b/modules/core/services/department_service.go
@@ -62,7 +62,10 @@ func (s *DepartmentService) GetByID(ctx context.Context, id uuid.UUID) (departme
 	return s.repo.GetByID(ctx, id)
 }
 
-// GetAll returns all departments.
+// GetAll returns departments for the caller's tenant, up to a fixed cap of
+// 1000 rows. This is a convenience for small organizations and admin pickers;
+// it is NOT a complete listing. Callers that may exceed 1000 departments must
+// use GetPaginated with explicit Limit/Offset instead.
 func (s *DepartmentService) GetAll(ctx context.Context) ([]department.Department, error) {
 	if err := composables.CanUser(ctx, permissions.DepartmentRead); err != nil {
 		return nil, err
@@ -146,13 +149,14 @@ func (s *DepartmentService) Update(ctx context.Context, d department.Department)
 
 // Delete removes a department by its ID.
 func (s *DepartmentService) Delete(ctx context.Context, id uuid.UUID) error {
+	const op serrors.Op = "DepartmentService.Delete"
 	if err := composables.CanUser(ctx, permissions.DepartmentDelete); err != nil {
 		return err
 	}
 
 	actor, err := composables.UseUser(ctx)
 	if err != nil {
-		return err
+		return serrors.E(op, err)
 	}
 
 	var d department.Department
@@ -165,7 +169,7 @@ func (s *DepartmentService) Delete(ctx context.Context, id uuid.UUID) error {
 		return s.repo.Delete(txCtx, id)
 	})
 	if err != nil {
-		return err
+		return serrors.E(op, err)
 	}
 
 	s.publisher.Publish(department.NewDeletedEvent(d, actor))

--- a/modules/core/services/org_query_service.go
+++ b/modules/core/services/org_query_service.go
@@ -1,0 +1,62 @@
+// Package services provides this package.
+package services
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/query"
+	"github.com/iota-uz/iota-sdk/modules/core/permissions"
+	"github.com/iota-uz/iota-sdk/pkg/composables"
+)
+
+// OrgQuery is the consumer-facing read API for organizational membership and
+// hierarchy lookups. It is the foundation that permission-scoping code (e.g.
+// EDO granular permissions) builds on. All lookups are tenant-scoped.
+type OrgQuery interface {
+	// UserDepartments returns the departments the user holds a position in.
+	UserDepartments(ctx context.Context, userID uint) ([]uuid.UUID, error)
+	// UserManagedDepartments returns the departments where the user holds a
+	// manager position. When includeSubtree is true the result also contains
+	// every descendant department.
+	UserManagedDepartments(ctx context.Context, userID uint, includeSubtree bool) ([]uuid.UUID, error)
+	// DepartmentSubtree returns the department and all of its descendants.
+	DepartmentSubtree(ctx context.Context, deptID uuid.UUID) ([]uuid.UUID, error)
+}
+
+// OrgQueryService implements OrgQuery on top of the org query repository.
+type OrgQueryService struct {
+	repo query.OrgQueryRepository
+}
+
+// NewOrgQueryService creates a new org query service instance.
+func NewOrgQueryService(repo query.OrgQueryRepository) *OrgQueryService {
+	return &OrgQueryService{repo: repo}
+}
+
+var _ OrgQuery = (*OrgQueryService)(nil)
+
+func (s *OrgQueryService) UserDepartments(ctx context.Context, userID uint) ([]uuid.UUID, error) {
+	if err := composables.CanUser(ctx, permissions.DepartmentRead); err != nil {
+		return nil, err
+	}
+	return s.repo.UserDepartments(ctx, userID)
+}
+
+func (s *OrgQueryService) UserManagedDepartments(
+	ctx context.Context,
+	userID uint,
+	includeSubtree bool,
+) ([]uuid.UUID, error) {
+	if err := composables.CanUser(ctx, permissions.DepartmentRead); err != nil {
+		return nil, err
+	}
+	return s.repo.UserManagedDepartments(ctx, userID, includeSubtree)
+}
+
+func (s *OrgQueryService) DepartmentSubtree(ctx context.Context, deptID uuid.UUID) ([]uuid.UUID, error) {
+	if err := composables.CanUser(ctx, permissions.DepartmentRead); err != nil {
+		return nil, err
+	}
+	return s.repo.DepartmentSubtree(ctx, deptID)
+}

--- a/modules/core/services/org_service_test.go
+++ b/modules/core/services/org_service_test.go
@@ -73,7 +73,7 @@ func requireValidation(t *testing.T, err error) {
 	require.Error(t, err)
 	var se *serrors.Error
 	if assert.ErrorAs(t, err, &se) {
-		assert.Equal(t, "validation", se.ErrorKind(), "expected a validation-kind error, got: %v", err)
+		assert.Equalf(t, "validation", se.ErrorKind(), "expected a validation-kind error, got: %v", err)
 	}
 }
 

--- a/modules/core/services/org_service_test.go
+++ b/modules/core/services/org_service_test.go
@@ -1,0 +1,285 @@
+package services_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/department"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/user"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/userposition"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/value_objects/internet"
+	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence"
+	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/query"
+	"github.com/iota-uz/iota-sdk/modules/core/permissions"
+	"github.com/iota-uz/iota-sdk/modules/core/services"
+	"github.com/iota-uz/iota-sdk/pkg/composables"
+	crudmodels "github.com/iota-uz/iota-sdk/pkg/crud/models"
+	"github.com/iota-uz/iota-sdk/pkg/eventbus"
+	"github.com/iota-uz/iota-sdk/pkg/itf"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withActor injects a permissioned actor into ctx so service-layer permission
+// checks (CanUser) and actor resolution (UseUser) succeed. The actor only
+// drives RBAC/event attribution; tenant scoping still comes from the context's
+// tenant id, so a single actor is reused across tenant contexts.
+func withActor(ctx context.Context) context.Context {
+	actor := itf.User(
+		permissions.DepartmentCreate,
+		permissions.DepartmentUpdate,
+		permissions.DepartmentRead,
+		permissions.PositionCreate,
+		permissions.PositionUpdate,
+		permissions.PositionRead,
+	)
+	return composables.WithUser(ctx, actor)
+}
+
+func orgName(t *testing.T, base string) crudmodels.MultiLang {
+	t.Helper()
+	ml, err := crudmodels.NewMultiLangFromMap(map[string]string{
+		"en":      base + " EN",
+		"ru":      base + " RU",
+		"uz":      base + " UZ",
+		"uz-Cyrl": base + " UZ-CYRL",
+	})
+	require.NoError(t, err)
+	return ml
+}
+
+func newDepartmentService() (*services.DepartmentService, department.Repository, query.OrgQueryRepository) {
+	repo := persistence.NewDepartmentRepository()
+	orgQuery := query.NewPgOrgQueryRepository()
+	bus := eventbus.NewEventPublisher(logrus.New())
+	return services.NewDepartmentService(repo, orgQuery, bus), repo, orgQuery
+}
+
+func newUserPositionService() (*services.UserPositionService, department.Repository, user.Repository) {
+	uploadRepo := persistence.NewUploadRepository()
+	userRepo := persistence.NewUserRepository(uploadRepo)
+	deptRepo := persistence.NewDepartmentRepository()
+	posRepo := persistence.NewUserPositionRepository()
+	bus := eventbus.NewEventPublisher(logrus.New())
+	return services.NewUserPositionService(posRepo, deptRepo, userRepo, bus), deptRepo, userRepo
+}
+
+// requireValidation asserts err is non-nil and classified as a validation error.
+func requireValidation(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	var se *serrors.Error
+	if assert.ErrorAs(t, err, &se) {
+		assert.Equal(t, "validation", se.ErrorKind(), "expected a validation-kind error, got: %v", err)
+	}
+}
+
+func TestDepartmentService_Create_StructuralValidation(t *testing.T) {
+	t.Parallel()
+	f := setupTest(t)
+	svc, repo, _ := newDepartmentService()
+
+	ctx := withActor(f.Ctx)
+	tenantA, err := composables.UseTenantID(ctx)
+	require.NoError(t, err)
+
+	t.Run("rejects missing locale", func(t *testing.T) {
+		partial, err := crudmodels.NewMultiLangFromMap(map[string]string{"en": "x", "ru": "y", "uz": "z"})
+		require.NoError(t, err)
+		_, err = svc.Create(ctx, department.New(
+			"NO-LOCALE", partial,
+			department.WithID(uuid.New()), department.WithTenantID(tenantA),
+		))
+		requireValidation(t, err)
+	})
+
+	t.Run("rejects self-referential parent", func(t *testing.T) {
+		id := uuid.New()
+		_, err := svc.Create(ctx, department.New(
+			"SELF", orgName(t, "Self"),
+			department.WithID(id), department.WithTenantID(tenantA),
+			department.WithParentID(&id),
+		))
+		requireValidation(t, err)
+	})
+
+	t.Run("rejects non-existent parent", func(t *testing.T) {
+		missing := uuid.New()
+		_, err := svc.Create(ctx, department.New(
+			"NOPARENT", orgName(t, "NoParent"),
+			department.WithID(uuid.New()), department.WithTenantID(tenantA),
+			department.WithParentID(&missing),
+		))
+		requireValidation(t, err)
+	})
+
+	t.Run("rejects cross-tenant parent", func(t *testing.T) {
+		// Parent lives in tenant A; child attempts to attach from tenant B.
+		parentID := uuid.New()
+		_, err := repo.Save(ctx, department.New(
+			"XT-PARENT", orgName(t, "Parent"),
+			department.WithID(parentID), department.WithTenantID(tenantA),
+		))
+		require.NoError(t, err)
+
+		secondTenant := mkTenant(t, f)
+		ctxB := withActor(composables.WithTenantID(f.Ctx, secondTenant))
+		_, err = svc.Create(ctxB, department.New(
+			"XT-CHILD", orgName(t, "Child"),
+			department.WithID(uuid.New()), department.WithTenantID(secondTenant),
+			department.WithParentID(&parentID),
+		))
+		requireValidation(t, err)
+	})
+
+	t.Run("accepts valid parent in same tenant", func(t *testing.T) {
+		parentID := uuid.New()
+		_, err := svc.Create(ctx, department.New(
+			"OK-PARENT", orgName(t, "OkParent"),
+			department.WithID(parentID), department.WithTenantID(tenantA),
+		))
+		require.NoError(t, err)
+
+		_, err = svc.Create(ctx, department.New(
+			"OK-CHILD", orgName(t, "OkChild"),
+			department.WithID(uuid.New()), department.WithTenantID(tenantA),
+			department.WithParentID(&parentID),
+		))
+		require.NoError(t, err)
+	})
+}
+
+func TestDepartmentService_Update_CycleRejected(t *testing.T) {
+	t.Parallel()
+	f := setupTest(t)
+	svc, _, _ := newDepartmentService()
+
+	ctx := withActor(f.Ctx)
+	tenantA, err := composables.UseTenantID(ctx)
+	require.NoError(t, err)
+
+	// Build A -> B -> C.
+	aID := uuid.New()
+	a, err := svc.Create(ctx, department.New(
+		"CYC-A", orgName(t, "A"),
+		department.WithID(aID), department.WithTenantID(tenantA),
+	))
+	require.NoError(t, err)
+
+	bID := uuid.New()
+	_, err = svc.Create(ctx, department.New(
+		"CYC-B", orgName(t, "B"),
+		department.WithID(bID), department.WithTenantID(tenantA),
+		department.WithParentID(&aID),
+	))
+	require.NoError(t, err)
+
+	cID := uuid.New()
+	_, err = svc.Create(ctx, department.New(
+		"CYC-C", orgName(t, "C"),
+		department.WithID(cID), department.WithTenantID(tenantA),
+		department.WithParentID(&bID),
+	))
+	require.NoError(t, err)
+
+	t.Run("reparenting A under its descendant C is rejected", func(t *testing.T) {
+		// A is the root; making C (a descendant) its parent forms a cycle.
+		_, err := svc.Update(ctx, a.SetParentID(&cID))
+		requireValidation(t, err)
+	})
+
+	t.Run("reparenting A under itself is rejected", func(t *testing.T) {
+		_, err := svc.Update(ctx, a.SetParentID(&aID))
+		requireValidation(t, err)
+	})
+}
+
+func TestUserPositionService_Create_RefValidation(t *testing.T) {
+	t.Parallel()
+	f := setupTest(t)
+	svc, deptRepo, userRepo := newUserPositionService()
+
+	ctx := withActor(f.Ctx)
+	tenantA, err := composables.UseTenantID(ctx)
+	require.NoError(t, err)
+
+	// Valid user + department in tenant A.
+	emailA, err := internet.NewEmail("pos-svc-a@gmail.com")
+	require.NoError(t, err)
+	userA, err := userRepo.Create(ctx, user.New(
+		"Pos", "A", emailA, user.UILanguageEN, user.WithTenantID(tenantA),
+	))
+	require.NoError(t, err)
+
+	deptAID := uuid.New()
+	_, err = deptRepo.Save(ctx, department.New(
+		"POS-A", orgName(t, "DeptA"),
+		department.WithID(deptAID), department.WithTenantID(tenantA),
+	))
+	require.NoError(t, err)
+
+	t.Run("rejects non-existent department", func(t *testing.T) {
+		_, err := svc.Create(ctx, userposition.New(
+			userA.ID(), uuid.New(), orgName(t, "Eng"),
+			userposition.WithID(uuid.New()), userposition.WithTenantID(tenantA),
+		))
+		requireValidation(t, err)
+	})
+
+	t.Run("rejects cross-tenant department", func(t *testing.T) {
+		// Department exists only in tenant B; tenant-A caller must be rejected.
+		secondTenant := mkTenant(t, f)
+		ctxB := composables.WithTenantID(f.Ctx, secondTenant)
+		deptBID := uuid.New()
+		_, err := deptRepo.Save(ctxB, department.New(
+			"POS-B", orgName(t, "DeptB"),
+			department.WithID(deptBID), department.WithTenantID(secondTenant),
+		))
+		require.NoError(t, err)
+
+		_, err = svc.Create(ctx, userposition.New(
+			userA.ID(), deptBID, orgName(t, "Eng"),
+			userposition.WithID(uuid.New()), userposition.WithTenantID(tenantA),
+		))
+		requireValidation(t, err)
+	})
+
+	t.Run("rejects cross-tenant user", func(t *testing.T) {
+		// User exists only in tenant B; assigning to a tenant-A department
+		// from a tenant-A caller must be rejected on the user reference.
+		secondTenant := mkTenant(t, f)
+		ctxB := composables.WithTenantID(f.Ctx, secondTenant)
+		emailB, err := internet.NewEmail("pos-svc-b@gmail.com")
+		require.NoError(t, err)
+		userB, err := userRepo.Create(ctxB, user.New(
+			"Pos", "B", emailB, user.UILanguageEN, user.WithTenantID(secondTenant),
+		))
+		require.NoError(t, err)
+
+		_, err = svc.Create(ctx, userposition.New(
+			userB.ID(), deptAID, orgName(t, "Eng"),
+			userposition.WithID(uuid.New()), userposition.WithTenantID(tenantA),
+		))
+		requireValidation(t, err)
+	})
+
+	t.Run("accepts valid same-tenant references", func(t *testing.T) {
+		_, err := svc.Create(ctx, userposition.New(
+			userA.ID(), deptAID, orgName(t, "Eng"),
+			userposition.WithID(uuid.New()), userposition.WithTenantID(tenantA),
+		))
+		require.NoError(t, err)
+	})
+}
+
+// mkTenant provisions a second tenant for cross-tenant service tests and
+// returns its ID.
+func mkTenant(t *testing.T, f *itf.TestEnvironment) uuid.UUID {
+	t.Helper()
+	secondTenant, err := itf.CreateTestTenant(f.Ctx, f.Pool)
+	require.NoError(t, err)
+	return secondTenant.ID
+}

--- a/modules/core/services/org_validation.go
+++ b/modules/core/services/org_validation.go
@@ -1,0 +1,190 @@
+// Package services hosts organizational-model write-path validation shared by
+// the department/user-position services and their seeders (tenant isolation,
+// hierarchy integrity, multilingual completeness).
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/department"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/user"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/userposition"
+	"github.com/iota-uz/iota-sdk/pkg/crud/models"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
+)
+
+// orgRequiredLocales is the set of locale codes that every multilingual
+// organizational name/title must populate. These mirror the EAI-supported UI
+// languages (see pkg/intl: en, ru, uz, uz-Cyrl).
+var orgRequiredLocales = []string{"en", "ru", "uz", "uz-Cyrl"}
+
+// SubtreeFunc returns the department subtree rooted at the given department id
+// (the department itself plus all descendants). It is satisfied by
+// query.OrgQueryRepository.DepartmentSubtree and the OrgQuery service, and is
+// injected so this package stays decoupled from a concrete query backend.
+type SubtreeFunc func(ctx context.Context, deptID uuid.UUID) ([]uuid.UUID, error)
+
+// validateOrgMultiLang ensures a multilingual value is present and carries a
+// non-empty translation for every required locale. field is used to build a
+// human-readable error context (e.g. "name", "title").
+func validateOrgMultiLang(op serrors.Op, field string, ml models.MultiLang) error {
+	if ml == nil || ml.IsEmpty() {
+		return serrors.E(op, serrors.KindValidation, fmt.Errorf("%s must be provided in all required locales", field))
+	}
+	var missing []string
+	for _, locale := range orgRequiredLocales {
+		if !ml.HasLocale(locale) {
+			missing = append(missing, locale)
+		}
+	}
+	if len(missing) > 0 {
+		return serrors.E(
+			op,
+			serrors.KindValidation,
+			fmt.Errorf("%s is missing required locales: %v", field, missing),
+		)
+	}
+	return nil
+}
+
+// ValidateDepartment enforces the department write-path invariants: a complete
+// multilingual name and, when a parent is set, a structurally sound and
+// tenant-consistent hierarchy. It is the single validation entrypoint shared by
+// DepartmentService (Create/Update) and the department seeder.
+//
+// tenantID is the authoritative caller tenant (resolved from context in
+// services, or the seeded row's own tenant in seeds). repo loads the parent and
+// subtree resolves the department's descendant set for cycle detection. All
+// lookups run against the context's transaction, so this must be called inside
+// the same unit of work as the subsequent save.
+func ValidateDepartment(
+	ctx context.Context,
+	op serrors.Op,
+	tenantID uuid.UUID,
+	d department.Department,
+	repo department.Repository,
+	subtree SubtreeFunc,
+) error {
+	if err := validateOrgMultiLang(op, "name", d.NameI18n()); err != nil {
+		return err
+	}
+	return validateDepartmentParent(ctx, op, tenantID, d.ID(), d.ParentID(), repo, subtree)
+}
+
+// validateDepartmentParent rejects parent assignments that would corrupt the
+// tenant boundary or the hierarchy: a missing parent, a cross-tenant parent, a
+// self-reference, or a parent that already sits within the department's own
+// subtree (which would create a cycle). A nil parentID is always valid.
+func validateDepartmentParent(
+	ctx context.Context,
+	op serrors.Op,
+	tenantID uuid.UUID,
+	deptID uuid.UUID,
+	parentID *uuid.UUID,
+	repo department.Repository,
+	subtree SubtreeFunc,
+) error {
+	if parentID == nil {
+		return nil
+	}
+
+	if *parentID == deptID {
+		return serrors.E(op, serrors.KindValidation, fmt.Errorf("department %s cannot be its own parent", deptID))
+	}
+
+	parent, err := repo.GetByID(ctx, *parentID)
+	if err != nil {
+		return serrors.E(op, serrors.KindValidation, fmt.Errorf("parent department %s not found: %w", *parentID, err))
+	}
+	if parent.TenantID() != tenantID {
+		return serrors.E(
+			op,
+			serrors.KindValidation,
+			fmt.Errorf("parent department %s belongs to a different tenant", *parentID),
+		)
+	}
+
+	// Cycle detection: the new parent must not be the department itself or any
+	// of its descendants. On create the department row does not yet exist, so
+	// the subtree is empty and this check is a no-op.
+	descendants, err := subtree(ctx, deptID)
+	if err != nil {
+		return serrors.E(op, fmt.Errorf("failed to resolve department subtree for cycle check: %w", err))
+	}
+	for _, id := range descendants {
+		if id == *parentID {
+			return serrors.E(
+				op,
+				serrors.KindValidation,
+				fmt.Errorf("parent department %s is a descendant of %s (would create a cycle)", *parentID, deptID),
+			)
+		}
+	}
+
+	return nil
+}
+
+// ValidateUserPosition enforces the user-position write-path invariants: a
+// complete multilingual title plus tenant-consistent department and user
+// references. It is the single validation entrypoint shared by
+// UserPositionService (Create/Update) and the user-position seeder.
+//
+// tenantID is the authoritative caller tenant. deptRepo/userRepo load the
+// referenced rows; both lookups run against the context's transaction and must
+// be called inside the same unit of work as the subsequent save.
+func ValidateUserPosition(
+	ctx context.Context,
+	op serrors.Op,
+	tenantID uuid.UUID,
+	p userposition.UserPosition,
+	deptRepo department.Repository,
+	userRepo user.Repository,
+) error {
+	if err := validateOrgMultiLang(op, "title", p.TitleI18n()); err != nil {
+		return err
+	}
+	return validatePositionRefs(ctx, op, tenantID, p.UserID(), p.DepartmentID(), deptRepo, userRepo)
+}
+
+// validatePositionRefs rejects a position whose department or user is missing
+// or belongs to a different tenant than the caller. The repositories are
+// tenant-scoped, so a cross-tenant reference surfaces as "not found"; the
+// explicit tenant comparison documents the invariant and guards any future
+// unscoped lookup path.
+func validatePositionRefs(
+	ctx context.Context,
+	op serrors.Op,
+	tenantID uuid.UUID,
+	userID uint,
+	departmentID uuid.UUID,
+	deptRepo department.Repository,
+	userRepo user.Repository,
+) error {
+	dept, err := deptRepo.GetByID(ctx, departmentID)
+	if err != nil {
+		return serrors.E(op, serrors.KindValidation, fmt.Errorf("department %s not found: %w", departmentID, err))
+	}
+	if dept.TenantID() != tenantID {
+		return serrors.E(
+			op,
+			serrors.KindValidation,
+			fmt.Errorf("department %s belongs to a different tenant", departmentID),
+		)
+	}
+
+	targetUser, err := userRepo.GetByID(ctx, userID)
+	if err != nil {
+		return serrors.E(op, serrors.KindValidation, fmt.Errorf("user %d not found: %w", userID, err))
+	}
+	if targetUser.TenantID() != tenantID {
+		return serrors.E(
+			op,
+			serrors.KindValidation,
+			fmt.Errorf("user %d belongs to a different tenant", userID),
+		)
+	}
+
+	return nil
+}

--- a/modules/core/services/org_validation.go
+++ b/modules/core/services/org_validation.go
@@ -67,6 +67,13 @@ func ValidateDepartment(
 	repo department.Repository,
 	subtree SubtreeFunc,
 ) error {
+	if d.TenantID() != tenantID {
+		return serrors.E(
+			op,
+			serrors.KindValidation,
+			fmt.Errorf("department %s belongs to a different tenant than the caller", d.ID()),
+		)
+	}
 	if err := validateOrgMultiLang(op, "name", d.NameI18n()); err != nil {
 		return err
 	}
@@ -142,6 +149,13 @@ func ValidateUserPosition(
 	deptRepo department.Repository,
 	userRepo user.Repository,
 ) error {
+	if p.TenantID() != tenantID {
+		return serrors.E(
+			op,
+			serrors.KindValidation,
+			fmt.Errorf("user position %s belongs to a different tenant than the caller", p.ID()),
+		)
+	}
 	if err := validateOrgMultiLang(op, "title", p.TitleI18n()); err != nil {
 		return err
 	}

--- a/modules/core/services/org_validation_test.go
+++ b/modules/core/services/org_validation_test.go
@@ -1,0 +1,52 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/iota-uz/iota-sdk/pkg/crud/models"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateOrgMultiLang(t *testing.T) {
+	t.Parallel()
+
+	const op serrors.Op = "test"
+
+	t.Run("all required locales present", func(t *testing.T) {
+		t.Parallel()
+		ml, err := models.NewMultiLangFromMap(map[string]string{
+			"en":      "Engineering",
+			"ru":      "Инженерия",
+			"uz":      "Muhandislik",
+			"uz-Cyrl": "Муҳандислик",
+		})
+		require.NoError(t, err)
+		require.NoError(t, validateOrgMultiLang(op, "name", ml))
+	})
+
+	t.Run("nil value rejected", func(t *testing.T) {
+		t.Parallel()
+		require.Error(t, validateOrgMultiLang(op, "name", nil))
+	})
+
+	t.Run("missing locale rejected", func(t *testing.T) {
+		t.Parallel()
+		ml, err := models.NewMultiLangFromMap(map[string]string{
+			"en": "Engineering",
+			"ru": "Инженерия",
+			"uz": "Muhandislik",
+			// uz-Cyrl intentionally omitted
+		})
+		require.NoError(t, err)
+		err = validateOrgMultiLang(op, "name", ml)
+		require.Error(t, err)
+	})
+
+	t.Run("empty value rejected", func(t *testing.T) {
+		t.Parallel()
+		ml, err := models.NewMultiLangFromMap(map[string]string{})
+		require.NoError(t, err)
+		require.Error(t, validateOrgMultiLang(op, "title", ml))
+	})
+}

--- a/modules/core/services/user_position_service.go
+++ b/modules/core/services/user_position_service.go
@@ -146,13 +146,14 @@ func (s *UserPositionService) Update(
 
 // Delete removes a user position by its ID.
 func (s *UserPositionService) Delete(ctx context.Context, id uuid.UUID) error {
+	const op serrors.Op = "UserPositionService.Delete"
 	if err := composables.CanUser(ctx, permissions.PositionDelete); err != nil {
 		return err
 	}
 
 	actor, err := composables.UseUser(ctx)
 	if err != nil {
-		return err
+		return serrors.E(op, err)
 	}
 
 	var p userposition.UserPosition
@@ -165,7 +166,7 @@ func (s *UserPositionService) Delete(ctx context.Context, id uuid.UUID) error {
 		return s.repo.Delete(txCtx, id)
 	})
 	if err != nil {
-		return err
+		return serrors.E(op, err)
 	}
 
 	s.publisher.Publish(userposition.NewDeletedEvent(p, actor))

--- a/modules/core/services/user_position_service.go
+++ b/modules/core/services/user_position_service.go
@@ -1,0 +1,173 @@
+// Package services provides this package.
+package services
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/department"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/user"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/userposition"
+	"github.com/iota-uz/iota-sdk/modules/core/permissions"
+	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"github.com/iota-uz/iota-sdk/pkg/eventbus"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
+)
+
+// UserPositionService provides operations for managing user positions.
+type UserPositionService struct {
+	repo      userposition.Repository
+	deptRepo  department.Repository
+	userRepo  user.Repository
+	publisher eventbus.EventBus
+}
+
+// NewUserPositionService creates a new user position service instance.
+// deptRepo and userRepo are used to validate that a position's department and
+// user references stay within the caller's tenant.
+func NewUserPositionService(
+	repo userposition.Repository,
+	deptRepo department.Repository,
+	userRepo user.Repository,
+	publisher eventbus.EventBus,
+) *UserPositionService {
+	return &UserPositionService{
+		repo:      repo,
+		deptRepo:  deptRepo,
+		userRepo:  userRepo,
+		publisher: publisher,
+	}
+}
+
+// Count returns the total number of user positions.
+func (s *UserPositionService) Count(ctx context.Context, params *userposition.FindParams) (int64, error) {
+	if err := composables.CanUser(ctx, permissions.PositionRead); err != nil {
+		return 0, err
+	}
+	return s.repo.Count(ctx, params)
+}
+
+// GetPaginated returns a paginated list of user positions.
+func (s *UserPositionService) GetPaginated(
+	ctx context.Context,
+	params *userposition.FindParams,
+) ([]userposition.UserPosition, error) {
+	if err := composables.CanUser(ctx, permissions.PositionRead); err != nil {
+		return nil, err
+	}
+	return s.repo.GetPaginated(ctx, params)
+}
+
+// GetByID returns a user position by its ID.
+func (s *UserPositionService) GetByID(ctx context.Context, id uuid.UUID) (userposition.UserPosition, error) {
+	if err := composables.CanUser(ctx, permissions.PositionRead); err != nil {
+		return nil, err
+	}
+	return s.repo.GetByID(ctx, id)
+}
+
+// Create creates a new user position.
+func (s *UserPositionService) Create(
+	ctx context.Context,
+	p userposition.UserPosition,
+) (userposition.UserPosition, error) {
+	const op serrors.Op = "UserPositionService.Create"
+	if err := composables.CanUser(ctx, permissions.PositionCreate); err != nil {
+		return nil, err
+	}
+
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return nil, serrors.E(op, err)
+	}
+
+	actor, err := composables.UseUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var saved userposition.UserPosition
+	err = composables.InTx(ctx, func(txCtx context.Context) error {
+		if err := ValidateUserPosition(txCtx, op, tenantID, p, s.deptRepo, s.userRepo); err != nil {
+			return err
+		}
+		saved, err = s.repo.Save(txCtx, p)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	s.publisher.Publish(userposition.NewCreatedEvent(saved, actor))
+	return saved, nil
+}
+
+// Update updates an existing user position.
+func (s *UserPositionService) Update(
+	ctx context.Context,
+	p userposition.UserPosition,
+) (userposition.UserPosition, error) {
+	const op serrors.Op = "UserPositionService.Update"
+	if err := composables.CanUser(ctx, permissions.PositionUpdate); err != nil {
+		return nil, err
+	}
+
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return nil, serrors.E(op, err)
+	}
+
+	actor, err := composables.UseUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var oldPosition userposition.UserPosition
+	var updated userposition.UserPosition
+	err = composables.InTx(ctx, func(txCtx context.Context) error {
+		var err error
+		oldPosition, err = s.repo.GetByID(txCtx, p.ID())
+		if err != nil {
+			return err
+		}
+		if err := ValidateUserPosition(txCtx, op, tenantID, p, s.deptRepo, s.userRepo); err != nil {
+			return err
+		}
+		updated, err = s.repo.Save(txCtx, p)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	s.publisher.Publish(userposition.NewUpdatedEvent(oldPosition, updated, actor))
+	return updated, nil
+}
+
+// Delete removes a user position by its ID.
+func (s *UserPositionService) Delete(ctx context.Context, id uuid.UUID) error {
+	if err := composables.CanUser(ctx, permissions.PositionDelete); err != nil {
+		return err
+	}
+
+	actor, err := composables.UseUser(ctx)
+	if err != nil {
+		return err
+	}
+
+	var p userposition.UserPosition
+	err = composables.InTx(ctx, func(txCtx context.Context) error {
+		var err error
+		p, err = s.repo.GetByID(txCtx, id)
+		if err != nil {
+			return err
+		}
+		return s.repo.Delete(txCtx, id)
+	})
+	if err != nil {
+		return err
+	}
+
+	s.publisher.Publish(userposition.NewDeletedEvent(p, actor))
+	return nil
+}


### PR DESCRIPTION
Implements the backend foundation of #780 — a reusable organizational-unit model in `core`, the predecessor for EAI's EDO department-scoped access control (iota-uz/eai#2865).

## What

**Aggregates**
- `department` — hierarchical (self-referencing `parent_id`), tenant-scoped, multilingual `name` (jsonb), `order`/`status`.
- `userposition` — user↔department link with `is_manager` (dept-head) and `is_primary` flags, multilingual `title`.

**Read service** — `OrgQuery` (consumed by downstream access resolvers):
- `UserDepartments(userID)` — departments the user holds a position in
- `UserManagedDepartments(userID, includeSubtree)` — departments a user heads; subtree walk includes descendants
- `DepartmentSubtree(deptID)` — department + all descendants

Hierarchy walks use **recursive CTEs**, tenant-scoped on both anchor and recursive terms. **No Postgres views or triggers.**

**Write validation** (shared by services *and* seeders): 4-locale completeness (en/ru/uz/uz-Cyrl), cross-tenant rejection for `parent_id` / `department_id` / `user_id`, self-reference and re-parent **cycle** guards — all `serrors.KindValidation`.

**Plus**: `Department`/`Position` CRUD permissions (seeded), seed plumbing, DI wiring, migration `changes-1779808179.sql` (+ `core-schema.sql` sync).

## Design notes
- Mirrors the existing `group` aggregate vertical slice (interfaces, empty repos + `composables.UseTx`, `pkg/repo` builders, immutable setters).
- `user_positions.user_id` is `integer` to match `users.id`; all other PKs/tenant ids are `uuid`.
- Tenant integrity is enforced **app-side** (not composite FKs): a self-referencing `parent_id` with `ON DELETE SET NULL` is incompatible with a composite `(id, tenant_id)` FK, and app-level validation keeps `users`/schema untouched.

## Verification
- `go vet ./modules/core/...` and `./modules/... ./cmd/...` — clean
- `gofmt -l modules/core/` — clean
- Full new suite against a real Postgres — **49 pass / 0 fail**, incl. cross-tenant isolation (subtree never bleeds across tenants), structural/cross-tenant validation rejections, and re-parent cycle rejection
- Migration up → down → up — clean

## Follow-ups (not in this PR)
- Admin CRUD UI for departments + positions
- Real EAI org-chart seed data (plumbing is in place via `DepartmentsSeedFunc`/`UserPositionsSeedFunc`)

Closes #780

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage hierarchical departments (multilingual names, ordering, active/inactive) with full CRUD and validation.
  * Manage user positions linking users to departments (multilingual titles, manager/primary flags) with CRUD and validation.
  * Read-only org queries: user departments, managed departments (optionally with descendants), and department subtrees.
  * Permission-enforced services that publish lifecycle events.

* **Chores**
  * Database updated to support tenant-scoped org tables and tenant-qualified user references; seeders included.

* **Tests**
  * Integration and validation tests for CRUD, tenant isolation, queries and validation rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iota-uz/iota-sdk/pull/781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->