### PR TITLE
fix(htmx): prevent unstyled pages on back/forward navigation

### DIFF
--- a/pkg/htmx/htmx.go
+++ b/pkg/htmx/htmx.go
@@ -97,6 +97,18 @@ func IsHistoryRestoreRequest(r *http.Request) bool {
 	return r.Header.Get("Hx-History-Restore-Request") == "true"
 }
 
+// WantsFullPage reports whether the handler should render a full HTML document
+// (layout + <head>) rather than an HTMX fragment.
+//
+// It is true for a normal navigation and for a history-restore request: htmx
+// fetches the latter on a local history-cache miss and swaps it into the
+// history element, so it must receive the whole page or the layout shell is
+// lost. Branch on this instead of a bare IsHxRequest check when deciding
+// fragment-vs-page, so history restoration keeps the shell and styling intact.
+func WantsFullPage(r *http.Request) bool {
+	return !IsHxRequest(r) || IsHistoryRestoreRequest(r)
+}
+
 // Target returns the ID of the element that triggered the request.
 func Target(r *http.Request) string {
 	return r.Header.Get("Hx-Target")

--- a/pkg/middleware/htmx_cache.go
+++ b/pkg/middleware/htmx_cache.go
@@ -1,0 +1,100 @@
+// Package middleware provides this package.
+package middleware
+
+import (
+	"bufio"
+	"errors"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+)
+
+// HTMXCacheControl protects against an HTMX fragment response being cached and
+// later served in place of a full-page navigation.
+//
+// Controllers answer an HTMX request with a layout-less, <head>-less fragment
+// and a normal navigation with a full HTML document, but both responses share
+// the same URL. Without a Vary header that distinguishes them, any shared cache
+// (the browser HTTP cache, a reverse proxy, or a CDN) may serve the cached
+// fragment to a back/forward or address-bar navigation, rendering the page with
+// no stylesheet at all — completely unstyled raw HTML.
+//
+// For text/html responses the middleware:
+//   - adds "Vary: Hx-Request" so a cache key can never match an HTMX fragment to
+//     a normal navigation; and
+//   - sets "Cache-Control: no-store" (these pages are per-user / per-tenant and
+//     must never be cached) unless a handler already set Cache-Control — for
+//     example the static-asset handler, which keeps its own public caching.
+//
+// It also normalizes history-restore requests. On a local history-cache miss
+// htmx issues a GET carrying "Hx-History-Restore-Request: true" together with
+// "Hx-Request: true"; left untouched, controllers answer with a fragment that
+// htmx swaps into <body>, discarding the surrounding layout shell. Removing the
+// HTMX request markers makes controllers render the full page, which htmx
+// restores correctly (it extracts <body> and drops the duplicate <head>).
+func HTMXCacheControl() mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// A history-restore is semantically a full navigation: render the
+			// whole page so the layout shell survives a history-cache miss.
+			if r.Header.Get("Hx-History-Restore-Request") == "true" {
+				r.Header.Del("Hx-Request")
+				r.Header.Del("Hx-Boosted")
+			}
+			next.ServeHTTP(&htmxCacheControlWriter{ResponseWriter: w}, r)
+		})
+	}
+}
+
+type htmxCacheControlWriter struct {
+	http.ResponseWriter
+	decorated bool
+}
+
+// decorate sets cache-safety headers for HTML responses. It runs once, on the
+// first WriteHeader/Write, when the handler's Content-Type is known.
+func (w *htmxCacheControlWriter) decorate() {
+	if w.decorated {
+		return
+	}
+	w.decorated = true
+	h := w.Header()
+	if !strings.HasPrefix(h.Get("Content-Type"), "text/html") {
+		return
+	}
+	h.Add("Vary", "Hx-Request")
+	if h.Get("Cache-Control") == "" {
+		h.Set("Cache-Control", "no-store")
+	}
+}
+
+func (w *htmxCacheControlWriter) WriteHeader(code int) {
+	// Don't latch on 1xx informational responses.
+	if code >= 200 {
+		w.decorate()
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *htmxCacheControlWriter) Write(b []byte) (int, error) {
+	w.decorate()
+	return w.ResponseWriter.Write(b)
+}
+
+// Flush forwards to the underlying writer so streamed responses
+// (templ WithStreaming) and SSE keep working.
+func (w *htmxCacheControlWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Hijack forwards to the underlying writer so WebSocket / SSE upgrades keep working.
+func (w *htmxCacheControlWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hj, ok := w.ResponseWriter.(http.Hijacker); ok {
+		return hj.Hijack()
+	}
+	return nil, nil, errors.New("htmxCacheControlWriter: underlying ResponseWriter does not implement http.Hijacker")
+}

--- a/pkg/server/builder.go
+++ b/pkg/server/builder.go
@@ -105,6 +105,7 @@ func New(rt *bootstrap.Runtime, opts ...Option) (*HTTPServer, error) {
 	stack = append(stack, cfg.before...)
 	stack = append(stack,
 		middleware.WithLogger(cfg.logger, middleware.DefaultLoggerOptions()),
+		middleware.HTMXCacheControl(),
 		middleware.TracedMiddleware("database"),
 		middleware.Provide(constants.AppKey, rt.App),
 		middleware.Provide(constants.ContainerKey, rt.Container()),


### PR DESCRIPTION
## Problem

Long-standing bug across all iota-sdk apps: hitting the browser **Back** button (sometimes after a few presses) lands on a page rendered as **raw, completely unstyled HTML**.

Root cause: controllers branch on `htmx.IsHxRequest(r)` and return a **headless, layout-less fragment** for HTMX requests vs a full document for normal navigations — but both responses **share the same URL** with:
- **no `Vary: HX-Request`** (only `Vary: Accept-Encoding, Origin`), and
- **no `Cache-Control`**.

So the fragment and the full page are indistinguishable to any cache. A shared cache (browser HTTP cache, reverse proxy, or CDN) can serve the cached **headless fragment** to a normal back/forward or address-bar navigation → the document has no `<head>`, no stylesheet → fully unstyled.

A second, related symptom: on a local htmx history-cache miss, htmx fetches the history-restore response and swaps it into `<body>`. Since the server returns a fragment, the **layout shell is dropped** (content renders without the sidebar/topbar).

## Fix

New `middleware.HTMXCacheControl()` (registered in the server builder). For `text/html` responses it:
- adds **`Vary: Hx-Request`** so a cache key can never match an HTMX fragment to a normal navigation, and
- sets **`Cache-Control: no-store`** (these pages are per-user/per-tenant) unless a handler already set `Cache-Control` (static assets keep their own `public, max-age`).

It also **normalizes history-restore requests**: htmx sends `Hx-History-Restore-Request: true` together with `Hx-Request: true` on a cache miss; the middleware strips the HTMX markers so controllers render the **full page**, which htmx restores correctly (it extracts `<body>` and discards the duplicate `<head>`).

Also adds `htmx.WantsFullPage(r)` documenting the fragment-vs-page rule (`!IsHxRequest || IsHistoryRestoreRequest`).

## Verification

Against a real app (EAI):
- `Vary: Hx-Request` + `Cache-Control: no-store` now present on all HTML responses; static CSS still `public, max-age=3600`.
- History-restore request now returns a full document (`<head>` + stylesheet) instead of a 12 KB headless fragment.
- End-to-end: a forced history-cache miss on Back now restores the **full shell, fully styled** (was shell-less / unstyled before).

Non-HTML responses and static assets are unaffected; streaming (templ `WithStreaming`), SSE, and WebSocket upgrades are preserved (Flusher/Hijacker pass-through).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced HTMX history restoration to properly render full page layouts instead of fragments.
  * Implemented cache control headers for HTMX requests with `Vary: Hx-Request` and appropriate `Cache-Control` directives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->