### PR TITLE
[codex] Add request-scoped nav item decorator

### DIFF
--- a/pkg/middleware/sidebar.go
+++ b/pkg/middleware/sidebar.go
@@ -26,6 +26,15 @@ var sidebarPropsDecorator SidebarPropsDecorator = func(_ context.Context, _ *htt
 	return props
 }
 
+// NavItemsDecorator allows host applications to adjust request-scoped
+// navigation items before permission filtering, pin splitting, workspace
+// grouping, sidebar mapping, and context storage.
+type NavItemsDecorator func(ctx context.Context, r *http.Request, items []types.NavigationItem) []types.NavigationItem
+
+var navItemsDecorator NavItemsDecorator = func(_ context.Context, _ *http.Request, items []types.NavigationItem) []types.NavigationItem {
+	return items
+}
+
 // SetSidebarPropsDecorator overrides the default no-op sidebar props decorator.
 func SetSidebarPropsDecorator(decorator SidebarPropsDecorator) {
 	if decorator == nil {
@@ -35,6 +44,17 @@ func SetSidebarPropsDecorator(decorator SidebarPropsDecorator) {
 		return
 	}
 	sidebarPropsDecorator = decorator
+}
+
+// SetNavItemsDecorator overrides the default no-op nav item decorator.
+func SetNavItemsDecorator(decorator NavItemsDecorator) {
+	if decorator == nil {
+		navItemsDecorator = func(_ context.Context, _ *http.Request, items []types.NavigationItem) []types.NavigationItem {
+			return items
+		}
+		return
+	}
+	navItemsDecorator = decorator
 }
 
 func filterItems(items []types.NavigationItem, user user.User) []types.NavigationItem {
@@ -143,7 +163,8 @@ func NavItemsWithInitialState(initialState sidebar.SidebarState) mux.MiddlewareF
 					next.ServeHTTP(w, r)
 					return
 				}
-				filtered := filterItems(app.NavItems(localizer), u)
+				items := navItemsDecorator(r.Context(), r, app.NavItems(localizer))
+				filtered := filterItems(items, u)
 				if len(u.Roles()) == 0 {
 					filtered = []types.NavigationItem{}
 				}

--- a/pkg/middleware/sidebar_test.go
+++ b/pkg/middleware/sidebar_test.go
@@ -1,6 +1,8 @@
 package middleware
 
 import (
+	"context"
+	"net/http"
 	"testing"
 
 	"github.com/iota-uz/iota-sdk/pkg/types"
@@ -14,6 +16,24 @@ func keysOf(items []types.NavigationItem) []string {
 		out = append(out, item.Key)
 	}
 	return out
+}
+
+func TestSetNavItemsDecorator(t *testing.T) {
+	t.Cleanup(func() {
+		SetNavItemsDecorator(nil)
+	})
+
+	items := []types.NavigationItem{{Key: "original"}}
+	require.Equal(t, items, navItemsDecorator(context.Background(), nil, items))
+
+	SetNavItemsDecorator(func(_ context.Context, _ *http.Request, items []types.NavigationItem) []types.NavigationItem {
+		return append(items, types.NavigationItem{Key: "added"})
+	})
+	decorated := navItemsDecorator(context.Background(), nil, items)
+	require.Equal(t, []string{"original", "added"}, keysOf(decorated))
+
+	SetNavItemsDecorator(nil)
+	require.Equal(t, items, navItemsDecorator(context.Background(), nil, items))
 }
 
 func TestSplitPinnedItems(t *testing.T) {


### PR DESCRIPTION
## What changed

Adds a request-scoped navigation item decorator to the sidebar middleware.

The decorator runs after localized app nav items are loaded and before:
- permission filtering
- pinned-item splitting
- workspace grouping
- sidebar item mapping
- nav item context storage

This gives host applications a canonical hook for request/DB-backed nav changes without mutating rendered sidebar props after the fact.

## Validation

- `go test ./pkg/middleware -run TestSetNavItemsDecorator`

Note: full `go test ./pkg/middleware` also runs an existing pgxpool collector test that requires a local `iota_erp` database and fails in this workspace because that DB is not available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing navigation items through a new decorator hook, enabling applications to extend or modify how navigation items are displayed and processed without direct modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->