### PR TITLE
fix(combobox): size dropdown to available viewport space, not a fixed cap

### DIFF
--- a/components/base/combobox.templ
+++ b/components/base/combobox.templ
@@ -285,7 +285,7 @@ templ Combobox(props ComboboxProps) {
 				x-ref="list"
 				x-cloak
 				popover="manual"
-				class={ "combobox-dropdown bg-white z-10 m-0 max-h-44 flex-col gap-0.5 overflow-hidden overflow-y-auto border border-secondary p-1.5 rounded-md drop-shadow-sm", props.ListClass }
+				class={ "combobox-dropdown bg-white z-10 m-0 flex-col gap-0.5 overflow-hidden overflow-y-auto border border-secondary p-1.5 rounded-md drop-shadow-sm", props.ListClass }
 				x-on:keydown.down.prevent="$focus.wrap().next()"
 				x-on:keydown.up.prevent="$focus.wrap().previous()"
 				x-trap="openedWithKeyboard"

--- a/components/base/combobox_templ.go
+++ b/components/base/combobox_templ.go
@@ -538,7 +538,7 @@ func Combobox(props ComboboxProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var15 = []any{"combobox-dropdown bg-white z-10 m-0 max-h-44 flex-col gap-0.5 overflow-hidden overflow-y-auto border border-secondary p-1.5 rounded-md drop-shadow-sm", props.ListClass}
+		var templ_7745c5c3_Var15 = []any{"combobox-dropdown bg-white z-10 m-0 flex-col gap-0.5 overflow-hidden overflow-y-auto border border-secondary p-1.5 rounded-md drop-shadow-sm", props.ListClass}
 		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var15...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err

--- a/modules/core/presentation/assets/js/alpine.js
+++ b/modules/core/presentation/assets/js/alpine.js
@@ -261,6 +261,7 @@ let combobox = (searchable = false, canCreateNew = false) => ({
     if (!list || !trigger) return;
     let rect = trigger.getBoundingClientRect();
     let gap = 4;
+    let edge = 8; // keep the menu clear of the viewport edge
     // Match the field width. Callers passing `!w-auto` via ListClass override this.
     list.style.width = rect.width + 'px';
     if (this.supportsPopover(list) && list.matches(':popover-open')) {
@@ -269,17 +270,39 @@ let combobox = (searchable = false, canCreateNew = false) => ({
       list.style.margin = '0';
       list.style.inset = 'auto';
       list.style.position = 'fixed';
-      let listHeight = list.offsetHeight;
-      let spaceBelow = window.innerHeight - rect.bottom;
-      let flipUp = spaceBelow < listHeight + gap && rect.top > spaceBelow;
+      // Size the menu to the available space rather than a fixed cap: measure the
+      // natural content height (bounded by any caller-supplied cap such as
+      // `!max-h-60`), then clamp to whichever side of the trigger has more room.
+      // Grows on tall screens; stays clip-safe (never taller than the viewport gap)
+      // when forced to flip up on short ones. Applied `important` so the clip-safe
+      // ceiling also wins over a caller's `!important` cap on short screens, while
+      // still never exceeding that cap (it bounds contentHeight) on tall ones.
+      list.style.removeProperty('max-height');
+      let contentHeight = Math.min(this.dropdownMaxHeightCap(list), list.scrollHeight + 2);
+      let spaceBelow = window.innerHeight - rect.bottom - gap - edge;
+      let spaceAbove = rect.top - gap - edge;
+      let flipUp = spaceBelow < contentHeight && spaceAbove > spaceBelow;
+      let height = Math.min(contentHeight, Math.max(0, flipUp ? spaceAbove : spaceBelow));
+      list.style.setProperty('max-height', height + 'px', 'important');
       list.style.left = rect.left + 'px';
-      list.style.top = (flipUp ? Math.max(gap, rect.top - listHeight - gap) : rect.bottom + gap) + 'px';
+      list.style.top = (flipUp ? rect.top - height - gap : rect.bottom + gap) + 'px';
     } else {
       // Fallback (no Popover API): sit just below the field, in flow.
       list.style.position = 'absolute';
       list.style.left = '0px';
       list.style.top = '100%';
+      list.style.removeProperty('max-height');
+      let avail = Math.max(0, window.innerHeight - rect.bottom - gap - edge);
+      let height = Math.min(this.dropdownMaxHeightCap(list), list.scrollHeight + 2, avail);
+      list.style.setProperty('max-height', height + 'px', 'important');
     }
+  },
+  dropdownMaxHeightCap(list) {
+    // Caller-supplied max-height cap (e.g. ListClass `!max-h-60`) in pixels, or
+    // Infinity when none. Must be read with our own inline max-height cleared.
+    let cap = getComputedStyle(list).maxHeight;
+    let px = cap && cap !== 'none' ? parseFloat(cap) : NaN;
+    return Number.isFinite(px) ? px : Infinity;
   },
   setValue(value) {
     if (!this.options.length && this.canCreateNew && this.searchQuery.length) {


### PR DESCRIPTION
## Problem
After #816 moved the combobox dropdown into the browser top layer (Popover API) to stop it being clipped by overflow-hidden ancestors, the menu looks cramped — only ~4 rows tall **even on tall screens**. Cause: the list still carried a static `max-h-44` (176px) cap. Before #816 that cap was masked by the parent clipping; now it's the sole height constraint.

## Fix
Replace the fixed cap with a dynamic one computed in `positionDropdown` (`alpine.js`):
- Measure natural content height, bounded by any caller-supplied cap (e.g. the filterbuilder chip's `ListClass: "!max-h-60"`), read via `getComputedStyle`.
- Clamp to whichever side of the trigger has more room (`spaceAbove` / `spaceBelow`, with an 8px viewport margin).
- Apply with `important` so the clip-safe ceiling wins over a caller's `!important` cap when flipping up on short screens, while never exceeding that cap on tall ones.
- Remove `max-h-44` from the list class (`combobox.templ`), regenerated with templ **v0.3.857** (no version-header drift).

## Behavior
| Context | Before | After |
|---|---|---|
| Tall screen, default combobox | capped 176px (~4 rows) | grows to fit content, up to viewport gap |
| Short screen, flips up | clip-safe but tiny | shrinks to fit above trigger — no clip |
| Filterbuilder chip (`!max-h-60`) | 240px always | ≤240px on tall (cap respected), smaller on short (clip-safe) |

## Verification
- Height math checked across tall / short-flip-up / chip-cap scenarios.
- `go vet ./components/base/` clean; generated `combobox_templ.go` shows the class change with no templ version-header change.

Follow-up to #816.

https://claude.ai/code/session_01TYWbL17fPDRzN5j7JoqWdD