### PR TITLE
fix(ui): combobox opacity + table drag cursor + dashboard info-icon polish

### DIFF
--- a/components/base/combobox.templ
+++ b/components/base/combobox.templ
@@ -275,7 +275,7 @@ templ Combobox(props ComboboxProps) {
 				x-ref="list"
 				x-cloak
 				x-show="open || openedWithKeyboard"
-				class={ "bg-surface-300 absolute z-10 left-0 top-11 mt-1 flex max-h-44 flex-col gap-0.5 overflow-hidden overflow-y-auto border border-secondary p-1.5 rounded-md drop-shadow-sm w-full", props.ListClass }
+				class={ "bg-white absolute z-10 left-0 top-11 mt-1 flex max-h-44 flex-col gap-0.5 overflow-hidden overflow-y-auto border border-secondary p-1.5 rounded-md drop-shadow-sm w-full", props.ListClass }
 				x-on:keydown.down.prevent="$focus.wrap().next()"
 				x-on:keydown.up.prevent="$focus.wrap().previous()"
 				x-transition

--- a/components/base/combobox_templ.go
+++ b/components/base/combobox_templ.go
@@ -534,7 +534,7 @@ func Combobox(props ComboboxProps) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		var templ_7745c5c3_Var15 = []any{"bg-surface-300 absolute z-10 left-0 top-11 mt-1 flex max-h-44 flex-col gap-0.5 overflow-hidden overflow-y-auto border border-secondary p-1.5 rounded-md drop-shadow-sm w-full", props.ListClass}
+		var templ_7745c5c3_Var15 = []any{"bg-white absolute z-10 left-0 top-11 mt-1 flex max-h-44 flex-col gap-0.5 overflow-hidden overflow-y-auto border border-secondary p-1.5 rounded-md drop-shadow-sm w-full", props.ListClass}
 		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var15...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err

--- a/components/base/table.templ
+++ b/components/base/table.templ
@@ -357,7 +357,7 @@ templ Table(props TableProps) {
 												hx-include="closest form"
 											>
 												if col.Configurable {
-													<button x-sort:handle type="button" class="-ml-1.5">
+													<button x-sort:handle type="button" class="-ml-1.5 cursor-grab active:cursor-grabbing">
 														@icons.DotsSixVertical(icons.Props{Size: "20"})
 													</button>
 												}
@@ -403,7 +403,7 @@ templ Table(props TableProps) {
 										<div class="flex flex-col gap-1">
 											<div class="flex items-center gap-2">
 												if col.Configurable {
-													<button x-sort:handle type="button" class="-ml-1.5">
+													<button x-sort:handle type="button" class="-ml-1.5 cursor-grab active:cursor-grabbing">
 														@icons.DotsSixVertical(icons.Props{Size: "20"})
 													</button>
 												}
@@ -525,7 +525,7 @@ templ Table(props TableProps) {
 												hx-include="closest form"
 											>
 												if col.Configurable {
-													<button x-sort:handle type="button" class="-ml-1.5">
+													<button x-sort:handle type="button" class="-ml-1.5 cursor-grab active:cursor-grabbing">
 														@icons.DotsSixVertical(icons.Props{Size: "20"})
 													</button>
 												}
@@ -572,7 +572,7 @@ templ Table(props TableProps) {
 										<div class="flex flex-col gap-1">
 											<div class="flex items-center gap-2">
 												if col.Configurable {
-													<button x-sort:handle type="button" class="-ml-1.5">
+													<button x-sort:handle type="button" class="-ml-1.5 cursor-grab active:cursor-grabbing">
 														@icons.DotsSixVertical(icons.Props{Size: "20"})
 													</button>
 												}

--- a/components/base/table_templ.go
+++ b/components/base/table_templ.go
@@ -521,7 +521,7 @@ func Table(props TableProps) templ.Component {
 						return templ_7745c5c3_Err
 					}
 					if col.Configurable {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<button x-sort:handle type=\"button\" class=\"-ml-1.5\">")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<button x-sort:handle type=\"button\" class=\"-ml-1.5 cursor-grab active:cursor-grabbing\">")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
@@ -709,7 +709,7 @@ func Table(props TableProps) templ.Component {
 						return templ_7745c5c3_Err
 					}
 					if col.Configurable {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<button x-sort:handle type=\"button\" class=\"-ml-1.5\">")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<button x-sort:handle type=\"button\" class=\"-ml-1.5 cursor-grab active:cursor-grabbing\">")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
@@ -1043,7 +1043,7 @@ func Table(props TableProps) templ.Component {
 						return templ_7745c5c3_Err
 					}
 					if col.Configurable {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "<button x-sort:handle type=\"button\" class=\"-ml-1.5\">")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "<button x-sort:handle type=\"button\" class=\"-ml-1.5 cursor-grab active:cursor-grabbing\">")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
@@ -1231,7 +1231,7 @@ func Table(props TableProps) templ.Component {
 						return templ_7745c5c3_Err
 					}
 					if col.Configurable {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 106, "<button x-sort:handle type=\"button\" class=\"-ml-1.5\">")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 106, "<button x-sort:handle type=\"button\" class=\"-ml-1.5 cursor-grab active:cursor-grabbing\">")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}

