### PR TITLE
feat(core): tenant-qualified unique on user_groups (tenant_id, id)

### DIFF
--- a/migrations/changes-1779900000.sql
+++ b/migrations/changes-1779900000.sql
@@ -1,0 +1,14 @@
+-- Migration: Tenant-qualified unique key on user_groups
+-- Purpose: Add a UNIQUE (tenant_id, id) constraint to user_groups so downstream
+--   modules can declare tenant-qualified composite foreign keys
+--   (e.g. FOREIGN KEY (tenant_id, group_id) REFERENCES user_groups (tenant_id, id)),
+--   preventing cross-tenant references at the database level. id is already the
+--   primary key, so the composite is always satisfiable for existing rows.
+
+-- +migrate Up
+ALTER TABLE user_groups
+    ADD CONSTRAINT user_groups_tenant_id_id_key UNIQUE (tenant_id, id);
+
+-- +migrate Down
+ALTER TABLE user_groups
+    DROP CONSTRAINT IF EXISTS user_groups_tenant_id_id_key;

--- a/modules/core/infrastructure/persistence/schema/core-schema.sql
+++ b/modules/core/infrastructure/persistence/schema/core-schema.sql
@@ -124,7 +124,8 @@ CREATE TABLE user_groups (
     description text,
     created_at timestamp DEFAULT now(),
     updated_at timestamp DEFAULT now(),
-    UNIQUE (tenant_id, name)
+    UNIQUE (tenant_id, name),
+    CONSTRAINT user_groups_tenant_id_id_key UNIQUE (tenant_id, id)
 );
 
 CREATE TABLE group_users (


### PR DESCRIPTION
## What
Adds `UNIQUE (tenant_id, id)` to `user_groups` (migration `changes-1779900000.sql` + schema snapshot).

## Why
Downstream modules need to declare tenant-qualified composite foreign keys against `user_groups`:
```sql
FOREIGN KEY (tenant_id, group_id) REFERENCES user_groups (tenant_id, id)
```
so a row can never reference a group in another tenant — enforced by the database, not only the application. `id` is already the primary key, so the composite is always satisfiable for existing rows (no data change, safe additive constraint).

Mirrors the `users_tenant_id_id_key` / `departments_tenant_id_id_key` constraints added in the core org-model PR (#781).

## Unblocks
Tenant-qualified participant FKs in the EAI EDO granular-permissions work (iota-uz/eai#2865), addressing a Codex review finding (cross-tenant participant rows possible at the DB level).

## Risk
Minimal — single additive UNIQUE constraint; no data migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced database schema with improved data integrity constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iota-uz/iota-sdk/pull/783?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->