### PR TITLE
[codex] Add declarative sidebar workspaces

### DIFF
--- a/components/sidebar/sidebar.templ
+++ b/components/sidebar/sidebar.templ
@@ -19,6 +19,7 @@ const (
 type Props struct {
 	Header       templ.Component
 	TabGroups    TabGroupCollection
+	PinnedItems  []Item
 	Footer       templ.Component
 	InitialState SidebarState // Server-side initial state hint
 }
@@ -107,8 +108,22 @@ templ Sidebar(props Props) {
 }
 
 templ SidebarNav(props Props) {
-	{{ tabs := BuildSidebarNavTabs(ctx, props.TabGroups) }}
+	{{
+		tabs := BuildSidebarNavTabs(ctx, props.TabGroups)
+		pinnedNodes := buildSidebarNavNodes(ctx, props.PinnedItems)
+	}}
 	<nav x-data="sidebarNavigation()" x-init="initSidebarNavigation()" class="py-4 flex-1 min-h-0 overflow-y-auto hide-scrollbar">
+		if len(pinnedNodes) > 0 {
+			<ul
+				id="sidebar-pinned-navigation"
+				:class="{ 'px-2': isCollapsed, 'px-6': !isCollapsed }"
+				class="flex flex-col gap-2 pb-4 mb-4 border-b border-surface-300 transition-all duration-300"
+			>
+				for _, node := range pinnedNodes {
+					@SidebarNode(node, SidebarRenderModeMain, 0)
+				}
+			</ul>
+		}
 		for _, tab := range tabs {
 			@navtabs.Content(tab.Value) {
 				<ul

--- a/components/sidebar/sidebar.templ
+++ b/components/sidebar/sidebar.templ
@@ -150,11 +150,12 @@ templ SidebarPinnedNav(props Props) {
 // label) that switches the active tab via the same navTabs Alpine state used by
 // the expanded selector, so the two stay in sync.
 templ SidebarCollapsedWorkspaceTabs(props Props) {
-	<div x-show="isCollapsed" class="mt-4 flex flex-col items-center gap-1">
+	<div x-show="isCollapsed" role="tablist" aria-orientation="vertical" class="mt-4 flex flex-col items-center gap-1">
 		for _, group := range props.TabGroups.Groups {
 			<button
 				type="button"
 				role="tab"
+				aria-label={ group.Label }
 				data-tab-value={ group.Value }
 				@click={ fmt.Sprintf("setActiveTab('%s')", group.Value) }
 				x-bind:aria-selected={ fmt.Sprintf("isActive('%s') ? 'true' : 'false'", group.Value) }

--- a/components/sidebar/sidebar.templ
+++ b/components/sidebar/sidebar.templ
@@ -1,10 +1,12 @@
 package sidebar
 
 import (
+	"fmt"
 	icons "github.com/iota-uz/icons/phosphor"
 	"github.com/iota-uz/iota-sdk/components/base/button"
 	"github.com/iota-uz/iota-sdk/components/base/navtabs"
 	"strconv"
+	"strings"
 )
 
 // SidebarState represents the initial state of the sidebar
@@ -50,6 +52,19 @@ func depthAttr(depth int) string {
 	return strconv.Itoa(depth)
 }
 
+// workspaceTabBadge derives a compact, icon-sized label for the collapsed
+// workspace switcher. Short labels (e.g. "ERP", "CRM", "ЭДО") are shown as-is;
+// longer labels are truncated to their first 3 runes so they fit the 4rem rail.
+// The full label is always available via the button's tooltip.
+func workspaceTabBadge(label string) string {
+	label = strings.TrimSpace(label)
+	runes := []rune(label)
+	if len(runes) <= 3 {
+		return strings.ToUpper(label)
+	}
+	return strings.ToUpper(string(runes[:3]))
+}
+
 templ Sidebar(props Props) {
 	<div
 		x-data="sidebarShell()"
@@ -78,6 +93,7 @@ templ Sidebar(props Props) {
 				if props.Header != nil {
 					@props.Header
 				}
+				@SidebarPinnedNav(props)
 				if len(props.TabGroups.Groups) > 1 {
 					<div x-show="!isCollapsed" x-transition>
 						<div class="mt-4">
@@ -95,6 +111,7 @@ templ Sidebar(props Props) {
 							}
 						</div>
 					</div>
+					@SidebarCollapsedWorkspaceTabs(props)
 				}
 			</div>
 			@SidebarNav(props)
@@ -107,23 +124,58 @@ templ Sidebar(props Props) {
 	</div>
 }
 
-templ SidebarNav(props Props) {
-	{{
-		tabs := BuildSidebarNavTabs(ctx, props.TabGroups)
-		pinnedNodes := buildSidebarNavNodes(ctx, props.PinnedItems)
-	}}
-	<nav x-data="sidebarNavigation()" x-init="initSidebarNavigation()" class="py-4 flex-1 min-h-0 overflow-y-auto hide-scrollbar">
-		if len(pinnedNodes) > 0 {
+// SidebarPinnedNav renders the pinned navigation items above the workspace tab
+// selector. Pinned items stay visible regardless of the active workspace tab and
+// in the collapsed sidebar, so they live in the header region (outside the tab
+// content) rather than inside the scrollable per-tab nav.
+templ SidebarPinnedNav(props Props) {
+	{{ pinnedNodes := buildSidebarNavNodes(ctx, props.PinnedItems) }}
+	if len(pinnedNodes) > 0 {
+		<nav x-data="sidebarNavigation()" x-init="initSidebarNavigation()" class="mt-4">
 			<ul
 				id="sidebar-pinned-navigation"
-				:class="{ 'px-2': isCollapsed, 'px-6': !isCollapsed }"
-				class="flex flex-col gap-2 pb-4 mb-4 border-b border-surface-300 transition-all duration-300"
+				class="flex flex-col gap-2 pb-4 border-b border-surface-300"
 			>
 				for _, node := range pinnedNodes {
 					@SidebarNode(node, SidebarRenderModeMain, 0)
 				}
 			</ul>
+		</nav>
+	}
+}
+
+// SidebarCollapsedWorkspaceTabs renders the workspace selector for the collapsed
+// sidebar, where the horizontal tab bar is hidden. Each workspace becomes a
+// compact, icon-sized pill (badge label + right-placed tooltip with the full
+// label) that switches the active tab via the same navTabs Alpine state used by
+// the expanded selector, so the two stay in sync.
+templ SidebarCollapsedWorkspaceTabs(props Props) {
+	<div x-show="isCollapsed" class="mt-4 flex flex-col items-center gap-1">
+		for _, group := range props.TabGroups.Groups {
+			<button
+				type="button"
+				role="tab"
+				data-tab-value={ group.Value }
+				@click={ fmt.Sprintf("setActiveTab('%s')", group.Value) }
+				x-bind:aria-selected={ fmt.Sprintf("isActive('%s') ? 'true' : 'false'", group.Value) }
+				x-bind:class={ fmt.Sprintf("isActive('%s') ? 'bg-white text-slate-900' : 'text-gray-100 hover:bg-white/10'", group.Value) }
+				x-tooltip.placement.right.raw={ sidebarTooltipText(group.Label, group.IsBeta) }
+				class="relative w-10 h-10 rounded-xl text-[11px] font-semibold leading-none flex items-center justify-center transition-colors duration-200 !cursor-pointer"
+			>
+				{ workspaceTabBadge(group.Label) }
+				if group.IsBeta {
+					@SidebarBetaBadge("absolute -top-1 -right-1 z-10 pointer-events-none text-[8px] px-1", true)
+				}
+			</button>
 		}
+	</div>
+}
+
+templ SidebarNav(props Props) {
+	{{
+		tabs := BuildSidebarNavTabs(ctx, props.TabGroups)
+	}}
+	<nav x-data="sidebarNavigation()" x-init="initSidebarNavigation()" class="py-4 flex-1 min-h-0 overflow-y-auto hide-scrollbar">
 		for _, tab := range tabs {
 			@navtabs.Content(tab.Value) {
 				<ul

--- a/components/sidebar/sidebar_templ.go
+++ b/components/sidebar/sidebar_templ.go
@@ -324,90 +324,103 @@ func SidebarCollapsedWorkspaceTabs(props Props) templ.Component {
 			templ_7745c5c3_Var7 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<div x-show=\"isCollapsed\" class=\"mt-4 flex flex-col items-center gap-1\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<div x-show=\"isCollapsed\" role=\"tablist\" aria-orientation=\"vertical\" class=\"mt-4 flex flex-col items-center gap-1\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, group := range props.TabGroups.Groups {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<button type=\"button\" role=\"tab\" data-tab-value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<button type=\"button\" role=\"tab\" aria-label=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var8 string
-			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(group.Value)
+			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(group.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 158, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 158, Col: 28}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "\" @click=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "\" data-tab-value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var9 string
-			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("setActiveTab('%s')", group.Value))
+			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(group.Value)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 159, Col: 59}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 159, Col: 32}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\" x-bind:aria-selected=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\" @click=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var10 string
-			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("isActive('%s') ? 'true' : 'false'", group.Value))
+			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("setActiveTab('%s')", group.Value))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 160, Col: 88}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 160, Col: 59}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\" x-bind:class=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\" x-bind:aria-selected=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var11 string
-			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("isActive('%s') ? 'bg-white text-slate-900' : 'text-gray-100 hover:bg-white/10'", group.Value))
+			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("isActive('%s') ? 'true' : 'false'", group.Value))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 161, Col: 125}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 161, Col: 88}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\" x-tooltip.placement.right.raw=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\" x-bind:class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var12 string
-			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(sidebarTooltipText(group.Label, group.IsBeta))
+			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("isActive('%s') ? 'bg-white text-slate-900' : 'text-gray-100 hover:bg-white/10'", group.Value))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 162, Col: 81}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 162, Col: 125}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\" class=\"relative w-10 h-10 rounded-xl text-[11px] font-semibold leading-none flex items-center justify-center transition-colors duration-200 !cursor-pointer\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\" x-tooltip.placement.right.raw=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var13 string
-			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(workspaceTabBadge(group.Label))
+			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(sidebarTooltipText(group.Label, group.IsBeta))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 165, Col: 36}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 163, Col: 81}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "\" class=\"relative w-10 h-10 rounded-xl text-[11px] font-semibold leading-none flex items-center justify-center transition-colors duration-200 !cursor-pointer\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var14 string
+			templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(workspaceTabBadge(group.Label))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 166, Col: 36}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -417,12 +430,12 @@ func SidebarCollapsedWorkspaceTabs(props Props) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</button>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</button>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -446,19 +459,19 @@ func SidebarNav(props Props) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var14 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var14 == nil {
-			templ_7745c5c3_Var14 = templ.NopComponent
+		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var15 == nil {
+			templ_7745c5c3_Var15 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 
 		tabs := BuildSidebarNavTabs(ctx, props.TabGroups)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<nav x-data=\"sidebarNavigation()\" x-init=\"initSidebarNavigation()\" class=\"py-4 flex-1 min-h-0 overflow-y-auto hide-scrollbar\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<nav x-data=\"sidebarNavigation()\" x-init=\"initSidebarNavigation()\" class=\"py-4 flex-1 min-h-0 overflow-y-auto hide-scrollbar\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, tab := range tabs {
-			templ_7745c5c3_Var15 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_Var16 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 				if !templ_7745c5c3_IsBuffer {
@@ -470,7 +483,7 @@ func SidebarNav(props Props) templ.Component {
 					}()
 				}
 				ctx = templ.InitializeContext(ctx)
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<ul id=\"sidebar-navigation\" :class=\"{ &#39;px-2&#39;: isCollapsed, &#39;px-6&#39;: !isCollapsed }\" class=\"flex flex-col gap-2 transition-all duration-300\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<ul id=\"sidebar-navigation\" :class=\"{ &#39;px-2&#39;: isCollapsed, &#39;px-6&#39;: !isCollapsed }\" class=\"flex flex-col gap-2 transition-all duration-300\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -480,18 +493,18 @@ func SidebarNav(props Props) templ.Component {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</ul>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</ul>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				return nil
 			})
