### PR TITLE
fix(roles): make delete button work on role edit page

### DIFF
--- a/modules/core/presentation/templates/pages/roles/edit.templ
+++ b/modules/core/presentation/templates/pages/roles/edit.templ
@@ -151,7 +151,7 @@ templ Edit(props *EditFormProps) {
 			hx-target="closest .content"
 			hx-swap="innerHTML"
 			hx-indicator="#delete-role-btn"
-			hx-disabled-elt="find button"
+			hx-disabled-elt="#delete-role-btn"
 			class="hidden"
 		>
 			@composables.CSRFTokenField()

--- a/modules/core/presentation/templates/pages/roles/edit_templ.go
+++ b/modules/core/presentation/templates/pages/roles/edit_templ.go
@@ -434,7 +434,7 @@ func Edit(props *EditFormProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\" hx-trigger=\"submit\" hx-target=\"closest .content\" hx-swap=\"innerHTML\" hx-indicator=\"#delete-role-btn\" hx-disabled-elt=\"find button\" class=\"hidden\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\" hx-trigger=\"submit\" hx-target=\"closest .content\" hx-swap=\"innerHTML\" hx-indicator=\"#delete-role-btn\" hx-disabled-elt=\"#delete-role-btn\" class=\"hidden\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}


### PR DESCRIPTION
## Problem

On the role edit page, clicking **Delete → confirm** did nothing — the role was not deleted and the button stayed stuck on a loading spinner. Reported in iota-uz/eai#2818 (severity: high / blocker).

## Root cause

The hidden `#delete-form` carried `hx-disabled-elt="find button"`, but that form contains **only the CSRF field** — there is no `<button>` inside it. The actual delete button (`#delete-role-btn`) lives *outside* the form and merely dispatches the Alpine confirmation event.

So `find button` resolved to `null`, and htmx 2.0.2 threw inside `htmx.trigger(deleteForm, "submit")`:

```
Uncaught TypeError: Cannot read properties of null (reading 'htmx-internal-data')
    at Object.de [as trigger]        ← htmx.trigger
    at __self.result (alpine eval)   ← dialog @closing handler
```

The exception aborts the DELETE pipeline after the XHR is opened but before it completes, leaving the button locked in `htmx-request` (the "three dots" spinner the reporter saw). Backend `RolesController.Delete → RoleService.Delete → repo.Delete` is correct and untouched.

This regressed in `870461f10` (2026-03-03), which moved the delete button out of the form but kept `hx-disabled-elt="find button"` on the now button-less form. Every other module keeps its delete button inside the form, so `find button` resolves there — roles was the only broken case.

## Fix

Point `hx-disabled-elt` at the real button `#delete-role-btn` (which already backs `hx-indicator`), so htmx resolves a valid element and disables it during the request.

```diff
- hx-disabled-elt="find button"
+ hx-disabled-elt="#delete-role-btn"
```

## Verification

Reproduced and verified on staging (`eai-backend-staging`):
- **Before:** confirm → JS TypeError, no DELETE completes, role remains, button stuck.
- **After (this change applied to the live form):** created a throwaway role `QA-Delete-Test-2818`, confirmed delete → `DELETE /roles/{id}` completes → redirect to `/roles` → role gone, no console error.

`templ generate` (v0.3.857) regenerated `edit_templ.go`; `go vet ./modules/core/presentation/templates/pages/roles/` passes.

Fixes iota-uz/eai#2818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the delete button behavior in roles management to properly disable during deletion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->