### PR TITLE
fix(scaffold/table): keyboard-nav double-step + un-skip wide-table e2e (#799)

### DIFF
--- a/components/scaffold/table/helpers.go
+++ b/components/scaffold/table/helpers.go
@@ -722,7 +722,10 @@ func (r *tableRowImpl) ApplyOpts(opts ...RowOpt) TableRow {
 
 func WithDrawer(fetchURL string) RowOpt {
 	return func(r *tableRowImpl) {
-		r.attrs["class"] = r.attrs["class"].(string) +
+		// Comma-ok guard: Row() initializes class as a string, but defend against
+		// a nil/non-string class set by a prior opt instead of panicking.
+		existing, _ := r.attrs["class"].(string)
+		r.attrs["class"] = existing +
 			" cursor-pointer hover:bg-surface-500 transition-colors" +
 			" focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary"
 		r.attrs["hx-get"] = fetchURL

--- a/e2e/tests/finance/table-wide.spec.ts
+++ b/e2e/tests/finance/table-wide.spec.ts
@@ -10,33 +10,30 @@ import { resetTestDatabase, seedScenario } from '../../fixtures/test-data';
  *   - WithDrawer()    keyboard navigation (arrow keys + Enter)
  *   - horizontal scroll affordance overlays
  *
- * The list lives at /finance/expense-categories. We seed a category through the
- * create drawer so at least one real data row exists regardless of scenario.
+ * The list lives at /finance/expense-categories and is empty after a reseed, so
+ * each test creates a category through the create drawer to get a real data row.
  */
 
 const BASE = '/finance/expense-categories';
 
 async function createCategory(page: Page, name: string, description: string) {
   await page.goto(BASE);
-  await page.locator('[hx-get$="/new/drawer"]').first().click();
-  // Drawer form fields are plain inputs named name/description.
-  await page.locator('input[name="name"]').fill(name);
-  const desc = page.locator('textarea[name="description"], input[name="description"]').first();
-  await desc.fill(description);
+  await waitForAlpine(page);
+  // CreateAction renders a trigger with hx-get=".../new/drawer" targeting #view-drawer.
+  // The layout renders a responsive pair (toolbar + collapsed menu); click the visible one.
+  await page.locator('[hx-get*="/new/drawer"]:visible').first().click();
+  // Drawer form fields are named with capitalised DTO field names (Name / Description).
+  await page.locator('#view-drawer input[name="Name"]').fill(name);
+  await page.locator('#view-drawer textarea[name="Description"]').fill(description);
   await Promise.all([
     page.waitForResponse((r) => r.url().includes(BASE) && r.request().method() === 'POST'),
-    page.getByRole('button', { name: /save|add|create/i }).first().click(),
+    page.locator('#create-form button[type="submit"]').first().click(),
   ]);
   await page.goto(BASE);
   await waitForAlpine(page);
 }
 
-// TODO(#799): selectors in createCategory() and the assertions below were authored
-// without a live e2e run (the dev env had no Playwright deps). The create-drawer flow
-// and data-col/tooltip selectors need validation against a running instance before this
-// is un-skipped. The primitives are covered by helpers_test.go unit tests and dogfooded
-// on /finance/expense-categories. Tracking: iota-uz/iota-sdk#799.
-test.describe.skip('Wide-dataset scaffold table (expense categories)', () => {
+test.describe('Wide-dataset scaffold table (expense categories)', () => {
   test.describe.configure({ mode: 'serial' });
 
   const longDescription =
@@ -74,11 +71,12 @@ test.describe.skip('Wide-dataset scaffold table (expense categories)', () => {
   test('priority column is hidden on narrow viewports, visible on wide', async ({
     page,
   }) => {
-    await page.goto(BASE);
-    await waitForAlpine(page);
+    await createCategory(page, 'Priority Cat', 'Short');
 
-    const createdHeader = page.locator('thead th[data-col="created_at"]').first();
-    await expect(createdHeader).toHaveAttribute('data-col-priority', '2');
+    // The created_at header carries WithPriority(2). Headers don't emit data-col,
+    // so target the priority attribute itself (created_at is the only priority col).
+    const createdHeader = page.locator('thead th[data-col-priority="2"]').first();
+    await expect(createdHeader).toHaveCount(1);
 
     // Desktop: visible.
     await page.setViewportSize({ width: 1280, height: 800 });
@@ -104,12 +102,14 @@ test.describe.skip('Wide-dataset scaffold table (expense categories)', () => {
 
     // Focus first row, ArrowDown moves focus to the next drawer row (if any).
     await rows.first().focus();
+    await expect(rows.first()).toBeFocused();
     const count = await rows.count();
     if (count > 1) {
       await page.keyboard.press('ArrowDown');
-      const secondFocused = await rows.nth(1).evaluate((el) => el === document.activeElement);
-      expect(secondFocused).toBe(true);
+      // toBeFocused auto-retries while the Alpine handler applies focus.
+      await expect(rows.nth(1)).toBeFocused();
       await page.keyboard.press('ArrowUp');
+      await expect(rows.first()).toBeFocused();
     }
 
     // Enter triggers the row's hx-get into #view-drawer.
@@ -124,13 +124,12 @@ test.describe.skip('Wide-dataset scaffold table (expense categories)', () => {
   test('horizontal scroll affordance overlays exist in the table wrapper', async ({
     page,
   }) => {
-    await page.goto(BASE);
-    await waitForAlpine(page);
+    await createCategory(page, 'Overlay Cat', 'Short');
 
-    // Gradient overlays are rendered (visibility is driven by scroll state).
+    // Both gradient edge overlays are rendered (visibility is driven by scroll state).
     const overlays = page.locator(
       '#sortable-table-container [class*="bg-gradient-to-r"], #sortable-table-container [class*="bg-gradient-to-l"]',
     );
-    await expect(overlays.first()).toHaveCount(1);
+    await expect(overlays).toHaveCount(2);
   });
 });

--- a/e2e/tests/finance/table-wide.spec.ts
+++ b/e2e/tests/finance/table-wide.spec.ts
@@ -90,27 +90,33 @@ test.describe('Wide-dataset scaffold table (expense categories)', () => {
   test('drawer rows are keyboard-navigable and Enter opens the drawer', async ({
     page,
   }) => {
-    await createCategory(page, 'Keyboard Cat', 'Short');
+    // Seed at least 3 rows so single-step navigation can be asserted
+    // unconditionally: the regression this guards (focus jumping row 0 -> row 2)
+    // only manifests with 3+ rows, so the test must not be conditional on count.
+    await createCategory(page, 'Keyboard Cat A', 'Short');
+    await createCategory(page, 'Keyboard Cat B', 'Short');
+    await createCategory(page, 'Keyboard Cat C', 'Short');
     await page.setViewportSize({ width: 1280, height: 800 });
 
     const rows = page.locator('tbody tr[data-row-drawer]');
     await expect(rows.first()).toBeVisible();
+    expect(await rows.count()).toBeGreaterThanOrEqual(3);
 
     // Rows expose the accessibility/keyboard hooks.
     await expect(rows.first()).toHaveAttribute('tabindex', '0');
     await expect(rows.first()).toHaveAttribute('role', 'button');
 
-    // Focus first row, ArrowDown moves focus to the next drawer row (if any).
+    // Each ArrowDown/ArrowUp must move focus exactly ONE row (guards the
+    // double-listener double-step bug). toBeFocused auto-retries while the
+    // Alpine handler applies focus.
     await rows.first().focus();
     await expect(rows.first()).toBeFocused();
-    const count = await rows.count();
-    if (count > 1) {
-      await page.keyboard.press('ArrowDown');
-      // toBeFocused auto-retries while the Alpine handler applies focus.
-      await expect(rows.nth(1)).toBeFocused();
-      await page.keyboard.press('ArrowUp');
-      await expect(rows.first()).toBeFocused();
-    }
+    await page.keyboard.press('ArrowDown');
+    await expect(rows.nth(1)).toBeFocused();
+    await page.keyboard.press('ArrowDown');
+    await expect(rows.nth(2)).toBeFocused();
+    await page.keyboard.press('ArrowUp');
+    await expect(rows.nth(1)).toBeFocused();
 
     // Enter triggers the row's hx-get into #view-drawer.
     await rows.first().focus();

--- a/modules/core/presentation/assets/js/alpine.js
+++ b/modules/core/presentation/assets/js/alpine.js
@@ -2170,12 +2170,20 @@ let cellTruncate = () => ({
       if (!el) return;
       this.overflowText = el.scrollWidth > el.clientWidth ? el.textContent.trim() : '';
     };
+    // Coalesce ResizeObserver callbacks into a single rAF so a burst of resize
+    // notifications (container reflow, gear toggles) does one layout read, not
+    // a forced reflow per callback.
+    this._schedule = () => {
+      if (this._raf) return;
+      this._raf = requestAnimationFrame(() => { this._raf = 0; this._measure(); });
+    };
     this.$nextTick(() => this._measure());
-    this._ro = new ResizeObserver(() => this._measure());
+    this._ro = new ResizeObserver(() => this._schedule());
     this._ro.observe(this.$el);
   },
   destroy() {
     if (this._ro) this._ro.disconnect();
+    if (this._raf) cancelAnimationFrame(this._raf);
   },
 });
 

--- a/modules/core/presentation/assets/js/alpine.js
+++ b/modules/core/presentation/assets/js/alpine.js
@@ -2248,9 +2248,17 @@ let tableKeyboardNav = () => ({
   onKey(e) {
     const active = document.activeElement;
     if (!active || !active.matches || !active.matches('[data-row-drawer]')) return;
+    // Guard against the handler running more than once for the same keypress
+    // (e.g. if htmx-alpine-init re-initialises the tbody and binds a second
+    // @keydown listener). Both listeners share the event object, so a one-shot
+    // flag keeps a single ArrowDown/ArrowUp to exactly one row of movement.
+    if (e.__rowNavHandled) return;
     const rows = this.rows();
     const idx = rows.indexOf(active);
     if (idx === -1) return;
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp' || e.key === 'Enter') {
+      e.__rowNavHandled = true;
+    }
     if (e.key === 'ArrowDown') {
       e.preventDefault();
       const next = rows[idx + 1];


### PR DESCRIPTION
Follow-up to #803. Validating the skipped #799 e2e spec against a live server surfaced — and fixes — a real keyboard-navigation bug, and un-skips the spec.

## 1. Bug fix: keyboard nav moved two rows per keypress
`tableKeyboardNav.onKey` was firing **twice per keypress** — `htmx-alpine-init` re-initialises the tbody and binds a second `@keydown` listener, and both listeners share the same event object, so each `ArrowDown`/`ArrowUp` re-read `document.activeElement` and advanced focus twice (row 0 → row 2, skipping row 1).

Fix: a per-event one-shot guard (`e.__rowNavHandled`) so a single keypress moves focus **exactly one row**, regardless of how many listeners end up attached. Verified instrumented: raw invocation count = 2, post-fix focus delta = 1.

## 2. Un-skip the e2e spec (was blind-authored in #803)
The spec shipped skipped because its selectors were never run. Corrected against the real `/finance/expense-categories` DOM and **un-skipped**:
- Create-drawer form fields are `Name` / `Description` (capitalised DTO field names); submit via `#create-form button[type=submit]`.
- The layout renders a responsive **pair** of create triggers — click the `:visible` one.
- Table headers don't emit `data-col`; the priority column is targeted via `data-col-priority="2"`.
- Assert **both** gradient overlays (`toHaveCount(2)`); use auto-retrying `toBeFocused()` for keyboard focus (the Alpine handler applies focus async); each test seeds its own row so it's order-independent.

## Verification
Ran the full suite locally against a live server (Postgres on 5438, server on 3201 with `ENABLE_TEST_ENDPOINTS=true`):

```
✓ truncate column wraps cell content in a clamped, tooltip-bound container
✓ priority column is hidden on narrow viewports, visible on wide
✓ drawer rows are keyboard-navigable and Enter opens the drawer
✓ horizontal scroll affordance overlays exist in the table wrapper
4 passed
```
Green across two consecutive runs.

Closes the e2e gap noted on #799.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate actions from keyboard navigation in table rows.
  * Corrected horizontal scroll overlay rendering for wide tables.
  * Improved table drawer create/interaction stability and row focus movement.
  * Smoother truncation/resize behavior for table cells.

* **Tests**
  * Activated comprehensive finance table test suite.
  * Enhanced keyboard navigation, focus verification, and wide-table behavior tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->