-			templ_7745c5c3_Err = navtabs.Content(tab.Value).Render(templ.WithChildren(ctx, templ_7745c5c3_Var15), templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = navtabs.Content(tab.Value).Render(templ.WithChildren(ctx, templ_7745c5c3_Var16), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</nav>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</nav>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -515,9 +528,9 @@ func SidebarNode(node NavNode, mode SidebarRenderMode, depth int) templ.Componen
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var16 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var16 == nil {
-			templ_7745c5c3_Var16 = templ.NopComponent
+		templ_7745c5c3_Var17 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var17 == nil {
+			templ_7745c5c3_Var17 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		if node.Kind == NavNodeKindLeaf {
@@ -551,69 +564,29 @@ func SidebarLinkNode(node NavNode, mode SidebarRenderMode) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var17 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var17 == nil {
-			templ_7745c5c3_Var17 = templ.NopComponent
+		templ_7745c5c3_Var18 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var18 == nil {
+			templ_7745c5c3_Var18 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 
 		tooltipText := sidebarTooltipText(node.Text, node.IsBeta)
 		className := sidebarButtonClass(node.IsActive)
 		if mode == SidebarRenderModeMain {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<li><div x-show=\"isCollapsed\" x-tooltip.placement.right.raw=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<li><div x-show=\"isCollapsed\" x-tooltip.placement.right.raw=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var18 string
-			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(tooltipText)
+			var templ_7745c5c3_Var19 string
+			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(tooltipText)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 210, Col: 72}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 211, Col: 72}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Var19 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-				if !templ_7745c5c3_IsBuffer {
-					defer func() {
-						templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-						if templ_7745c5c3_Err == nil {
-							templ_7745c5c3_Err = templ_7745c5c3_BufErr
-						}
-					}()
-				}
-				ctx = templ.InitializeContext(ctx)
-				if node.Icon != nil {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div class=\"w-6 h-6 flex items-center justify-center\">")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = node.Icon.Render(ctx, templ_7745c5c3_Buffer)
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</div>")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-				}
-				return nil
-			})
-			templ_7745c5c3_Err = button.Sidebar(button.Props{
-				Size:  button.SizeMD,
-				Href:  node.Href,
-				Class: "p-2 w-auto flex justify-center",
-			}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var19), templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</div><div x-show=\"!isCollapsed\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -630,30 +603,15 @@ func SidebarLinkNode(node NavNode, mode SidebarRenderMode) templ.Component {
 				}
 				ctx = templ.InitializeContext(ctx)
 				if node.Icon != nil {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<div class=\"w-6 h-6 flex items-center justify-center\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
 					templ_7745c5c3_Err = node.Icon.Render(ctx, templ_7745c5c3_Buffer)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, " ")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var21 string
-				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(node.Text)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 232, Col: 16}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, " ")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				if node.IsBeta {
-					templ_7745c5c3_Err = SidebarBetaBadge("ml-auto", false).Render(ctx, templ_7745c5c3_Buffer)
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -663,21 +621,16 @@ func SidebarLinkNode(node NavNode, mode SidebarRenderMode) templ.Component {
 			templ_7745c5c3_Err = button.Sidebar(button.Props{
 				Size:  button.SizeMD,
 				Href:  node.Href,
-				Class: className,
+				Class: "p-2 w-auto flex justify-center",
 			}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var20), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</div></li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</div><div x-show=\"!isCollapsed\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<li>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Var22 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_Var21 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 				if !templ_7745c5c3_IsBuffer {
@@ -695,20 +648,80 @@ func SidebarLinkNode(node NavNode, mode SidebarRenderMode) templ.Component {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, " ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var23 string
-				templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(node.Text)
+				var templ_7745c5c3_Var22 string
+				templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(node.Text)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 252, Col: 15}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 233, Col: 16}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, " ")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				if node.IsBeta {
+					templ_7745c5c3_Err = SidebarBetaBadge("ml-auto", false).Render(ctx, templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				return nil
+			})
+			templ_7745c5c3_Err = button.Sidebar(button.Props{
+				Size:  button.SizeMD,
+				Href:  node.Href,
+				Class: className,
+			}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var21), templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "</div></li>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		} else {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "<li>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Var23 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+				if !templ_7745c5c3_IsBuffer {
+					defer func() {
+						templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+						if templ_7745c5c3_Err == nil {
+							templ_7745c5c3_Err = templ_7745c5c3_BufErr
+						}
+					}()
+				}
+				ctx = templ.InitializeContext(ctx)
+				if node.Icon != nil {
+					templ_7745c5c3_Err = node.Icon.Render(ctx, templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
 				}
 				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, " ")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var24 string
+				templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(node.Text)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 253, Col: 15}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -727,11 +740,11 @@ func SidebarLinkNode(node NavNode, mode SidebarRenderMode) templ.Component {
 				Attrs: templ.Attributes{
 					"@click": "closeCollapsedMenus()",
 				},
-			}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var22), templ_7745c5c3_Buffer)
+			}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var23), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "</li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "</li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -756,9 +769,9 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var24 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var24 == nil {
-			templ_7745c5c3_Var24 = templ.NopComponent
+		templ_7745c5c3_Var25 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var25 == nil {
+			templ_7745c5c3_Var25 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 
@@ -772,85 +785,85 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 			caretClass = "duration-200 group-open:rotate-180"
 		}
 		if mode == SidebarRenderModeMain {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "<div><div x-show=\"isCollapsed\" @click.stop=\"onCollapsedGroupTrigger($event)\" x-tooltip.placement.right.raw=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var25 string
-			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(tooltipText)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 278, Col: 47}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "\" data-sidebar-collapsed-group-trigger=\"true\" data-group-id=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "<div><div x-show=\"isCollapsed\" @click.stop=\"onCollapsedGroupTrigger($event)\" x-tooltip.placement.right.raw=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var26 string
-			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(node.ID)
+			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(tooltipText)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 280, Col: 27}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 279, Col: 47}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\" data-depth=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\" data-sidebar-collapsed-group-trigger=\"true\" data-group-id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var27 string
-			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(depthAttr(depth))
+			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(node.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 281, Col: 33}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 281, Col: 27}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "\" class=\"accordion-group-collapsed w-full cursor-pointer\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "\" data-depth=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
-			}
-			if node.Icon != nil {
-				templ_7745c5c3_Err = node.Icon.Render(ctx, templ_7745c5c3_Buffer)
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "</div><details x-show=\"!isCollapsed\" class=\"group\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			if node.IsActive {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, " open")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "><summary class=\"btn btn-sidebar btn-md gap-2 w-full cursor-pointer\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			if node.Icon != nil {
-				templ_7745c5c3_Err = node.Icon.Render(ctx, templ_7745c5c3_Buffer)
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
 			}
 			var templ_7745c5c3_Var28 string
-			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(node.Text)
+			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(depthAttr(depth))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 293, Col: 16}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 282, Col: 33}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "\" class=\"accordion-group-collapsed w-full cursor-pointer\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if node.Icon != nil {
+				templ_7745c5c3_Err = node.Icon.Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</div><details x-show=\"!isCollapsed\" class=\"group\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if node.IsActive {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, " open")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "><summary class=\"btn btn-sidebar btn-md gap-2 w-full cursor-pointer\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if node.Icon != nil {
+				templ_7745c5c3_Err = node.Icon.Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			var templ_7745c5c3_Var29 string
+			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(node.Text)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 294, Col: 16}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -864,7 +877,7 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</summary><ul class=\"ml-4 mt-2 flex flex-col gap-2\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</summary><ul class=\"ml-4 mt-2 flex flex-col gap-2\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -874,7 +887,7 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</ul></details>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</ul></details>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -882,60 +895,60 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "<li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var29 = []any{buttonClass}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var29...)
+			var templ_7745c5c3_Var30 = []any{buttonClass}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var30...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "<button type=\"button\" @click.stop=\"onCollapsedGroupTrigger($event)\" data-sidebar-collapsed-group-trigger=\"true\" data-group-id=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var30 string
-			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(node.ID)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 313, Col: 27}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "\" data-depth=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<button type=\"button\" @click.stop=\"onCollapsedGroupTrigger($event)\" data-sidebar-collapsed-group-trigger=\"true\" data-group-id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var31 string
-			templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(depthAttr(depth))
+			templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(node.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 314, Col: 33}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 314, Col: 27}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "\" class=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "\" data-depth=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var32 string
-			templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var29).String())
+			templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(depthAttr(depth))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 1, Col: 0}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 315, Col: 33}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "\" class=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var33 string
+			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var30).String())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 1, Col: 0}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -945,20 +958,20 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "<span class=\"truncate\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "<span class=\"truncate\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var33 string
-			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(node.Text)
+			var templ_7745c5c3_Var34 string
+			templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(node.Text)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 320, Col: 38}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 321, Col: 38}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "</span> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "</span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -972,7 +985,7 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "</button></li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "</button></li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1001,38 +1014,38 @@ func CollapsedGroupFlyout(node NavNode, depth int) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var34 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var34 == nil {
-			templ_7745c5c3_Var34 = templ.NopComponent
+		templ_7745c5c3_Var35 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var35 == nil {
+			templ_7745c5c3_Var35 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "<template x-teleport=\"body\"><div x-cloak x-show=\"isCollapsedMenuOpenFor($el)\" :style=\"collapsedMenuStyleFor($el)\" data-sidebar-collapsed-menu=\"true\" data-group-id=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var35 string
-		templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(node.ID)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 338, Col: 26}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "\" data-depth=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "<template x-teleport=\"body\"><div x-cloak x-show=\"isCollapsedMenuOpenFor($el)\" :style=\"collapsedMenuStyleFor($el)\" data-sidebar-collapsed-menu=\"true\" data-group-id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var36 string
-		templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(depthAttr(depth))
+		templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(node.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 339, Col: 32}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 339, Col: 26}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "\" x-transition class=\"sidebar-flyout fixed z-[70] w-64 rounded-lg p-1.5\"><ul class=\"flex flex-col gap-1\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "\" data-depth=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var37 string
+		templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(depthAttr(depth))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 340, Col: 32}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "\" x-transition class=\"sidebar-flyout fixed z-[70] w-64 rounded-lg p-1.5\"><ul class=\"flex flex-col gap-1\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1042,7 +1055,7 @@ func CollapsedGroupFlyout(node NavNode, depth int) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "</ul></div></template>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "</ul></div></template>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1066,54 +1079,54 @@ func SidebarBetaBadge(className string, active bool) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var37 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var37 == nil {
-			templ_7745c5c3_Var37 = templ.NopComponent
+		templ_7745c5c3_Var38 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var38 == nil {
+			templ_7745c5c3_Var38 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		if active {
-			var templ_7745c5c3_Var38 = []any{"text-[10px] px-2 py-0.5 rounded-full bg-blue-100 text-blue-700 leading-none", className}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var38...)
+			var templ_7745c5c3_Var39 = []any{"text-[10px] px-2 py-0.5 rounded-full bg-blue-100 text-blue-700 leading-none", className}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var39...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "<span class=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "<span class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var39 string
-			templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var38).String())
+			var templ_7745c5c3_Var40 string
+			templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var39).String())
 			if templ_7745c5c3_Err != nil {
 				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 1, Col: 0}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "\">Beta</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "\">Beta</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			var templ_7745c5c3_Var40 = []any{"text-[10px] px-2 py-0.5 rounded-full bg-surface-300 text-200 leading-none", className}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var40...)
+			var templ_7745c5c3_Var41 = []any{"text-[10px] px-2 py-0.5 rounded-full bg-surface-300 text-200 leading-none", className}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var41...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "<span class=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "<span class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var41 string
-			templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var40).String())
+			var templ_7745c5c3_Var42 string
+			templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var41).String())
 			if templ_7745c5c3_Err != nil {
 				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 1, Col: 0}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "\">Beta</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "\">Beta</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/components/sidebar/sidebar_templ.go
+++ b/components/sidebar/sidebar_templ.go
@@ -9,10 +9,12 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
+	"fmt"
 	icons "github.com/iota-uz/icons/phosphor"
 	"github.com/iota-uz/iota-sdk/components/base/button"
 	"github.com/iota-uz/iota-sdk/components/base/navtabs"
 	"strconv"
+	"strings"
 )
 
 // SidebarState represents the initial state of the sidebar