--- a/pkg/lens/render/templ/dashboard.templ
+++ b/pkg/lens/render/templ/dashboard.templ
@@ -553,7 +553,7 @@ templ MetricInfoButtonWithText(infoText, class string) {
 	{{ chartText := localizedChartText(ctx) }}
 	<button
 		type="button"
-		class={ "inline-flex h-7 w-7 items-center justify-center rounded-full text-slate-300 transition hover:text-slate-500 focus:outline-none cursor-pointer", class }
+		class={ "inline-flex h-7 w-7 items-center justify-center rounded-full text-slate-400 transition hover:text-slate-600 focus:outline-none cursor-pointer", class }
 		x-tooltip.placement.bottom-start.interactive.theme.light.html.raw={ metricInfoTooltipHTML(ctx, infoText) }
 		@click.stop=""
 		aria-label={ chartText.MetricInfo }

--- a/pkg/lens/render/templ/dashboard_templ.go
+++ b/pkg/lens/render/templ/dashboard_templ.go
@@ -2288,7 +2288,7 @@ func MetricInfoButtonWithText(infoText, class string) templ.Component {
 			return
 		}
 		chartText := localizedChartText(ctx)
-		var templ_7745c5c3_Var108 = []any{"inline-flex h-7 w-7 items-center justify-center rounded-full text-slate-300 transition hover:text-slate-500 focus:outline-none cursor-pointer", class}
+		var templ_7745c5c3_Var108 = []any{"inline-flex h-7 w-7 items-center justify-center rounded-full text-slate-400 transition hover:text-slate-600 focus:outline-none cursor-pointer", class}
 		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var108...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err

--- a/pkg/lens/render/templ/helpers.go
+++ b/pkg/lens/render/templ/helpers.go
@@ -848,7 +848,14 @@ func panelChartClass(spec panel.Spec, fullscreen bool) string {
 }
 
 func panelCardClass(spec panel.Spec) string {
-	base := "flex h-full flex-col overflow-hidden rounded-xl border border-slate-200/90 bg-white shadow-sm transition-all duration-200"
+	// Stat panels host an info (ⓘ) tooltip that pops outside the card body; keeping
+	// overflow-hidden here would clip it (the tooltip mounts in-tree, not portaled).
+	// Chart/table panels still clip their content to the rounded card.
+	overflow := "overflow-hidden"
+	if spec.Kind == panel.KindStat {
+		overflow = "overflow-visible"
+	}
+	base := "flex h-full flex-col " + overflow + " rounded-xl border border-slate-200/90 bg-white shadow-sm transition-all duration-200"
 	if panelIsInteractive(spec) {
 		base += " hover:border-blue-200 hover:shadow-md"
 	} else {


### PR DESCRIPTION
## What

SDK-side UI fixes for two EAI issues.

### iota-uz/eai#3078 — shared component defects
- **Combobox dropdown was low-contrast / see-through.** The dropdown `<ul>` used `bg-surface-300`; over light pages (e.g. `/analytics/sales-renewals` → Products) it blended into the background. Switched to `bg-white` — matches the sibling floating menu `components/base/selects/search_select.templ`, always opaque.
- **No grab cursor on reorderable table columns.** Added `cursor-grab active:cursor-grabbing` to the four `x-sort:handle` drag handles in `components/base/table.templ`, so the cursor reads `grab` on hover and `grabbing` while dragging.

### iota-uz/eai#3077 — dashboard metric info icons
- **Info (ⓘ) icon too light.** `MetricInfoButtonWithText` icon `text-slate-300` / hover `text-slate-500` → `text-slate-400` / hover `text-slate-600` for legibility.
- **Tooltip clipped by the card.** The Tippy tooltip mounts in-tree (not portaled — see `alpine-tooltip` README: parent must not have `overflow: hidden`), so `panelCardClass`'s `overflow-hidden` clipped it. Stat panels — the only ones that host the info tooltip — now use `overflow-visible`; chart/table panels still clip to the rounded card.

## Notes
- `templ generate` run at the pinned **v0.3.857**; only the three touched `_templ.go` files changed (no generator drift).
- **CSS:** `cursor-grab` / `cursor-grabbing` are new utilities not yet present in the committed `modules/core/presentation/assets/css/main.min.css`. I did **not** regenerate it here — the isolated worktree has no `node_modules` and a full Tailwind regen would be noisy. EAI rebuilds its own Tailwind from SDK templates at build time, so the user-facing fix is covered; `main.min.css` can be refreshed on the next normal css build.

## Cross-repo
This is the SDK half. The EAI submodule pointer is bumped to this commit in two root PRs which close `iota-uz/eai#3078` and `iota-uz/eai#3077`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated combobox dropdown container background styling
  * Enhanced table sort handles with grab and grabbing cursor indicators during interaction
  * Adjusted metric info button text color values and hover states
  * Refined panel card overflow handling with conditional display settings for different panel types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->