### PR TITLE
fix(filterbuilder): set explicit Y-m-d date format on chip date pickers

### DIFF
--- a/components/scaffold/filterbuilder/builder_test.go
+++ b/components/scaffold/filterbuilder/builder_test.go
@@ -99,11 +99,16 @@ func TestDateEditorEmitsExplicitFlatpickrFormat(t *testing.T) {
 	// silently dropped and the date filter never applies. "Y-m-d" == DateLayout.
 	html := renderComponent(t, Props{Registry: testRegistry()}, false)
 
-	// The date field ("issue_at") draft editor renders flatpickr date pickers...
+	// The date field ("issue_at") draft editor renders both flatpickr pickers
+	// (single + range). Each must serialize an explicit Y-m-d dateFormat into
+	// its x-data; assert on the serialized field for BOTH (count >= 2), not just
+	// a loose "Y-m-d" substring, so a regression on one picker is still caught.
+	// HTML-attribute escaping of the JSON quotes is &#34; (verified).
+	const wantFmt = `&#34;dateFormat&#34;:&#34;Y-m-d&#34;`
 	assert.Contains(t, html, "datePicker(")
-	// ...and they must declare the Y-m-d format, never the empty 'z'-fallback.
-	assert.Contains(t, html, "Y-m-d")
-	assert.NotContains(t, html, `dateFormat&#34;:&#34;&#34;`)
+	assert.GreaterOrEqual(t, strings.Count(html, wantFmt), 2)
+	// Never the empty value that triggers the bogus 'z' flatpickr fallback.
+	assert.NotContains(t, html, `&#34;dateFormat&#34;:&#34;&#34;`)
 }
 
 func TestBuilderUnknownFieldChipSkipped(t *testing.T) {

--- a/components/scaffold/filterbuilder/builder_test.go
+++ b/components/scaffold/filterbuilder/builder_test.go
@@ -90,6 +90,22 @@ func TestBuilderRendersChipsAndHiddenInputs(t *testing.T) {
 	assert.Contains(t, html, "Scaffold.FilterBuilder.ClearAll")
 }
 
+func TestDateEditorEmitsExplicitFlatpickrFormat(t *testing.T) {
+	// Regression for eai#3080: the date editor's pickers (single + range) must
+	// pass an explicit DateFormat. An empty value serializes as "" and the
+	// datePicker Alpine component falls back to the bogus 'z' flatpickr token
+	// (dateFormat || 'z'), so the hidden input holds a value filterq.Decode
+	// cannot time.Parse against DateLayout (2006-01-02). The condition is then
+	// silently dropped and the date filter never applies. "Y-m-d" == DateLayout.
+	html := renderComponent(t, Props{Registry: testRegistry()}, false)
+
+	// The date field ("issue_at") draft editor renders flatpickr date pickers...
+	assert.Contains(t, html, "datePicker(")
+	// ...and they must declare the Y-m-d format, never the empty 'z'-fallback.
+	assert.Contains(t, html, "Y-m-d")
+	assert.NotContains(t, html, `dateFormat&#34;:&#34;&#34;`)
+}
+
 func TestBuilderUnknownFieldChipSkipped(t *testing.T) {
 	fs := filterq.FilterSet{{Field: "ghost", Op: filterq.OpIs, Values: []string{"1"}}}
 	html := renderComponent(t, Props{Registry: testRegistry(), Filters: fs}, false)

--- a/components/scaffold/filterbuilder/chip.templ
+++ b/components/scaffold/filterbuilder/chip.templ
@@ -169,17 +169,25 @@ templ editorPanel(field FieldDef, cond *filterq.Condition, chipIdx int) {
 				}
 				<div x-show="op !== 'between'" data-fb-variant="single">
 					@input.DatePicker(input.DatePickerProps{
-						Mode:     input.DatePickerModeSingle,
-						Name:     "",
-						Selected: singleDateSelected(cond),
+						Mode: input.DatePickerModeSingle,
+						// DateFormat must be set: an empty value serializes as
+						// "" and the datePicker falls back to the bogus 'z'
+						// flatpickr token, so the hidden input holds a string
+						// filterq.Decode can't time.Parse(DateLayout) — the
+						// condition is silently dropped and the filter never
+						// applies. "Y-m-d" matches filterq DateLayout 2006-01-02.
+						DateFormat: "Y-m-d",
+						Name:       "",
+						Selected:   singleDateSelected(cond),
 					})
 				</div>
 				<div x-cloak x-show="op === 'between'" data-fb-variant="range">
 					@input.DatePicker(input.DatePickerProps{
-						Mode:      input.DatePickerModeRange,
-						StartName: "",
-						EndName:   "",
-						Selected:  rangeDateSelected(cond),
+						Mode:       input.DatePickerModeRange,
+						DateFormat: "Y-m-d",
+						StartName:  "",
+						EndName:    "",
+						Selected:   rangeDateSelected(cond),
 					})
 				</div>
 			case filterq.FieldTypeNumber:

--- a/components/scaffold/filterbuilder/chip_templ.go
+++ b/components/scaffold/filterbuilder/chip_templ.go
@@ -537,9 +537,16 @@ func editorPanel(field FieldDef, cond *filterq.Condition, chipIdx int) templ.Com
 				return templ_7745c5c3_Err
 			}
 			templ_7745c5c3_Err = input.DatePicker(input.DatePickerProps{
-				Mode:     input.DatePickerModeSingle,
-				Name:     "",
-				Selected: singleDateSelected(cond),
+				Mode: input.DatePickerModeSingle,
+				// DateFormat must be set: an empty value serializes as
+				// "" and the datePicker falls back to the bogus 'z'
+				// flatpickr token, so the hidden input holds a string
+				// filterq.Decode can't time.Parse(DateLayout) — the
+				// condition is silently dropped and the filter never
+				// applies. "Y-m-d" matches filterq DateLayout 2006-01-02.
+				DateFormat: "Y-m-d",
+				Name:       "",
+				Selected:   singleDateSelected(cond),
 			}).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -549,10 +556,11 @@ func editorPanel(field FieldDef, cond *filterq.Condition, chipIdx int) templ.Com
 				return templ_7745c5c3_Err
 			}
 			templ_7745c5c3_Err = input.DatePicker(input.DatePickerProps{
-				Mode:      input.DatePickerModeRange,
-				StartName: "",
-				EndName:   "",
-				Selected:  rangeDateSelected(cond),
+				Mode:       input.DatePickerModeRange,
+				DateFormat: "Y-m-d",
+				StartName:  "",
+				EndName:    "",
+				Selected:   rangeDateSelected(cond),
 			}).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