@@ -56,6 +58,19 @@ func sidebarButtonClass(active bool) string {
 
 func depthAttr(depth int) string {
 	return strconv.Itoa(depth)
+}
+
+// workspaceTabBadge derives a compact, icon-sized label for the collapsed
+// workspace switcher. Short labels (e.g. "ERP", "CRM", "ЭДО") are shown as-is;
+// longer labels are truncated to their first 3 runes so they fit the 4rem rail.
+// The full label is always available via the button's tooltip.
+func workspaceTabBadge(label string) string {
+	label = strings.TrimSpace(label)
+	runes := []rune(label)
+	if len(runes) <= 3 {
+		return strings.ToUpper(label)
+	}
+	return strings.ToUpper(string(runes[:3]))
 }
 
 func Sidebar(props Props) templ.Component {
@@ -118,6 +133,10 @@ func Sidebar(props Props) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
+			templ_7745c5c3_Err = SidebarPinnedNav(props).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 			if len(props.TabGroups.Groups) > 1 {
 				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div x-show=\"!isCollapsed\" x-transition><div class=\"mt-4\">")
 				if templ_7745c5c3_Err != nil {
@@ -155,7 +174,7 @@ func Sidebar(props Props) templ.Component {
 							var templ_7745c5c3_Var5 string
 							templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(group.Label)
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 88, Col: 30}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 104, Col: 30}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 							if templ_7745c5c3_Err != nil {
@@ -189,6 +208,10 @@ func Sidebar(props Props) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</div></div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = SidebarCollapsedWorkspaceTabs(props).Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -229,7 +252,11 @@ func Sidebar(props Props) templ.Component {
 	})
 }
 
-func SidebarNav(props Props) templ.Component {
+// SidebarPinnedNav renders the pinned navigation items above the workspace tab
+// selector. Pinned items stay visible regardless of the active workspace tab and
+// in the collapsed sidebar, so they live in the header region (outside the tab
+// content) rather than inside the scrollable per-tab nav.
+func SidebarPinnedNav(props Props) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -250,15 +277,9 @@ func SidebarNav(props Props) templ.Component {
 			templ_7745c5c3_Var6 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-
-		tabs := BuildSidebarNavTabs(ctx, props.TabGroups)
 		pinnedNodes := buildSidebarNavNodes(ctx, props.PinnedItems)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<nav x-data=\"sidebarNavigation()\" x-init=\"initSidebarNavigation()\" class=\"py-4 flex-1 min-h-0 overflow-y-auto hide-scrollbar\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
 		if len(pinnedNodes) > 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<ul id=\"sidebar-pinned-navigation\" :class=\"{ &#39;px-2&#39;: isCollapsed, &#39;px-6&#39;: !isCollapsed }\" class=\"flex flex-col gap-2 pb-4 mb-4 border-b border-surface-300 transition-all duration-300\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<nav x-data=\"sidebarNavigation()\" x-init=\"initSidebarNavigation()\" class=\"mt-4\"><ul id=\"sidebar-pinned-navigation\" class=\"flex flex-col gap-2 pb-4 border-b border-surface-300\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -268,13 +289,176 @@ func SidebarNav(props Props) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</ul>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</ul></nav>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
+		return nil
+	})
+}
+
+// SidebarCollapsedWorkspaceTabs renders the workspace selector for the collapsed
+// sidebar, where the horizontal tab bar is hidden. Each workspace becomes a
+// compact, icon-sized pill (badge label + right-placed tooltip with the full
+// label) that switches the active tab via the same navTabs Alpine state used by
+// the expanded selector, so the two stay in sync.
+func SidebarCollapsedWorkspaceTabs(props Props) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<div x-show=\"isCollapsed\" class=\"mt-4 flex flex-col items-center gap-1\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		for _, group := range props.TabGroups.Groups {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<button type=\"button\" role=\"tab\" data-tab-value=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var8 string
+			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(group.Value)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 158, Col: 32}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "\" @click=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var9 string
+			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("setActiveTab('%s')", group.Value))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 159, Col: 59}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\" x-bind:aria-selected=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var10 string
+			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("isActive('%s') ? 'true' : 'false'", group.Value))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 160, Col: 88}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\" x-bind:class=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var11 string
+			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("isActive('%s') ? 'bg-white text-slate-900' : 'text-gray-100 hover:bg-white/10'", group.Value))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 161, Col: 125}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\" x-tooltip.placement.right.raw=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var12 string
+			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(sidebarTooltipText(group.Label, group.IsBeta))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 162, Col: 81}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\" class=\"relative w-10 h-10 rounded-xl text-[11px] font-semibold leading-none flex items-center justify-center transition-colors duration-200 !cursor-pointer\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var13 string
+			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(workspaceTabBadge(group.Label))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 165, Col: 36}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, " ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if group.IsBeta {
+				templ_7745c5c3_Err = SidebarBetaBadge("absolute -top-1 -right-1 z-10 pointer-events-none text-[8px] px-1", true).Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</button>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func SidebarNav(props Props) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var14 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var14 == nil {
+			templ_7745c5c3_Var14 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+
+		tabs := BuildSidebarNavTabs(ctx, props.TabGroups)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<nav x-data=\"sidebarNavigation()\" x-init=\"initSidebarNavigation()\" class=\"py-4 flex-1 min-h-0 overflow-y-auto hide-scrollbar\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		for _, tab := range tabs {
-			templ_7745c5c3_Var7 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_Var15 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 				if !templ_7745c5c3_IsBuffer {
@@ -286,7 +470,7 @@ func SidebarNav(props Props) templ.Component {
 					}()
 				}
 				ctx = templ.InitializeContext(ctx)
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<ul id=\"sidebar-navigation\" :class=\"{ &#39;px-2&#39;: isCollapsed, &#39;px-6&#39;: !isCollapsed }\" class=\"flex flex-col gap-2 transition-all duration-300\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<ul id=\"sidebar-navigation\" :class=\"{ &#39;px-2&#39;: isCollapsed, &#39;px-6&#39;: !isCollapsed }\" class=\"flex flex-col gap-2 transition-all duration-300\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -296,18 +480,18 @@ func SidebarNav(props Props) templ.Component {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</ul>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</ul>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				return nil
 			})
-			templ_7745c5c3_Err = navtabs.Content(tab.Value).Render(templ.WithChildren(ctx, templ_7745c5c3_Var7), templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = navtabs.Content(tab.Value).Render(templ.WithChildren(ctx, templ_7745c5c3_Var15), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</nav>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</nav>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -331,9 +515,9 @@ func SidebarNode(node NavNode, mode SidebarRenderMode, depth int) templ.Componen
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var8 == nil {
-			templ_7745c5c3_Var8 = templ.NopComponent
+		templ_7745c5c3_Var16 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var16 == nil {
+			templ_7745c5c3_Var16 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		if node.Kind == NavNodeKindLeaf {
@@ -367,33 +551,33 @@ func SidebarLinkNode(node NavNode, mode SidebarRenderMode) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var9 == nil {
-			templ_7745c5c3_Var9 = templ.NopComponent
+		templ_7745c5c3_Var17 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var17 == nil {
+			templ_7745c5c3_Var17 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 
 		tooltipText := sidebarTooltipText(node.Text, node.IsBeta)
 		className := sidebarButtonClass(node.IsActive)
 		if mode == SidebarRenderModeMain {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<li><div x-show=\"isCollapsed\" x-tooltip.placement.right.raw=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<li><div x-show=\"isCollapsed\" x-tooltip.placement.right.raw=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var10 string
-			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(tooltipText)
+			var templ_7745c5c3_Var18 string
+			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(tooltipText)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 158, Col: 72}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 210, Col: 72}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Var11 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Var19 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 				if !templ_7745c5c3_IsBuffer {
@@ -406,7 +590,7 @@ func SidebarLinkNode(node NavNode, mode SidebarRenderMode) templ.Component {
 				}
 				ctx = templ.InitializeContext(ctx)
 				if node.Icon != nil {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<div class=\"w-6 h-6 flex items-center justify-center\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div class=\"w-6 h-6 flex items-center justify-center\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -414,7 +598,7 @@ func SidebarLinkNode(node NavNode, mode SidebarRenderMode) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -425,15 +609,15 @@ func SidebarLinkNode(node NavNode, mode SidebarRenderMode) templ.Component {
 				Size:  button.SizeMD,
 				Href:  node.Href,
 				Class: "p-2 w-auto flex justify-center",
-			}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var11), templ_7745c5c3_Buffer)
+			}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var19), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</div><div x-show=\"!isCollapsed\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</div><div x-show=\"!isCollapsed\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Var12 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_Var20 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 				if !templ_7745c5c3_IsBuffer {
@@ -451,20 +635,20 @@ func SidebarLinkNode(node NavNode, mode SidebarRenderMode) templ.Component {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, " ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var13 string
-				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(node.Text)
+				var templ_7745c5c3_Var21 string
+				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(node.Text)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 180, Col: 16}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 232, Col: 16}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, " ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -480,20 +664,20 @@ func SidebarLinkNode(node NavNode, mode SidebarRenderMode) templ.Component {
 				Size:  button.SizeMD,
 				Href:  node.Href,
 				Class: className,
-			}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var12), templ_7745c5c3_Buffer)
+			}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var20), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</div></li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</div></li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Var14 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_Var22 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 				if !templ_7745c5c3_IsBuffer {
@@ -511,20 +695,20 @@ func SidebarLinkNode(node NavNode, mode SidebarRenderMode) templ.Component {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, " ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var15 string
-				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(node.Text)
+				var templ_7745c5c3_Var23 string
+				templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(node.Text)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 200, Col: 15}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 252, Col: 15}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, " ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -543,11 +727,11 @@ func SidebarLinkNode(node NavNode, mode SidebarRenderMode) templ.Component {
 				Attrs: templ.Attributes{
 					"@click": "closeCollapsedMenus()",
 				},
-			}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var14), templ_7745c5c3_Buffer)
+			}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var22), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "</li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "</li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -572,9 +756,9 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var16 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var16 == nil {
-			templ_7745c5c3_Var16 = templ.NopComponent
+		templ_7745c5c3_Var24 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var24 == nil {
+			templ_7745c5c3_Var24 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 
@@ -588,46 +772,46 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 			caretClass = "duration-200 group-open:rotate-180"
 		}
 		if mode == SidebarRenderModeMain {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div><div x-show=\"isCollapsed\" @click.stop=\"onCollapsedGroupTrigger($event)\" x-tooltip.placement.right.raw=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "<div><div x-show=\"isCollapsed\" @click.stop=\"onCollapsedGroupTrigger($event)\" x-tooltip.placement.right.raw=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var17 string
-			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(tooltipText)
+			var templ_7745c5c3_Var25 string
+			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(tooltipText)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 226, Col: 47}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 278, Col: 47}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\" data-sidebar-collapsed-group-trigger=\"true\" data-group-id=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var18 string
-			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(node.ID)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 228, Col: 27}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "\" data-sidebar-collapsed-group-trigger=\"true\" data-group-id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\" data-depth=\"")
+			var templ_7745c5c3_Var26 string
+			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(node.ID)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 280, Col: 27}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var19 string
-			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(depthAttr(depth))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 229, Col: 33}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\" data-depth=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\" class=\"accordion-group-collapsed w-full cursor-pointer\">")
+			var templ_7745c5c3_Var27 string
+			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(depthAttr(depth))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 281, Col: 33}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "\" class=\"accordion-group-collapsed w-full cursor-pointer\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -637,17 +821,17 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</div><details x-show=\"!isCollapsed\" class=\"group\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "</div><details x-show=\"!isCollapsed\" class=\"group\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if node.IsActive {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, " open")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, " open")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "><summary class=\"btn btn-sidebar btn-md gap-2 w-full cursor-pointer\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "><summary class=\"btn btn-sidebar btn-md gap-2 w-full cursor-pointer\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -657,16 +841,16 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 					return templ_7745c5c3_Err
 				}
 			}
-			var templ_7745c5c3_Var20 string
-			templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(node.Text)
+			var templ_7745c5c3_Var28 string
+			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(node.Text)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 241, Col: 16}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 293, Col: 16}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -680,7 +864,7 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</summary><ul class=\"ml-4 mt-2 flex flex-col gap-2\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</summary><ul class=\"ml-4 mt-2 flex flex-col gap-2\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -690,7 +874,7 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "</ul></details>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</ul></details>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -698,60 +882,60 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "<li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var21 = []any{buttonClass}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var21...)
+			var templ_7745c5c3_Var29 = []any{buttonClass}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var29...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "<button type=\"button\" @click.stop=\"onCollapsedGroupTrigger($event)\" data-sidebar-collapsed-group-trigger=\"true\" data-group-id=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "<button type=\"button\" @click.stop=\"onCollapsedGroupTrigger($event)\" data-sidebar-collapsed-group-trigger=\"true\" data-group-id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var22 string
-			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(node.ID)
+			var templ_7745c5c3_Var30 string
+			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(node.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 261, Col: 27}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 313, Col: 27}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "\" data-depth=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var23 string
-			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(depthAttr(depth))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 262, Col: 33}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "\" data-depth=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "\" class=\"")
+			var templ_7745c5c3_Var31 string
+			templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(depthAttr(depth))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 314, Col: 33}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var24 string
-			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var21).String())
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "\" class=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var32 string
+			templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var29).String())
 			if templ_7745c5c3_Err != nil {
 				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 1, Col: 0}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -761,20 +945,20 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "<span class=\"truncate\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "<span class=\"truncate\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var25 string
-			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(node.Text)
+			var templ_7745c5c3_Var33 string
+			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(node.Text)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 268, Col: 38}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 320, Col: 38}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "</span> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "</span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -788,7 +972,7 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</button></li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "</button></li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -817,38 +1001,38 @@ func CollapsedGroupFlyout(node NavNode, depth int) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var26 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var26 == nil {
-			templ_7745c5c3_Var26 = templ.NopComponent
+		templ_7745c5c3_Var34 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var34 == nil {
+			templ_7745c5c3_Var34 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "<template x-teleport=\"body\"><div x-cloak x-show=\"isCollapsedMenuOpenFor($el)\" :style=\"collapsedMenuStyleFor($el)\" data-sidebar-collapsed-menu=\"true\" data-group-id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "<template x-teleport=\"body\"><div x-cloak x-show=\"isCollapsedMenuOpenFor($el)\" :style=\"collapsedMenuStyleFor($el)\" data-sidebar-collapsed-menu=\"true\" data-group-id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var27 string
-		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(node.ID)
+		var templ_7745c5c3_Var35 string
+		templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(node.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 286, Col: 26}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 338, Col: 26}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "\" data-depth=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var28 string
-		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(depthAttr(depth))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 287, Col: 32}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "\" data-depth=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "\" x-transition class=\"sidebar-flyout fixed z-[70] w-64 rounded-lg p-1.5\"><ul class=\"flex flex-col gap-1\">")
+		var templ_7745c5c3_Var36 string
+		templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(depthAttr(depth))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 339, Col: 32}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "\" x-transition class=\"sidebar-flyout fixed z-[70] w-64 rounded-lg p-1.5\"><ul class=\"flex flex-col gap-1\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -858,7 +1042,7 @@ func CollapsedGroupFlyout(node NavNode, depth int) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</ul></div></template>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "</ul></div></template>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -882,54 +1066,54 @@ func SidebarBetaBadge(className string, active bool) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var29 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var29 == nil {
-			templ_7745c5c3_Var29 = templ.NopComponent
+		templ_7745c5c3_Var37 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var37 == nil {
+			templ_7745c5c3_Var37 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		if active {
-			var templ_7745c5c3_Var30 = []any{"text-[10px] px-2 py-0.5 rounded-full bg-blue-100 text-blue-700 leading-none", className}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var30...)
+			var templ_7745c5c3_Var38 = []any{"text-[10px] px-2 py-0.5 rounded-full bg-blue-100 text-blue-700 leading-none", className}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var38...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<span class=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "<span class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var31 string
-			templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var30).String())
+			var templ_7745c5c3_Var39 string
+			templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var38).String())
 			if templ_7745c5c3_Err != nil {
 				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 1, Col: 0}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "\">Beta</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "\">Beta</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			var templ_7745c5c3_Var32 = []any{"text-[10px] px-2 py-0.5 rounded-full bg-surface-300 text-200 leading-none", className}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var32...)
