### PR TITLE
fix: combobox top-layer dropdown + pinned-column drag walls

### DIFF
--- a/components/base/combobox.templ
+++ b/components/base/combobox.templ
@@ -271,16 +271,24 @@ templ Combobox(props ComboboxProps) {
 					},
 				})
 			}
+			<!--
+				The option list renders as a native Popover (top layer) so it is
+				never clipped by an overflow-hidden ancestor nor hidden behind a
+				modal drawer. Visibility, width and position are driven from the
+				combobox Alpine component (syncDropdown/positionDropdown). It stays
+				in the DOM (only painted in the top layer), so $refs and the
+				click.outside guard on the wrapper keep working. `flex` is applied
+				inline (not as a class) so it does not override the UA rule that
+				hides a closed popover.
+			-->
 			<ul
 				x-ref="list"
 				x-cloak
-				x-show="open || openedWithKeyboard"
-				class={ "bg-white absolute z-10 left-0 top-11 mt-1 flex max-h-44 flex-col gap-0.5 overflow-hidden overflow-y-auto border border-secondary p-1.5 rounded-md drop-shadow-sm w-full", props.ListClass }
+				popover="manual"
+				class={ "combobox-dropdown bg-white z-10 m-0 max-h-44 flex-col gap-0.5 overflow-hidden overflow-y-auto border border-secondary p-1.5 rounded-md drop-shadow-sm", props.ListClass }
 				x-on:keydown.down.prevent="$focus.wrap().next()"
 				x-on:keydown.up.prevent="$focus.wrap().previous()"
-				x-transition
 				x-trap="openedWithKeyboard"
-				x-anchor="$refs.trigger"
 			>
 				<template x-for="(item, index) in options" x-bind:key="item.value + ':' + index">
 					<li

