### PR TITLE
fix(spotlight): wire opts.Meili + prune Meili task DB/orphan indexes after reindex

### DIFF
--- a/pkg/bootstrap/iota_source.go
+++ b/pkg/bootstrap/iota_source.go
@@ -12,6 +12,7 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/application"
 	"github.com/iota-uz/iota-sdk/pkg/config"
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/dbconfig"
+	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/meiliconfig"
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/telemetryconfig"
 	"github.com/iota-uz/iota-sdk/pkg/eventbus"
 	"github.com/iota-uz/iota-sdk/pkg/health"
@@ -147,11 +148,27 @@ func IotaSourceWithServiceName(src config.Source, serviceName string) Option {
 				}
 			}
 
+			// Wire the Spotlight search engine from the Meili source. Without
+			// this the SpotlightService falls back to a no-op engine, which
+			// silently breaks global search reads AND turns the periodic full
+			// reindex (ReindexTenant) into a no-op — the index then survives
+			// only on incremental single-doc writes. The legacy path read this
+			// from configuration.Use(); after the config-source migration the
+			// bootstrap must read it explicitly and pass it via opts.Meili.
+			var meiliCfg *meiliconfig.Config
+			if _, hasMeili := src.Get("meili.url"); hasMeili {
+				var mc meiliconfig.Config
+				if err := src.Unmarshal("meili", &mc); err == nil && strings.TrimSpace(mc.URL) != "" {
+					meiliCfg = &mc
+				}
+			}
+
 			return application.New(&application.ApplicationOptions{
 				Pool:               rt.Pool,
 				Bundle:             rt.Bundle,
 				EventBus:           eventbus.NewEventPublisher(rt.Logger),
 				Logger:             rt.Logger,
+				Meili:              meiliCfg,
 				SupportedLanguages: application.DefaultSupportedLanguages(),
 				Huber: application.NewHub(&application.HuberOptions{
 					Pool:           rt.Pool,

--- a/pkg/spotlight/engine_meilisearch.go
+++ b/pkg/spotlight/engine_meilisearch.go
@@ -501,6 +501,15 @@ func (s *meiliRebuildSession) Commit(ctx context.Context) error {
 		}
 	}
 
+	// Best-effort housekeeping after a successful swap. The reindex runs on
+	// a tight cron (minutes apart); Meili retains terminal task records and
+	// their update_files payloads indefinitely, and LMDB never returns freed
+	// pages to the OS — so without pruning here the task DB grows unbounded
+	// and orphan build indexes from prior schema versions accumulate. The
+	// rebuild has already committed, so a prune hiccup must NOT surface as a
+	// reindex failure: errors are logged inside, never returned.
+	s.engine.postCommitHousekeeping(ctx)
+
 	return nil
 }
 
@@ -651,6 +660,77 @@ func (e *MeilisearchEngine) PruneOrphanBuildIndexes(ctx context.Context, minAge 
 		}
 	}
 	return pruned, nil
+}
+
+// taskPruneRetention bounds how long terminal Meili tasks — and the
+// update_files payloads they pin on disk — are retained. The periodic
+// reindex enqueues many addDocuments+swap+delete tasks per cycle and Meili
+// never expires task history on its own, so the task DB grows without bound
+// until pruned. 24h keeps a useful operational audit window.
+const taskPruneRetention = 24 * time.Hour
+
+// orphanIndexMinAge is the slack the janitor leaves before deleting a
+// stale rebuild scratch index, matching the production rebuild window so it
+// never removes an index another node is still populating.
+const orphanIndexMinAge = 6 * time.Hour
+
+// PruneTasks deletes terminal (succeeded/failed/canceled) Meili tasks
+// enqueued before `before`, reclaiming the task DB and the update_files
+// payloads those tasks reference. Meili performs the deletion as its own
+// async task; this waits for it so the call is self-verifying, and returns
+// the number of task records removed. Only terminal statuses are targeted,
+// so an in-flight enqueued/processing task is never affected.
+func (e *MeilisearchEngine) PruneTasks(ctx context.Context, before time.Time) (int64, error) {
+	const op serrors.Op = "spotlight.MeilisearchEngine.PruneTasks"
+	if before.IsZero() {
+		return 0, serrors.E(op, errors.New("before timestamp is required"))
+	}
+
+	task, err := e.client.DeleteTasksWithContext(ctx, &meilisearch.DeleteTasksQuery{
+		Statuses: []meilisearch.TaskStatus{
+			meilisearch.TaskStatusSucceeded,
+			meilisearch.TaskStatusFailed,
+			meilisearch.TaskStatusCanceled,
+		},
+		BeforeEnqueuedAt: before,
+	})
+	if err != nil {
+		return 0, serrors.E(op, err)
+	}
+	if task == nil {
+		return 0, nil
+	}
+
+	status, err := waitTaskCtxClient(ctx, e.client, task.TaskUID)
+	if err != nil {
+		return 0, serrors.E(op, err)
+	}
+	if status == nil {
+		return 0, nil
+	}
+	return status.Details.DeletedTasks, nil
+}
+
+// postCommitHousekeeping runs best-effort task-DB and orphan-index pruning
+// after a successful rebuild swap. Every error is logged and swallowed:
+// housekeeping must never fail an already-committed reindex. Safe to call
+// on every Commit — both prunes are idempotent and cheap.
+func (e *MeilisearchEngine) postCommitHousekeeping(ctx context.Context) {
+	if deleted, err := e.PruneTasks(ctx, time.Now().Add(-taskPruneRetention)); err != nil {
+		if e.logger != nil {
+			e.logger.WithError(err).Warn("spotlight janitor: task-DB prune failed (non-fatal)")
+		}
+	} else if deleted > 0 && e.logger != nil {
+		e.logger.WithField("deleted_tasks", deleted).Info("spotlight janitor pruned terminal Meili tasks")
+	}
+
+	if pruned, err := e.PruneOrphanBuildIndexes(ctx, orphanIndexMinAge); err != nil {
+		if e.logger != nil {
+			e.logger.WithError(err).Warn("spotlight janitor: orphan-index prune failed (non-fatal)")
+		}
+	} else if len(pruned) > 0 && e.logger != nil {
+		e.logger.WithField("pruned_indexes", len(pruned)).Info("spotlight janitor pruned orphan build indexes")
+	}
 }
 
 // upsertSplitMaxDepth bounds the 413 split-and-retry recursion so a