+			var templ_7745c5c3_Var40 = []any{"text-[10px] px-2 py-0.5 rounded-full bg-surface-300 text-200 leading-none", className}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var40...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "<span class=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "<span class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var33 string
-			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var32).String())
+			var templ_7745c5c3_Var41 string
+			templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var40).String())
 			if templ_7745c5c3_Err != nil {
 				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 1, Col: 0}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "\">Beta</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "\">Beta</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/components/sidebar/sidebar_templ.go
+++ b/components/sidebar/sidebar_templ.go
@@ -27,6 +27,7 @@ const (
 type Props struct {
 	Header       templ.Component
 	TabGroups    TabGroupCollection
+	PinnedItems  []Item
 	Footer       templ.Component
 	InitialState SidebarState // Server-side initial state hint
 }
@@ -154,7 +155,7 @@ func Sidebar(props Props) templ.Component {
 							var templ_7745c5c3_Var5 string
 							templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(group.Label)
 							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 87, Col: 30}
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 88, Col: 30}
 							}
 							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 							if templ_7745c5c3_Err != nil {
@@ -249,10 +250,28 @@ func SidebarNav(props Props) templ.Component {
 			templ_7745c5c3_Var6 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+
 		tabs := BuildSidebarNavTabs(ctx, props.TabGroups)
+		pinnedNodes := buildSidebarNavNodes(ctx, props.PinnedItems)
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<nav x-data=\"sidebarNavigation()\" x-init=\"initSidebarNavigation()\" class=\"py-4 flex-1 min-h-0 overflow-y-auto hide-scrollbar\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
+		}
+		if len(pinnedNodes) > 0 {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<ul id=\"sidebar-pinned-navigation\" :class=\"{ &#39;px-2&#39;: isCollapsed, &#39;px-6&#39;: !isCollapsed }\" class=\"flex flex-col gap-2 pb-4 mb-4 border-b border-surface-300 transition-all duration-300\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			for _, node := range pinnedNodes {
+				templ_7745c5c3_Err = SidebarNode(node, SidebarRenderModeMain, 0).Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</ul>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
 		for _, tab := range tabs {
 			templ_7745c5c3_Var7 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
@@ -267,7 +286,7 @@ func SidebarNav(props Props) templ.Component {
 					}()
 				}
 				ctx = templ.InitializeContext(ctx)
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<ul id=\"sidebar-navigation\" :class=\"{ &#39;px-2&#39;: isCollapsed, &#39;px-6&#39;: !isCollapsed }\" class=\"flex flex-col gap-2 transition-all duration-300\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<ul id=\"sidebar-navigation\" :class=\"{ &#39;px-2&#39;: isCollapsed, &#39;px-6&#39;: !isCollapsed }\" class=\"flex flex-col gap-2 transition-all duration-300\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -277,7 +296,7 @@ func SidebarNav(props Props) templ.Component {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</ul>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</ul>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -288,7 +307,7 @@ func SidebarNav(props Props) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</nav>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</nav>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -357,20 +376,20 @@ func SidebarLinkNode(node NavNode, mode SidebarRenderMode) templ.Component {
 		tooltipText := sidebarTooltipText(node.Text, node.IsBeta)
 		className := sidebarButtonClass(node.IsActive)
 		if mode == SidebarRenderModeMain {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<li><div x-show=\"isCollapsed\" x-tooltip.placement.right.raw=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<li><div x-show=\"isCollapsed\" x-tooltip.placement.right.raw=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var10 string
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(tooltipText)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 143, Col: 72}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 158, Col: 72}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -387,7 +406,7 @@ func SidebarLinkNode(node NavNode, mode SidebarRenderMode) templ.Component {
 				}
 				ctx = templ.InitializeContext(ctx)
 				if node.Icon != nil {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<div class=\"w-6 h-6 flex items-center justify-center\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<div class=\"w-6 h-6 flex items-center justify-center\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -395,7 +414,7 @@ func SidebarLinkNode(node NavNode, mode SidebarRenderMode) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -410,7 +429,7 @@ func SidebarLinkNode(node NavNode, mode SidebarRenderMode) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</div><div x-show=\"!isCollapsed\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</div><div x-show=\"!isCollapsed\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -432,20 +451,20 @@ func SidebarLinkNode(node NavNode, mode SidebarRenderMode) templ.Component {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, " ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var13 string
 				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(node.Text)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 165, Col: 16}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 180, Col: 16}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, " ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -465,12 +484,12 @@ func SidebarLinkNode(node NavNode, mode SidebarRenderMode) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</div></li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</div></li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -492,20 +511,20 @@ func SidebarLinkNode(node NavNode, mode SidebarRenderMode) templ.Component {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, " ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var15 string
 				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(node.Text)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 185, Col: 15}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 200, Col: 15}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, " ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -528,7 +547,7 @@ func SidebarLinkNode(node NavNode, mode SidebarRenderMode) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "</li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -569,46 +588,46 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 			caretClass = "duration-200 group-open:rotate-180"
 		}
 		if mode == SidebarRenderModeMain {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<div><div x-show=\"isCollapsed\" @click.stop=\"onCollapsedGroupTrigger($event)\" x-tooltip.placement.right.raw=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div><div x-show=\"isCollapsed\" @click.stop=\"onCollapsedGroupTrigger($event)\" x-tooltip.placement.right.raw=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var17 string
 			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(tooltipText)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 211, Col: 47}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 226, Col: 47}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\" data-sidebar-collapsed-group-trigger=\"true\" data-group-id=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\" data-sidebar-collapsed-group-trigger=\"true\" data-group-id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var18 string
 			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(node.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 213, Col: 27}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 228, Col: 27}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\" data-depth=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "\" data-depth=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var19 string
 			templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(depthAttr(depth))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 214, Col: 33}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 229, Col: 33}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\" class=\"accordion-group-collapsed w-full cursor-pointer\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\" class=\"accordion-group-collapsed w-full cursor-pointer\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -618,17 +637,17 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</div><details x-show=\"!isCollapsed\" class=\"group\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</div><details x-show=\"!isCollapsed\" class=\"group\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if node.IsActive {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, " open")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, " open")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "><summary class=\"btn btn-sidebar btn-md gap-2 w-full cursor-pointer\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "><summary class=\"btn btn-sidebar btn-md gap-2 w-full cursor-pointer\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -641,13 +660,13 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 			var templ_7745c5c3_Var20 string
 			templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(node.Text)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 226, Col: 16}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 241, Col: 16}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -661,7 +680,7 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "</summary><ul class=\"ml-4 mt-2 flex flex-col gap-2\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</summary><ul class=\"ml-4 mt-2 flex flex-col gap-2\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -671,7 +690,7 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</ul></details>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "</ul></details>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -679,12 +698,12 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "<li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -693,33 +712,33 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "<button type=\"button\" @click.stop=\"onCollapsedGroupTrigger($event)\" data-sidebar-collapsed-group-trigger=\"true\" data-group-id=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "<button type=\"button\" @click.stop=\"onCollapsedGroupTrigger($event)\" data-sidebar-collapsed-group-trigger=\"true\" data-group-id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var22 string
 			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(node.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 246, Col: 27}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 261, Col: 27}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "\" data-depth=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "\" data-depth=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var23 string
 			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(depthAttr(depth))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 247, Col: 33}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 262, Col: 33}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\" class=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "\" class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -732,7 +751,7 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -742,20 +761,20 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "<span class=\"truncate\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "<span class=\"truncate\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var25 string
 			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(node.Text)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 253, Col: 38}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 268, Col: 38}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</span> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "</span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -769,7 +788,7 @@ func SidebarGroupNode(node NavNode, mode SidebarRenderMode, depth int) templ.Com
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</button></li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</button></li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -803,33 +822,33 @@ func CollapsedGroupFlyout(node NavNode, depth int) templ.Component {
 			templ_7745c5c3_Var26 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<template x-teleport=\"body\"><div x-cloak x-show=\"isCollapsedMenuOpenFor($el)\" :style=\"collapsedMenuStyleFor($el)\" data-sidebar-collapsed-menu=\"true\" data-group-id=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "<template x-teleport=\"body\"><div x-cloak x-show=\"isCollapsedMenuOpenFor($el)\" :style=\"collapsedMenuStyleFor($el)\" data-sidebar-collapsed-menu=\"true\" data-group-id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var27 string
 		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(node.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 271, Col: 26}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 286, Col: 26}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "\" data-depth=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "\" data-depth=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var28 string
 		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(depthAttr(depth))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 272, Col: 32}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/sidebar/sidebar.templ`, Line: 287, Col: 32}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "\" x-transition class=\"sidebar-flyout fixed z-[70] w-64 rounded-lg p-1.5\"><ul class=\"flex flex-col gap-1\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "\" x-transition class=\"sidebar-flyout fixed z-[70] w-64 rounded-lg p-1.5\"><ul class=\"flex flex-col gap-1\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -839,7 +858,7 @@ func CollapsedGroupFlyout(node NavNode, depth int) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</ul></div></template>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "</ul></div></template>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -874,7 +893,7 @@ func SidebarBetaBadge(className string, active bool) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<span class=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<span class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -887,7 +906,7 @@ func SidebarBetaBadge(className string, active bool) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "\">Beta</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "\">Beta</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -897,7 +916,7 @@ func SidebarBetaBadge(className string, active bool) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "<span class=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "<span class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -910,7 +929,7 @@ func SidebarBetaBadge(className string, active bool) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "\">Beta</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "\">Beta</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/modules/core/component.go
+++ b/modules/core/component.go
@@ -55,6 +55,10 @@ type ModuleOptions struct {
 	// registered. Use this for specialized binaries like superadmin that
 	// provide their own admin UI.
 	SkipAdminControllers bool
+
+	// SkipAdminNavItems suppresses contribution of the built-in admin
+	// navigation without affecting controller or spotlight registration.
+	SkipAdminNavItems bool
 }
 
 func NewComponent(opts *ModuleOptions) composition.Component {
@@ -86,7 +90,9 @@ func (c *component) Build(builder *composition.Builder) error {
 		spotlight.NewQuickLink("Account.Sessions.Title", "/account/sessions"),
 	)
 	if !c.options.SkipAdminControllers {
-		composition.AddNavItems(builder, BuildNavItems(c.options.DashboardLinkPermissions, c.options.SettingsLinkPermissions)...)
+		if !c.options.SkipAdminNavItems {
+			composition.AddNavItems(builder, BuildNavItems(c.options.DashboardLinkPermissions, c.options.SettingsLinkPermissions)...)
+		}
 		composition.AddQuickLinks(builder,
 			spotlight.NewQuickLink(DashboardLink.Name, DashboardLink.Href),
 			spotlight.NewQuickLink(UsersLink.Name, UsersLink.Href),

--- a/modules/core/component_test.go
+++ b/modules/core/component_test.go
@@ -1,0 +1,57 @@
+package core_test
+
+import (
+	"testing"
+
+	"github.com/iota-uz/iota-sdk/modules/core"
+	"github.com/iota-uz/iota-sdk/pkg/composition"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComponentSkipAdminNavItems(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		opts             *core.ModuleOptions
+		wantNavItems     bool
+		wantAdminQuickLk bool
+	}{
+		{
+			name:             "zero value preserves admin nav items",
+			opts:             &core.ModuleOptions{},
+			wantNavItems:     true,
+			wantAdminQuickLk: true,
+		},
+		{
+			name:             "SkipAdminNavItems suppresses nav items but keeps quick links",
+			opts:             &core.ModuleOptions{SkipAdminNavItems: true},
+			wantNavItems:     false,
+			wantAdminQuickLk: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			component := core.NewComponent(tt.opts)
+			contributions, err := composition.InspectStatic(component)
+			require.NoError(t, err)
+
+			if tt.wantNavItems {
+				assert.NotEmpty(t, contributions.NavItems, "expected admin nav items to be contributed")
+			} else {
+				assert.Empty(t, contributions.NavItems, "expected no nav items when SkipAdminNavItems is true")
+			}
+
+			// Quick-link / spotlight registration is unaffected by SkipAdminNavItems:
+			// self-service quick links plus admin quick links should still register.
+			require.NotEmpty(t, contributions.QuickLinks)
+			if tt.wantAdminQuickLk {
+				assert.GreaterOrEqual(t, len(contributions.QuickLinks), 3,
+					"admin quick links should still register regardless of SkipAdminNavItems")
+			}
+		})
+	}
+}

--- a/modules/core/links.go
+++ b/modules/core/links.go
@@ -9,6 +9,7 @@ import (
 )
 
 var DashboardLink = types.NavigationItem{
+	Key:      "core.dashboard",
 	Name:     "NavigationLinks.Dashboard",
 	Icon:     icons.Gauge(icons.Props{Size: "20"}),
 	Href:     "/",
@@ -16,6 +17,7 @@ var DashboardLink = types.NavigationItem{
 }
 
 var UsersLink = types.NavigationItem{
+	Key:         "core.users",
 	Name:        "NavigationLinks.Users",
 	Icon:        nil,
 	Href:        "/users",
@@ -24,6 +26,7 @@ var UsersLink = types.NavigationItem{
 }
 
 var RolesLink = types.NavigationItem{
+	Key:         "core.roles",
 	Name:        "NavigationLinks.Roles",
 	Icon:        nil,
 	Href:        "/roles",
@@ -32,6 +35,7 @@ var RolesLink = types.NavigationItem{
 }
 
 var GroupsLink = types.NavigationItem{
+	Key:         "core.groups",
 	Name:        "NavigationLinks.Groups",
 	Icon:        nil,
 	Href:        "/groups",
@@ -40,6 +44,7 @@ var GroupsLink = types.NavigationItem{
 }
 
 var DepartmentsLink = types.NavigationItem{
+	Key:         "core.departments",
 	Name:        "NavigationLinks.Departments",
 	Icon:        nil,
 	Href:        "/departments",
@@ -48,6 +53,7 @@ var DepartmentsLink = types.NavigationItem{
 }
 
 var PositionsLink = types.NavigationItem{
+	Key:         "core.positions",
 	Name:        "NavigationLinks.Positions",
 	Icon:        nil,
 	Href:        "/positions",
@@ -56,6 +62,7 @@ var PositionsLink = types.NavigationItem{
 }
 
 var SettingsLink = types.NavigationItem{
+	Key:      "core.settings",
 	Name:     "NavigationLinks.Settings",
 	Icon:     nil,
 	Href:     "/settings/logo",
@@ -63,6 +70,7 @@ var SettingsLink = types.NavigationItem{
 }
 
 var AdministrationLink = types.NavigationItem{
+	Key:  "core.administration",
 	Name: "NavigationLinks.Administration",
 	Icon: icons.AirTrafficControl(icons.Props{Size: "20"}),
 	Href: "#",

--- a/modules/core/presentation/templates/pages/roles/edit.templ
+++ b/modules/core/presentation/templates/pages/roles/edit.templ
@@ -151,7 +151,7 @@ templ Edit(props *EditFormProps) {
 			hx-target="closest .content"
 			hx-swap="innerHTML"
 			hx-indicator="#delete-role-btn"
-			hx-disabled-elt="find button"
+			hx-disabled-elt="#delete-role-btn"
 			class="hidden"
 		>
 			@composables.CSRFTokenField()

--- a/modules/core/presentation/templates/pages/roles/edit_templ.go
+++ b/modules/core/presentation/templates/pages/roles/edit_templ.go
@@ -434,7 +434,7 @@ func Edit(props *EditFormProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\" hx-trigger=\"submit\" hx-target=\"closest .content\" hx-swap=\"innerHTML\" hx-indicator=\"#delete-role-btn\" hx-disabled-elt=\"find button\" class=\"hidden\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\" hx-trigger=\"submit\" hx-target=\"closest .content\" hx-swap=\"innerHTML\" hx-indicator=\"#delete-role-btn\" hx-disabled-elt=\"#delete-role-btn\" class=\"hidden\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -37,9 +37,12 @@ func translate(localizer *i18n.Localizer, items []types.NavigationItem) []types.
 	translated := make([]types.NavigationItem, 0, len(items))
 	for _, item := range items {
 		translated = append(translated, types.NavigationItem{
+			Key: item.Key,
 			Name: intl.MustLocalize(localizer, &i18n.LocalizeConfig{
 				MessageID: item.Name,
 			}),
+			Workspace:   item.Workspace,
+			Pinned:      item.Pinned,
 			Href:        item.Href,
 			Children:    translate(localizer, item.Children),
 			Keywords:    append([]string(nil), item.Keywords...),
@@ -301,6 +304,13 @@ func (app *application) NavItems(localizer *i18n.Localizer) []types.NavigationIt
 		return nil
 	}
 	return translate(localizer, app.runtimeSource.NavItems())
+}
+
+func (app *application) NavWorkspaces() []types.NavWorkspace {
+	if app.runtimeSource == nil {
+		return nil
+	}
+	return app.runtimeSource.NavWorkspaces()
 }
 
 func navItemsToQuickLinks(items ...types.NavigationItem) []*spotlight.QuickLink {

--- a/pkg/application/interface.go
+++ b/pkg/application/interface.go
@@ -35,6 +35,7 @@ type RuntimeSource interface {
 	GraphSchemas() []GraphSchema
 	Applets() []Applet
 	NavItems() []types.NavigationItem
+	NavWorkspaces() []types.NavWorkspace
 	QuickLinks() []*spotlight.QuickLink
 	SpotlightProviders() []spotlight.SearchProvider
 	SpotlightAgent() spotlight.Agent
@@ -58,6 +59,7 @@ type Application interface {
 	QuickLinks() *spotlight.QuickLinks
 	Migrations() MigrationManager
 	NavItems(localizer *i18n.Localizer) []types.NavigationItem
+	NavWorkspaces() []types.NavWorkspace
 	GraphSchemas() []GraphSchema
 	Bundle() *i18n.Bundle
 	GetSupportedLanguages() []string

--- a/pkg/application/navigation_quicklinks_test.go
+++ b/pkg/application/navigation_quicklinks_test.go
@@ -20,15 +20,16 @@ type testRuntimeSource struct {
 	applets  []Applet
 }
 
-func (s *testRuntimeSource) Controllers() []Controller          { return nil }
-func (s *testRuntimeSource) Middleware() []mux.MiddlewareFunc   { return nil }
-func (s *testRuntimeSource) Assets() []*embed.FS                { return nil }
-func (s *testRuntimeSource) HashFSAssets() []*hashfs.FS         { return nil }
-func (s *testRuntimeSource) LocaleFiles() []*embed.FS           { return nil }
-func (s *testRuntimeSource) GraphSchemas() []GraphSchema        { return nil }
-func (s *testRuntimeSource) Applets() []Applet                  { return s.applets }
-func (s *testRuntimeSource) NavItems() []types.NavigationItem   { return s.navItems }
-func (s *testRuntimeSource) QuickLinks() []*spotlight.QuickLink { return nil }
+func (s *testRuntimeSource) Controllers() []Controller           { return nil }
+func (s *testRuntimeSource) Middleware() []mux.MiddlewareFunc    { return nil }
+func (s *testRuntimeSource) Assets() []*embed.FS                 { return nil }
+func (s *testRuntimeSource) HashFSAssets() []*hashfs.FS          { return nil }
+func (s *testRuntimeSource) LocaleFiles() []*embed.FS            { return nil }
+func (s *testRuntimeSource) GraphSchemas() []GraphSchema         { return nil }
+func (s *testRuntimeSource) Applets() []Applet                   { return s.applets }
+func (s *testRuntimeSource) NavItems() []types.NavigationItem    { return s.navItems }
+func (s *testRuntimeSource) NavWorkspaces() []types.NavWorkspace { return nil }
+func (s *testRuntimeSource) QuickLinks() []*spotlight.QuickLink  { return nil }
 func (s *testRuntimeSource) SpotlightProviders() []spotlight.SearchProvider {
 	return nil
 }

--- a/pkg/composition/add.go
+++ b/pkg/composition/add.go
@@ -29,6 +29,48 @@ func AddNavItems(builder *Builder, items ...types.NavigationItem) {
 	})
 }
 
+// AddNavWorkspaces attaches one or more sidebar workspace declarations.
+func AddNavWorkspaces(builder *Builder, workspaces ...types.NavWorkspace) {
+	if builder == nil {
+		panic("composition: builder is nil")
+	}
+	if len(workspaces) == 0 {
+		return
+	}
+	captured := append([]types.NavWorkspace(nil), workspaces...)
+	ContributeNavWorkspaces(builder, func(*Container) ([]types.NavWorkspace, error) {
+		return captured, nil
+	})
+}
+
+// RemoveNavItemsByKey removes contributed navigation items with matching
+// stable keys after all nav contributions have materialized.
+func RemoveNavItemsByKey(builder *Builder, keys ...string) {
+	if builder == nil {
+		panic("composition: builder is nil")
+	}
+	for _, key := range keys {
+		if key == "" {
+			continue
+		}
+		builder.navItemRemovals = append(builder.navItemRemovals, key)
+	}
+}
+
+// ReplaceNavItemsByKey replaces contributed navigation items by their stable
+// keys after all nav contributions have materialized.
+func ReplaceNavItemsByKey(builder *Builder, items ...types.NavigationItem) {
+	if builder == nil {
+		panic("composition: builder is nil")
+	}
+	for _, item := range items {
+		if item.Key == "" {
+			continue
+		}
+		builder.navItemOverrides = append(builder.navItemOverrides, item)
+	}
+}
+
 // AddHashFS attaches one or more hashfs.FS asset bundles.
 func AddHashFS(builder *Builder, assets ...*hashfs.FS) {
 	if builder == nil {

--- a/pkg/composition/builder.go
+++ b/pkg/composition/builder.go
@@ -102,19 +102,20 @@ type Builder struct {
 	context    BuildContext
 	descriptor Descriptor
 
-	providers           []*providerEntry
-	controllerFactories []namedFactory[[]application.Controller]
-	navItemFactories    []namedFactory[[]types.NavigationItem]
-	localeFactories     []namedFactory[[]*embed.FS]
-	schemaFactories     []namedFactory[[]application.GraphSchema]
-	appletFactories     []namedFactory[[]application.Applet]
-	assetFactories      []namedFactory[[]*embed.FS]
-	hashFSFactories     []namedFactory[[]*hashfs.FS]
-	quickLinkFactories  []namedFactory[[]*spotlight.QuickLink]
-	spotlightFactories  []namedFactory[[]spotlight.SearchProvider]
-	spotlightAgent      *namedFactory[spotlight.Agent]
-	middlewareFactories []namedFactory[[]mux.MiddlewareFunc]
-	hookFactories       []namedFactory[[]Hook]
+	providers             []*providerEntry
+	controllerFactories   []namedFactory[[]application.Controller]
+	navItemFactories      []namedFactory[[]types.NavigationItem]
+	navWorkspaceFactories []namedFactory[[]types.NavWorkspace]
+	localeFactories       []namedFactory[[]*embed.FS]
+	schemaFactories       []namedFactory[[]application.GraphSchema]
+	appletFactories       []namedFactory[[]application.Applet]
+	assetFactories        []namedFactory[[]*embed.FS]
+	hashFSFactories       []namedFactory[[]*hashfs.FS]
+	quickLinkFactories    []namedFactory[[]*spotlight.QuickLink]
+	spotlightFactories    []namedFactory[[]spotlight.SearchProvider]
+	spotlightAgent        *namedFactory[spotlight.Agent]
+	middlewareFactories   []namedFactory[[]mux.MiddlewareFunc]
+	hookFactories         []namedFactory[[]Hook]
 
 	// Removals are recorded here and processed after every builder has
 	// contributed, so a downstream component can cleanly replace upstream
@@ -123,6 +124,8 @@ type Builder struct {
 	// Container.addBuilder.
 	providerRemovals   []Key
 	controllerRemovals []string // matched against Controller.Key()
+	navItemRemovals    []string // matched against NavigationItem.Key
+	navItemOverrides   []types.NavigationItem
 	hookRemovals       []string // matched against Hook.Name
 
 	eventHandlerSeq int // monotonic counter for unique event-handler hook names
@@ -331,6 +334,10 @@ func ContributeControllers(builder *Builder, factory func(*Container) ([]applica
 
 func ContributeNavItems(builder *Builder, factory func(*Container) ([]types.NavigationItem, error)) {
 	appendFactory(builder, "nav-items", factory, &builder.navItemFactories)
+}
+
+func ContributeNavWorkspaces(builder *Builder, factory func(*Container) ([]types.NavWorkspace, error)) {
+	appendFactory(builder, "nav-workspaces", factory, &builder.navWorkspaceFactories)
 }
 
 func ContributeSchemas(builder *Builder, factory func(*Container) ([]application.GraphSchema, error)) {

--- a/pkg/composition/engine.go
+++ b/pkg/composition/engine.go
@@ -267,6 +267,7 @@ type Container struct {
 
 	controllerBatches     []controllerBatch
 	navItemFactories      []namedFactory[[]types.NavigationItem]
+	navWorkspaceFactories []namedFactory[[]types.NavWorkspace]
 	localeFactories       []namedFactory[[]*embed.FS]
 	schemaFactories       []namedFactory[[]application.GraphSchema]
 	appletFactories       []namedFactory[[]application.Applet]
@@ -282,10 +283,13 @@ type Container struct {
 	// applied as post-collect filters inside materialize.
 	// Provider removals are processed inline at the top of addBuilder
 	// (per-builder ordering) and are not cached on the container.
-	pendingHookRemovals []string
+	pendingHookRemovals     []string
+	pendingNavItemRemovals  []string
+	pendingNavItemOverrides []types.NavigationItem
 
 	controllers        []application.Controller
 	navItems           []types.NavigationItem
+	navWorkspaces      []types.NavWorkspace
 	locales            []*embed.FS
 	graphSchemas       []application.GraphSchema
 	applets            []application.Applet
@@ -328,6 +332,10 @@ func (c *Container) Controllers() []application.Controller {
 
 func (c *Container) NavItems() []types.NavigationItem {
 	return append([]types.NavigationItem(nil), c.navItems...)
+}
+
+func (c *Container) NavWorkspaces() []types.NavWorkspace {
+	return append([]types.NavWorkspace(nil), c.navWorkspaces...)
 }
 
 func (c *Container) LocaleFiles() []*embed.FS {
@@ -580,6 +588,7 @@ func (c *Container) addBuilder(builder *Builder) error {
 		removals:  append([]string(nil), builder.controllerRemovals...),
 	})
 	c.navItemFactories = append(c.navItemFactories, builder.navItemFactories...)
+	c.navWorkspaceFactories = append(c.navWorkspaceFactories, builder.navWorkspaceFactories...)
 	c.localeFactories = append(c.localeFactories, builder.localeFactories...)
 	c.schemaFactories = append(c.schemaFactories, builder.schemaFactories...)
 	c.appletFactories = append(c.appletFactories, builder.appletFactories...)
@@ -601,6 +610,8 @@ func (c *Container) addBuilder(builder *Builder) error {
 	// the container and let materialize filter the collected slices after each
 	// collectInto call.
 	c.pendingHookRemovals = append(c.pendingHookRemovals, builder.hookRemovals...)
+	c.pendingNavItemRemovals = append(c.pendingNavItemRemovals, builder.navItemRemovals...)
+	c.pendingNavItemOverrides = append(c.pendingNavItemOverrides, builder.navItemOverrides...)
 	return nil
 }
 
@@ -641,6 +652,10 @@ func (c *Container) materialize() error {
 		c.controllers = filtered
 	}
 	if err := collectInto(c, c.navItemFactories, &c.navItems); err != nil {
+		return err
+	}
+	c.navItems = applyNavItemOverrides(c.navItems, c.pendingNavItemRemovals, c.pendingNavItemOverrides)
+	if err := collectInto(c, c.navWorkspaceFactories, &c.navWorkspaces); err != nil {
 		return err
 	}
 	if err := collectInto(c, c.localeFactories, &c.locales); err != nil {
@@ -761,6 +776,43 @@ func collectInto[T any](container *Container, factories []namedFactory[[]T], tar
 		*target = append(*target, values...)
 	}
 	return nil
+}
+
+func applyNavItemOverrides(
+	items []types.NavigationItem,
+	removals []string,
+	overrides []types.NavigationItem,
+) []types.NavigationItem {
+	if len(items) == 0 || (len(removals) == 0 && len(overrides) == 0) {
+		return items
+	}
+
+	removed := make(map[string]struct{}, len(removals))
+	for _, key := range removals {
+		if key != "" {
+			removed[key] = struct{}{}
+		}
+	}
+	replacements := make(map[string]types.NavigationItem, len(overrides))
+	for _, item := range overrides {
+		if item.Key != "" {
+			replacements[item.Key] = item
+		}
+	}
+
+	out := make([]types.NavigationItem, 0, len(items))
+	for _, item := range items {
+		if _, ok := removed[item.Key]; ok && item.Key != "" {
+			continue
+		}
+		if replacement, ok := replacements[item.Key]; ok && item.Key != "" {
+			out = append(out, replacement)
+			continue
+		}
+		item.Children = applyNavItemOverrides(item.Children, removals, overrides)
+		out = append(out, item)
+	}
+	return out
 }
 
 func collectControllerContributions(container *Container, factories []namedFactory[[]application.Controller]) ([]controllerContribution, error) {

--- a/pkg/composition/engine.go
+++ b/pkg/composition/engine.go
@@ -806,6 +806,10 @@ func applyNavItemOverrides(
 			continue
 		}
 		if replacement, ok := replacements[item.Key]; ok && item.Key != "" {
+			// Apply removals/overrides recursively into the replacement's
+			// subtree too, so a removal nested inside a replacement is honored
+			// rather than the replacement being appended verbatim.
+			replacement.Children = applyNavItemOverrides(replacement.Children, removals, overrides)
 			out = append(out, replacement)
 			continue
 		}

--- a/pkg/composition/engine_test.go
+++ b/pkg/composition/engine_test.go
@@ -87,6 +87,38 @@ func TestEngineCompileNavWorkspacesAndKeyOverrides(t *testing.T) {
 	}, container.NavWorkspaces())
 }
 
+func TestApplyNavItemOverridesRecursesIntoReplacementSubtree(t *testing.T) {
+	t.Parallel()
+
+	items := []types.NavigationItem{
+		{Key: "core.admin", Name: "Admin"},
+	}
+	// Replacement carries its own children; one of them is targeted for removal.
+	overrides := []types.NavigationItem{
+		{Key: "core.admin", Name: "Admin", Children: []types.NavigationItem{
+			{Key: "core.users", Name: "Users", Href: "/users"},
+			{Key: "core.secret", Name: "Secret", Href: "/secret"},
+			{Key: "core.nested", Name: "Nested", Children: []types.NavigationItem{
+				{Key: "core.deep-secret", Name: "DeepSecret", Href: "/deep"},
+				{Key: "core.deep-keep", Name: "DeepKeep", Href: "/keep"},
+			}},
+		}},
+	}
+	removals := []string{"core.secret", "core.deep-secret"}
+
+	got := applyNavItemOverrides(items, removals, overrides)
+
+	want := []types.NavigationItem{
+		{Key: "core.admin", Name: "Admin", Children: []types.NavigationItem{
+			{Key: "core.users", Name: "Users", Href: "/users"},
+			{Key: "core.nested", Name: "Nested", Children: []types.NavigationItem{
+				{Key: "core.deep-keep", Name: "DeepKeep", Href: "/keep"},
+			}},
+		}},
+	}
+	require.Equal(t, want, got)
+}
+
 func TestEngineCompileDetectsCycles(t *testing.T) {
 	engine := NewEngine()
 	err := engine.Register(

--- a/pkg/composition/engine_test.go
+++ b/pkg/composition/engine_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/iota-uz/iota-sdk/pkg/spotlight"
+	"github.com/iota-uz/iota-sdk/pkg/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,6 +48,43 @@ func TestEngineCompileTopoSort(t *testing.T) {
 	_, err = engine.Compile(BuildContext{})
 	require.NoError(t, err)
 	require.Equal(t, []string{"core", "crm", "ui"}, buildOrder)
+}
+
+func TestEngineCompileNavWorkspacesAndKeyOverrides(t *testing.T) {
+	engine := NewEngine()
+	err := engine.Register(
+		testComponent{
+			descriptor: Descriptor{Name: "core"},
+			build: func(builder *Builder) error {
+				AddNavItems(builder,
+					types.NavigationItem{Key: "core.dashboard", Name: "Dashboard", Href: "/"},
+					types.NavigationItem{Key: "core.admin", Name: "Admin", Children: []types.NavigationItem{
+						{Key: "core.users", Name: "Users", Href: "/users"},
+					}},
+				)
+				AddNavWorkspaces(builder, types.NavWorkspace{Key: "erp", Label: "ERP", Default: true})
+				return nil
+			},
+		},
+		testComponent{
+			descriptor: Descriptor{Name: "host", Requires: []string{"core"}},
+			build: func(builder *Builder) error {
+				RemoveNavItemsByKey(builder, "core.admin")
+				ReplaceNavItemsByKey(builder, types.NavigationItem{Key: "core.dashboard", Name: "Home", Href: "/"})
+				AddNavWorkspaces(builder, types.NavWorkspace{Key: "crm", Label: "CRM", Order: 1})
+				return nil
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	container, err := engine.Compile(BuildContext{})
+	require.NoError(t, err)
+	require.Equal(t, []types.NavigationItem{{Key: "core.dashboard", Name: "Home", Href: "/"}}, container.NavItems())
+	require.Equal(t, []types.NavWorkspace{
+		{Key: "erp", Label: "ERP", Default: true},
+		{Key: "crm", Label: "CRM", Order: 1},
+	}, container.NavWorkspaces())
 }
 
 func TestEngineCompileDetectsCycles(t *testing.T) {

--- a/pkg/composition/inspect.go
+++ b/pkg/composition/inspect.go
@@ -1,0 +1,54 @@
+package composition
+
+import (
+	"github.com/iota-uz/iota-sdk/pkg/spotlight"
+	"github.com/iota-uz/iota-sdk/pkg/types"
+)
+
+// StaticContributions captures the static, container-independent contributions
+// a component declares during Build. It is populated by InspectStatic and is
+// primarily useful for asserting Build-time wiring (e.g. whether a component
+// contributes navigation under a given set of options) without standing up a
+// full container or database.
+type StaticContributions struct {
+	NavItems   []types.NavigationItem
+	QuickLinks []*spotlight.QuickLink
+}
+
+// InspectStatic runs a component's Build against a fresh builder and returns its
+// static nav-item and quick-link contributions, without instantiating providers
+// or touching a database.
+//
+// It is intended for components whose nav-item/quick-link factories are static
+// (e.g. registered via AddNavItems / AddQuickLinks, which ignore the container).
+// Such factories are evaluated with a nil container. A container-dependent
+// factory (e.g. one that calls Resolve) will fail against the nil container and
+// that error is returned, so InspectStatic must not be used to obtain fully
+// materialized output — use Compile for that. Returns the component's Build
+// error, or the first factory error, if any.
+func InspectStatic(component Component) (StaticContributions, error) {
+	var out StaticContributions
+	if component == nil {
+		return out, nil
+	}
+	descriptor := normalizeDescriptor(component)
+	builder := newBuilder(BuildContext{}, descriptor)
+	if err := component.Build(builder); err != nil {
+		return out, err
+	}
+	for _, entry := range builder.navItemFactories {
+		values, err := entry.factory(nil)
+		if err != nil {
+			return out, err
+		}
+		out.NavItems = append(out.NavItems, values...)
+	}
+	for _, entry := range builder.quickLinkFactories {
+		values, err := entry.factory(nil)
+		if err != nil {
+			return out, err
+		}
+		out.QuickLinks = append(out.QuickLinks, values...)
+	}
+	return out, nil
+}

--- a/pkg/itf/harness_internal_test.go
+++ b/pkg/itf/harness_internal_test.go
@@ -199,6 +199,7 @@ func (a *testApp) Websocket() application.Huber                    { return nil 
 func (a *testApp) Spotlight() spotlight.Service                    { return nil }
 func (a *testApp) QuickLinks() *spotlight.QuickLinks               { return nil }
 func (a *testApp) NavItems(*i18n.Localizer) []types.NavigationItem { return nil }
+func (a *testApp) NavWorkspaces() []types.NavWorkspace             { return nil }
 func (a *testApp) GraphSchemas() []application.GraphSchema         { return nil }
 func (a *testApp) Bundle() *i18n.Bundle                            { return nil }
 func (a *testApp) GetSupportedLanguages() []string                 { return nil }

--- a/pkg/middleware/sidebar.go
+++ b/pkg/middleware/sidebar.go
@@ -168,7 +168,10 @@ func NavItemsWithInitialState(initialState sidebar.SidebarState) mux.MiddlewareF
 				sidebarProps = sidebarPropsDecorator(r.Context(), r, sidebarProps)
 
 				ctx := context.WithValue(r.Context(), constants.AllNavItemsKey, filtered)
-				ctx = context.WithValue(ctx, constants.NavItemsKey, append(enabledPinnedItems, enabledNavItems...))
+				// Fresh allocation to avoid mutating enabledPinnedItems' backing
+				// array (used above for PinnedItems sidebar props).
+				allNavItems := append(append([]types.NavigationItem(nil), enabledPinnedItems...), enabledNavItems...)
+				ctx = context.WithValue(ctx, constants.NavItemsKey, allNavItems)
 				ctx = context.WithValue(ctx, constants.SidebarPropsKey, sidebarProps)
 				next.ServeHTTP(w, r.WithContext(ctx))
 			},

--- a/pkg/middleware/sidebar.go
+++ b/pkg/middleware/sidebar.go
@@ -47,9 +47,13 @@ func filterItems(items []types.NavigationItem, user user.User) []types.Navigatio
 				continue
 			}
 			filteredItems = append(filteredItems, types.NavigationItem{
+				Key:         item.Key,
 				Name:        item.Name,
+				Workspace:   item.Workspace,
+				Pinned:      item.Pinned,
 				Href:        item.Href,
 				Children:    filteredChildren,
+				Keywords:    append([]string(nil), item.Keywords...),
 				Icon:        item.Icon,
 				Permissions: item.Permissions,
 				IsBeta:      item.IsBeta,
@@ -63,7 +67,14 @@ func getEnabledNavItems(items []types.NavigationItem) []types.NavigationItem {
 	var out []types.NavigationItem
 	for _, item := range items {
 		if len(item.Children) > 0 {
-			children := getEnabledNavItems(item.Children)
+			childrenWithInheritedWorkspace := make([]types.NavigationItem, len(item.Children))
+			copy(childrenWithInheritedWorkspace, item.Children)
+			for i := range childrenWithInheritedWorkspace {
+				if childrenWithInheritedWorkspace[i].Workspace == "" {
+					childrenWithInheritedWorkspace[i].Workspace = item.Workspace
+				}
+			}
+			children := getEnabledNavItems(childrenWithInheritedWorkspace)
 			childrenLen := len(children)
 			if childrenLen == 0 {
 				continue
@@ -80,6 +91,26 @@ func getEnabledNavItems(items []types.NavigationItem) []types.NavigationItem {
 	}
 
 	return out
+}
+
+func splitPinnedItems(items []types.NavigationItem) ([]types.NavigationItem, []types.NavigationItem) {
+	pinned := make([]types.NavigationItem, 0)
+	unpinned := make([]types.NavigationItem, 0, len(items))
+	for _, item := range items {
+		if item.Pinned {
+			pinned = append(pinned, item)
+			continue
+		}
+		hadChildren := len(item.Children) > 0
+		childPinned, childUnpinned := splitPinnedItems(item.Children)
+		pinned = append(pinned, childPinned...)
+		item.Children = childUnpinned
+		if hadChildren && len(childUnpinned) == 0 {
+			continue
+		}
+		unpinned = append(unpinned, item)
+	}
+	return pinned, unpinned
 }
 
 func normalizeTabGroups(collection sidebar.TabGroupCollection) sidebar.TabGroupCollection {
@@ -116,21 +147,28 @@ func NavItemsWithInitialState(initialState sidebar.SidebarState) mux.MiddlewareF
 				if len(u.Roles()) == 0 {
 					filtered = []types.NavigationItem{}
 				}
-				enabledNavItems := getEnabledNavItems(filtered)
+				pinnedItems, unpinnedItems := splitPinnedItems(filtered)
+				enabledPinnedItems := getEnabledNavItems(pinnedItems)
+				enabledNavItems := getEnabledNavItems(unpinnedItems)
 
 				// Build sidebar props with configurable tab groups
-				tabGroups := normalizeTabGroups(pkgsidebar.BuildTabGroups(enabledNavItems, localizer))
+				tabGroups := normalizeTabGroups(pkgsidebar.BuildTabGroupsWithWorkspaces(
+					enabledNavItems,
+					app.NavWorkspaces(),
+					localizer,
+				))
 
 				sidebarProps := sidebar.Props{
 					Header:       layouts.DefaultSidebarHeader(),
 					TabGroups:    tabGroups,
+					PinnedItems:  layouts.MapNavItemsToSidebar(enabledPinnedItems),
 					Footer:       layouts.DefaultSidebarFooter(),
 					InitialState: initialState,
 				}
 				sidebarProps = sidebarPropsDecorator(r.Context(), r, sidebarProps)
 
 				ctx := context.WithValue(r.Context(), constants.AllNavItemsKey, filtered)
-				ctx = context.WithValue(ctx, constants.NavItemsKey, enabledNavItems)
+				ctx = context.WithValue(ctx, constants.NavItemsKey, append(enabledPinnedItems, enabledNavItems...))
 				ctx = context.WithValue(ctx, constants.SidebarPropsKey, sidebarProps)
 				next.ServeHTTP(w, r.WithContext(ctx))
 			},

--- a/pkg/middleware/sidebar_test.go
+++ b/pkg/middleware/sidebar_test.go
@@ -127,10 +127,10 @@ func TestGetEnabledNavItems(t *testing.T) {
 		require.Equal(t, []string{"leaf-deep", "leaf"}, keysOf(out))
 	})
 
-	t.Run("parent with two child-groups that all collapse to empty is pruned", func(t *testing.T) {
+	t.Run("single-child group chain collapses to grandchild leaf", func(t *testing.T) {
 		t.Parallel()
-		// Both child groups are non-leaf (have a Children slice) but yield zero
-		// enabled descendants, so the parent has no enabled children and is dropped.
+		// parent -> g1 (group) -> g1a (leaf, empty Children). Both single-child
+		// levels collapse, hoisting g1a to the top.
 		out := getEnabledNavItems([]types.NavigationItem{
 			{Key: "parent", Workspace: "erp", Children: []types.NavigationItem{
 				{Key: "g1", Children: []types.NavigationItem{

--- a/pkg/middleware/sidebar_test.go
+++ b/pkg/middleware/sidebar_test.go
@@ -1,0 +1,145 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/iota-uz/iota-sdk/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func keysOf(items []types.NavigationItem) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		out = append(out, item.Key)
+	}
+	return out
+}
+
+func TestSplitPinnedItems(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		items        []types.NavigationItem
+		wantPinned   []string
+		wantUnpinned []string
+	}{
+		{
+			name: "top-level pinned extracted and removed from unpinned",
+			items: []types.NavigationItem{
+				{Key: "a", Pinned: true},
+				{Key: "b"},
+				{Key: "c", Pinned: true},
+			},
+			wantPinned:   []string{"a", "c"},
+			wantUnpinned: []string{"b"},
+		},
+		{
+			name: "pinned child hoisted, parent kept with remaining children",
+			items: []types.NavigationItem{
+				{Key: "parent", Children: []types.NavigationItem{
+					{Key: "child-pinned", Pinned: true},
+					{Key: "child-plain"},
+				}},
+			},
+			wantPinned:   []string{"child-pinned"},
+			wantUnpinned: []string{"parent"},
+		},
+		{
+			name: "parent pruned when all children pinned",
+			items: []types.NavigationItem{
+				{Key: "parent", Children: []types.NavigationItem{
+					{Key: "c1", Pinned: true},
+					{Key: "c2", Pinned: true},
+				}},
+			},
+			wantPinned:   []string{"c1", "c2"},
+			wantUnpinned: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			pinned, unpinned := splitPinnedItems(tt.items)
+			assert.Equal(t, tt.wantPinned, keysOf(pinned))
+			assert.Equal(t, tt.wantUnpinned, keysOf(unpinned))
+		})
+	}
+}
+
+func TestSplitPinnedItemsRemainingChildren(t *testing.T) {
+	t.Parallel()
+
+	_, unpinned := splitPinnedItems([]types.NavigationItem{
+		{Key: "parent", Children: []types.NavigationItem{
+			{Key: "child-pinned", Pinned: true},
+			{Key: "child-plain"},
+		}},
+	})
+
+	require.Len(t, unpinned, 1)
+	require.Equal(t, []string{"child-plain"}, keysOf(unpinned[0].Children))
+}
+
+func TestGetEnabledNavItems(t *testing.T) {
+	t.Parallel()
+
+	t.Run("child inherits parent workspace when empty", func(t *testing.T) {
+		t.Parallel()
+		out := getEnabledNavItems([]types.NavigationItem{
+			{Key: "parent", Workspace: "erp", Children: []types.NavigationItem{
+				{Key: "c1", Href: "/c1"},
+				{Key: "c2", Href: "/c2", Workspace: "crm"},
+			}},
+		})
+		require.Len(t, out, 1)
+		// Two children => parent retained, children carry inherited/own workspace.
+		require.Equal(t, "parent", out[0].Key)
+		require.Equal(t, "erp", out[0].Children[0].Workspace)
+		require.Equal(t, "crm", out[0].Children[1].Workspace)
+	})
+
+	t.Run("single child collapses to the child", func(t *testing.T) {
+		t.Parallel()
+		out := getEnabledNavItems([]types.NavigationItem{
+			{Key: "parent", Workspace: "erp", Children: []types.NavigationItem{
+				{Key: "only", Href: "/only"},
+			}},
+		})
+		require.Equal(t, []string{"only"}, keysOf(out))
+		require.Equal(t, "erp", out[0].Workspace)
+	})
+
+	t.Run("single-child parent collapses to grandchild leaf", func(t *testing.T) {
+		t.Parallel()
+		// Parent has one child group; that group has one leaf. Both single-child
+		// levels collapse so the grandchild is hoisted to the top, parent dropped.
+		out := getEnabledNavItems([]types.NavigationItem{
+			{Key: "parent", Workspace: "erp", Children: []types.NavigationItem{
+				{Key: "group", Children: []types.NavigationItem{
+					{Key: "leaf-deep", Href: "/deep"},
+				}},
+			}},
+			{Key: "leaf", Href: "/leaf"},
+		})
+		require.Equal(t, []string{"leaf-deep", "leaf"}, keysOf(out))
+	})
+
+	t.Run("parent with two child-groups that all collapse to empty is pruned", func(t *testing.T) {
+		t.Parallel()
+		// Both child groups are non-leaf (have a Children slice) but yield zero
+		// enabled descendants, so the parent has no enabled children and is dropped.
+		out := getEnabledNavItems([]types.NavigationItem{
+			{Key: "parent", Workspace: "erp", Children: []types.NavigationItem{
+				{Key: "g1", Children: []types.NavigationItem{
+					{Key: "g1a", Children: []types.NavigationItem{}},
+				}},
+			}},
+			{Key: "leaf", Href: "/leaf"},
+		})
+		// g1a is a leaf (empty Children) -> g1 collapses to g1a -> parent collapses to g1a.
+		require.Equal(t, []string{"g1a", "leaf"}, keysOf(out))
+	})
+}

--- a/pkg/sidebar/config.go
+++ b/pkg/sidebar/config.go
@@ -7,7 +7,6 @@ import (
 	"github.com/iota-uz/go-i18n/v2/i18n"
 	"github.com/iota-uz/iota-sdk/components/sidebar"
 	"github.com/iota-uz/iota-sdk/modules/core/presentation/templates/layouts"
-	"github.com/iota-uz/iota-sdk/pkg/intl"
 	"github.com/iota-uz/iota-sdk/pkg/types"
 )
 
@@ -126,12 +125,18 @@ func localizeWorkspaceLabel(localizer *i18n.Localizer, workspace types.NavWorksp
 	if localizer == nil || workspace.Label == "" {
 		return workspace.Label
 	}
-	// Mirror nav-item name localization (pkg/application.translate): fail loudly
-	// on a missing/typo'd NavWorkspaces.* key instead of silently shipping the
-	// raw key as a visible sidebar tab label.
-	return intl.MustLocalize(localizer, &i18n.LocalizeConfig{
+	// Workspace labels are i18n keys declared by the consuming app, not the SDK.
+	// Degrade gracefully (fall back to the raw key) rather than panicking on a
+	// missing/typo'd NavWorkspaces.* key — a missing label must not take down the
+	// whole authenticated sidebar. Consumers catch missing keys via their own
+	// i18n key-consistency checks (e.g. `just check tr`).
+	label, err := localizer.Localize(&i18n.LocalizeConfig{
 		MessageID: workspace.Label,
 	})
+	if err != nil {
+		return workspace.Label
+	}
+	return label
 }
 
 // DefaultTabGroupBuilder maintains current behavior.

--- a/pkg/sidebar/config.go
+++ b/pkg/sidebar/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/iota-uz/go-i18n/v2/i18n"
 	"github.com/iota-uz/iota-sdk/components/sidebar"
 	"github.com/iota-uz/iota-sdk/modules/core/presentation/templates/layouts"
+	"github.com/iota-uz/iota-sdk/pkg/intl"
 	"github.com/iota-uz/iota-sdk/pkg/types"
 )
 
@@ -52,9 +53,18 @@ func WorkspaceTabGroupBuilder(
 	workspaces []types.NavWorkspace,
 	localizer *i18n.Localizer,
 ) sidebar.TabGroupCollection {
+	if len(workspaces) == 0 {
+		return BuildTabGroups(items, localizer)
+	}
+
 	orderedWorkspaces := append([]types.NavWorkspace(nil), workspaces...)
 	sort.SliceStable(orderedWorkspaces, func(i, j int) bool {
-		return orderedWorkspaces[i].Order < orderedWorkspaces[j].Order
+		if orderedWorkspaces[i].Order != orderedWorkspaces[j].Order {
+			return orderedWorkspaces[i].Order < orderedWorkspaces[j].Order
+		}
+		// Deterministic secondary tie-break: equal-Order workspaces sort by Key
+		// ascending so ordering is self-evident rather than relying on insertion.
+		return orderedWorkspaces[i].Key < orderedWorkspaces[j].Key
 	})
 
 	defaultWorkspace := orderedWorkspaces[0]
@@ -103,13 +113,12 @@ func localizeWorkspaceLabel(localizer *i18n.Localizer, workspace types.NavWorksp
 	if localizer == nil || workspace.Label == "" {
 		return workspace.Label
 	}
-	label, err := localizer.Localize(&i18n.LocalizeConfig{
+	// Mirror nav-item name localization (pkg/application.translate): fail loudly
+	// on a missing/typo'd NavWorkspaces.* key instead of silently shipping the
+	// raw key as a visible sidebar tab label.
+	return intl.MustLocalize(localizer, &i18n.LocalizeConfig{
 		MessageID: workspace.Label,
 	})
-	if err != nil {
-		return workspace.Label
-	}
-	return label
 }
 
 // DefaultTabGroupBuilder maintains current behavior.

--- a/pkg/sidebar/config.go
+++ b/pkg/sidebar/config.go
@@ -81,13 +81,26 @@ func WorkspaceTabGroupBuilder(
 		workspaceByKey[workspace.Key] = workspace
 	}
 
-	for _, item := range items {
-		workspaceKey := item.Workspace
-		if _, ok := workspaceByKey[workspaceKey]; workspaceKey == "" || !ok {
-			workspaceKey = defaultWorkspace.Key
+	resolveKey := func(workspace string) string {
+		if _, ok := workspaceByKey[workspace]; workspace == "" || !ok {
+			return defaultWorkspace.Key
 		}
+		return workspace
+	}
+
+	for _, item := range items {
+		workspaceKey := resolveKey(item.Workspace)
 		if item.Workspace != "" && len(item.Children) > 0 {
-			groupItems[workspaceKey] = append(groupItems[workspaceKey], layouts.MapNavItemsToSidebar(item.Children)...)
+			// Tagged container: flatten its children into workspaces. A child
+			// that declares its own (valid) Workspace is routed there; otherwise
+			// it inherits the container's workspace.
+			for _, child := range item.Children {
+				childKey := workspaceKey
+				if child.Workspace != "" {
+					childKey = resolveKey(child.Workspace)
+				}
+				groupItems[childKey] = append(groupItems[childKey], layouts.MapNavItemToSidebar(child))
+			}
 			continue
 		}
 		groupItems[workspaceKey] = append(groupItems[workspaceKey], layouts.MapNavItemToSidebar(item))

--- a/pkg/sidebar/config.go
+++ b/pkg/sidebar/config.go
@@ -2,6 +2,8 @@
 package sidebar
 
 import (
+	"sort"
+
 	"github.com/iota-uz/go-i18n/v2/i18n"
 	"github.com/iota-uz/iota-sdk/components/sidebar"
 	"github.com/iota-uz/iota-sdk/modules/core/presentation/templates/layouts"
@@ -11,7 +13,8 @@ import (
 // TabGroupBuilder is a function that takes navigation items and returns tab groups
 type TabGroupBuilder func(items []types.NavigationItem, localizer *i18n.Localizer) sidebar.TabGroupCollection
 
-// BuildTabGroups is the global variable that users can override to customize tab grouping
+// BuildTabGroups is the global variable that users can override to customize tab grouping.
+// Deprecated: use composition.AddNavWorkspaces and NavigationItem.Workspace instead.
 var BuildTabGroups TabGroupBuilder = DefaultTabGroupBuilder
 
 func AppendIfNotEmpty(groups *[]sidebar.TabGroup, group sidebar.TabGroup) {
@@ -33,7 +36,83 @@ func NormalizeDefaultTab(groups []sidebar.TabGroup, preferred string) string {
 	return groups[0].Value
 }
 
-// DefaultTabGroupBuilder maintains current behavior (single "Core" tab)
+func BuildTabGroupsWithWorkspaces(
+	items []types.NavigationItem,
+	workspaces []types.NavWorkspace,
+	localizer *i18n.Localizer,
+) sidebar.TabGroupCollection {
+	if len(workspaces) == 0 {
+		return BuildTabGroups(items, localizer)
+	}
+	return WorkspaceTabGroupBuilder(items, workspaces, localizer)
+}
+
+func WorkspaceTabGroupBuilder(
+	items []types.NavigationItem,
+	workspaces []types.NavWorkspace,
+	localizer *i18n.Localizer,
+) sidebar.TabGroupCollection {
+	orderedWorkspaces := append([]types.NavWorkspace(nil), workspaces...)
+	sort.SliceStable(orderedWorkspaces, func(i, j int) bool {
+		return orderedWorkspaces[i].Order < orderedWorkspaces[j].Order
+	})
+
+	defaultWorkspace := orderedWorkspaces[0]
+	for _, workspace := range orderedWorkspaces {
+		if workspace.Default {
+			defaultWorkspace = workspace
+			break
+		}
+	}
+
+	workspaceByKey := make(map[string]types.NavWorkspace, len(orderedWorkspaces))
+	groupItems := make(map[string][]sidebar.Item, len(orderedWorkspaces))
+	for _, workspace := range orderedWorkspaces {
+		workspaceByKey[workspace.Key] = workspace
+	}
+
+	for _, item := range items {
+		workspaceKey := item.Workspace
+		if _, ok := workspaceByKey[workspaceKey]; workspaceKey == "" || !ok {
+			workspaceKey = defaultWorkspace.Key
+		}
+		if item.Workspace != "" && len(item.Children) > 0 {
+			groupItems[workspaceKey] = append(groupItems[workspaceKey], layouts.MapNavItemsToSidebar(item.Children)...)
+			continue
+		}
+		groupItems[workspaceKey] = append(groupItems[workspaceKey], layouts.MapNavItemToSidebar(item))
+	}
+
+	groups := make([]sidebar.TabGroup, 0, len(orderedWorkspaces))
+	for _, workspace := range orderedWorkspaces {
+		AppendIfNotEmpty(&groups, sidebar.TabGroup{
+			Label:  localizeWorkspaceLabel(localizer, workspace),
+			Value:  workspace.Key,
+			Items:  groupItems[workspace.Key],
+			IsBeta: workspace.IsBeta,
+		})
+	}
+
+	return sidebar.TabGroupCollection{
+		Groups:       groups,
+		DefaultValue: NormalizeDefaultTab(groups, defaultWorkspace.Key),
+	}
+}
+
+func localizeWorkspaceLabel(localizer *i18n.Localizer, workspace types.NavWorkspace) string {
+	if localizer == nil || workspace.Label == "" {
+		return workspace.Label
+	}
+	label, err := localizer.Localize(&i18n.LocalizeConfig{
+		MessageID: workspace.Label,
+	})
+	if err != nil {
+		return workspace.Label
+	}
+	return label
+}
+
+// DefaultTabGroupBuilder maintains current behavior.
 func DefaultTabGroupBuilder(items []types.NavigationItem, localizer *i18n.Localizer) sidebar.TabGroupCollection {
 	sidebarItems := []sidebar.Item{}
 	crmItems := []sidebar.Item{}

--- a/pkg/sidebar/config_test.go
+++ b/pkg/sidebar/config_test.go
@@ -44,6 +44,37 @@ func TestWorkspaceTabGroupBuilderLocalizesAndFlattensWorkspaceContainers(t *test
 	require.Equal(t, "Clients", collection.Groups[1].Items[0].(interface{ Text() string }).Text())
 }
 
+func TestWorkspaceTabGroupBuilderHonorsChildWorkspaceOverride(t *testing.T) {
+	collection := WorkspaceTabGroupBuilder(
+		[]types.NavigationItem{
+			{
+				Name:      "CRM",
+				Href:      "/crm",
+				Workspace: "crm",
+				Children: []types.NavigationItem{
+					{Name: "Clients", Href: "/crm/clients"},
+					// Child declares a different workspace: it must land in ERP,
+					// not be flattened into the parent's CRM workspace.
+					{Name: "Shared Report", Href: "/reports", Workspace: "erp"},
+				},
+			},
+		},
+		[]types.NavWorkspace{
+			{Key: "erp", Label: "ERP", Default: true, Order: 0},
+			{Key: "crm", Label: "CRM", Order: 1},
+		},
+		nil,
+	)
+
+	require.Len(t, collection.Groups, 2)
+	require.Equal(t, "erp", collection.Groups[0].Value)
+	require.Len(t, collection.Groups[0].Items, 1)
+	require.Equal(t, "Shared Report", collection.Groups[0].Items[0].(interface{ Text() string }).Text())
+	require.Equal(t, "crm", collection.Groups[1].Value)
+	require.Len(t, collection.Groups[1].Items, 1)
+	require.Equal(t, "Clients", collection.Groups[1].Items[0].(interface{ Text() string }).Text())
+}
+
 func TestBuildTabGroupsWithWorkspacesFallsBackToLegacyBuilder(t *testing.T) {
 	collection := BuildTabGroupsWithWorkspaces(
 		[]types.NavigationItem{

--- a/pkg/sidebar/config_test.go
+++ b/pkg/sidebar/config_test.go
@@ -1,0 +1,65 @@
+package sidebar
+
+import (
+	"testing"
+
+	"github.com/iota-uz/go-i18n/v2/i18n"
+	"github.com/iota-uz/iota-sdk/pkg/types"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/language"
+)
+
+func TestWorkspaceTabGroupBuilderLocalizesAndFlattensWorkspaceContainers(t *testing.T) {
+	bundle := i18n.NewBundle(language.English)
+	bundle.AddMessages(language.English,
+		&i18n.Message{ID: "NavWorkspaces.ERP", Other: "ERP"},
+		&i18n.Message{ID: "NavWorkspaces.CRM", Other: "CRM"},
+	)
+	localizer := i18n.NewLocalizer(bundle, language.English.String())
+
+	collection := WorkspaceTabGroupBuilder(
+		[]types.NavigationItem{
+			{Name: "Dashboard", Href: "/"},
+			{
+				Name:      "CRM",
+				Href:      "/crm",
+				Workspace: "crm",
+				Children: []types.NavigationItem{
+					{Name: "Clients", Href: "/crm/clients", Workspace: "crm"},
+				},
+			},
+		},
+		[]types.NavWorkspace{
+			{Key: "erp", Label: "NavWorkspaces.ERP", Default: true, Order: 0},
+			{Key: "crm", Label: "NavWorkspaces.CRM", Order: 1},
+		},
+		localizer,
+	)
+
+	require.Equal(t, "erp", collection.DefaultValue)
+	require.Len(t, collection.Groups, 2)
+	require.Equal(t, "ERP", collection.Groups[0].Label)
+	require.Equal(t, "Dashboard", collection.Groups[0].Items[0].(interface{ Text() string }).Text())
+	require.Equal(t, "CRM", collection.Groups[1].Label)
+	require.Equal(t, "Clients", collection.Groups[1].Items[0].(interface{ Text() string }).Text())
+}
+
+func TestBuildTabGroupsWithWorkspacesFallsBackToLegacyBuilder(t *testing.T) {
+	collection := BuildTabGroupsWithWorkspaces(
+		[]types.NavigationItem{
+			{
+				Name: "CRM",
+				Href: "/crm",
+				Children: []types.NavigationItem{
+					{Name: "Clients", Href: "/crm/clients"},
+				},
+			},
+		},
+		nil,
+		nil,
+	)
+
+	require.Len(t, collection.Groups, 1)
+	require.Equal(t, "crm", collection.Groups[0].Value)
+	require.Equal(t, "Clients", collection.Groups[0].Items[0].(interface{ Text() string }).Text())
+}

--- a/pkg/types/navigation.go
+++ b/pkg/types/navigation.go
@@ -8,6 +8,9 @@ import (
 )
 
 type NavigationItem struct {
+	Key         string
+	Workspace   string
+	Pinned      bool
 	Name        string
 	Href        string
 	Children    []NavigationItem
@@ -27,4 +30,12 @@ func (n NavigationItem) HasPermission(user user.User) bool {
 		}
 	}
 	return true
+}
+
+type NavWorkspace struct {
+	Key     string
+	Label   string
+	Order   int
+	Default bool
+	IsBeta  bool
 }


### PR DESCRIPTION
## Summary

- Adds stable navigation item keys plus workspace and pinned metadata.
- Adds composition APIs for declaring nav workspaces and removing/replacing nav items by key.
- Builds sidebar tab groups from declared workspaces with localized labels, while preserving the legacy `BuildTabGroups` hook when no workspaces are declared.
- Adds a pinned sidebar render region and `SkipAdminNavItems` for core admin nav decoupling.

Closes iota-uz/iota-sdk#791.
Unblocks iota-uz/eai#2941.

## Base branch

This PR targets `feat/archival-portfolio-import-2856` because EAI currently pins SDK commit `dd67fd82` from that branch. Targeting this branch keeps the downstream EAI build on the import APIs it already consumes; the navigation commit can be carried forward when that SDK branch lands on `main`.

## Validation

- `go test ./pkg/sidebar ./pkg/composition ./pkg/application ./modules/core ./components/sidebar`
- `go vet ./pkg/sidebar ./pkg/composition ./pkg/application ./modules/core ./components/sidebar`
- `git diff --check`

Note: a broader `go test ./pkg/middleware` run compiled the package but hit local Postgres because `TestPgxPoolCollector_CollectsFromRealPool` expects an `iota_erp` database on `127.0.0.1:5432`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for pinned navigation items in the sidebar for quick access to frequently used sections.
  * Implemented workspace-aware navigation organization, allowing navigation items to be grouped by workspace.
  * Enhanced collapsed sidebar mode with a compact workspace selector displaying workspace labels as abbreviated badges with tooltips.

* **Improvements**
  * Refined role management delete confirmation dialog to improve button interaction precision.
  * Added capability to independently control visibility of admin navigation items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->