--- a/components/base/combobox_templ.go
+++ b/components/base/combobox_templ.go
@@ -534,12 +534,16 @@ func Combobox(props ComboboxProps) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		var templ_7745c5c3_Var15 = []any{"bg-white absolute z-10 left-0 top-11 mt-1 flex max-h-44 flex-col gap-0.5 overflow-hidden overflow-y-auto border border-secondary p-1.5 rounded-md drop-shadow-sm w-full", props.ListClass}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<!--\n\t\t\t\tThe option list renders as a native Popover (top layer) so it is\n\t\t\t\tnever clipped by an overflow-hidden ancestor nor hidden behind a\n\t\t\t\tmodal drawer. Visibility, width and position are driven from the\n\t\t\t\tcombobox Alpine component (syncDropdown/positionDropdown). It stays\n\t\t\t\tin the DOM (only painted in the top layer), so $refs and the\n\t\t\t\tclick.outside guard on the wrapper keep working. `flex` is applied\n\t\t\t\tinline (not as a class) so it does not override the UA rule that\n\t\t\t\thides a closed popover.\n\t\t\t-->")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var15 = []any{"combobox-dropdown bg-white z-10 m-0 max-h-44 flex-col gap-0.5 overflow-hidden overflow-y-auto border border-secondary p-1.5 rounded-md drop-shadow-sm", props.ListClass}
 		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var15...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<ul x-ref=\"list\" x-cloak x-show=\"open || openedWithKeyboard\" class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<ul x-ref=\"list\" x-cloak popover=\"manual\" class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -552,7 +556,7 @@ func Combobox(props ComboboxProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\" x-on:keydown.down.prevent=\"$focus.wrap().next()\" x-on:keydown.up.prevent=\"$focus.wrap().previous()\" x-transition x-trap=\"openedWithKeyboard\" x-anchor=\"$refs.trigger\"><template x-for=\"(item, index) in options\" x-bind:key=\"item.value + &#39;:&#39; + index\"><li class=\"combobox-option inline-flex cursor-pointer justify-between gap-6 px-4 py-2 text-sm rounded-md duration-100 hover:bg-surface-400 focus-visible:bg-surface-400 focus-visible:outline-none\" :class=\"[\n\t\t\t\t\t\t\tactiveValue == item.value ? &#39;bg-surface-400&#39; : &#39;&#39;,\n\t\t\t\t\t\t\titem.disabled ? (item.dataset.fbHeader ? &#39;!cursor-default !py-1 mt-1 text-xs uppercase tracking-wide text-200 pointer-events-none hover:bg-transparent&#39; : &#39;opacity-40 !cursor-not-allowed hover:bg-transparent&#39;) : &#39;&#39;,\n\t\t\t\t\t\t]\" x-on:click=\"setValue(item.value)\" x-on:keydown.enter=\"setValue(item.value)\" x-bind:id=\"$id(&#39;combobox&#39;) + &#39;-option-&#39; + index\" x-bind:tabindex=\"item.disabled ? -1 : 0\"><span class=\"inline-flex min-w-0 items-baseline gap-1.5\"><span class=\"whitespace-nowrap\" x-text=\"item.textContent\"></span> <span class=\"text-xs text-200 whitespace-nowrap\" x-cloak x-show=\"item.dataset.fbCount !== undefined\" x-text=\"item.dataset.fbCount !== undefined ? &#39;(&#39; + Number(item.dataset.fbCount).toLocaleString() + &#39;)&#39; : &#39;&#39;\"></span></span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\" x-on:keydown.down.prevent=\"$focus.wrap().next()\" x-on:keydown.up.prevent=\"$focus.wrap().previous()\" x-trap=\"openedWithKeyboard\"><template x-for=\"(item, index) in options\" x-bind:key=\"item.value + &#39;:&#39; + index\"><li class=\"combobox-option inline-flex cursor-pointer justify-between gap-6 px-4 py-2 text-sm rounded-md duration-100 hover:bg-surface-400 focus-visible:bg-surface-400 focus-visible:outline-none\" :class=\"[\n\t\t\t\t\t\t\tactiveValue == item.value ? &#39;bg-surface-400&#39; : &#39;&#39;,\n\t\t\t\t\t\t\titem.disabled ? (item.dataset.fbHeader ? &#39;!cursor-default !py-1 mt-1 text-xs uppercase tracking-wide text-200 pointer-events-none hover:bg-transparent&#39; : &#39;opacity-40 !cursor-not-allowed hover:bg-transparent&#39;) : &#39;&#39;,\n\t\t\t\t\t\t]\" x-on:click=\"setValue(item.value)\" x-on:keydown.enter=\"setValue(item.value)\" x-bind:id=\"$id(&#39;combobox&#39;) + &#39;-option-&#39; + index\" x-bind:tabindex=\"item.disabled ? -1 : 0\"><span class=\"inline-flex min-w-0 items-baseline gap-1.5\"><span class=\"whitespace-nowrap\" x-text=\"item.textContent\"></span> <span class=\"text-xs text-200 whitespace-nowrap\" x-cloak x-show=\"item.dataset.fbCount !== undefined\" x-text=\"item.dataset.fbCount !== undefined ? &#39;(&#39; + Number(item.dataset.fbCount).toLocaleString() + &#39;)&#39; : &#39;&#39;\"></span></span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -563,12 +567,12 @@ func Combobox(props ComboboxProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "</li></template>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</li></template>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if props.CanCreateNew {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<li x-ref=\"createOption\" x-show=\"options.length == 0\" class=\"cursor-pointer px-4 py-2 text-sm rounded-md duration-100 hover:bg-surface-400 focus-visible:bg-surface-400 focus-visible:outline-none\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<li x-ref=\"createOption\" x-show=\"options.length == 0\" class=\"cursor-pointer px-4 py-2 text-sm rounded-md duration-100 hover:bg-surface-400 focus-visible:bg-surface-400 focus-visible:outline-none\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -576,38 +580,38 @@ func Combobox(props ComboboxProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "><input type=\"hidden\" name=\"_SearchQuery\" :value=\"searchQuery\"> <span class=\"whitespace-nowrap\" x-text=\"searchQuery\"></span></li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "><input type=\"hidden\" name=\"_SearchQuery\" :value=\"searchQuery\"> <span class=\"whitespace-nowrap\" x-text=\"searchQuery\"></span></li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "<li x-show=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "<li x-show=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var17 string
 		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("options.length == 0 && %t", !props.CanCreateNew))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/combobox.templ`, Line: 318, Col: 78}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/combobox.templ`, Line: 326, Col: 78}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\" class=\"px-4 py-2 text-sm text-200\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "\" class=\"px-4 py-2 text-sm text-200\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var18 string
 		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(props.NotFoundText)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/combobox.templ`, Line: 319, Col: 25}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/combobox.templ`, Line: 327, Col: 25}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</li></ul></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</li></ul></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/components/base/table.templ