@@ -569,7 +577,7 @@ func editorPanel(field FieldDef, cond *filterq.Condition, chipIdx int) templ.Com
 			var templ_7745c5c3_Var25 string
 			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(numberValue(cond, 0))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/filterbuilder/chip.templ`, Line: 192, Col: 34}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/filterbuilder/chip.templ`, Line: 200, Col: 34}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {
@@ -582,7 +590,7 @@ func editorPanel(field FieldDef, cond *filterq.Condition, chipIdx int) templ.Com
 			var templ_7745c5c3_Var26 string
 			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(numberValue(cond, 0))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/filterbuilder/chip.templ`, Line: 201, Col: 34}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/filterbuilder/chip.templ`, Line: 209, Col: 34}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 			if templ_7745c5c3_Err != nil {
@@ -595,7 +603,7 @@ func editorPanel(field FieldDef, cond *filterq.Condition, chipIdx int) templ.Com
 			var templ_7745c5c3_Var27 string
 			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(numberValue(cond, 1))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/filterbuilder/chip.templ`, Line: 209, Col: 34}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/filterbuilder/chip.templ`, Line: 217, Col: 34}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 			if templ_7745c5c3_Err != nil {
@@ -621,7 +629,7 @@ func editorPanel(field FieldDef, cond *filterq.Condition, chipIdx int) templ.Com
 			var templ_7745c5c3_Var29 string
 			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Scaffold.FilterBuilder.Apply"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/filterbuilder/chip.templ`, Line: 221, Col: 46}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/filterbuilder/chip.templ`, Line: 229, Col: 46}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 			if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
## Problem

On the chip-filter builder, selecting an explicit **date** (single `on/before/after` or a `between` range) and clicking Apply does **not** apply the filter — the condition is silently dropped, no chip appears, the list doesn't re-query. Preset chips (This year, etc.) work.

Reproduced live on EAI Granite `/portfolio/policies` → «Дата заключения»: a valid range "Июнь 1 — Июнь 10, 2026" shows in the input, but Apply leaves the querystring and chip unchanged.

## Root cause

The filterbuilder's single and range `DatePicker`s in `components/scaffold/filterbuilder/chip.templ` were created **without** `DateFormat`.

- `DatePickerProps.DateFormat` has no `omitempty`, so an unset value serializes as `"dateFormat":""`.
- In the `datePicker` Alpine component, `dateFormat = dateFormat || 'z'` — an empty string falls through to the bogus **`'z'`** flatpickr token. (The destructuring default `'Y-m-d'` only applies to `undefined`, not `""`.)
- flatpickr then writes the hidden input value with `'z'` instead of `YYYY-MM-DD`, so `filterq.Decode` cannot `time.Parse` it against `DateLayout = "2006-01-02"` and drops the condition.

Presets work because `applyPreset()` bypasses the picker and dispatches `values: ['preset:<token>']` directly.

Every other `DatePicker` caller in SDK + EAI already passes `DateFormat: "Y-m-d"` — the two filterbuilder pickers were the only ones relying on the broken default.

## Fix

Pass `DateFormat: "Y-m-d"` (== `DateLayout`) on both filterbuilder date pickers. Minimal and consistent with all other callers; does **not** touch the global `'z'` fallback (broader blast radius, and no other caller hits it).

## Tests

- New `TestDateEditorEmitsExplicitFlatpickrFormat`: renders the Builder and asserts the date editor emits `Y-m-d` and never the empty `dateFormat":""` that triggers the `'z'` bug.
- `go test ./components/scaffold/filterbuilder/... ./pkg/filterq/...` — PASS. `go vet` clean.

## Consumer

Pairs with the EAI submodule bump + claims-list fix in iota-uz/eai#3080 (PR there bundles the eai-side changes and points the submodule at this commit).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date filter editor to explicitly set the correct date format, ensuring dates are properly serialized and recognized by the filtering system.

* **Tests**
  * Added regression test to verify date picker format is correctly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->