### PR TITLE
feat(copy_button): add CopyableText click-to-copy component

### DIFF
--- a/components/copy_button/copy_button.templ
+++ b/components/copy_button/copy_button.templ
@@ -10,12 +10,38 @@ type Props struct {
 	ShowText bool
 }
 
+// TextProps configures CopyableText: an inline value rendered alongside a
+// hover-revealed copy affordance. Label is the localized tooltip / aria-label
+// (the SDK has no i18n, so callers pass a translated string).
+type TextProps struct {
+	Text  string
+	Label string
+	Size  string
+	Class string
+}
+
 type Variant string
 
 const (
 	VariantDefault Variant = "default"
 	VariantMinimal Variant = "minimal"
 )
+
+// clipboardData is the shared Alpine handler. The value to copy is read from the
+// element's data-copy-text attribute (templ-escaped) rather than interpolated
+// into this JS string, so values containing quotes/backslashes/newlines are safe.
+const clipboardData = `{
+	copied: false,
+	async copyText() {
+		try {
+			await navigator.clipboard.writeText(this.$el.dataset.copyText);
+			this.copied = true;
+			setTimeout(() => this.copied = false, 2000);
+		} catch (err) {
+			console.error('Failed to copy text: ', err);
+		}
+	}
+}`
 
 templ CopyButton(props Props) {
 	{{ size := props.Size }}
@@ -34,18 +60,8 @@ templ CopyButton(props Props) {
 			templ.KV("hover:bg-gray-100 p-1", variant == VariantMinimal),
 			props.Class,
 		}
-		x-data={ `{
-			copied: false,
-			async copyText() {
-				try {
-					await navigator.clipboard.writeText('` + props.Text + `');
-					this.copied = true;
-					setTimeout(() => this.copied = false, 2000);
-				} catch (err) {
-					console.error('Failed to copy text: ', err);
-				}
-			}
-		}` }
+		data-copy-text={ props.Text }
+		x-data={ clipboardData }
 		@click="copyText()"
 		x-bind:class="copied ? 'text-green-600' : ''"
 	>
@@ -59,4 +75,43 @@ templ CopyButton(props Props) {
 			<span class="text-xs font-medium" x-text="copied ? 'Copied!' : 'Copy'"></span>
 		}
 	</button>
+}
+
+// CopyableText renders a short identifier (policy/contract number, INN, PINFL,
+// passport, external ID) as a click-to-copy element: clicking anywhere on it
+// copies the value to the clipboard and briefly swaps the hover icon for a green
+// check. The whole element is the click target; the copy icon fades in on hover.
+//
+// The value is carried in a data-attribute and read via $el.dataset at click time
+// — never interpolated into the handler — so values with quotes/backslashes are
+// safe. `@click.stop` prevents the click from also firing a row-level handler
+// (e.g. a drawer-opening table row). Empty values render as a "-" placeholder.
+// Colors inherit the surrounding text color so it reads on any background.
+templ CopyableText(props TextProps) {
+	{{ size := props.Size }}
+	if size == "" {
+		{{ size = "16" }}
+	}
+	if props.Text == "" {
+		{ "-" }
+	} else {
+		<span
+			class={ "inline-flex items-center gap-1 cursor-pointer group whitespace-nowrap max-w-full", props.Class }
+			data-copy-text={ props.Text }
+			if props.Label != "" {
+				title={ props.Label }
+				aria-label={ props.Label }
+			}
+			x-data="{ copied: false }"
+			@click.stop="navigator.clipboard.writeText($el.dataset.copyText); copied = true; setTimeout(() => copied = false, 1500)"
+		>
+			<span class="truncate">{ props.Text }</span>
+			<span x-show="!copied" class="shrink-0 text-current opacity-0 group-hover:opacity-100 transition-opacity">
+				@icons.Copy(icons.Props{Size: size})
+			</span>
+			<span x-show="copied" class="shrink-0 text-green-500">
+				@icons.CheckCircle(icons.Props{Size: size})
+			</span>
+		</span>
+	}
 }

--- a/components/copy_button/copy_button_templ.go
+++ b/components/copy_button/copy_button_templ.go
@@ -18,12 +18,38 @@ type Props struct {
 	ShowText bool
 }
 
+// TextProps configures CopyableText: an inline value rendered alongside a
+// hover-revealed copy affordance. Label is the localized tooltip / aria-label
+// (the SDK has no i18n, so callers pass a translated string).
+type TextProps struct {
+	Text  string
+	Label string
+	Size  string
+	Class string
+}
+
 type Variant string
 
 const (
 	VariantDefault Variant = "default"
 	VariantMinimal Variant = "minimal"
 )
+
+// clipboardData is the shared Alpine handler. The value to copy is read from the
+// element's data-copy-text attribute (templ-escaped) rather than interpolated
+// into this JS string, so values containing quotes/backslashes/newlines are safe.
+const clipboardData = `{
+	copied: false,
+	async copyText() {
+		try {
+			await navigator.clipboard.writeText(this.$el.dataset.copyText);
+			this.copied = true;
+			setTimeout(() => this.copied = false, 2000);
+		} catch (err) {
+			console.error('Failed to copy text: ', err);
+		}
+	}
+}`
 
 func CopyButton(props Props) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