+++ b/components/base/table.templ
@@ -326,6 +326,7 @@ templ Table(props TableProps) {
 								x-sort:config="{
 									handle: '[x-sort\\:handle]',
 									filter: '[data-col-sticky]',
+									onMove: (event) => !(event.related && event.related.matches && event.related.matches('[data-col-sticky]')),
 									onEnd: (event) => {
 										moveColumn(event.oldIndex, event.newIndex, true);
 									},
@@ -493,6 +494,7 @@ templ Table(props TableProps) {
 								x-sort.ghost
 								x-sort:config="{
 								draggable: '[data-sortable]',
+								onMove: (event) => !(event.related && event.related.matches && event.related.matches('[data-col-sticky]')),
 								onEnd: (event) => {
 									moveColumn(event.oldIndex, event.newIndex, true);
 								},

--- a/components/base/table_templ.go
+++ b/components/base/table_templ.go
@@ -414,7 +414,7 @@ func Table(props TableProps) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			if props.Configurable {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, " x-sort.ghost x-sort:config=\"{\n\t\t\t\t\t\t\t\t\thandle: &#39;[x-sort\\\\:handle]&#39;,\n\t\t\t\t\t\t\t\t\tfilter: &#39;[data-col-sticky]&#39;,\n\t\t\t\t\t\t\t\t\tonEnd: (event) =&gt; {\n\t\t\t\t\t\t\t\t\t\tmoveColumn(event.oldIndex, event.newIndex, true);\n\t\t\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\t\t}\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, " x-sort.ghost x-sort:config=\"{\n\t\t\t\t\t\t\t\t\thandle: &#39;[x-sort\\\\:handle]&#39;,\n\t\t\t\t\t\t\t\t\tfilter: &#39;[data-col-sticky]&#39;,\n\t\t\t\t\t\t\t\t\tonMove: (event) =&gt; !(event.related &amp;&amp; event.related.matches &amp;&amp; event.related.matches(&#39;[data-col-sticky]&#39;)),\n\t\t\t\t\t\t\t\t\tonEnd: (event) =&gt; {\n\t\t\t\t\t\t\t\t\t\tmoveColumn(event.oldIndex, event.newIndex, true);\n\t\t\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\t\t}\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -455,7 +455,7 @@ func Table(props TableProps) templ.Component {
 						var templ_7745c5c3_Var15 string
 						templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(col.Key)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 340, Col: 29}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 341, Col: 29}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 						if templ_7745c5c3_Err != nil {
@@ -486,7 +486,7 @@ func Table(props TableProps) templ.Component {
 						var templ_7745c5c3_Var16 string
 						templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(col.Priority))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 345, Col: 57}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 346, Col: 57}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 						if templ_7745c5c3_Err != nil {
@@ -510,7 +510,7 @@ func Table(props TableProps) templ.Component {
 					var templ_7745c5c3_Var17 string
 					templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(col.SortURL)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 354, Col: 32}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 355, Col: 32}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 					if templ_7745c5c3_Err != nil {
@@ -542,7 +542,7 @@ func Table(props TableProps) templ.Component {
 						var templ_7745c5c3_Var18 string
 						templ_7745c5c3_Var18, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(truncateStyle(col.TruncateWidth))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 365, Col: 76}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 366, Col: 76}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 						if templ_7745c5c3_Err != nil {
@@ -555,7 +555,7 @@ func Table(props TableProps) templ.Component {
 						var templ_7745c5c3_Var19 string
 						templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(col.Label)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 365, Col: 90}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 366, Col: 90}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 						if templ_7745c5c3_Err != nil {
@@ -573,7 +573,7 @@ func Table(props TableProps) templ.Component {
 						var templ_7745c5c3_Var20 string
 						templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(col.Label)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 367, Col: 30}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 368, Col: 30}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 						if templ_7745c5c3_Err != nil {
@@ -656,7 +656,7 @@ func Table(props TableProps) templ.Component {
 						var templ_7745c5c3_Var23 string
 						templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(col.Key)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 392, Col: 29}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 393, Col: 29}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 						if templ_7745c5c3_Err != nil {
@@ -687,7 +687,7 @@ func Table(props TableProps) templ.Component {
 						var templ_7745c5c3_Var24 string
 						templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(col.Priority))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 397, Col: 57}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 398, Col: 57}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 						if templ_7745c5c3_Err != nil {
@@ -730,7 +730,7 @@ func Table(props TableProps) templ.Component {
 						var templ_7745c5c3_Var25 string
 						templ_7745c5c3_Var25, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(truncateStyle(col.TruncateWidth))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 411, Col: 76}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 412, Col: 76}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 						if templ_7745c5c3_Err != nil {
@@ -743,7 +743,7 @@ func Table(props TableProps) templ.Component {
 						var templ_7745c5c3_Var26 string
 						templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(col.Label)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 411, Col: 90}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 412, Col: 90}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 						if templ_7745c5c3_Err != nil {
@@ -757,7 +757,7 @@ func Table(props TableProps) templ.Component {
 						var templ_7745c5c3_Var27 string
 						templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(col.Label)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 413, Col: 24}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 414, Col: 24}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 						if templ_7745c5c3_Err != nil {
@@ -936,7 +936,7 @@ func Table(props TableProps) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			if props.Configurable {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, " x-sort.ghost x-sort:config=\"{\n\t\t\t\t\t\t\t\tdraggable: &#39;[data-sortable]&#39;,\n\t\t\t\t\t\t\t\tonEnd: (event) =&gt; {\n\t\t\t\t\t\t\t\t\tmoveColumn(event.oldIndex, event.newIndex, true);\n\t\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\t}\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, " x-sort.ghost x-sort:config=\"{\n\t\t\t\t\t\t\t\tdraggable: &#39;[data-sortable]&#39;,\n\t\t\t\t\t\t\t\tonMove: (event) =&gt; !(event.related &amp;&amp; event.related.matches &amp;&amp; event.related.matches(&#39;[data-col-sticky]&#39;)),\n\t\t\t\t\t\t\t\tonEnd: (event) =&gt; {\n\t\t\t\t\t\t\t\t\tmoveColumn(event.oldIndex, event.newIndex, true);\n\t\t\t\t\t\t\t\t},\n\t\t\t\t\t\t\t}\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -977,7 +977,7 @@ func Table(props TableProps) templ.Component {
 						var templ_7745c5c3_Var38 string
 						templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(col.Key)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 507, Col: 29}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 509, Col: 29}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 						if templ_7745c5c3_Err != nil {
@@ -1008,7 +1008,7 @@ func Table(props TableProps) templ.Component {
 						var templ_7745c5c3_Var39 string
 						templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(col.Priority))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 512, Col: 57}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 514, Col: 57}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 						if templ_7745c5c3_Err != nil {
@@ -1032,7 +1032,7 @@ func Table(props TableProps) templ.Component {
 					var templ_7745c5c3_Var40 string
 					templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(col.SortURL)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 522, Col: 32}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 524, Col: 32}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 					if templ_7745c5c3_Err != nil {
@@ -1064,7 +1064,7 @@ func Table(props TableProps) templ.Component {
 						var templ_7745c5c3_Var41 string
 						templ_7745c5c3_Var41, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(truncateStyle(col.TruncateWidth))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 533, Col: 76}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 535, Col: 76}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
 						if templ_7745c5c3_Err != nil {
@@ -1077,7 +1077,7 @@ func Table(props TableProps) templ.Component {
 						var templ_7745c5c3_Var42 string
 						templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(col.Label)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 533, Col: 90}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 535, Col: 90}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
 						if templ_7745c5c3_Err != nil {
@@ -1095,7 +1095,7 @@ func Table(props TableProps) templ.Component {
 						var templ_7745c5c3_Var43 string
 						templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(col.Label)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 535, Col: 30}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 537, Col: 30}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 						if templ_7745c5c3_Err != nil {
@@ -1178,7 +1178,7 @@ func Table(props TableProps) templ.Component {
 						var templ_7745c5c3_Var46 string
 						templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(col.Key)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 560, Col: 29}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 562, Col: 29}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 						if templ_7745c5c3_Err != nil {
@@ -1209,7 +1209,7 @@ func Table(props TableProps) templ.Component {
 						var templ_7745c5c3_Var47 string
 						templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(col.Priority))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 565, Col: 57}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 567, Col: 57}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
 						if templ_7745c5c3_Err != nil {
@@ -1252,7 +1252,7 @@ func Table(props TableProps) templ.Component {
 						var templ_7745c5c3_Var48 string
 						templ_7745c5c3_Var48, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(truncateStyle(col.TruncateWidth))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 580, Col: 76}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 582, Col: 76}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
 						if templ_7745c5c3_Err != nil {
@@ -1265,7 +1265,7 @@ func Table(props TableProps) templ.Component {
 						var templ_7745c5c3_Var49 string
 						templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(col.Label)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 580, Col: 90}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 582, Col: 90}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
 						if templ_7745c5c3_Err != nil {
@@ -1279,7 +1279,7 @@ func Table(props TableProps) templ.Component {
 						var templ_7745c5c3_Var50 string
 						templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(col.Label)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 582, Col: 24}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/table.templ`, Line: 584, Col: 24}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
 						if templ_7745c5c3_Err != nil {

--- a/modules/core/presentation/assets/js/alpine.js
+++ b/modules/core/presentation/assets/js/alpine.js
@@ -205,6 +205,82 @@ let combobox = (searchable = false, canCreateNew = false) => ({
   searchQuery: '',
   searchable,
   canCreateNew,
+  init() {
+    // Reposition the (top-layer) dropdown when the page scrolls/resizes while open.
+    this._reflow = () => {
+      if (this.open || this.openedWithKeyboard) this.positionDropdown();
+    };
+    this.$watch('open', () => this.syncDropdown());
+    this.$watch('openedWithKeyboard', () => this.syncDropdown());
+    window.addEventListener('scroll', this._reflow, true);
+    window.addEventListener('resize', this._reflow);
+    // Start hidden. Popover-capable browsers also hide via UA styles; this
+    // covers the in-flow fallback path. Deferred because $refs.list is a child
+    // ref not yet registered when the component's init() runs.
+    this.$nextTick(() => {
+      if (this.$refs.list) this.$refs.list.style.display = 'none';
+    });
+  },
+  destroy() {
+    if (this._reflow) {
+      window.removeEventListener('scroll', this._reflow, true);
+      window.removeEventListener('resize', this._reflow);
+    }
+    let list = this.$refs.list;
+    if (this.supportsPopover(list) && list.matches(':popover-open')) {
+      try { list.hidePopover(); } catch (e) { }
+    }
+  },
+  supportsPopover(el) {
+    return !!el && typeof el.showPopover === 'function' && el.hasAttribute('popover');
+  },
+  // Promote the option list to the top layer (Popover API) on open so it is
+  // never clipped by an overflow-hidden ancestor or hidden behind a modal drawer.
+  syncDropdown() {
+    let list = this.$refs.list;
+    if (!list) return;
+    let show = this.open || this.openedWithKeyboard;
+    if (show) {
+      list.style.display = 'flex';
+      if (this.supportsPopover(list) && !list.matches(':popover-open')) {
+        try { list.showPopover(); } catch (e) { }
+      }
+      this.$nextTick(() => this.positionDropdown());
+    } else {
+      if (this.supportsPopover(list) && list.matches(':popover-open')) {
+        try { list.hidePopover(); } catch (e) { }
+      }
+      list.style.display = 'none';
+    }
+  },
+  // Anchor the dropdown to the trigger using viewport coordinates, flipping
+  // above when there is not enough room below.
+  positionDropdown() {
+    let list = this.$refs.list;
+    let trigger = this.$refs.trigger;
+    if (!list || !trigger) return;
+    let rect = trigger.getBoundingClientRect();
+    let gap = 4;
+    // Match the field width. Callers passing `!w-auto` via ListClass override this.
+    list.style.width = rect.width + 'px';
+    if (this.supportsPopover(list) && list.matches(':popover-open')) {
+      // Top-layer popover: position against the viewport (fixed coordinates)
+      // and reset the UA-default `inset:0; margin:auto` centering.
+      list.style.margin = '0';
+      list.style.inset = 'auto';
+      list.style.position = 'fixed';
+      let listHeight = list.offsetHeight;
+      let spaceBelow = window.innerHeight - rect.bottom;
+      let flipUp = spaceBelow < listHeight + gap && rect.top > spaceBelow;
+      list.style.left = rect.left + 'px';
+      list.style.top = (flipUp ? Math.max(gap, rect.top - listHeight - gap) : rect.bottom + gap) + 'px';
+    } else {
+      // Fallback (no Popover API): sit just below the field, in flow.
+      list.style.position = 'absolute';
+      list.style.left = '0px';
+      list.style.top = '100%';
+    }
+  },
   setValue(value) {
     if (!this.options.length && this.canCreateNew && this.searchQuery.length) {
       this.$refs.createOption.click();

--- a/modules/core/presentation/assets/js/alpine.js
+++ b/modules/core/presentation/assets/js/alpine.js
@@ -2042,6 +2042,18 @@ let tableConfig = (id) => ({
       return;
     }
     if (fromIndex === toIndex) return;
+    // Sticky (pinned) columns are fixed walls: a column may not be reordered
+    // across one. Clamp the target into the segment bounded by the nearest
+    // sticky columns on each side of the source position.
+    if (this.columns[fromIndex] && this.columns[fromIndex].sticky) return;
+    let lo = 0, hi = this.columns.length - 1;
+    for (let i = 0; i < this.columns.length; i++) {
+      if (!this.columns[i] || !this.columns[i].sticky) continue;
+      if (i < fromIndex) lo = Math.max(lo, i + 1);
+      else if (i > fromIndex) hi = Math.min(hi, i - 1);
+    }
+    toIndex = Math.max(lo, Math.min(hi, toIndex));
+    if (fromIndex === toIndex) return;
     let [col] = this.columns.splice(fromIndex, 1);
     this.columns.splice(toIndex, 0, col);
     if (sync) {


### PR DESCRIPTION
Two related table/overlay fixes consumed by the EAI portfolio/policies page.

## 1. Combobox dropdown clipping (`base.Combobox`)
The option list was `position:absolute`, so it was clipped by any `overflow-hidden` ancestor and could render *behind* modal drawers (top layer). On short viewports floating-ui flips it upward, and the clipping ancestor (e.g. the policies filter card) cut it off.

**Fix:** render the list as a native **`popover="manual"`** promoted to the top layer, driven from the `combobox` Alpine factory — `showPopover/hidePopover`, width synced to the trigger (`!w-auto` callers still override), flips above when low on space, repositions on scroll/resize, in-flow fallback for browsers without the Popover API. The list stays in the DOM, so `$refs`, `x-trap`, and the wrapper's `click.outside` are unchanged. Top layer escapes **both** overflow clipping and modal layering (teleport-to-body would fix the former but break the latter).

Verified in Chrome: dropdown in a short `overflow:hidden` box flips up fully visible; dropdown inside a `showModal()` dialog paints above the backdrop; option-select closes cleanly; no console errors.

## 2. Pinned columns are now hard walls for drag-reorder (`base.Table`)
Sticky/pinned columns could be *crossed* when dragging another column in the header: SortableJS `filter` only stops the pinned column from being dragged itself, not other columns from being dropped past it, and `moveColumn` spliced to any index — so e.g. the policies **Actions** column (sticky right) could be bypassed.

**Fix:**
- `moveColumn` clamps the target into the segment bounded by the nearest sticky column on each side of the source, so no column can be reordered across a pinned one (and a pinned column never moves).
- the header `x-sort` config gains an `onMove` guard rejecting a cross over any `[data-col-sticky]` element, so the drag is visually blocked at the wall (no snap-back).

The Actions column therefore stays pinned and other columns can't be dragged past it. Clamp logic verified with a deterministic unit test (past-right-pin, cross-left-pin, normal middle moves, multi-pin); `go vet ./components/...` passes; templ regenerated with the pinned v0.3.857.

The eai submodule + go.mod bump will follow once this merges.

https://claude.ai/code/session_01TYWbL17fPDRzN5j7JoqWdD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced combobox dropdown positioning with automatic repositioning during scroll/resize and improved open/close lifecycle handling.
  * Updated combobox dropdown rendering to use native browser Popover support when available, with a safe fallback behavior.
* **Bug Fixes**
  * Prevented column drag-and-drop from reordering across sticky (pinned) columns, keeping pinned columns in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->