--- a/pkg/spotlight/engine_meilisearch_test.go
+++ b/pkg/spotlight/engine_meilisearch_test.go
@@ -1,6 +1,7 @@
 package spotlight
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -390,8 +391,61 @@ func TestMeiliRebuildSessionCommitCreatesActiveIndexBeforeSwapWhenMissing(t *tes
 		WaitForTaskWithContext(mock.Anything, int64(22), 100*time.Millisecond).
 		Return(&meilisearch.Task{}, nil).
 		Once()
+	// Post-commit housekeeping: terminal-task prune, then orphan-index prune.
+	service.EXPECT().
+		DeleteTasksWithContext(mock.Anything, mock.AnythingOfType("*meilisearch.DeleteTasksQuery")).
+		Return(&meilisearch.TaskInfo{TaskUID: 23}, nil).
+		Once()
+	service.EXPECT().
+		WaitForTaskWithContext(mock.Anything, int64(23), 100*time.Millisecond).
+		Return(&meilisearch.Task{Details: meilisearch.Details{DeletedTasks: 5}}, nil).
+		Once()
+	service.EXPECT().
+		ListIndexesWithContext(mock.Anything, mock.AnythingOfType("*meilisearch.IndexesQuery")).
+		Return(&meilisearch.IndexesResults{}, nil).
+		Once()
 
 	require.NoError(t, session.Commit(t.Context()))
+}
+
+func TestMeilisearchEnginePruneTasksDeletesTerminalTasksBeforeCutoff(t *testing.T) {
+	service := meilimocks.NewMockmeilisearchServiceManager(t)
+	engine := &MeilisearchEngine{
+		client:    service,
+		indexName: "spotlight",
+	}
+
+	var captured *meilisearch.DeleteTasksQuery
+	service.EXPECT().
+		DeleteTasksWithContext(mock.Anything, mock.AnythingOfType("*meilisearch.DeleteTasksQuery")).
+		Run(func(_ context.Context, q *meilisearch.DeleteTasksQuery) { captured = q }).
+		Return(&meilisearch.TaskInfo{TaskUID: 70}, nil).
+		Once()
+	service.EXPECT().
+		WaitForTaskWithContext(mock.Anything, int64(70), 100*time.Millisecond).
+		Return(&meilisearch.Task{Details: meilisearch.Details{DeletedTasks: 12}}, nil).
+		Once()
+
+	cutoff := time.Now().Add(-24 * time.Hour)
+	deleted, err := engine.PruneTasks(t.Context(), cutoff)
+	require.NoError(t, err)
+	require.Equal(t, int64(12), deleted)
+	require.NotNil(t, captured)
+	require.Equal(t, cutoff, captured.BeforeEnqueuedAt)
+	require.ElementsMatch(t, []meilisearch.TaskStatus{
+		meilisearch.TaskStatusSucceeded,
+		meilisearch.TaskStatusFailed,
+		meilisearch.TaskStatusCanceled,
+	}, captured.Statuses)
+}
+
+func TestMeilisearchEnginePruneTasksRejectsZeroCutoff(t *testing.T) {
+	service := meilimocks.NewMockmeilisearchServiceManager(t)
+	engine := &MeilisearchEngine{client: service, indexName: "spotlight"}
+
+	deleted, err := engine.PruneTasks(t.Context(), time.Time{})
+	require.Error(t, err)
+	require.Zero(t, deleted)
 }
 
 func TestMeilisearchEngine_DeleteTenant_RemovesOnlyRequestedTenantDocuments(t *testing.T) {


### PR DESCRIPTION
## Problem
The periodic Spotlight reindex rebuilds the index every few minutes via a build-index swap (`meiliRebuildSession.Commit`). Two things then grow without bound:

1. **Task DB / `update_files`** — Meilisearch retains terminal task records (and the raw NDJSON payloads they reference) indefinitely; nothing in the codebase ever deletes tasks.
2. **Orphan build indexes** — `PruneOrphanBuildIndexes` existed but was **never called anywhere** (its doc claimed "the janitor task in EAI calls this hourly" — no such caller existed).

On EAI prod the `meili_data` volume reached **~34 GiB** for a ~2–4 GiB working set (~2.7M docs), tripping the deploy capacity warning.

## Change
- Add `MeilisearchEngine.PruneTasks(ctx, before)`: deletes terminal (`succeeded`/`failed`/`canceled`) tasks enqueued before a cutoff via `DeleteTasksWithContext`, waits for the async delete task, returns the removed count. Only terminal statuses → never touches in-flight work.
- `postCommitHousekeeping` runs after a successful rebuild swap: `PruneTasks` (24h retention) + `PruneOrphanBuildIndexes` (6h slack). **Best-effort** — the rebuild already committed, so prune errors are logged and swallowed, never surfaced as a reindex failure.

## Tests
- Updated the `Commit` happy-path mock to expect the new housekeeping calls.
- Added `PruneTasks` coverage: cutoff + terminal-status filter assertion; zero-cutoff guard.
- `go test ./pkg/spotlight/` green.

## Consumer
EAI bumps `back/go.mod` to this commit in a paired PR; no EAI code change needed (housekeeping is automatic on every reindex commit).

https://claude.ai/code/session_01WUSuvuv2zgvkmE5ABRpaxu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Meilisearch task pruning capability to remove terminal task history before a given cutoff time.
  * Wired Meilisearch configuration from the provided source into application startup when a Meilisearch URL is present.

* **Bug Fixes**
  * Improved post-rebuild housekeeping to automatically prune old task history and orphan indexes after swaps, without failing rebuild operations if cleanup encounters errors.

* **Tests**
  * Added/updated tests for pruning behavior (including cutoff validation) and post-commit cleanup steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## ⚠️ Added: critical fix — wire `opts.Meili` (prod search outage)

While validating the task-prune path on prod I found the periodic reindex never reaches Meili at all, and the root cause is broader than pruning:

**`bootstrap.IotaSource` never populated `ApplicationOptions.Meili`.** The config-source migration moved Meili config from `configuration.Use()` to `opts.Meili`, but the `appFactory` was never updated. So `application.New` fell back to a **no-op Spotlight engine** on every server booted via `bootstrap.NewRuntime(IotaSource(...))`:

- **Global search returned empty** — `app.Spotlight()` (search endpoints + `/system/spotlight`) read through the no-op engine.
- **`reindex_spotlight` wrote nothing** — `ReindexTenant` streamed ~1.3M docs into the no-op and logged a successful `sync completed`. The live index survived only on incremental single-doc writes from the separate `spotlightsync` engine — which is also what drove the unbounded LMDB/task growth this PR's pruning targets.

Fix: read `meili.url` / `meili.apikey` from the `config.Source` (same pattern as `http.origin`) and pass via `opts.Meili`. No-op fallback preserved when unset.

This makes the task-prune housekeeping in this PR actually run (it only fires on a real rebuild+swap commit).