@@ -77,31 +103,33 @@ func CopyButton(props Props) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\" x-data=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\" data-copy-text=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var4 string
-		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(`{
-			copied: false,
-			async copyText() {
-				try {
-					await navigator.clipboard.writeText('` + props.Text + `');
-					this.copied = true;
-					setTimeout(() => this.copied = false, 2000);
-				} catch (err) {
-					console.error('Failed to copy text: ', err);
-				}
-			}
-		}`)
+		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(props.Text)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 48, Col: 4}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 63, Col: 29}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\" @click=\"copyText()\" x-bind:class=\"copied ? &#39;text-green-600&#39; : &#39;&#39;\"><span x-show=\"!copied\" x-transition>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\" x-data=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var5 string
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(clipboardData)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 64, Col: 24}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\" @click=\"copyText()\" x-bind:class=\"copied ? &#39;text-green-600&#39; : &#39;&#39;\"><span x-show=\"!copied\" x-transition>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -109,7 +137,7 @@ func CopyButton(props Props) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</span> <span x-show=\"copied\" x-transition>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</span> <span x-show=\"copied\" x-transition>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -117,19 +145,170 @@ func CopyButton(props Props) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</span> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if props.ShowText {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<span class=\"text-xs font-medium\" x-text=\"copied ? &#39;Copied!&#39; : &#39;Copy&#39;\"></span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<span class=\"text-xs font-medium\" x-text=\"copied ? &#39;Copied!&#39; : &#39;Copy&#39;\"></span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</button>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</button>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+// CopyableText renders a short identifier (policy/contract number, INN, PINFL,
+// passport, external ID) as a click-to-copy element: clicking anywhere on it
+// copies the value to the clipboard and briefly swaps the hover icon for a green
+// check. The whole element is the click target; the copy icon fades in on hover.
+//
+// The value is carried in a data-attribute and read via $el.dataset at click time
+// — never interpolated into the handler — so values with quotes/backslashes are
+// safe. `@click.stop` prevents the click from also firing a row-level handler
+// (e.g. a drawer-opening table row). Empty values render as a "-" placeholder.
+// Colors inherit the surrounding text color so it reads on any background.
+func CopyableText(props TextProps) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		size := props.Size
+		if size == "" {
+			size = "16"
+		}
+		if props.Text == "" {
+			var templ_7745c5c3_Var7 string
+			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs("-")
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 96, Col: 7}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		} else {
+			var templ_7745c5c3_Var8 = []any{"inline-flex items-center gap-1 cursor-pointer group whitespace-nowrap max-w-full", props.Class}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var8...)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<span class=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var9 string
+			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var8).String())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 1, Col: 0}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\" data-copy-text=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var10 string
+			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(props.Text)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 100, Col: 30}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if props.Label != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, " title=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var11 string
+				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(props.Label)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 102, Col: 23}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\" aria-label=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var12 string
+				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(props.Label)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 103, Col: 28}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, " x-data=\"{ copied: false }\" @click.stop=\"navigator.clipboard.writeText($el.dataset.copyText); copied = true; setTimeout(() =&gt; copied = false, 1500)\"><span class=\"truncate\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var13 string
+			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(props.Text)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 108, Col: 38}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</span> <span x-show=\"!copied\" class=\"shrink-0 text-current opacity-0 group-hover:opacity-100 transition-opacity\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = icons.Copy(icons.Props{Size: size}).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</span> <span x-show=\"copied\" class=\"shrink-0 text-green-500\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = icons.CheckCircle(icons.Props{Size: size}).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</span></span>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
 		return nil
 	})


### PR DESCRIPTION
## Summary
Adds `CopyableText` to the `copy_button` package — the canonical click-to-copy element for short identifiers (policy/contract numbers, INN, PINFL, passport, external IDs) in tables.

- **Hover-reveal** copy icon next to the value; click copies to clipboard and swaps the icon for a green check (~1.5s).
- **Whole element is the click target** and uses `@click.stop`, so copying does not also fire a row-level handler (e.g. a drawer-opening table row).
- **Injection-safe**: the value is carried in a `data-copy-text` attribute and read via `$el.dataset` at click time, never interpolated into the Alpine handler. The same hardening is applied to the existing `CopyButton`.
- Empty values render as a `-` placeholder; colors inherit the surrounding text color.

## API
```go
copy_button.CopyableText(copy_button.TextProps{
    Text:  value,          // displayed and copied
    Label: localizedHint,   // tooltip / aria-label (SDK has no i18n; caller passes a translated string)
})
```

## Consumer
EAI adopts this for new copy affordances on claims / persons / organizations tables and migrates its in-house `pkg/templates.CopyableText` onto it (linked PR).

## Test plan
- `templ generate && go vet ./components/copy_button/...` clean.
- Verified in EAI against a prod-scale dataset (Chrome): hover reveals the icon, click copies + shows the green check, and on drawer-row tables (`/crm/lookups/persons`) clicking copies **without** opening the drawer.

https://claude.ai/code/session_016psCQKbeZbijyrsDyXJKhu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new CopyableText component for inline, clickable copy functionality with improved visual feedback.

* **Improvements**
  * Enhanced accessibility with better labeling and ARIA attributes for copy interactions.
  * Updated copy button behavior with more reliable data handling and faster visual feedback reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->