### PR TITLE
fix(config/env): treat empty env vars as absent (strict-mode boot panic)

### DIFF
--- a/pkg/config/providers/env/env.go
+++ b/pkg/config/providers/env/env.go
@@ -113,12 +113,29 @@ func (p *Provider) loadInto(k *koanf.Koanf) error {
 
 	// Build a merged environ: file vars first, then process env overrides.
 	// We supply this via EnvironFunc so the koanf env provider uses our merged set.
+	//
+	// Empty-valued vars are skipped at both layers: an empty env var carries
+	// no configuration signal. Container orchestrators commonly export optional
+	// settings via the `${VAR:-}` idiom, which sets the var unconditionally —
+	// to "" when the secret is absent. Loading those phantom keys would
+	// register entries under a feature's config prefix, making an
+	// otherwise-unset optional feature look *partially* configured
+	// (Source.HasPrefix true while IsConfigured is false) and tripping
+	// strict-mode boot failures. Skipping empties lets default tags apply,
+	// keeps such features cleanly disabled, and ensures an empty process-env
+	// var does not erase a non-empty value from a lower-precedence .env file.
 	processEnv := environToMap(os.Environ())
 	merged := make(map[string]string, len(fileVars)+len(processEnv))
 	for k, v := range fileVars {
+		if v == "" {
+			continue
+		}
 		merged[k] = v
 	}
 	for k, v := range processEnv {
+		if v == "" {
+			continue
+		}
 		merged[k] = v
 	}
 

--- a/pkg/config/providers/env/env_test.go
+++ b/pkg/config/providers/env/env_test.go
@@ -90,6 +90,48 @@ func TestEnv_KeyTransform_LeadingTrailingUnderscore(t *testing.T) {
 	}
 }
 
+// TestEnv_EmptyValuesTreatedAsAbsent guards the strict-mode regression where
+// the `${VAR:-}` container idiom exports optional settings as empty env vars.
+// Such phantom keys must not land in the Source, or an unset optional feature
+// looks "partially configured" (HasPrefix true, IsConfigured false) and trips
+// a production strict-mode boot panic.
+func TestEnv_EmptyValuesTreatedAsAbsent(t *testing.T) {
+	t.Parallel()
+
+	path := writeEnvFile(t, "TELEGRAM_CHAT_ID=\nTELEGRAM_CHAT_SOSTHREADID=\nAPP_HOST=localhost\n")
+	src, err := config.Build(New(path))
+	if err != nil {
+		t.Fatalf("config.Build: %v", err)
+	}
+
+	if _, ok := src.Get("telegram.chat.id"); ok {
+		t.Error("empty TELEGRAM_CHAT_ID must not be present in the source")
+	}
+	if src.HasPrefix("telegram.chat") {
+		t.Error("a prefix whose only env vars are empty must not register as present")
+	}
+	// Non-empty vars are unaffected.
+	if _, ok := src.Get("app.host"); !ok {
+		t.Error("non-empty APP_HOST should still be present")
+	}
+}
+
+// TestEnv_EmptyProcessEnvDoesNotOverrideFile documents that an empty process
+// env var is treated as absent rather than overriding a non-empty file value.
+func TestEnv_EmptyProcessEnvDoesNotOverrideFile(t *testing.T) {
+	path := writeEnvFile(t, "APP_HOST=from-file\n")
+	t.Setenv("APP_HOST", "")
+
+	src, err := config.Build(New(path))
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	v, ok := src.Get("app.host")
+	if !ok || v != "from-file" {
+		t.Errorf("empty process env should not erase file value: got %q ok=%v", v, ok)
+	}
+}
+
 func TestEnv_MissingFileIsSilent(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

Production deploys panic at boot:
```
panic: config: "telegram.chat" partially configured: TELEGRAM_CHAT_ID not set
  eai/modules/custom/auth/eimzo.NewLoginProvider()  provider.go:97
  eai/modules.init()  list.go:81
```
This aborts **every** binary built from the module — including the DB migrator (`migrate up` exit 2) — so a deploy cannot even run migrations.

## Root cause

Container stacks export optional settings with the `${VAR:-}` idiom (e.g. `TELEGRAM_CHAT_ID=${PREPROD_TELEGRAM_CHAT_ID:-}`), which sets the env var **unconditionally** — to an empty string when the secret is absent. The env provider loaded these empty vars as real config keys, so `Source.HasPrefix("telegram.chat")` returned true while `IsConfigured()` was false. In `production` (`StrictYes`) that state is "partially configured" → fatal.

Any optional-config group with a `${VAR:-}` line in the stack was a latent boot panic.

## Fix

Skip empty-valued vars at both the `.env`-file and process-env layers in the env provider. Empty ⇒ absent: default tags apply, optional features stay cleanly `Disabled`, and an empty process-env var no longer erases a non-empty `.env` value.

## Tests
- `TestEnv_EmptyValuesTreatedAsAbsent` — empty vars don't register under a prefix; non-empty unaffected.
- `TestEnv_EmptyProcessEnvDoesNotOverrideFile` — precedence guard.

Found while deploying eai#2342 (config-subsystem migration) to preprod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed handling of environment variables with empty string values to prevent them from incorrectly overriding configuration sources with lower precedence, ensuring proper configuration priority resolution.

* **Tests**
  * Added test cases to verify that environment variables with empty values are properly excluded from configuration loading and do not interfere with configuration precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->