### PR TITLE
feat(bichat/sql): add WithAllSchemas / WithDescribeAllSchemas opt-in

### DIFF
--- a/pkg/bichat/sql/adapters.go
+++ b/pkg/bichat/sql/adapters.go
@@ -16,6 +16,12 @@ var validIdentifier = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 // maxCacheEntries limits the cache map size; stale entries are evicted when exceeded.
 const maxCacheEntries = 256
 
+// systemSchemaExclusion is the WHERE predicate used by the all-schemas
+// (WithAllSchemas / WithDescribeAllSchemas) mode: every schema except the
+// Postgres-internal ones (pg_catalog, pg_toast, pg_temp_*, …) and
+// information_schema. It is a constant — never interpolate user input here.
+const systemSchemaExclusion = `n.nspname NOT LIKE 'pg\_%' AND n.nspname <> 'information_schema'`
+
 // CacheKeyFunc extracts a cache key (typically tenant ID) from context.
 type CacheKeyFunc func(context.Context) (string, error)
 
@@ -47,6 +53,21 @@ func WithSchemaAllowlist(schemas []string) SchemaListerOption {
 	}
 }
 
+// WithAllSchemas opts SchemaList out of the inclusion allowlist entirely:
+// every non-system schema the current role can read becomes visible
+// (system schemas pg_* and information_schema are still excluded). This is
+// for trusted operator tooling that needs to enumerate the whole database;
+// the default (no option / empty allowlist) stays closed so LLM-facing
+// consumers are not silently widened. Per-relation has_table_privilege
+// filtering still applies, so the role's grants remain the real boundary.
+//
+// Takes precedence over WithSchemaAllowlist when both are set.
+func WithAllSchemas() SchemaListerOption {
+	return func(l *QueryExecutorSchemaLister) {
+		l.allSchemas = true
+	}
+}
+
 type cachedCounts struct {
 	counts    map[string]int64
 	fetchedAt time.Time
@@ -59,6 +80,7 @@ type QueryExecutorSchemaLister struct {
 	cacheTTL     time.Duration
 	cacheKeyFunc CacheKeyFunc
 	allowlist    []string
+	allSchemas   bool
 	mu           sync.Mutex
 	cache        map[string]*cachedCounts
 }
@@ -83,7 +105,17 @@ func NewQueryExecutorSchemaLister(executor QueryExecutor, opts ...SchemaListerOp
 // has_table_privilege check filters by per-relation grant so a restricted
 // role (e.g. ai_readonly) sees only what it can actually read.
 func (l *QueryExecutorSchemaLister) SchemaList(ctx context.Context) ([]TableInfo, error) {
-	query := `
+	// schemaPredicate / args are the only part that differs between the
+	// inclusion-allowlist mode and the all-schemas mode. Both predicates are
+	// constant SQL (no user input), so the format below cannot inject.
+	schemaPredicate := "n.nspname = ANY($1)"
+	args := []any{l.allowlist}
+	if l.allSchemas {
+		schemaPredicate = systemSchemaExclusion
+		args = nil
+	}
+
+	query := fmt.Sprintf(`
 		SELECT
 			n.nspname AS schema,
 			c.relname AS name,
@@ -92,13 +124,13 @@ func (l *QueryExecutorSchemaLister) SchemaList(ctx context.Context) ([]TableInfo
 			c.relkind::text
 		FROM pg_class c
 		JOIN pg_namespace n ON n.oid = c.relnamespace
-		WHERE n.nspname = ANY($1)
+		WHERE %s
 		  AND c.relkind IN ('v', 'r', 'm')
 		  AND has_table_privilege(current_user, c.oid, 'SELECT')
 		ORDER BY n.nspname, c.relname
-	`
+	`, schemaPredicate)
 
-	result, err := l.executor.ExecuteQuery(ctx, query, []any{l.allowlist}, 10*time.Second)
+	result, err := l.executor.ExecuteQuery(ctx, query, args, 10*time.Second)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list schema: %w", err)
 	}
@@ -246,6 +278,12 @@ func (l *QueryExecutorSchemaLister) fetchViewCounts(ctx context.Context, schema 
 
 // containsString reports whether needle is present in haystack. Small
 // helper used by SchemaDescribe's allowlist-enforcement check.
+// isSystemSchema reports whether name is a Postgres-internal schema that the
+// all-schemas mode keeps hidden (mirrors systemSchemaExclusion in Go).
+func isSystemSchema(name string) bool {
+	return strings.HasPrefix(name, "pg_") || name == "information_schema"
+}
+
 func containsString(haystack []string, needle string) bool {
 	for _, h := range haystack {
 		if h == needle {
@@ -288,6 +326,19 @@ func WithDescribeSchemaAllowlist(schemas []string) SchemaDescriberOption {
 	}
 }
 
+// WithDescribeAllSchemas is the describer counterpart to WithAllSchemas: it
+// lets the describer resolve a table in any non-system schema the role can
+// read, instead of only the allowlisted ones. A schema-qualified reference
+// is accepted as long as it is not a system schema; an unqualified name
+// resolves deterministically with public preferred, then alphabetical.
+//
+// Takes precedence over WithDescribeSchemaAllowlist when both are set.
+func WithDescribeAllSchemas() SchemaDescriberOption {
+	return func(d *QueryExecutorSchemaDescriber) {
+		d.allSchemas = true
+	}
+}
+
 // WithDescribeSampleRows opts the describer into fetching a small
 // preview of actual table rows (up to n) via the executor. The rows
 // land in TableSchema.SampleRows. Setting n <= 0 disables the feature
@@ -310,6 +361,7 @@ func WithDescribeSampleRows(n int) SchemaDescriberOption {
 type QueryExecutorSchemaDescriber struct {
 	executor   QueryExecutor
 	allowlist  []string
+	allSchemas bool
 	sampleRows int
 }
 
@@ -346,21 +398,49 @@ func NewQueryExecutorSchemaDescriber(executor QueryExecutor, opts ...SchemaDescr
 func (d *QueryExecutorSchemaDescriber) SchemaDescribe(ctx context.Context, tableName string) (*TableSchema, error) {
 	schemaFilter := d.allowlist
 	bareName := tableName
+	pinned := ""
 	if idx := strings.Index(tableName, "."); idx > 0 && idx < len(tableName)-1 {
-		pinned := tableName[:idx]
-		if !containsString(d.allowlist, pinned) {
+		pinned = tableName[:idx]
+		switch {
+		case d.allSchemas:
+			// Any non-system schema is describable; system schemas stay
+			// invisible even when qualified explicitly.
+			if isSystemSchema(pinned) {
+				return nil, fmt.Errorf("schema %q is a system schema and cannot be described", pinned)
+			}
+		case !containsString(d.allowlist, pinned):
+			// Allowlist mode: a schema outside the allowlist is rejected
+			// rather than silently widening access.
 			return nil, fmt.Errorf("schema %q is not in the describer allowlist", pinned)
 		}
 		schemaFilter = []string{pinned}
 		bareName = tableName[idx+1:]
 	}
 
-	// Table description (one row) — also asserts the table exists in an
-	// allowed schema. Done as a separate small query to keep the column
-	// query simple. ORDER BY array_position makes the tiebreak for
-	// same-named tables in multiple schemas deterministic: earliest
-	// allowlist entry wins.
-	tableQuery := `
+	// Table description (one row) — also asserts the table exists in a
+	// reachable schema. Done as a separate small query to keep the column
+	// query simple. The tiebreak for same-named tables across schemas is
+	// deterministic: in allowlist mode the earliest allowlist entry wins
+	// (array_position); in all-schemas mode public is preferred, then
+	// alphabetical.
+	var tableQuery string
+	var tableArgs []any
+	if d.allSchemas && pinned == "" {
+		tableQuery = `
+		SELECT
+			n.nspname AS schema,
+			COALESCE(obj_description(c.oid, 'pg_class'), '') AS description
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE c.relname = $1
+		  AND ` + systemSchemaExclusion + `
+		  AND has_table_privilege(current_user, c.oid, 'SELECT')
+		ORDER BY (n.nspname <> 'public'), n.nspname
+		LIMIT 1
+	`
+		tableArgs = []any{bareName}
+	} else {
+		tableQuery = `
 		SELECT
 			n.nspname AS schema,
 			COALESCE(obj_description(c.oid, 'pg_class'), '') AS description
@@ -372,7 +452,9 @@ func (d *QueryExecutorSchemaDescriber) SchemaDescribe(ctx context.Context, table
 		ORDER BY array_position($2::text[], n.nspname), n.nspname
 		LIMIT 1
 	`
-	tableRes, err := d.executor.ExecuteQuery(ctx, tableQuery, []any{bareName, schemaFilter}, 10*time.Second)
+		tableArgs = []any{bareName, schemaFilter}
+	}
+	tableRes, err := d.executor.ExecuteQuery(ctx, tableQuery, tableArgs, 10*time.Second)
 	if err != nil {
 		return nil, fmt.Errorf("failed to look up table: %w", err)
 	}

--- a/pkg/bichat/sql/adapters_test.go
+++ b/pkg/bichat/sql/adapters_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -404,6 +405,86 @@ func TestSchemaDescriber_ReturnsColumns(t *testing.T) {
 	assert.Contains(t, colMap["name"].Type, "text")
 	assert.Equal(t, "numeric(10,2)", colMap["amount"].Type)
 	assert.Contains(t, colMap["created_at"].Type, "timestamp")
+}
+
+func TestSchemaLister_AllSchemas(t *testing.T) {
+	t.Parallel()
+	requirePostgres(t)
+	env := itf.Setup(t, itf.WithComponents(modules.Components()...))
+
+	_, err := env.Pool.Exec(env.Ctx, `CREATE SCHEMA IF NOT EXISTS _test_allsch`)
+	require.NoError(t, err)
+	_, err = env.Pool.Exec(env.Ctx, `
+		CREATE TABLE IF NOT EXISTS _test_allsch.widgets (
+			id SERIAL PRIMARY KEY,
+			name TEXT
+		)
+	`)
+	require.NoError(t, err)
+	defer func() {
+		_, _ = env.Pool.Exec(env.Ctx, "DROP SCHEMA IF EXISTS _test_allsch CASCADE")
+	}()
+
+	executor := newTestExecutor(env.Pool)
+	// No allowlist passed — WithAllSchemas must still surface the table in a
+	// schema no allowlist mentions.
+	lister := bichatsql.NewQueryExecutorSchemaLister(executor, bichatsql.WithAllSchemas())
+
+	tables, err := lister.SchemaList(env.Ctx)
+	require.NoError(t, err)
+
+	var foundWidgets bool
+	for _, tbl := range tables {
+		if tbl.Schema == "_test_allsch" && tbl.Name == "widgets" {
+			foundWidgets = true
+		}
+		// System schemas must never leak through the all-schemas mode.
+		assert.NotEqual(t, "information_schema", tbl.Schema)
+		assert.False(t, strings.HasPrefix(tbl.Schema, "pg_"),
+			"system schema %q should be excluded from WithAllSchemas", tbl.Schema)
+	}
+	assert.True(t, foundWidgets, "expected _test_allsch.widgets via WithAllSchemas")
+}
+
+func TestSchemaDescriber_AllSchemas(t *testing.T) {
+	t.Parallel()
+	requirePostgres(t)
+	env := itf.Setup(t, itf.WithComponents(modules.Components()...))
+
+	_, err := env.Pool.Exec(env.Ctx, `CREATE SCHEMA IF NOT EXISTS _test_allsch_desc`)
+	require.NoError(t, err)
+	_, err = env.Pool.Exec(env.Ctx, `
+		CREATE TABLE IF NOT EXISTS _test_allsch_desc.gadgets (
+			id SERIAL PRIMARY KEY,
+			label TEXT NOT NULL
+		)
+	`)
+	require.NoError(t, err)
+	defer func() {
+		_, _ = env.Pool.Exec(env.Ctx, "DROP SCHEMA IF EXISTS _test_allsch_desc CASCADE")
+	}()
+
+	executor := newTestExecutor(env.Pool)
+	// No allowlist — WithDescribeAllSchemas resolves any non-system schema.
+	describer := bichatsql.NewQueryExecutorSchemaDescriber(executor, bichatsql.WithDescribeAllSchemas())
+
+	// Schema-qualified reference in a schema no allowlist mentions now resolves.
+	qualified, err := describer.SchemaDescribe(env.Ctx, "_test_allsch_desc.gadgets")
+	require.NoError(t, err)
+	require.NotNil(t, qualified)
+	assert.Equal(t, "_test_allsch_desc", qualified.Schema)
+	assert.Equal(t, "gadgets", qualified.Name)
+	require.Len(t, qualified.Columns, 2)
+
+	// Bare name resolves too (uniquely named, so no ambiguity).
+	bare, err := describer.SchemaDescribe(env.Ctx, "gadgets")
+	require.NoError(t, err)
+	require.NotNil(t, bare)
+	assert.Equal(t, "_test_allsch_desc", bare.Schema)
+
+	// System schemas stay invisible even when qualified explicitly.
+	_, err = describer.SchemaDescribe(env.Ctx, "pg_catalog.pg_class")
+	require.Error(t, err)
 }
 
 func TestSchemaDescriber_NonExistentTable(t *testing.T) {


### PR DESCRIPTION
## What

Adds two opt-in options to the bichat SQL schema adapters:

- `WithAllSchemas()` (lister) and `WithDescribeAllSchemas()` (describer).

When set, the schema-discovery queries switch from the inclusion allowlist
(`n.nspname = ANY($allowlist)`) to **system-schema exclusion** at query time
(`n.nspname NOT LIKE 'pg\_%' AND n.nspname <> 'information_schema'`), so every
non-system schema the role can read becomes visible — and new schemas are
picked up without a restart. `has_table_privilege(current_user, …)` still
gates per-relation access.

## Why

The default stays **closed** (empty allowlist = nothing visible), which is the
safety boundary LLM-facing consumers like Ali bichat rely on — this PR does not
change it. The new options are for **trusted operator tooling** (the granite-ops
MCP in `iota-uz/eai`) that needs to enumerate/describe the whole database
without maintaining a hardcoded schema list.

Describer details: a schema-qualified reference to a system schema is rejected;
an unqualified name resolves deterministically (public first, then
alphabetical) instead of by allowlist position.

## Tests

`pkg/bichat/sql/adapters_test.go`: `TestSchemaLister_AllSchemas` and
`TestSchemaDescriber_AllSchemas` (bare + qualified names, system-schema
exclusion). `go vet ./pkg/bichat/sql/` clean.

## Consumer

Paired with the granite-ops DX PR in iota-uz/eai (closes eai#3070); that repo's
`back/go.mod` pins this branch commit.

https://claude.ai/code/session_01NqnqQBJkr2U7XUuzkk3xCF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to list tables across all non-system schemas without needing an explicit allowlist.
  * Added an option to describe tables across all non-system schemas, automatically excluding system schemas.
  * Improved table lookups to support schema-qualified references in all-schemas mode, with stricter handling of system schemas.
* **Tests**
  * Added regression tests covering all-schemas listing and describing, including verification that system schemas are not exposed and system schema descriptions fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->