### PR TITLE
fix(multiselect): keep dropdown open while picking multiple options

### DIFF
--- a/components/scaffold/filters/filters.templ
+++ b/components/scaffold/filters/filters.templ
@@ -36,7 +36,7 @@ templ Dropdown(props DropdownProps) {
 			</button>
 			<!-- Dropdown Button -->
 			<button
-				@click="open = !open"
+				@click="toggle()"
 				type="button"
 				class={
 					"w-full border border-gray-300 rounded-md shadow-sm cursor-pointer",
@@ -59,7 +59,7 @@ templ Dropdown(props DropdownProps) {
 		<!-- Dropdown Items -->
 		<ul
 			x-show="open"
-			@click.away="open = false"
+			@click.away="close()"
 			x-transition
 			class={
 				"absolute z-20 mt-2 bg-white max-h-80 overflow-y-auto min-w-fit",
@@ -93,10 +93,10 @@ templ DropdownItem(props DropdownItemProps) {
 			Checked: props.Checked,
 			Class:   templ.Classes("p-2"),
 			Attrs: templ.Attributes{
-				"value":    props.Value,
-				"name":     props.Name,
-				"@change":  "toggleValue($event.target.value)",
-				":checked": "selected.includes('" + props.Value + "')",
+				"value":     props.Value,
+				"name":      props.Name,
+				"@change.stop": "toggleValue($event.target.value)",
+				":checked":  "selected.includes('" + props.Value + "')",
 			},
 		})
 	</li>

--- a/components/scaffold/filters/filters.templ
+++ b/components/scaffold/filters/filters.templ
@@ -93,10 +93,10 @@ templ DropdownItem(props DropdownItemProps) {
 			Checked: props.Checked,
 			Class:   templ.Classes("p-2"),
 			Attrs: templ.Attributes{
-				"value":     props.Value,
-				"name":      props.Name,
+				"value":        props.Value,
+				"name":         props.Name,
 				"@change.stop": "toggleValue($event.target.value)",
-				":checked":  "selected.includes('" + props.Value + "')",
+				":checked":     "selected.includes('" + props.Value + "')",
 			},
 		})
 	</li>

--- a/components/scaffold/filters/filters_templ.go
+++ b/components/scaffold/filters/filters_templ.go
@@ -107,7 +107,7 @@ func Dropdown(props DropdownProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<button @click=\"open = !open\" type=\"button\" class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<button @click=\"toggle()\" type=\"button\" class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -159,7 +159,7 @@ func Dropdown(props DropdownProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<ul x-show=\"open\" @click.away=\"open = false\" x-transition class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<ul x-show=\"open\" @click.away=\"close()\" x-transition class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -249,10 +249,10 @@ func DropdownItem(props DropdownItemProps) templ.Component {
 			Checked: props.Checked,
 			Class:   templ.Classes("p-2"),
 			Attrs: templ.Attributes{
-				"value":    props.Value,
-				"name":     props.Name,
-				"@change":  "toggleValue($event.target.value)",
-				":checked": "selected.includes('" + props.Value + "')",
+				"value":        props.Value,
+				"name":         props.Name,
+				"@change.stop": "toggleValue($event.target.value)",
+				":checked":     "selected.includes('" + props.Value + "')",
 			},
 		}).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {

--- a/modules/core/presentation/assets/js/alpine.js
+++ b/modules/core/presentation/assets/js/alpine.js
@@ -350,8 +350,15 @@ let combobox = (searchable = false, canCreateNew = false) => ({
         label: option.textContent,
       });
     }
-    this.open = false;
-    this.openedWithKeyboard = false;
+    // Single-select picks one value and closes. Multi-select keeps the dropdown
+    // open so the user can tick several options without re-opening it each time;
+    // adding a chip can grow the trigger, so re-anchor the top-layer popover.
+    if (this.multiple) {
+      this.$nextTick(() => this.positionDropdown());
+    } else {
+      this.open = false;
+      this.openedWithKeyboard = false;
+    }
     this.searchQuery = '';
     this.options = [...this.allOptions];
     if (this.selectedValues.size === 0) {
@@ -473,6 +480,10 @@ let combobox = (searchable = false, canCreateNew = false) => ({
 
 let filtersDropdown = () => ({
   open: false,
+  // Pending change accumulated while the dropdown is open. Each tick re-renders
+  // the table fragment (this dropdown lives inside the HTMX swap target), which
+  // would collapse the dropdown mid-selection — so we batch and apply on close.
+  dirty: false,
   selected: [],
   init() {
     // Use [checked] attribute selector instead of :checked pseudo-selector
@@ -487,9 +498,25 @@ let filtersDropdown = () => ({
     } else {
       this.selected.splice(index, 1);
     }
-    // Dispatch custom event after Alpine state is updated
-    // We use 'filter-changed' custom event instead of 'change' to avoid race condition
-    // where HTMX collects form data before Alpine updates checkbox state
+    // Defer the reload until the dropdown closes so multiple options can be
+    // ticked without the table re-rendering (and closing the dropdown) on each.
+    this.dirty = true;
+  },
+  toggle() {
+    this.open = !this.open;
+    if (!this.open) this.flush();
+  },
+  close() {
+    if (!this.open) return;
+    this.open = false;
+    this.flush();
+  },
+  flush() {
+    if (!this.dirty) return;
+    this.dirty = false;
+    // Dispatch custom event after Alpine state is updated. We use 'filter-changed'
+    // instead of 'change' to avoid a race where HTMX collects form data before
+    // Alpine updates checkbox state.
     this.$nextTick(() => {
       this.$el.dispatchEvent(new CustomEvent('filter-changed', { bubbles: true }));
     });
@@ -497,6 +524,7 @@ let filtersDropdown = () => ({
   clearAll() {
     this.selected = [];
     this.$el.querySelectorAll('input[type=checkbox]').forEach(cb => cb.checked = false);
+    this.dirty = false;
     this.$nextTick(() => {
       this.$el.dispatchEvent(new CustomEvent('filter-changed', { bubbles: true }));
     });


### PR DESCRIPTION
## Problem
Any multi-select field or filter (combobox chips and checkbox filter dropdowns) closed the dropdown the moment one item was picked, so the user had to re-open it for every additional value.

## Root causes
Two distinct ones:

1. **Combobox** (`base/combobox.templ` + `alpine.js setValue`) — `setValue` unconditionally set `open = false`, closing even for `multiple`.
2. **Filter dropdown** (`scaffold/filters`) — the checkbox bar renders **inside** the table's HTMX swap target. Each tick fired a native `change` (caught by the form's `change from:input[type='checkbox']` trigger) **and** dispatched `filter-changed`, so the fragment reloaded and re-rendered the dropdown with `open = false`.

## Fix
- **Combobox:** `setValue` closes only for single-select. For `multiple` it stays open and re-anchors the top-layer popover (a new chip can grow the trigger).
- **Filter dropdown (apply-on-close):** `toggleValue` now just marks the panel `dirty`; `toggle()` / `close()` flush a single `filter-changed` when the dropdown closes. The item's `@change.stop` keeps the native `change` from reaching the form trigger. Checkbox state stays live in the form, so any other reload still includes the pending selection. `clearAll` still applies immediately.

Scope is limited to `filters.Dropdown` checkboxes — side-filter and row-selection checkboxes still reload as before.

## Verification
- `go vet ./components/scaffold/filters/` clean
- `node --check alpine.js` valid
- `templ generate` (pinned v0.3.857) — no version-header drift; generated diff is only the handler strings

https://claude.ai/code/session_01BHLheDrZey6qrqku54ECSu