### PR TITLE
feat(pykernel): sandboxed Python kernel primitive (foundation)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -91,6 +91,7 @@ require (
 	golang.org/x/net v0.49.0
 	golang.org/x/oauth2 v0.34.0
 	golang.org/x/sync v0.19.0
+	golang.org/x/sys v0.41.0
 	golang.org/x/text v0.34.0
 	google.golang.org/api v0.209.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -222,7 +223,6 @@ require (
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/image v0.25.0 // indirect
 	golang.org/x/mod v0.32.0 // indirect
-	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/tools v0.41.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260128011058-8636f8732409 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect

--- a/pkg/pykernel/bridge/bridge.go
+++ b/pkg/pykernel/bridge/bridge.go
@@ -1,0 +1,252 @@
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// Limits bounds a single exec. Zero fields mean "use the kernel/policy default".
+type Limits struct {
+	WallClockMS int64 `json:"wall_clock_ms,omitempty"`
+	OutputCap   int   `json:"output_cap,omitempty"`
+}
+
+// Call is a kernel→host capability invocation. It deliberately carries no
+// tenant, permissions, or run Mode — the CallDispatcher injects those host-side
+// from the Session (the host-binds-context invariant).
+type Call struct {
+	ExecID string
+	Name   string
+	Args   json.RawMessage
+}
+
+// Reply is the host's answer to a Call. Exactly one of Result/Err is meaningful:
+// when Err is non-nil it is surfaced inside the kernel as a raised Python
+// exception; otherwise Result (already JSON-encoded by the caller) is returned.
+type Reply struct {
+	Result json.RawMessage
+	Err    *CallError
+}
+
+// CallError is a controlled failure the kernel should raise at the call site —
+// e.g. a plan-mode write refusal or a permission denial. Type names the Python
+// exception class for the shim to instantiate.
+type CallError struct {
+	Type    string
+	Message string
+}
+
+func (e *CallError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Type == "" {
+		return e.Message
+	}
+	return fmt.Sprintf("%s: %s", e.Type, e.Message)
+}
+
+// CallDispatcher resolves a kernel capability call to a host handler. The
+// implementation binds the Session's tenant + Mode and routes through the
+// pykernel plan/apply authorization before invoking the capability. Dispatch
+// must always return a Reply (never panic); unexpected failures become a
+// CallError so the kernel still gets a definite answer.
+type CallDispatcher interface {
+	Dispatch(ctx context.Context, call Call) Reply
+}
+
+// RawEvent is a decoded kernel→host output notification handed to the sink. Kind
+// is the short event name ("stdout", "metric", "log", "result", "error",
+// "done"); Params is the raw JSON payload for that kind.
+type RawEvent struct {
+	Kind   string
+	Params json.RawMessage
+}
+
+// Event kind names used in RawEvent.Kind.
+const (
+	KindStdout = "stdout"
+	KindMetric = "metric"
+	KindLog    = "log"
+	KindResult = "result"
+	KindError  = "error"
+	KindDone   = "done"
+)
+
+// EventSink receives kernel→host output notifications keyed by exec id. The
+// Manager fans these into the per-Exec event channel. Emit must not block the
+// bridge read loop for long.
+type EventSink interface {
+	Emit(execID string, ev RawEvent)
+}
+
+// Bridge is the host side of one kernel's control channel.
+type Bridge interface {
+	// Serve runs the read loop until ctx is cancelled or the connection closes.
+	// Inbound cap.call requests are dispatched (and answered) via dispatcher;
+	// inbound output notifications are forwarded to sink. Serve returns the
+	// terminating error (nil on a clean ctx cancel / EOF after Close).
+	Serve(ctx context.Context, dispatcher CallDispatcher, sink EventSink) error
+	// Submit sends an exec.submit notification to the kernel.
+	Submit(ctx context.Context, execID, code string, limits Limits) error
+	// Cancel sends a cooperative exec.cancel notification to the kernel.
+	Cancel(ctx context.Context, execID string) error
+	// Close closes the underlying connection, unblocking Serve.
+	Close() error
+}
+
+// New returns a Bridge over conn. conn is typically a per-kernel unix-socket
+// connection, but any full-duplex io.ReadWriteCloser works (tests use net.Pipe).
+func New(conn io.ReadWriteCloser) Bridge {
+	return &bridge{conn: conn}
+}
+
+type bridge struct {
+	conn io.ReadWriteCloser
+
+	writeMu   sync.Mutex // serializes all frame writes (responses + notifications)
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func (b *bridge) Serve(ctx context.Context, dispatcher CallDispatcher, sink EventSink) error {
+	// Closing the connection is the portable way to unblock the blocking
+	// ReadFull in readFrame when ctx is cancelled.
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = b.Close()
+		case <-stop:
+		}
+	}()
+
+	for {
+		msg, err := readFrame(b.conn)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil // cancelled: the close above caused this read error
+			}
+			if err == io.EOF {
+				return nil // kernel closed cleanly
+			}
+			return err
+		}
+		switch {
+		case msg.isRequest():
+			// The kernel serializes one capability call at a time, so handling
+			// it inline keeps response ordering trivial. A hung handler is
+			// bounded by the manager's wall-clock timer, which closes conn.
+			b.handleCall(ctx, dispatcher, msg)
+		case msg.isNotification():
+			b.handleNotification(sink, msg)
+		default:
+			// A bare response with no matching request: ignore.
+		}
+	}
+}
+
+func (b *bridge) handleCall(ctx context.Context, dispatcher CallDispatcher, msg *message) {
+	if msg.Method != MethodCapCall {
+		b.writeError(msg.ID, codeMethodNotFound, "unknown method: "+msg.Method, "")
+		return
+	}
+	var p capCallParams
+	if err := json.Unmarshal(msg.Params, &p); err != nil {
+		b.writeError(msg.ID, codeCapabilityArgs, "invalid cap.call params: "+err.Error(), "")
+		return
+	}
+	reply := dispatcher.Dispatch(ctx, Call{ExecID: p.ExecID, Name: p.Name, Args: p.Args})
+	if reply.Err != nil {
+		b.writeError(msg.ID, codeCapabilityError, reply.Err.Message, reply.Err.Type)
+		return
+	}
+	b.writeResult(msg.ID, reply.Result)
+}
+
+func (b *bridge) handleNotification(sink EventSink, msg *message) {
+	kind, ok := notificationKind(msg.Method)
+	if !ok {
+		return // unknown notification: ignore
+	}
+	execID := peekExecID(msg.Params)
+	sink.Emit(execID, RawEvent{Kind: kind, Params: msg.Params})
+}
+
+// notificationKind maps a kernel→host notification method to a RawEvent kind.
+func notificationKind(method string) (string, bool) {
+	switch method {
+	case MethodOutStdout:
+		return KindStdout, true
+	case MethodOutMetric:
+		return KindMetric, true
+	case MethodOutLog:
+		return KindLog, true
+	case MethodExecResult:
+		return KindResult, true
+	case MethodExecError:
+		return KindError, true
+	case MethodExecDone:
+		return KindDone, true
+	default:
+		return "", false
+	}
+}
+
+// peekExecID extracts only the exec_id from a notification payload so the sink
+// can key the event without fully decoding the (kind-specific) params.
+func peekExecID(params json.RawMessage) string {
+	var head struct {
+		ExecID string `json:"exec_id"`
+	}
+	_ = json.Unmarshal(params, &head)
+	return head.ExecID
+}
+
+func (b *bridge) Submit(_ context.Context, execID, code string, limits Limits) error {
+	params, err := json.Marshal(execSubmitParams{ExecID: execID, Code: code, Limits: limits})
+	if err != nil {
+		return fmt.Errorf("pykernel/bridge: marshal exec.submit: %w", err)
+	}
+	return b.writeMessage(&message{JSONRPC: jsonrpcVersion, Method: MethodExecSubmit, Params: params})
+}
+
+func (b *bridge) Cancel(_ context.Context, execID string) error {
+	params, err := json.Marshal(execCancelParams{ExecID: execID})
+	if err != nil {
+		return fmt.Errorf("pykernel/bridge: marshal exec.cancel: %w", err)
+	}
+	return b.writeMessage(&message{JSONRPC: jsonrpcVersion, Method: MethodExecCancel, Params: params})
+}
+
+func (b *bridge) Close() error {
+	b.closeOnce.Do(func() { b.closeErr = b.conn.Close() })
+	return b.closeErr
+}
+
+func (b *bridge) writeResult(id, result json.RawMessage) {
+	if result == nil {
+		result = json.RawMessage("null")
+	}
+	_ = b.writeMessage(&message{JSONRPC: jsonrpcVersion, ID: id, Result: result})
+}
+
+func (b *bridge) writeError(id json.RawMessage, code int, msg, excType string) {
+	rerr := &rpcError{Code: code, Message: msg}
+	if excType != "" {
+		if data, err := json.Marshal(capErrorData{Type: excType}); err == nil {
+			rerr.Data = data
+		}
+	}
+	_ = b.writeMessage(&message{JSONRPC: jsonrpcVersion, ID: id, Error: rerr})
+}
+
+func (b *bridge) writeMessage(msg *message) error {
+	b.writeMu.Lock()
+	defer b.writeMu.Unlock()
+	return writeFrame(b.conn, msg)
+}

--- a/pkg/pykernel/bridge/bridge.go
+++ b/pkg/pykernel/bridge/bridge.go
@@ -90,9 +90,15 @@ type Bridge interface {
 	// inbound output notifications are forwarded to sink. Serve returns the
 	// terminating error (nil on a clean ctx cancel / EOF after Close).
 	Serve(ctx context.Context, dispatcher CallDispatcher, sink EventSink) error
-	// Submit sends an exec.submit notification to the kernel.
+	// Submit sends an exec.submit notification to the kernel. ctx is accepted
+	// for call-site symmetry but is NOT honored for the write itself: conn is a
+	// generic io.ReadWriteCloser with no write deadline, so a stalled write is
+	// unblocked only by Close() (which the manager's watchdog invokes on
+	// timeout/cancel).
 	Submit(ctx context.Context, execID, code string, limits Limits) error
-	// Cancel sends a cooperative exec.cancel notification to the kernel.
+	// Cancel sends a cooperative exec.cancel notification to the kernel. As with
+	// Submit, ctx does not bound the write; a stalled write is unblocked only by
+	// Close().
 	Cancel(ctx context.Context, execID string) error
 	// Close closes the underlying connection, unblocking Serve.
 	Close() error
@@ -160,6 +166,10 @@ func (b *bridge) handleCall(ctx context.Context, dispatcher CallDispatcher, msg 
 		b.writeError(msg.ID, codeCapabilityArgs, "invalid cap.call params: "+err.Error(), "")
 		return
 	}
+	// ctx here is the Serve-lifetime context, not a per-exec context, so per-exec
+	// cancellation/timeout does NOT propagate into a capability handler today; a
+	// hung handler is bounded only by the manager's wall-clock watchdog closing
+	// conn.
 	reply := dispatcher.Dispatch(ctx, Call(p))
 	if reply.Err != nil {
 		b.writeError(msg.ID, codeCapabilityError, reply.Err.Message, reply.Err.Type)

--- a/pkg/pykernel/bridge/bridge.go
+++ b/pkg/pykernel/bridge/bridge.go
@@ -160,7 +160,7 @@ func (b *bridge) handleCall(ctx context.Context, dispatcher CallDispatcher, msg 
 		b.writeError(msg.ID, codeCapabilityArgs, "invalid cap.call params: "+err.Error(), "")
 		return
 	}
-	reply := dispatcher.Dispatch(ctx, Call{ExecID: p.ExecID, Name: p.Name, Args: p.Args})
+	reply := dispatcher.Dispatch(ctx, Call(p))
 	if reply.Err != nil {
 		b.writeError(msg.ID, codeCapabilityError, reply.Err.Message, reply.Err.Type)
 		return

--- a/pkg/pykernel/bridge/bridge_test.go
+++ b/pkg/pykernel/bridge/bridge_test.go
@@ -75,6 +75,35 @@ func TestFrameRoundTrip(t *testing.T) {
 	assert.JSONEq(t, string(in.Params), string(out.Params))
 }
 
+// shortWriter accepts at most one byte per Write to exercise writeFrame's
+// short-write loop; everything is appended to buf so the frame can be replayed.
+type shortWriter struct{ buf bytes.Buffer }
+
+func (w *shortWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	return w.buf.Write(p[:1])
+}
+
+func TestWriteFrame_ToleratesShortWrites(t *testing.T) {
+	t.Parallel()
+
+	in := &message{
+		JSONRPC: jsonrpcVersion,
+		Method:  MethodOutStdout,
+		Params:  json.RawMessage(`{"exec_id":"e1","chunk":"a longer chunk so the frame spans many bytes"}`),
+	}
+	w := &shortWriter{}
+	require.NoError(t, writeFrame(w, in))
+
+	// The full frame must have been delivered intact and round-trip cleanly.
+	out, err := readFrame(&w.buf)
+	require.NoError(t, err)
+	assert.Equal(t, in.Method, out.Method)
+	assert.JSONEq(t, string(in.Params), string(out.Params))
+}
+
 func TestBridge_CapCallAndStream(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/pykernel/bridge/bridge_test.go
+++ b/pkg/pykernel/bridge/bridge_test.go
@@ -47,9 +47,16 @@ func (k *fakeKernel) write(t *testing.T, m *message) {
 
 func (k *fakeKernel) notify(t *testing.T, method string, params any) {
 	t.Helper()
-	raw, err := json.Marshal(params)
+	k.write(t, &message{JSONRPC: jsonrpcVersion, Method: method, Params: mustMarshal(t, params)})
+}
+
+// mustMarshal JSON-encodes v and fails the test on error. It must be called on
+// the test goroutine (it uses require).
+func mustMarshal(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	raw, err := json.Marshal(v)
 	require.NoError(t, err)
-	k.write(t, &message{JSONRPC: jsonrpcVersion, Method: method, Params: raw})
+	return raw
 }
 
 func TestFrameRoundTrip(t *testing.T) {
@@ -75,9 +82,11 @@ func TestBridge_CapCallAndStream(t *testing.T) {
 	k := &fakeKernel{conn: kernConn}
 
 	var gotCall Call
+	// Precompute the reply on the test goroutine so the dispatcher (invoked from
+	// the Serve goroutine) need not marshal/assert off-goroutine.
+	res := mustMarshal(t, []map[string]any{{"n": 1}})
 	disp := funcDispatcher(func(_ context.Context, c Call) Reply {
 		gotCall = c
-		res, _ := json.Marshal([]map[string]any{{"n": 1}})
 		return Reply{Result: res}
 	})
 	sink := chanSink{ch: make(chan sinkItem, 8)}
@@ -88,33 +97,33 @@ func TestBridge_CapCallAndStream(t *testing.T) {
 	serveErr := make(chan error, 1)
 	go func() { serveErr <- b.Serve(ctx, disp, sink) }()
 
-	kernDone := make(chan struct{})
-	go func() {
-		defer close(kernDone)
+	// Submit blocks until the kernel reads the frame off the pipe, so run it in a
+	// goroutine and channel its error back to the main goroutine. All require/assert
+	// calls (including the k.read/k.write/k.notify helpers) stay on this goroutine.
+	submitErr := make(chan error, 1)
+	go func() { submitErr <- b.Submit(ctx, "e1", "print(sql('select 1'))", Limits{}) }()
 
-		// 1. receive exec.submit.
-		m := k.read(t)
-		assert.Equal(t, MethodExecSubmit, m.Method)
-		var sp execSubmitParams
-		require.NoError(t, json.Unmarshal(m.Params, &sp))
-		assert.Equal(t, "e1", sp.ExecID)
+	// 1. receive exec.submit.
+	m := k.read(t)
+	assert.Equal(t, MethodExecSubmit, m.Method)
+	var sp execSubmitParams
+	require.NoError(t, json.Unmarshal(m.Params, &sp))
+	assert.Equal(t, "e1", sp.ExecID)
+	require.NoError(t, <-submitErr)
 
-		// 2. issue a blocking cap.call and read the host's response.
-		args, _ := json.Marshal(map[string]any{"query": "select 1"})
-		cp, _ := json.Marshal(capCallParams{ExecID: "e1", Name: "sql", Args: args})
-		k.write(t, &message{JSONRPC: jsonrpcVersion, ID: json.RawMessage(`1`), Method: MethodCapCall, Params: cp})
-		resp := k.read(t)
-		require.Nil(t, resp.Error)
-		assert.JSONEq(t, `[{"n":1}]`, string(resp.Result))
-		assert.JSONEq(t, `1`, string(resp.ID))
+	// 2. issue a blocking cap.call and read the host's response.
+	args := mustMarshal(t, map[string]any{"query": "select 1"})
+	cp := mustMarshal(t, capCallParams{ExecID: "e1", Name: "sql", Args: args})
+	k.write(t, &message{JSONRPC: jsonrpcVersion, ID: json.RawMessage(`1`), Method: MethodCapCall, Params: cp})
+	resp := k.read(t)
+	require.Nil(t, resp.Error)
+	assert.JSONEq(t, `[{"n":1}]`, string(resp.Result))
+	assert.JSONEq(t, `1`, string(resp.ID))
 
-		// 3. stream output then terminate.
-		k.notify(t, MethodOutStdout, map[string]any{"exec_id": "e1", "chunk": "hi"})
-		k.notify(t, MethodExecResult, map[string]any{"exec_id": "e1", "text": "None"})
-		k.notify(t, MethodExecDone, map[string]any{"exec_id": "e1"})
-	}()
-
-	require.NoError(t, b.Submit(ctx, "e1", "print(sql('select 1'))", Limits{}))
+	// 3. stream output then terminate.
+	k.notify(t, MethodOutStdout, map[string]any{"exec_id": "e1", "chunk": "hi"})
+	k.notify(t, MethodExecResult, map[string]any{"exec_id": "e1", "text": "None"})
+	k.notify(t, MethodExecDone, map[string]any{"exec_id": "e1"})
 
 	kinds := map[string]bool{}
 	for i := 0; i < 3; i++ {
@@ -134,7 +143,6 @@ func TestBridge_CapCallAndStream(t *testing.T) {
 	assert.Equal(t, "e1", gotCall.ExecID)
 	assert.JSONEq(t, `{"query":"select 1"}`, string(gotCall.Args))
 
-	<-kernDone
 	cancel()
 	require.NoError(t, <-serveErr)
 }
@@ -154,23 +162,19 @@ func TestBridge_CapCallRefusalSurfacesTypedError(t *testing.T) {
 	defer cancel()
 	go func() { _ = b.Serve(ctx, disp, nopSink{}) }()
 
-	kernDone := make(chan struct{})
-	go func() {
-		defer close(kernDone)
-		cp, _ := json.Marshal(capCallParams{ExecID: "e1", Name: "pg_upsert", Args: json.RawMessage(`{}`)})
-		k.write(t, &message{JSONRPC: jsonrpcVersion, ID: json.RawMessage(`7`), Method: MethodCapCall, Params: cp})
+	// Serve reads on its own goroutine, so this kernel-side dialog can run on the
+	// test goroutine: writes unblock as Serve reads, and the assertions stay here.
+	cp := mustMarshal(t, capCallParams{ExecID: "e1", Name: "pg_upsert", Args: json.RawMessage(`{}`)})
+	k.write(t, &message{JSONRPC: jsonrpcVersion, ID: json.RawMessage(`7`), Method: MethodCapCall, Params: cp})
 
-		resp := k.read(t)
-		require.NotNil(t, resp.Error)
-		assert.Equal(t, codeCapabilityError, resp.Error.Code)
-		assert.Equal(t, "write refused in plan mode", resp.Error.Message)
-		var d capErrorData
-		require.NoError(t, json.Unmarshal(resp.Error.Data, &d))
-		assert.Equal(t, "PlanModeViolation", d.Type)
-		assert.JSONEq(t, `7`, string(resp.ID))
-	}()
-
-	<-kernDone
+	resp := k.read(t)
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, codeCapabilityError, resp.Error.Code)
+	assert.Equal(t, "write refused in plan mode", resp.Error.Message)
+	var d capErrorData
+	require.NoError(t, json.Unmarshal(resp.Error.Data, &d))
+	assert.Equal(t, "PlanModeViolation", d.Type)
+	assert.JSONEq(t, `7`, string(resp.ID))
 }
 
 func TestBridge_Cancel(t *testing.T) {
@@ -186,16 +190,15 @@ func TestBridge_Cancel(t *testing.T) {
 		_ = b.Serve(ctx, funcDispatcher(func(context.Context, Call) Reply { return Reply{} }), nopSink{})
 	}()
 
-	kernDone := make(chan struct{})
-	go func() {
-		defer close(kernDone)
-		m := k.read(t)
-		assert.Equal(t, MethodExecCancel, m.Method)
-		var cp execCancelParams
-		require.NoError(t, json.Unmarshal(m.Params, &cp))
-		assert.Equal(t, "e1", cp.ExecID)
-	}()
+	// Cancel blocks until the kernel reads the frame off the pipe; run it in a
+	// goroutine and assert on the test goroutine.
+	cancelErr := make(chan error, 1)
+	go func() { cancelErr <- b.Cancel(ctx, "e1") }()
 
-	require.NoError(t, b.Cancel(ctx, "e1"))
-	<-kernDone
+	m := k.read(t)
+	assert.Equal(t, MethodExecCancel, m.Method)
+	var cp execCancelParams
+	require.NoError(t, json.Unmarshal(m.Params, &cp))
+	assert.Equal(t, "e1", cp.ExecID)
+	require.NoError(t, <-cancelErr)
 }

--- a/pkg/pykernel/bridge/bridge_test.go
+++ b/pkg/pykernel/bridge/bridge_test.go
@@ -1,0 +1,201 @@
+package bridge
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// funcDispatcher adapts a function to CallDispatcher.
+type funcDispatcher func(context.Context, Call) Reply
+
+func (f funcDispatcher) Dispatch(ctx context.Context, c Call) Reply { return f(ctx, c) }
+
+type sinkItem struct {
+	execID string
+	ev     RawEvent
+}
+
+type chanSink struct{ ch chan sinkItem }
+
+func (s chanSink) Emit(execID string, ev RawEvent) { s.ch <- sinkItem{execID, ev} }
+
+type nopSink struct{}
+
+func (nopSink) Emit(string, RawEvent) {}
+
+// fakeKernel speaks the wire protocol from the kernel side over a net.Pipe.
+type fakeKernel struct{ conn net.Conn }
+
+func (k *fakeKernel) read(t *testing.T) *message {
+	t.Helper()
+	m, err := readFrame(k.conn)
+	require.NoError(t, err)
+	return m
+}
+
+func (k *fakeKernel) write(t *testing.T, m *message) {
+	t.Helper()
+	require.NoError(t, writeFrame(k.conn, m))
+}
+
+func (k *fakeKernel) notify(t *testing.T, method string, params any) {
+	t.Helper()
+	raw, err := json.Marshal(params)
+	require.NoError(t, err)
+	k.write(t, &message{JSONRPC: jsonrpcVersion, Method: method, Params: raw})
+}
+
+func TestFrameRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	in := &message{
+		JSONRPC: jsonrpcVersion,
+		Method:  MethodOutLog,
+		Params:  json.RawMessage(`{"exec_id":"e1","level":"info","message":"hi"}`),
+	}
+	require.NoError(t, writeFrame(&buf, in))
+	out, err := readFrame(&buf)
+	require.NoError(t, err)
+	assert.Equal(t, in.Method, out.Method)
+	assert.JSONEq(t, string(in.Params), string(out.Params))
+}
+
+func TestBridge_CapCallAndStream(t *testing.T) {
+	t.Parallel()
+
+	hostConn, kernConn := net.Pipe()
+	k := &fakeKernel{conn: kernConn}
+
+	var gotCall Call
+	disp := funcDispatcher(func(_ context.Context, c Call) Reply {
+		gotCall = c
+		res, _ := json.Marshal([]map[string]any{{"n": 1}})
+		return Reply{Result: res}
+	})
+	sink := chanSink{ch: make(chan sinkItem, 8)}
+
+	b := New(hostConn)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- b.Serve(ctx, disp, sink) }()
+
+	kernDone := make(chan struct{})
+	go func() {
+		defer close(kernDone)
+
+		// 1. receive exec.submit.
+		m := k.read(t)
+		assert.Equal(t, MethodExecSubmit, m.Method)
+		var sp execSubmitParams
+		require.NoError(t, json.Unmarshal(m.Params, &sp))
+		assert.Equal(t, "e1", sp.ExecID)
+
+		// 2. issue a blocking cap.call and read the host's response.
+		args, _ := json.Marshal(map[string]any{"query": "select 1"})
+		cp, _ := json.Marshal(capCallParams{ExecID: "e1", Name: "sql", Args: args})
+		k.write(t, &message{JSONRPC: jsonrpcVersion, ID: json.RawMessage(`1`), Method: MethodCapCall, Params: cp})
+		resp := k.read(t)
+		require.Nil(t, resp.Error)
+		assert.JSONEq(t, `[{"n":1}]`, string(resp.Result))
+		assert.JSONEq(t, `1`, string(resp.ID))
+
+		// 3. stream output then terminate.
+		k.notify(t, MethodOutStdout, map[string]any{"exec_id": "e1", "chunk": "hi"})
+		k.notify(t, MethodExecResult, map[string]any{"exec_id": "e1", "text": "None"})
+		k.notify(t, MethodExecDone, map[string]any{"exec_id": "e1"})
+	}()
+
+	require.NoError(t, b.Submit(ctx, "e1", "print(sql('select 1'))", Limits{}))
+
+	kinds := map[string]bool{}
+	for i := 0; i < 3; i++ {
+		select {
+		case it := <-sink.ch:
+			assert.Equal(t, "e1", it.execID)
+			kinds[it.ev.Kind] = true
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for event %d", i)
+		}
+	}
+	assert.True(t, kinds[KindStdout], "expected a stdout event")
+	assert.True(t, kinds[KindResult], "expected a result event")
+	assert.True(t, kinds[KindDone], "expected a done event")
+
+	assert.Equal(t, "sql", gotCall.Name)
+	assert.Equal(t, "e1", gotCall.ExecID)
+	assert.JSONEq(t, `{"query":"select 1"}`, string(gotCall.Args))
+
+	<-kernDone
+	cancel()
+	require.NoError(t, <-serveErr)
+}
+
+func TestBridge_CapCallRefusalSurfacesTypedError(t *testing.T) {
+	t.Parallel()
+
+	hostConn, kernConn := net.Pipe()
+	k := &fakeKernel{conn: kernConn}
+
+	disp := funcDispatcher(func(_ context.Context, _ Call) Reply {
+		return Reply{Err: &CallError{Type: "PlanModeViolation", Message: "write refused in plan mode"}}
+	})
+
+	b := New(hostConn)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = b.Serve(ctx, disp, nopSink{}) }()
+
+	kernDone := make(chan struct{})
+	go func() {
+		defer close(kernDone)
+		cp, _ := json.Marshal(capCallParams{ExecID: "e1", Name: "pg_upsert", Args: json.RawMessage(`{}`)})
+		k.write(t, &message{JSONRPC: jsonrpcVersion, ID: json.RawMessage(`7`), Method: MethodCapCall, Params: cp})
+
+		resp := k.read(t)
+		require.NotNil(t, resp.Error)
+		assert.Equal(t, codeCapabilityError, resp.Error.Code)
+		assert.Equal(t, "write refused in plan mode", resp.Error.Message)
+		var d capErrorData
+		require.NoError(t, json.Unmarshal(resp.Error.Data, &d))
+		assert.Equal(t, "PlanModeViolation", d.Type)
+		assert.JSONEq(t, `7`, string(resp.ID))
+	}()
+
+	<-kernDone
+}
+
+func TestBridge_Cancel(t *testing.T) {
+	t.Parallel()
+
+	hostConn, kernConn := net.Pipe()
+	k := &fakeKernel{conn: kernConn}
+
+	b := New(hostConn)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() {
+		_ = b.Serve(ctx, funcDispatcher(func(context.Context, Call) Reply { return Reply{} }), nopSink{})
+	}()
+
+	kernDone := make(chan struct{})
+	go func() {
+		defer close(kernDone)
+		m := k.read(t)
+		assert.Equal(t, MethodExecCancel, m.Method)
+		var cp execCancelParams
+		require.NoError(t, json.Unmarshal(m.Params, &cp))
+		assert.Equal(t, "e1", cp.ExecID)
+	}()
+
+	require.NoError(t, b.Cancel(ctx, "e1"))
+	<-kernDone
+}

--- a/pkg/pykernel/bridge/doc.go
+++ b/pkg/pykernel/bridge/doc.go
@@ -1,0 +1,24 @@
+// Package bridge implements the host side of the pykernel host↔kernel control
+// channel: a length-prefixed JSON-RPC 2.0 protocol carried over a single
+// full-duplex connection (in production a per-kernel AF_UNIX socket; in tests
+// any io.ReadWriteCloser, e.g. net.Pipe).
+//
+// The channel multiplexes two logical directions over one connection:
+//
+//   - host→kernel: exec.submit (run code) and exec.cancel (cooperative cancel),
+//     sent as notifications.
+//   - kernel→host: cap.call (a blocking request — the kernel's capability proxy
+//     waits for the host's response), plus out.stdout / out.metric / out.log /
+//     exec.result / exec.error / exec.done notifications that stream an exec's
+//     output back.
+//
+// The security-critical property lives in the cap.call frame: it carries only
+// {exec_id, name, args}. It does NOT carry a tenant, permissions, or the run
+// Mode. The host's CallDispatcher injects those from the Session, so a kernel
+// cannot forge identity or escalate privileges over the wire. A capability
+// refusal (e.g. a write attempted during a plan run) comes back as a JSON-RPC
+// error whose data names the Python exception type to raise at the call site.
+//
+// This package is standalone — it does not import pykernel. The Manager adapts
+// a pykernel.CapabilitySet plus a run Mode into a CallDispatcher.
+package bridge

--- a/pkg/pykernel/bridge/protocol.go
+++ b/pkg/pykernel/bridge/protocol.go
@@ -112,8 +112,19 @@ func writeFrame(w io.Writer, msg *message) error {
 	buf := make([]byte, 4+len(payload))
 	binary.BigEndian.PutUint32(buf[:4], uint32(len(payload)))
 	copy(buf[4:], payload)
-	if _, err := w.Write(buf); err != nil {
-		return fmt.Errorf("pykernel/bridge: write frame: %w", err)
+	// Loop over the single buffer to tolerate short writes: the length prefix and
+	// payload stay one contiguous slice so frames never interleave, but a writer
+	// is free to accept fewer bytes than requested per call.
+	for len(buf) > 0 {
+		n, err := w.Write(buf)
+		if err != nil {
+			return fmt.Errorf("pykernel/bridge: write frame: %w", err)
+		}
+		if n == 0 {
+			// A nil-error zero-byte write would spin forever; treat it as a fault.
+			return fmt.Errorf("pykernel/bridge: write frame: %w", io.ErrShortWrite)
+		}
+		buf = buf[n:]
 	}
 	return nil
 }

--- a/pkg/pykernel/bridge/protocol.go
+++ b/pkg/pykernel/bridge/protocol.go
@@ -1,0 +1,140 @@
+package bridge
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// JSON-RPC method names exchanged over the channel.
+const (
+	// host→kernel notifications
+	MethodExecSubmit = "exec.submit"
+	MethodExecCancel = "exec.cancel"
+
+	// kernel→host request (blocking; expects a response)
+	MethodCapCall = "cap.call"
+
+	// kernel→host notifications
+	MethodOutStdout  = "out.stdout"
+	MethodOutMetric  = "out.metric"
+	MethodOutLog     = "out.log"
+	MethodExecResult = "exec.result"
+	MethodExecError  = "exec.error"
+	MethodExecDone   = "exec.done"
+)
+
+// JSON-RPC error codes. The reserved range mirrors the spec; capability errors
+// use the implementation-defined server range.
+const (
+	codeMethodNotFound  = -32601
+	codeCapabilityError = -32000 // a controlled error to raise inside the kernel
+	codeCapabilityArgs  = -32001 // malformed cap.call params
+)
+
+// maxFrameSize bounds a single decoded frame to guard against a hostile or
+// buggy kernel claiming an enormous length.
+const maxFrameSize = 64 << 20 // 64 MiB
+
+// ErrFrameTooLarge is returned when a frame's declared length exceeds the cap.
+var ErrFrameTooLarge = errors.New("pykernel/bridge: frame exceeds maximum size")
+
+// jsonrpcVersion is the only supported protocol version string.
+const jsonrpcVersion = "2.0"
+
+// message is a JSON-RPC 2.0 envelope. A frame is exactly one message.
+//
+//   - request:      Method set, ID set
+//   - notification: Method set, ID absent
+//   - response:     Method absent, ID set, one of Result/Error set
+//
+// ID is kept raw so a kernel may use a number or string id; the host echoes it
+// verbatim in the response.
+type message struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+func (m *message) isRequest() bool      { return m.Method != "" && len(m.ID) > 0 }
+func (m *message) isNotification() bool { return m.Method != "" && len(m.ID) == 0 }
+
+type rpcError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+// --- Wire payloads -------------------------------------------------------
+
+// host→kernel
+type execSubmitParams struct {
+	ExecID string `json:"exec_id"`
+	Code   string `json:"code"`
+	Limits Limits `json:"limits"`
+}
+
+type execCancelParams struct {
+	ExecID string `json:"exec_id"`
+}
+
+// kernel→host request
+type capCallParams struct {
+	ExecID string          `json:"exec_id"`
+	Name   string          `json:"name"`
+	Args   json.RawMessage `json:"args"`
+}
+
+// capErrorData travels in rpcError.Data so the kernel shim can reconstruct the
+// correct Python exception class (e.g. PlanModeViolation) at the call site.
+type capErrorData struct {
+	Type string `json:"type"`
+}
+
+// --- Framing -------------------------------------------------------------
+
+// writeFrame serializes msg and writes it as a 4-byte big-endian length prefix
+// followed by the JSON payload, in a single Write so frames never interleave
+// when multiple goroutines share the writer behind a mutex.
+func writeFrame(w io.Writer, msg *message) error {
+	payload, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("pykernel/bridge: marshal frame: %w", err)
+	}
+	if len(payload) > maxFrameSize {
+		return ErrFrameTooLarge
+	}
+	buf := make([]byte, 4+len(payload))
+	binary.BigEndian.PutUint32(buf[:4], uint32(len(payload)))
+	copy(buf[4:], payload)
+	if _, err := w.Write(buf); err != nil {
+		return fmt.Errorf("pykernel/bridge: write frame: %w", err)
+	}
+	return nil
+}
+
+// readFrame reads one length-prefixed frame and decodes the JSON-RPC message.
+func readFrame(r io.Reader) (*message, error) {
+	var hdr [4]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, err // io.EOF / io.ErrUnexpectedEOF propagate to the caller
+	}
+	n := binary.BigEndian.Uint32(hdr[:])
+	if n > maxFrameSize {
+		return nil, ErrFrameTooLarge
+	}
+	payload := make([]byte, n)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return nil, err
+	}
+	var msg message
+	if err := json.Unmarshal(payload, &msg); err != nil {
+		return nil, fmt.Errorf("pykernel/bridge: decode frame: %w", err)
+	}
+	return &msg, nil
+}

--- a/pkg/pykernel/bridge/unix.go
+++ b/pkg/pykernel/bridge/unix.go
@@ -1,0 +1,36 @@
+package bridge
+
+import (
+	"fmt"
+	"net"
+	"os"
+)
+
+// ListenUnix creates a unix-domain socket listener at path with 0700
+// permissions, clearing any stale socket first. The kernel subprocess connects
+// to this socket (it learns the path from its sandbox workdir). The caller owns
+// and closes the returned listener.
+func ListenUnix(path string) (net.Listener, error) {
+	if err := os.RemoveAll(path); err != nil {
+		return nil, fmt.Errorf("pykernel/bridge: remove stale socket %q: %w", path, err)
+	}
+	l, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, fmt.Errorf("pykernel/bridge: listen unix %q: %w", path, err)
+	}
+	if err := os.Chmod(path, 0o700); err != nil {
+		_ = l.Close()
+		return nil, fmt.Errorf("pykernel/bridge: chmod socket %q: %w", path, err)
+	}
+	return l, nil
+}
+
+// Accept waits for the kernel to connect and returns a Bridge over that
+// connection. At most one connection is expected per kernel.
+func Accept(l net.Listener) (Bridge, error) {
+	conn, err := l.Accept()
+	if err != nil {
+		return nil, fmt.Errorf("pykernel/bridge: accept: %w", err)
+	}
+	return New(conn), nil
+}

--- a/pkg/pykernel/capabilities/sqlcap/sqlcap.go
+++ b/pkg/pykernel/capabilities/sqlcap/sqlcap.go
@@ -1,0 +1,82 @@
+// Package sqlcap adapts the SDK's read-only SafeQueryExecutor into a pykernel
+// sql() capability — the data path for the Ali analyst REPL
+// (iota-uz/eai#3110). All tenant scoping, the ai_readonly role, the
+// accounting-schema guard, the timeout and the row limit come from the
+// executor; this is a thin marshaling shim. The capability is read-only, so
+// pykernel allows it in both plan and apply runs.
+package sqlcap
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	bichatsql "github.com/iota-uz/iota-sdk/pkg/bichat/sql"
+	"github.com/iota-uz/iota-sdk/pkg/pykernel"
+)
+
+// DefaultName is the Python function name the capability is exposed under.
+const DefaultName = "sql"
+
+// DefaultTimeout is used when no WithTimeout option is given.
+const DefaultTimeout = 30 * time.Second
+
+// Option configures the capability.
+type Option func(*config)
+
+type config struct {
+	name    string
+	timeout time.Duration
+}
+
+// WithTimeout sets the per-query timeout passed to the executor.
+func WithTimeout(d time.Duration) Option { return func(c *config) { c.timeout = d } }
+
+// WithName overrides the exposed Python function name (default "sql").
+func WithName(name string) Option { return func(c *config) { c.name = name } }
+
+// New returns the read-only sql() capability backed by executor. The kernel
+// calls it as sql(query, params=None) and receives a list of row dicts.
+func New(executor bichatsql.QueryExecutor, opts ...Option) pykernel.Capability {
+	cfg := config{name: DefaultName, timeout: DefaultTimeout}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	sig := pykernel.CapabilitySignature{
+		Params: []pykernel.ParamSpec{
+			{Name: "query", Type: "str", Required: true},
+			{Name: "params", Type: "list", Required: false},
+		},
+		Returns: "list[dict]",
+		Doc:     "Run a read-only SQL query against the internal database and return rows as a list of dicts.",
+	}
+	return pykernel.CapabilityFunc(cfg.name, pykernel.AccessRead, sig,
+		func(ctx context.Context, args pykernel.CallArgs) (any, error) {
+			query, ok := args["query"].(string)
+			if !ok || query == "" {
+				return nil, fmt.Errorf("sql: 'query' must be a non-empty string")
+			}
+			params, err := toParams(args["params"])
+			if err != nil {
+				return nil, err
+			}
+			res, err := executor.ExecuteQuery(ctx, query, params, cfg.timeout)
+			if err != nil {
+				return nil, err
+			}
+			return res.AllMaps(), nil
+		})
+}
+
+// toParams normalizes the optional params argument (a JSON array or absent)
+// into a []any for the executor.
+func toParams(v any) ([]any, error) {
+	switch p := v.(type) {
+	case nil:
+		return nil, nil
+	case []any:
+		return p, nil
+	default:
+		return nil, fmt.Errorf("sql: 'params' must be a list")
+	}
+}

--- a/pkg/pykernel/capabilities/sqlcap/sqlcap.go
+++ b/pkg/pykernel/capabilities/sqlcap/sqlcap.go
@@ -54,9 +54,9 @@ func New(executor bichatsql.QueryExecutor, opts ...Option) pykernel.Capability {
 		func(ctx context.Context, args pykernel.CallArgs) (any, error) {
 			query, ok := args["query"].(string)
 			if !ok || query == "" {
-				return nil, fmt.Errorf("sql: 'query' must be a non-empty string")
+				return nil, fmt.Errorf("%s: 'query' must be a non-empty string", cfg.name)
 			}
-			params, err := toParams(args["params"])
+			params, err := toParams(cfg.name, args["params"])
 			if err != nil {
 				return nil, err
 			}
@@ -70,13 +70,13 @@ func New(executor bichatsql.QueryExecutor, opts ...Option) pykernel.Capability {
 
 // toParams normalizes the optional params argument (a JSON array or absent)
 // into a []any for the executor.
-func toParams(v any) ([]any, error) {
+func toParams(name string, v any) ([]any, error) {
 	switch p := v.(type) {
 	case nil:
 		return nil, nil
 	case []any:
 		return p, nil
 	default:
-		return nil, fmt.Errorf("sql: 'params' must be a list")
+		return nil, fmt.Errorf("%s: 'params' must be a list", name)
 	}
 }

--- a/pkg/pykernel/capabilities/sqlcap/sqlcap_test.go
+++ b/pkg/pykernel/capabilities/sqlcap/sqlcap_test.go
@@ -1,0 +1,106 @@
+package sqlcap_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	bichatsql "github.com/iota-uz/iota-sdk/pkg/bichat/sql"
+	"github.com/iota-uz/iota-sdk/pkg/pykernel"
+	"github.com/iota-uz/iota-sdk/pkg/pykernel/capabilities/sqlcap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeExecutor struct {
+	gotSQL     string
+	gotParams  []any
+	gotTimeout time.Duration
+	res        *bichatsql.QueryResult
+	err        error
+}
+
+func (f *fakeExecutor) ExecuteQuery(_ context.Context, sql string, params []any, timeout time.Duration) (*bichatsql.QueryResult, error) {
+	f.gotSQL = sql
+	f.gotParams = params
+	f.gotTimeout = timeout
+	return f.res, f.err
+}
+
+func TestSQLCapability_ReturnsRowMaps(t *testing.T) {
+	t.Parallel()
+
+	fe := &fakeExecutor{res: &bichatsql.QueryResult{
+		Columns:  []string{"id", "name"},
+		Rows:     [][]any{{int64(1), "a"}, {int64(2), "b"}},
+		RowCount: 2,
+	}}
+	c := sqlcap.New(fe, sqlcap.WithTimeout(5*time.Second))
+
+	assert.Equal(t, "sql", c.Name())
+	assert.Equal(t, pykernel.AccessRead, c.Access())
+
+	out, err := c.Invoke(context.Background(), pykernel.CallArgs{
+		"query":  "select id, name from t where id = $1",
+		"params": []any{int64(1)},
+	})
+	require.NoError(t, err)
+
+	rows, ok := out.([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, rows, 2)
+	assert.Equal(t, int64(1), rows[0]["id"])
+	assert.Equal(t, "a", rows[0]["name"])
+
+	assert.Equal(t, "select id, name from t where id = $1", fe.gotSQL)
+	assert.Equal(t, []any{int64(1)}, fe.gotParams)
+	assert.Equal(t, 5*time.Second, fe.gotTimeout)
+}
+
+func TestSQLCapability_AllowedInPlanMode(t *testing.T) {
+	t.Parallel()
+
+	fe := &fakeExecutor{res: &bichatsql.QueryResult{Columns: []string{"n"}, Rows: [][]any{{int64(1)}}}}
+	set, err := pykernel.NewCapabilitySet(sqlcap.New(fe))
+	require.NoError(t, err)
+
+	// Read-only: a plan run must NOT refuse it.
+	out, err := pykernel.Dispatch(context.Background(), set, pykernel.ModePlan, "sql",
+		pykernel.CallArgs{"query": "select 1"})
+	require.NoError(t, err)
+	assert.Len(t, out, 1)
+	assert.Nil(t, fe.gotParams, "absent params must pass nil to the executor")
+}
+
+func TestSQLCapability_Errors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing query", func(t *testing.T) {
+		t.Parallel()
+		c := sqlcap.New(&fakeExecutor{res: &bichatsql.QueryResult{}})
+		_, err := c.Invoke(context.Background(), pykernel.CallArgs{})
+		require.Error(t, err)
+	})
+
+	t.Run("non-list params", func(t *testing.T) {
+		t.Parallel()
+		c := sqlcap.New(&fakeExecutor{res: &bichatsql.QueryResult{}})
+		_, err := c.Invoke(context.Background(), pykernel.CallArgs{"query": "select 1", "params": "nope"})
+		require.Error(t, err)
+	})
+
+	t.Run("executor error propagates", func(t *testing.T) {
+		t.Parallel()
+		boom := errors.New("db down")
+		c := sqlcap.New(&fakeExecutor{err: boom})
+		_, err := c.Invoke(context.Background(), pykernel.CallArgs{"query": "select 1"})
+		require.ErrorIs(t, err, boom)
+	})
+}
+
+func TestSQLCapability_WithName(t *testing.T) {
+	t.Parallel()
+	c := sqlcap.New(&fakeExecutor{res: &bichatsql.QueryResult{}}, sqlcap.WithName("query_db"))
+	assert.Equal(t, "query_db", c.Name())
+}

--- a/pkg/pykernel/capability.go
+++ b/pkg/pykernel/capability.go
@@ -60,8 +60,10 @@ func (m Mode) String() string {
 // invocation. Keys are the parameter names from the capability Signature.
 type CallArgs map[string]any
 
-// ParamSpec describes one capability parameter. It feeds both the generated
-// Python proxy stub and host-side argument validation.
+// ParamSpec describes one capability parameter. It is advisory metadata used to
+// synthesize the Python proxy signature; it is NOT enforced by a generic
+// host-side validator. Capabilities that need argument validation must perform
+// it themselves (e.g. in their invoke implementation).
 type ParamSpec struct {
 	Name     string
 	Type     string // doc/validation hint, e.g. "str", "list[dict]"

--- a/pkg/pykernel/capability.go
+++ b/pkg/pykernel/capability.go
@@ -1,0 +1,212 @@
+package pykernel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// Access classifies a capability's effect on data. The host — never the kernel
+// — decides, at dispatch time, whether a write capability is permitted given
+// the run's Mode.
+type Access int
+
+const (
+	// AccessRead is safe in both plan and apply mode.
+	AccessRead Access = iota
+	// AccessWrite mutates data and is refused by the host in plan mode.
+	AccessWrite
+)
+
+func (a Access) String() string {
+	switch a {
+	case AccessRead:
+		return "read"
+	case AccessWrite:
+		return "write"
+	default:
+		return fmt.Sprintf("Access(%d)", int(a))
+	}
+}
+
+// Mode is the dry-run dimension of a run, carried on the Session and propagated
+// to every capability call. There is exactly one such dimension (mirroring the
+// Python engine's RunMode); the consumer picks it when it builds the Session,
+// and capabilities cannot bypass it.
+type Mode int
+
+const (
+	// ModePlan is a read-only rehearsal: write capabilities are refused.
+	ModePlan Mode = iota
+	// ModeApply permits write capabilities.
+	ModeApply
+)
+
+// IsWritable reports whether write capabilities are permitted in this mode.
+func (m Mode) IsWritable() bool { return m == ModeApply }
+
+func (m Mode) String() string {
+	switch m {
+	case ModePlan:
+		return "plan"
+	case ModeApply:
+		return "apply"
+	default:
+		return fmt.Sprintf("Mode(%d)", int(m))
+	}
+}
+
+// CallArgs is the validated, boundary-converted argument map for a capability
+// invocation. Keys are the parameter names from the capability Signature.
+type CallArgs map[string]any
+
+// ParamSpec describes one capability parameter. It feeds both the generated
+// Python proxy stub and host-side argument validation.
+type ParamSpec struct {
+	Name     string
+	Type     string // doc/validation hint, e.g. "str", "list[dict]"
+	Required bool
+}
+
+// CapabilitySignature is the declared shape of a capability. The kernel shim
+// turns it into a callable Python function; the Doc becomes that function's
+// docstring, which the model sees.
+type CapabilitySignature struct {
+	Params  []ParamSpec
+	Returns string // doc hint, e.g. "list[dict]"
+	Doc     string
+}
+
+// Capability is one host function exposed into the kernel's Python namespace
+// under Name. The host owns invocation; kernel code can only call it by name
+// with JSON arguments. Implementations must be safe for concurrent use.
+type Capability interface {
+	// Name is the Python identifier exposed in the namespace (e.g. "sql").
+	Name() string
+	// Signature is the argument/return spec used to generate the proxy and to
+	// validate inbound arguments.
+	Signature() CapabilitySignature
+	// Access reports read vs write, which drives plan-mode refusal centrally.
+	Access() Access
+	// Invoke runs the host function. ctx already carries the host-bound tenant
+	// and request scope. The returned value is JSON-serialized at the boundary.
+	Invoke(ctx context.Context, args CallArgs) (any, error)
+}
+
+// CapabilitySet is the immutable bundle of capabilities frozen onto a kernel at
+// Acquire. A consumer's policy layer is mostly the choice of which capabilities
+// populate this set plus the run Mode.
+type CapabilitySet interface {
+	// List returns the capabilities in registration order.
+	List() []Capability
+	// Lookup resolves a capability by name.
+	Lookup(name string) (Capability, bool)
+}
+
+// Sentinel errors callers branch on.
+var (
+	// ErrPlanModeWrite is returned by Authorize/Dispatch when a write
+	// capability is invoked during a plan run. The bridge maps it to a Python
+	// exception raised at the call site inside the kernel.
+	ErrPlanModeWrite = errors.New("pykernel: write capability refused in plan mode")
+	// ErrCapabilityNotFound is returned when a call names an unregistered
+	// capability.
+	ErrCapabilityNotFound = errors.New("pykernel: capability not found")
+	// ErrDuplicateCapability is returned by NewCapabilitySet on a name clash.
+	ErrDuplicateCapability = errors.New("pykernel: duplicate capability name")
+)
+
+// NewCapabilitySet builds an immutable set, rejecting duplicate names and any
+// capability with an empty name.
+func NewCapabilitySet(caps ...Capability) (CapabilitySet, error) {
+	set := &capabilitySet{
+		order:  make([]Capability, 0, len(caps)),
+		byName: make(map[string]Capability, len(caps)),
+	}
+	for _, c := range caps {
+		if c == nil {
+			return nil, errors.New("pykernel: nil capability")
+		}
+		name := c.Name()
+		if name == "" {
+			return nil, errors.New("pykernel: capability with empty name")
+		}
+		if _, dup := set.byName[name]; dup {
+			return nil, fmt.Errorf("%w: %s", ErrDuplicateCapability, name)
+		}
+		set.byName[name] = c
+		set.order = append(set.order, c)
+	}
+	return set, nil
+}
+
+type capabilitySet struct {
+	order  []Capability
+	byName map[string]Capability
+}
+
+func (s *capabilitySet) List() []Capability {
+	out := make([]Capability, len(s.order))
+	copy(out, s.order)
+	return out
+}
+
+func (s *capabilitySet) Lookup(name string) (Capability, bool) {
+	c, ok := s.byName[name]
+	return c, ok
+}
+
+// Authorize reports whether cap may run under mode. A write capability in plan
+// mode is refused with ErrPlanModeWrite. This is the SINGLE enforcement point
+// for the plan/apply boundary — the Go analogue of the Python engine's
+// assert_writable. Keep all mode checks funneling through here.
+func Authorize(mode Mode, c Capability) error {
+	if c.Access() == AccessWrite && !mode.IsWritable() {
+		return fmt.Errorf("%w: %s", ErrPlanModeWrite, c.Name())
+	}
+	return nil
+}
+
+// Dispatch resolves name in set, authorizes it against mode, then invokes it.
+// The host-side bridge routes every kernel capability call through Dispatch so
+// the mode check cannot be skipped. ctx must already carry the host-bound
+// tenant and request scope from the Session.
+func Dispatch(ctx context.Context, set CapabilitySet, mode Mode, name string, args CallArgs) (any, error) {
+	c, ok := set.Lookup(name)
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrCapabilityNotFound, name)
+	}
+	if err := Authorize(mode, c); err != nil {
+		return nil, err
+	}
+	return c.Invoke(ctx, args)
+}
+
+// CapabilityFunc adapts a plain function to a Capability, mirroring the
+// adapter-function style used elsewhere in the SDK.
+func CapabilityFunc(
+	name string,
+	access Access,
+	sig CapabilitySignature,
+	fn func(context.Context, CallArgs) (any, error),
+) Capability {
+	return &capabilityFunc{name: name, access: access, sig: sig, fn: fn}
+}
+
+type capabilityFunc struct {
+	name   string
+	access Access
+	sig    CapabilitySignature
+	fn     func(context.Context, CallArgs) (any, error)
+}
+
+func (c *capabilityFunc) Name() string                   { return c.name }
+func (c *capabilityFunc) Signature() CapabilitySignature { return c.sig }
+func (c *capabilityFunc) Access() Access                 { return c.access }
+
+func (c *capabilityFunc) Invoke(ctx context.Context, args CallArgs) (any, error) {
+	if c.fn == nil {
+		return nil, fmt.Errorf("pykernel: capability %q has no handler", c.name)
+	}
+	return c.fn(ctx, args)
+}

--- a/pkg/pykernel/capability_test.go
+++ b/pkg/pykernel/capability_test.go
@@ -21,9 +21,11 @@ type recordingCap struct {
 	err     error
 }
 
-func (c *recordingCap) Name() string                            { return c.name }
-func (c *recordingCap) Signature() pykernel.CapabilitySignature { return pykernel.CapabilitySignature{} }
-func (c *recordingCap) Access() pykernel.Access                 { return c.access }
+func (c *recordingCap) Name() string { return c.name }
+func (c *recordingCap) Signature() pykernel.CapabilitySignature {
+	return pykernel.CapabilitySignature{}
+}
+func (c *recordingCap) Access() pykernel.Access { return c.access }
 func (c *recordingCap) Invoke(ctx context.Context, _ pykernel.CallArgs) (any, error) {
 	c.calls++
 	c.lastCtx = ctx

--- a/pkg/pykernel/capability_test.go
+++ b/pkg/pykernel/capability_test.go
@@ -1,0 +1,196 @@
+package pykernel_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/iota-uz/iota-sdk/pkg/pykernel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingCap counts Invoke calls so tests can assert a refused capability is
+// never actually executed.
+type recordingCap struct {
+	name    string
+	access  pykernel.Access
+	calls   int
+	lastCtx context.Context
+	result  any
+	err     error
+}
+
+func (c *recordingCap) Name() string                            { return c.name }
+func (c *recordingCap) Signature() pykernel.CapabilitySignature { return pykernel.CapabilitySignature{} }
+func (c *recordingCap) Access() pykernel.Access                 { return c.access }
+func (c *recordingCap) Invoke(ctx context.Context, _ pykernel.CallArgs) (any, error) {
+	c.calls++
+	c.lastCtx = ctx
+	return c.result, c.err
+}
+
+func TestNewCapabilitySet(t *testing.T) {
+	t.Parallel()
+
+	read := &recordingCap{name: "pg_query", access: pykernel.AccessRead}
+	write := &recordingCap{name: "pg_upsert", access: pykernel.AccessWrite}
+
+	set, err := pykernel.NewCapabilitySet(read, write)
+	require.NoError(t, err)
+
+	// Lookup resolves registered names and rejects unknown ones.
+	got, ok := set.Lookup("pg_query")
+	require.True(t, ok)
+	assert.Same(t, read, got)
+	_, ok = set.Lookup("missing")
+	assert.False(t, ok)
+
+	// List preserves registration order and is a defensive copy.
+	list := set.List()
+	require.Len(t, list, 2)
+	assert.Equal(t, "pg_query", list[0].Name())
+	assert.Equal(t, "pg_upsert", list[1].Name())
+	list[0] = nil
+	assert.NotNil(t, set.List()[0], "List must return a copy")
+}
+
+func TestNewCapabilitySet_Rejections(t *testing.T) {
+	t.Parallel()
+
+	t.Run("duplicate name", func(t *testing.T) {
+		t.Parallel()
+		a := &recordingCap{name: "sql", access: pykernel.AccessRead}
+		b := &recordingCap{name: "sql", access: pykernel.AccessRead}
+		_, err := pykernel.NewCapabilitySet(a, b)
+		require.ErrorIs(t, err, pykernel.ErrDuplicateCapability)
+	})
+
+	t.Run("empty name", func(t *testing.T) {
+		t.Parallel()
+		_, err := pykernel.NewCapabilitySet(&recordingCap{name: "", access: pykernel.AccessRead})
+		require.Error(t, err)
+	})
+
+	t.Run("nil capability", func(t *testing.T) {
+		t.Parallel()
+		_, err := pykernel.NewCapabilitySet(nil)
+		require.Error(t, err)
+	})
+}
+
+func TestAuthorize(t *testing.T) {
+	t.Parallel()
+
+	read := &recordingCap{name: "r", access: pykernel.AccessRead}
+	write := &recordingCap{name: "w", access: pykernel.AccessWrite}
+
+	// Reads are allowed in both modes.
+	assert.NoError(t, pykernel.Authorize(pykernel.ModePlan, read))
+	assert.NoError(t, pykernel.Authorize(pykernel.ModeApply, read))
+
+	// Writes are allowed only in apply mode; refused in plan mode.
+	assert.NoError(t, pykernel.Authorize(pykernel.ModeApply, write))
+	err := pykernel.Authorize(pykernel.ModePlan, write)
+	require.ErrorIs(t, err, pykernel.ErrPlanModeWrite)
+	assert.Contains(t, err.Error(), "w", "refusal should name the capability")
+}
+
+func TestDispatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unknown capability", func(t *testing.T) {
+		t.Parallel()
+		set, err := pykernel.NewCapabilitySet()
+		require.NoError(t, err)
+		_, err = pykernel.Dispatch(context.Background(), set, pykernel.ModeApply, "nope", nil)
+		require.ErrorIs(t, err, pykernel.ErrCapabilityNotFound)
+	})
+
+	t.Run("write refused in plan mode is never invoked", func(t *testing.T) {
+		t.Parallel()
+		write := &recordingCap{name: "pg_upsert", access: pykernel.AccessWrite, result: "ok"}
+		set, err := pykernel.NewCapabilitySet(write)
+		require.NoError(t, err)
+
+		_, err = pykernel.Dispatch(context.Background(), set, pykernel.ModePlan, "pg_upsert", nil)
+		require.ErrorIs(t, err, pykernel.ErrPlanModeWrite)
+		assert.Zero(t, write.calls, "refused write must not reach the host handler")
+	})
+
+	t.Run("write allowed in apply mode", func(t *testing.T) {
+		t.Parallel()
+		write := &recordingCap{name: "pg_upsert", access: pykernel.AccessWrite, result: int64(3)}
+		set, err := pykernel.NewCapabilitySet(write)
+		require.NoError(t, err)
+
+		out, err := pykernel.Dispatch(context.Background(), set, pykernel.ModeApply, "pg_upsert", nil)
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), out)
+		assert.Equal(t, 1, write.calls)
+	})
+
+	t.Run("read allowed in plan mode", func(t *testing.T) {
+		t.Parallel()
+		read := &recordingCap{name: "pg_query", access: pykernel.AccessRead, result: []any{1, 2}}
+		set, err := pykernel.NewCapabilitySet(read)
+		require.NoError(t, err)
+
+		out, err := pykernel.Dispatch(context.Background(), set, pykernel.ModePlan, "pg_query", nil)
+		require.NoError(t, err)
+		assert.Equal(t, []any{1, 2}, out)
+		assert.Equal(t, 1, read.calls)
+	})
+
+	t.Run("handler error propagates", func(t *testing.T) {
+		t.Parallel()
+		boom := errors.New("boom")
+		read := &recordingCap{name: "pg_query", access: pykernel.AccessRead, err: boom}
+		set, err := pykernel.NewCapabilitySet(read)
+		require.NoError(t, err)
+
+		_, err = pykernel.Dispatch(context.Background(), set, pykernel.ModeApply, "pg_query", nil)
+		require.ErrorIs(t, err, boom)
+	})
+}
+
+func TestCapabilityFunc(t *testing.T) {
+	t.Parallel()
+
+	sig := pykernel.CapabilitySignature{
+		Params:  []pykernel.ParamSpec{{Name: "query", Type: "str", Required: true}},
+		Returns: "list[dict]",
+		Doc:     "run read-only SQL",
+	}
+	var gotArgs pykernel.CallArgs
+	c := pykernel.CapabilityFunc("sql", pykernel.AccessRead, sig,
+		func(_ context.Context, args pykernel.CallArgs) (any, error) {
+			gotArgs = args
+			return "rows", nil
+		})
+
+	assert.Equal(t, "sql", c.Name())
+	assert.Equal(t, pykernel.AccessRead, c.Access())
+	assert.Equal(t, sig, c.Signature())
+
+	out, err := c.Invoke(context.Background(), pykernel.CallArgs{"query": "select 1"})
+	require.NoError(t, err)
+	assert.Equal(t, "rows", out)
+	assert.Equal(t, "select 1", gotArgs["query"])
+
+	// A capability with no handler fails rather than panicking.
+	_, err = pykernel.CapabilityFunc("noop", pykernel.AccessRead, sig, nil).
+		Invoke(context.Background(), nil)
+	require.Error(t, err)
+}
+
+func TestModeAndAccessStrings(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, pykernel.ModeApply.IsWritable())
+	assert.False(t, pykernel.ModePlan.IsWritable())
+	assert.Equal(t, "plan", pykernel.ModePlan.String())
+	assert.Equal(t, "apply", pykernel.ModeApply.String())
+	assert.Equal(t, "read", pykernel.AccessRead.String())
+	assert.Equal(t, "write", pykernel.AccessWrite.String())
+}

--- a/pkg/pykernel/deploy/Dockerfile
+++ b/pkg/pykernel/deploy/Dockerfile
@@ -1,0 +1,56 @@
+# pykernel-base — the co-located Python interpreter the pykernel manager spawns.
+#
+# Why a dedicated image: a Granite/SDK application binary ships on Alpine/musl,
+# but pandas/numpy/duckdb publish only glibc (manylinux) wheels — they will not
+# import on musl. The kernel therefore needs a glibc Python on PATH. This image
+# IS that runtime: a glibc CPython 3.11 with the analysis libraries pre-installed.
+# The application's final stage builds `FROM` this image and copies its static Go
+# binary in (the binary is CGO-free, so it runs unchanged on glibc). See README.
+#
+# The pykernel shim (bootstrap.py) is delivered at spawn time by the Go manager
+# (//go:embed → written to the per-run workdir); it is NOT baked here. The image's
+# only job is to provide `python3` + the agent-importable libraries.
+#
+# Build (from this directory):
+#   docker build -t iotauz/pykernel-base:3.11-analysis .
+# Smoke test:
+#   docker run --rm iotauz/pykernel-base:3.11-analysis python3 /opt/pykernel/smoke_test.py
+FROM python:3.11-slim-bookworm
+
+# uv: fast, deterministic installs from the pinned requirements.txt. Installed
+# via pip (rather than `COPY --from=ghcr.io/astral-sh/uv`) so the image builds on
+# the legacy Docker builder too — no buildx/BuildKit requirement.
+RUN pip install --no-cache-dir uv==0.5.11
+
+ENV UV_SYSTEM_PYTHON=1 \
+    UV_NO_CACHE=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Minimal OS deps: tzdata (so a migration that localises timestamps has zoneinfo)
+# and ca-certificates (TLS roots) only. No compilers, no clients — all data I/O
+# is via host capabilities, not the kernel.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt /opt/pykernel/requirements.txt
+RUN uv pip install --system -r /opt/pykernel/requirements.txt
+
+# Smoke test lives in the image so a deploy can self-verify (CI / healthcheck).
+COPY smoke_test.py /opt/pykernel/smoke_test.py
+
+# Run kernels as a non-root, no-login user. The Go manager additionally sandboxes
+# each spawn (rlimits, process group, env scrub, jailed workdir); this is the
+# baseline-least-privilege floor under that.
+RUN useradd --create-home --uid 10001 --shell /usr/sbin/nologin kernel
+USER kernel
+WORKDIR /home/kernel
+
+# The interpreter the pykernel manager should launch (datamig: DATAMIG_PYTHON_PATH;
+# generic: manager.Config.PythonPath). It is on PATH, so "python3" suffices.
+ENV PYKERNEL_PYTHON=python3
+
+# Default command is a no-op identity probe; real use FROMs this image and runs
+# the application binary (which spawns python3 itself).
+CMD ["python3", "/opt/pykernel/smoke_test.py"]

--- a/pkg/pykernel/deploy/README.md
+++ b/pkg/pykernel/deploy/README.md
@@ -1,0 +1,105 @@
+# pykernel-base image
+
+The co-located Python interpreter the [`pykernel`](../) manager spawns. The
+manager runs `python3 <shim>` as a sandboxed subprocess; this image is what
+provides that `python3` (plus the libraries an agent program may import).
+
+## Why a dedicated image
+
+A Granite/SDK application binary ships on **Alpine/musl**, but `pandas` / `numpy`
+/ `duckdb` publish only **glibc** (manylinux) wheels — they won't import on musl.
+So the kernel needs a glibc CPython on `PATH`. This image is that runtime: a
+`python:3.11-slim-bookworm` base with the analysis libraries pre-installed. The
+application's final image stage builds **`FROM` this image** and copies its
+static (CGO-free) Go binary in — the binary runs unchanged on glibc.
+
+The shim (`pkg/pykernel/runtime/bootstrap.py`) is **not baked in** — the Go
+manager delivers it at spawn time (`//go:embed` → per-run workdir). The image's
+only job is `python3` + the importable libraries.
+
+## Contents
+
+`requirements.txt` (the "analysis" profile, shared with the Ali REPL and the
+datamig engine):
+
+| lib | for |
+|---|---|
+| numpy, pandas | dataframes / transforms over capability-returned data |
+| duckdb | local SQL over in-memory data |
+| openpyxl | reading/writing `.xlsx` (some migrations ingest spreadsheets) |
+| matplotlib | charts (Ali analyst) |
+
+### Why no DB drivers
+
+There are deliberately **no** `psycopg` / `pymongo` / `minio` / `mysql` packages.
+The kernel has **no DSN and no network egress** — every byte of data reaches it
+through a host capability over the bridge — so a driver would be both unusable
+and an unnecessary risk surface. (This diverges from the original plan's literal
+"full tag (+pymongo/minio/mysql)"; the capability model makes those dead weight.)
+
+## Build & smoke test
+
+```sh
+cd pkg/pykernel/deploy
+docker build --platform linux/amd64 -t iotauz/pykernel-base:3.11-analysis .
+docker run --rm --platform linux/amd64 iotauz/pykernel-base:3.11-analysis
+# → python 3.11.x; shim stdlib OK; numpy/pandas/duckdb/openpyxl/matplotlib OK
+```
+
+`smoke_test.py` is copied into the image at `/opt/pykernel/smoke_test.py` so a CI
+step or container healthcheck can self-verify the wheels loaded (it asserts the
+shim's stdlib imports **and** runs a trivial op per analysis lib, exiting non-zero
+on any failure).
+
+Publish to wherever the SDK images live (same registry as `iotauz/sdk:base-*`):
+
+```sh
+docker push iotauz/pykernel-base:3.11-analysis
+```
+
+## Adopting it in an application image
+
+Point the application's **final runtime stage** at this image instead of Alpine,
+and tell the manager where Python is (it's already on `PATH`, so `python3`):
+
+```dockerfile
+# was: FROM alpine:3.21
+FROM iotauz/pykernel-base:3.11-analysis AS production
+USER root
+# re-add the OS tools the app needs (apt names, not apk):
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl bash postgresql-client zstd tzdata \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /run_server /run_server
+# … the rest of the existing runtime stage …
+# datamig reads DATAMIG_PYTHON_PATH (default "python3"); generic consumers set
+# manager.Config.PythonPath. Both resolve "python3" on PATH here.
+ENV DATAMIG_PYTHON_PATH=python3
+```
+
+## The size tradeoff (a deploy decision)
+
+This image is **~590 MB** vs an Alpine runtime's ~50 MB (glibc base + pandas/
+numpy/duckdb/matplotlib). Baking it into the *main* application image makes the
+kernel always available but enlarges **every** deploy of that image, even ones
+that never run datamig or Ali.
+
+Two ways to adopt — pick per your deploy topology:
+
+- **Single image** — swap the main runtime base to this (snippet above).
+  Simplest; one image; pays the size everywhere.
+- **Kernel-enabled variant** — keep the lean Alpine image as default and build a
+  second tag `FROM pykernel-base` for the service(s) that actually run the
+  kernel. Keeps unrelated deploys small at the cost of a second image in CI.
+
+The kernel **must** share the container with the application process (the manager
+`os/exec`s `python3` in the same PID namespace) — a separate sidecar container
+does not work.
+
+## Security
+
+The image is the least-privilege *floor*: non-root `kernel` user, no compilers,
+no DB clients, minimal apt set. The real isolation is enforced by the Go manager
+per spawn (rlimits, process group, env scrub so no secret/DSN reaches the kernel,
+jailed workdir). Strongest prod hardening (network namespace + seccomp
+deny-egress) is an orchestration-layer follow-up, not part of this image.

--- a/pkg/pykernel/deploy/requirements.txt
+++ b/pkg/pykernel/deploy/requirements.txt
@@ -1,0 +1,16 @@
+# pykernel-base "analysis" profile — the data-processing libraries an
+# agent-authored kernel program may import. The pykernel shim itself needs only
+# the CPython standard library (ast/json/os/socket/struct/sys/threading/
+# traceback/queue/ctypes), so this list is purely the agent surface.
+#
+# Deliberately NO database driver libraries (psycopg/pymongo/minio/mysql): the
+# kernel has no DSN and no network egress — every byte of data reaches it through
+# a host capability over the bridge — so a driver would be both unusable and an
+# unnecessary risk surface. See README.md "Why no DB drivers".
+#
+# Pinned for a reproducible image. Bump deliberately; rebuild + run smoke_test.py.
+numpy==2.2.1
+pandas==2.2.3
+duckdb==1.1.3
+openpyxl==3.1.5
+matplotlib==3.9.2

--- a/pkg/pykernel/deploy/smoke_test.py
+++ b/pkg/pykernel/deploy/smoke_test.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Self-verification for the pykernel-base image.
+
+Asserts two things the image must provide:
+  1. The standard-library modules the pykernel shim (bootstrap.py) imports — if
+     any are missing the kernel cannot even start.
+  2. The analysis libraries an agent program may import — with a trivial op each
+     so a broken/musl wheel surfaces here, not at first run.
+
+Exits non-zero on any failure so a Docker build, CI step, or container
+healthcheck can gate on it:
+
+    docker run --rm <image> python3 /opt/pykernel/smoke_test.py
+"""
+import importlib
+import sys
+
+# Stdlib the shim relies on (see pkg/pykernel/runtime/bootstrap.py).
+SHIM_STDLIB = ["ast", "json", "os", "socket", "struct", "sys",
+               "threading", "traceback", "queue", "ctypes"]
+
+
+def check_stdlib() -> None:
+    for name in SHIM_STDLIB:
+        importlib.import_module(name)
+    print(f"ok: shim stdlib imports ({len(SHIM_STDLIB)})")
+
+
+def check_analysis_libs() -> None:
+    import numpy as np
+    import pandas as pd
+    import duckdb
+    import openpyxl  # noqa: F401  (import is the test)
+    import matplotlib  # noqa: F401
+
+    # Tiny ops so a wheel that imports but is ABI-broken is caught.
+    assert int(np.arange(5).sum()) == 10
+    df = pd.DataFrame({"a": [1, 2, 3]})
+    assert int(df["a"].sum()) == 6
+    assert duckdb.sql("select 21 * 2 as n").fetchone()[0] == 42
+
+    print(f"ok: numpy {np.__version__}, pandas {pd.__version__}, "
+          f"duckdb {duckdb.__version__}, openpyxl {openpyxl.__version__}, "
+          f"matplotlib {matplotlib.__version__}")
+
+
+def main() -> int:
+    print(f"python {sys.version.split()[0]} ({sys.platform})")
+    try:
+        check_stdlib()
+        check_analysis_libs()
+    except Exception as exc:  # noqa: BLE001 — the test's whole job is to report
+        print(f"FAIL: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+    print("pykernel-base: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pkg/pykernel/doc.go
+++ b/pkg/pykernel/doc.go
@@ -42,7 +42,9 @@
 //
 // # Error convention
 //
-// pykernel is a foundation library and, like pkg/bichat, does not depend on
-// pkg/serrors. Wrap with fmt.Errorf("...: %w", err) and expose sentinel errors
+// pykernel deliberately uses the stdlib errors/fmt.Errorf rather than the SDK
+// pkg/serrors convention because it is a low-level primitive with no tenant or
+// operation context to carry; callers wrap pykernel errors with serrors at the
+// call site. Wrap with fmt.Errorf("...: %w", err) and expose sentinel errors
 // for conditions callers branch on.
 package pykernel

--- a/pkg/pykernel/doc.go
+++ b/pkg/pykernel/doc.go
@@ -1,0 +1,48 @@
+// Package pykernel runs untrusted, AI-agent-authored Python inside a sandboxed
+// subprocess and exposes a small, host-controlled capability surface to it.
+//
+// It is a reusable primitive shared by two consumers:
+//
+//   - the Ali analyst REPL — a warm, per-session kernel with a read-only sql()
+//     capability;
+//   - the data-migration engine — an ephemeral, per-run kernel with
+//     write-capable connector capabilities gated by a plan/apply mode.
+//
+// One primitive serves both; the only difference is the capability set, the
+// run Mode, and the lifecycle policy (see the lifecycle subpackage).
+//
+// # The host-binds-context invariant
+//
+// Everything security-relevant is decided on the HOST and is never supplied by
+// the kernel. A Session carries the tenant id, the capability set, the run
+// Mode, and the workdir; the Manager freezes these onto a kernel at Acquire and
+// they cannot be changed or escalated for the life of the lease. When kernel
+// code calls a capability, the wire frame carries only the capability name and
+// its arguments — the dispatcher injects tenant and Mode from the Session.
+// A kernel therefore cannot forge a tenant, widen its permissions, or turn a
+// plan run into a writing run.
+//
+// # Plan/apply enforcement is centralized
+//
+// Each Capability declares an Access (read or write). The plan/apply boundary
+// is enforced in exactly one place — Authorize / Dispatch — which refuses a
+// write capability while the run is in plan mode (ErrPlanModeWrite). This is the
+// Go analogue of the Python engine's assert_writable: a single, greppable choke
+// point rather than per-capability checks scattered through the code. A refused
+// call surfaces inside the kernel as a raised Python exception, so an agent that
+// tries to write during a dry run fails loudly instead of silently no-op-ing.
+//
+// # Defense in depth
+//
+// Authorization is the policy boundary, not the only one. The kernel runs with
+// no database/credentials in its environment and no network egress, so the only
+// path to data is a capability call over the bridge; rlimits and a wall-clock
+// timeout bound resource use; the workdir is jailed. Those mechanisms live in
+// the isolation and bridge subpackages.
+//
+// # Error convention
+//
+// pykernel is a foundation library and, like pkg/bichat, does not depend on
+// pkg/serrors. Wrap with fmt.Errorf("...: %w", err) and expose sentinel errors
+// for conditions callers branch on.
+package pykernel

--- a/pkg/pykernel/exec.go
+++ b/pkg/pykernel/exec.go
@@ -1,0 +1,119 @@
+package pykernel
+
+import (
+	"fmt"
+	"time"
+)
+
+// ExecRequest is one unit of code submitted to a kernel.
+type ExecRequest struct {
+	// Code is the Python source to execute in the kernel's persistent namespace.
+	Code string
+	// Timeout is the wall-clock cap for this exec; 0 selects the policy default.
+	Timeout time.Duration
+	// OutputCap is the maximum captured stdout+result size in bytes; 0 selects
+	// the default (~50KB). The cap is enforced on both kernel and host side.
+	OutputCap int
+	// Label is a human-readable tag for tracing and observability.
+	Label string
+}
+
+// ExecEventKind discriminates the streamed ExecEvent union.
+type ExecEventKind int
+
+const (
+	// EventStdout carries an incremental stdout chunk.
+	EventStdout ExecEventKind = iota
+	// EventResult carries the converted value of the final expression.
+	EventResult
+	// EventMetric carries a structured progress/metric sample.
+	EventMetric
+	// EventLog carries a structured log line emitted via the log capability.
+	EventLog
+	// EventError carries an uncaught Python exception.
+	EventError
+	// EventTruncated signals the output cap was hit and a marker was inserted.
+	EventTruncated
+	// EventDone is terminal: the exec finished (successfully or with an error).
+	// Exactly one EventDone closes the stream.
+	EventDone
+)
+
+func (k ExecEventKind) String() string {
+	switch k {
+	case EventStdout:
+		return "stdout"
+	case EventResult:
+		return "result"
+	case EventMetric:
+		return "metric"
+	case EventLog:
+		return "log"
+	case EventError:
+		return "error"
+	case EventTruncated:
+		return "truncated"
+	case EventDone:
+		return "done"
+	default:
+		return fmt.Sprintf("ExecEventKind(%d)", int(k))
+	}
+}
+
+// ExecEvent is one item in the stream returned by Kernel.Exec. The populated
+// payload field corresponds to Kind.
+type ExecEvent struct {
+	Kind      ExecEventKind
+	Stdout    []byte         // EventStdout
+	Result    *ResultPayload // EventResult
+	Metric    *MetricPayload // EventMetric
+	Log       *LogPayload    // EventLog
+	Err       *ExecError     // EventError
+	Timestamp time.Time
+}
+
+// ResultPayload carries the value of the final expression, already converted at
+// the host↔kernel boundary (datetime → ISO-8601, UUID → string, money as
+// integer tiyin, Decimal → string for precision).
+type ResultPayload struct {
+	// Text is the text/plain repr, already output-capped.
+	Text string
+	// MIME describes Data, e.g. "text/plain" or "image/png" for a rendered chart.
+	MIME string
+	// Data is a binary artifact (e.g. a chart), or a workdir-relative reference.
+	Data []byte
+	// Truncated reports whether the result was clipped to the output cap.
+	Truncated bool
+}
+
+// MetricPayload is a structured progress sample emitted by the kernel (e.g. the
+// migration emit_metric capability).
+type MetricPayload struct {
+	Name  string
+	Value float64
+	Tags  map[string]string
+}
+
+// LogPayload is a structured log line emitted by the kernel.
+type LogPayload struct {
+	Level   string
+	Message string
+	Fields  map[string]any
+}
+
+// ExecError describes an uncaught Python exception raised during an exec.
+type ExecError struct {
+	Type      string
+	Message   string
+	Traceback string
+}
+
+func (e *ExecError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Type == "" {
+		return e.Message
+	}
+	return fmt.Sprintf("%s: %s", e.Type, e.Message)
+}

--- a/pkg/pykernel/exec.go
+++ b/pkg/pykernel/exec.go
@@ -32,8 +32,6 @@ const (
 	EventLog
 	// EventError carries an uncaught Python exception.
 	EventError
-	// EventTruncated signals the output cap was hit and a marker was inserted.
-	EventTruncated
 	// EventDone is terminal: the exec finished (successfully or with an error).
 	// Exactly one EventDone closes the stream.
 	EventDone
@@ -51,8 +49,6 @@ func (k ExecEventKind) String() string {
 		return "log"
 	case EventError:
 		return "error"
-	case EventTruncated:
-		return "truncated"
 	case EventDone:
 		return "done"
 	default:

--- a/pkg/pykernel/isolation/launcher_unix.go
+++ b/pkg/pykernel/isolation/launcher_unix.go
@@ -1,0 +1,82 @@
+//go:build unix
+
+package isolation
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func newLauncher() Launcher { return &unixLauncher{} }
+
+type unixLauncher struct{}
+
+func (l *unixLauncher) Launch(_ context.Context, spec SandboxSpec) (Process, error) {
+	if len(spec.Command) == 0 {
+		return nil, fmt.Errorf("pykernel/isolation: empty command")
+	}
+
+	cmd := exec.Command(spec.Command[0], spec.Command[1:]...) //nolint:gosec // argv is built host-side, never from kernel input
+	cmd.Dir = spec.Workdir
+	cmd.Stdout = spec.Stdout
+	cmd.Stderr = spec.Stderr
+
+	// Force an explicit environment. A nil cmd.Env would inherit the host's
+	// environment (and its secrets); an empty non-nil slice yields none.
+	cmd.Env = spec.Env
+	if cmd.Env == nil {
+		cmd.Env = []string{}
+	}
+
+	// Own process group so a timeout or kill reaps the whole subtree.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("pykernel/isolation: start: %w", err)
+	}
+
+	// Apply rlimits to the started child. There is a tiny window between Start
+	// and this call; the kernel shim also self-applies limits at startup via
+	// Python's resource module, which closes the race. On non-Linux this is a
+	// no-op.
+	if err := applyRlimits(cmd.Process.Pid, spec.Limits); err != nil {
+		_ = killGroup(cmd.Process.Pid)
+		_ = cmd.Wait()
+		return nil, fmt.Errorf("pykernel/isolation: apply rlimits: %w", err)
+	}
+	if spec.Nice != 0 {
+		_ = syscall.Setpriority(syscall.PRIO_PROCESS, cmd.Process.Pid, spec.Nice)
+	}
+
+	return &unixProcess{cmd: cmd}, nil
+}
+
+type unixProcess struct{ cmd *exec.Cmd }
+
+func (p *unixProcess) PID() int { return p.cmd.Process.Pid }
+
+func (p *unixProcess) Wait() error { return p.cmd.Wait() }
+
+func (p *unixProcess) Signal(sig os.Signal) error {
+	ssig, ok := sig.(syscall.Signal)
+	if !ok {
+		return p.cmd.Process.Signal(sig)
+	}
+	// Negative pid targets the process group.
+	if err := syscall.Kill(-p.cmd.Process.Pid, ssig); err != nil && err != syscall.ESRCH {
+		return err
+	}
+	return nil
+}
+
+func (p *unixProcess) Kill() error { return killGroup(p.cmd.Process.Pid) }
+
+func killGroup(pid int) error {
+	if err := syscall.Kill(-pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+		return err
+	}
+	return nil
+}

--- a/pkg/pykernel/isolation/launcher_unix.go
+++ b/pkg/pykernel/isolation/launcher_unix.go
@@ -39,10 +39,10 @@ func (l *unixLauncher) Launch(_ context.Context, spec SandboxSpec) (Process, err
 		return nil, fmt.Errorf("pykernel/isolation: start: %w", err)
 	}
 
-	// Apply rlimits to the started child. There is a tiny window between Start
-	// and this call; the kernel shim also self-applies limits at startup via
-	// Python's resource module, which closes the race. On non-Linux this is a
-	// no-op.
+	// Apply rlimits to the started child via prlimit (Linux only). There is a
+	// small window between Start and this call during which the child runs
+	// without limits; the shim does not yet self-apply limits, so this window
+	// is currently unguarded (tracked follow-up). On non-Linux this is a no-op.
 	if err := applyRlimits(cmd.Process.Pid, spec.Limits); err != nil {
 		_ = killGroup(cmd.Process.Pid)
 		_ = cmd.Wait()
@@ -61,6 +61,9 @@ func (p *unixProcess) PID() int { return p.cmd.Process.Pid }
 
 func (p *unixProcess) Wait() error { return p.cmd.Wait() }
 
+// Signal sends sig to the process. For a syscall.Signal it targets the whole
+// process group (negative pid); any other os.Signal falls back to
+// cmd.Process.Signal, which targets only the leader process.
 func (p *unixProcess) Signal(sig os.Signal) error {
 	ssig, ok := sig.(syscall.Signal)
 	if !ok {

--- a/pkg/pykernel/isolation/launcher_unix.go
+++ b/pkg/pykernel/isolation/launcher_unix.go
@@ -23,6 +23,7 @@ func (l *unixLauncher) Launch(_ context.Context, spec SandboxSpec) (Process, err
 	cmd.Dir = spec.Workdir
 	cmd.Stdout = spec.Stdout
 	cmd.Stderr = spec.Stderr
+	cmd.ExtraFiles = spec.ExtraFiles // inherited starting at fd 3
 
 	// Force an explicit environment. A nil cmd.Env would inherit the host's
 	// environment (and its secrets); an empty non-nil slice yields none.

--- a/pkg/pykernel/isolation/launcher_unix.go
+++ b/pkg/pykernel/isolation/launcher_unix.go
@@ -14,7 +14,10 @@ func newLauncher() Launcher { return &unixLauncher{} }
 
 type unixLauncher struct{}
 
-func (l *unixLauncher) Launch(_ context.Context, spec SandboxSpec) (Process, error) {
+func (l *unixLauncher) Launch(ctx context.Context, spec SandboxSpec) (Process, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if len(spec.Command) == 0 {
 		return nil, fmt.Errorf("pykernel/isolation: empty command")
 	}
@@ -50,6 +53,15 @@ func (l *unixLauncher) Launch(_ context.Context, spec SandboxSpec) (Process, err
 	}
 	if spec.Nice != 0 {
 		_ = syscall.Setpriority(syscall.PRIO_PROCESS, cmd.Process.Pid, spec.Nice)
+	}
+
+	// Honor a mid-launch cancellation so we don't leak a just-started subprocess.
+	// We do NOT use exec.CommandContext: the kernel must outlive the Acquire
+	// call's ctx, so the only ctx coupling is this one-shot pre-handoff check.
+	if err := ctx.Err(); err != nil {
+		_ = killGroup(cmd.Process.Pid)
+		_ = cmd.Wait()
+		return nil, err
 	}
 
 	return &unixProcess{cmd: cmd}, nil

--- a/pkg/pykernel/isolation/launcher_unix_test.go
+++ b/pkg/pykernel/isolation/launcher_unix_test.go
@@ -1,0 +1,82 @@
+//go:build unix
+
+package isolation_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/iota-uz/iota-sdk/pkg/pykernel/isolation"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLauncher_WorkdirAndEnvScrub(t *testing.T) {
+	// No t.Parallel(): t.Setenv mutates process-wide state.
+	workdir := t.TempDir()
+	// Set a host env var that must NOT leak into the child.
+	t.Setenv("PYKERNEL_SECRET", "leaked")
+
+	l := isolation.NewLauncher()
+	// The child writes "$ALLOWED:$PYKERNEL_SECRET" into a file in its cwd. If
+	// the workdir is honoured the file lands in workdir; if the env is scrubbed
+	// PYKERNEL_SECRET is empty in the child.
+	proc, err := l.Launch(context.Background(), isolation.SandboxSpec{
+		Command: []string{"/bin/sh", "-c", `printf '%s' "$ALLOWED:$PYKERNEL_SECRET" > marker.txt`},
+		Workdir: workdir,
+		Env:     []string{"ALLOWED=ok"},
+	})
+	require.NoError(t, err)
+	require.NoError(t, proc.Wait())
+
+	got, err := os.ReadFile(filepath.Join(workdir, "marker.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "ok:", string(got), "ALLOWED should pass through; the host secret must be scrubbed")
+}
+
+func TestLauncher_NilEnvIsEmptyNotHost(t *testing.T) {
+	// No t.Parallel(): t.Setenv mutates process-wide state.
+	workdir := t.TempDir()
+	t.Setenv("PYKERNEL_SECRET", "leaked")
+
+	l := isolation.NewLauncher()
+	proc, err := l.Launch(context.Background(), isolation.SandboxSpec{
+		Command: []string{"/bin/sh", "-c", `printf '%s' "${PYKERNEL_SECRET}" > marker.txt`},
+		Workdir: workdir,
+		Env:     nil, // must yield an EMPTY child env, not the host's
+	})
+	require.NoError(t, err)
+	require.NoError(t, proc.Wait())
+
+	got, err := os.ReadFile(filepath.Join(workdir, "marker.txt"))
+	require.NoError(t, err)
+	assert.Empty(t, string(got), "nil Env must not inherit the host environment")
+}
+
+func TestLauncher_KillReapsProcessGroup(t *testing.T) {
+	t.Parallel()
+
+	l := isolation.NewLauncher()
+	proc, err := l.Launch(context.Background(), isolation.SandboxSpec{
+		Command: []string{"/bin/sh", "-c", "sleep 30"},
+		Workdir: t.TempDir(),
+		Env:     []string{},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, proc.Kill())
+
+	done := make(chan struct{})
+	go func() {
+		_ = proc.Wait() // returns a non-nil "signal: killed" error
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("killed process did not exit promptly")
+	}
+}

--- a/pkg/pykernel/isolation/launcher_unsupported.go
+++ b/pkg/pykernel/isolation/launcher_unsupported.go
@@ -1,0 +1,13 @@
+//go:build !unix
+
+package isolation
+
+import "context"
+
+func newLauncher() Launcher { return unsupportedLauncher{} }
+
+type unsupportedLauncher struct{}
+
+func (unsupportedLauncher) Launch(context.Context, SandboxSpec) (Process, error) {
+	return nil, ErrUnsupported
+}

--- a/pkg/pykernel/isolation/rlimit_linux.go
+++ b/pkg/pykernel/isolation/rlimit_linux.go
@@ -1,0 +1,34 @@
+//go:build linux
+
+package isolation
+
+import "golang.org/x/sys/unix"
+
+// applyRlimits sets each non-zero limit on the child by pid via prlimit(2).
+// Setting on the running child (rather than the parent) keeps the host process
+// unconstrained.
+func applyRlimits(pid int, lim ResourceLimits) error {
+	set := func(resource int, val uint64) error {
+		if val == 0 {
+			return nil
+		}
+		rl := &unix.Rlimit{Cur: val, Max: val}
+		return unix.Prlimit(pid, resource, rl, nil)
+	}
+	if err := set(unix.RLIMIT_CPU, lim.CPUSeconds); err != nil {
+		return err
+	}
+	if err := set(unix.RLIMIT_AS, lim.AddressSpaceBytes); err != nil {
+		return err
+	}
+	if err := set(unix.RLIMIT_FSIZE, lim.FileSizeBytes); err != nil {
+		return err
+	}
+	if err := set(unix.RLIMIT_NPROC, lim.MaxProcs); err != nil {
+		return err
+	}
+	if err := set(unix.RLIMIT_NOFILE, lim.MaxOpenFiles); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/pykernel/isolation/rlimit_other.go
+++ b/pkg/pykernel/isolation/rlimit_other.go
@@ -1,0 +1,9 @@
+//go:build unix && !linux
+
+package isolation
+
+// applyRlimits is a no-op on non-Linux unix systems (darwin/bsd), which the
+// project uses only for development. rlimit enforcement is a Linux-only control
+// in production; the kernel shim additionally self-applies limits via Python's
+// resource module where supported.
+func applyRlimits(_ int, _ ResourceLimits) error { return nil }

--- a/pkg/pykernel/isolation/rlimit_other.go
+++ b/pkg/pykernel/isolation/rlimit_other.go
@@ -4,6 +4,6 @@ package isolation
 
 // applyRlimits is a no-op on non-Linux unix systems (darwin/bsd), which the
 // project uses only for development. rlimit enforcement is a Linux-only control
-// in production; the kernel shim additionally self-applies limits via Python's
-// resource module where supported.
+// (applied via prlimit in production); there is no other limit enforcement on
+// these platforms.
 func applyRlimits(_ int, _ ResourceLimits) error { return nil }

--- a/pkg/pykernel/isolation/sandbox.go
+++ b/pkg/pykernel/isolation/sandbox.go
@@ -1,0 +1,104 @@
+// Package isolation launches the Python kernel subprocess under OS-level
+// confinement: resource limits (rlimits on Linux), a dedicated process group,
+// a jailed working directory, and a scrubbed environment that contains no
+// database credentials or secrets.
+//
+// The environment scrub is the load-bearing control: because the child receives
+// no DSNs and (in production) no network egress, importing a database driver
+// inside the kernel is inert — the only path to data is a capability call over
+// the bridge. rlimits and the wall-clock timeout bound resource use; the
+// process group lets a timeout or kill reap the whole subtree.
+package isolation
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+// ErrUnsupported is returned by Launch on platforms without sandbox support.
+var ErrUnsupported = errors.New("pykernel/isolation: sandbox launch not supported on this platform")
+
+// ResourceLimits are the per-kernel resource caps. A zero field means that
+// limit is not applied. They are enforced as OS rlimits on Linux and are a
+// no-op on other unixes (development only).
+type ResourceLimits struct {
+	// WallClock is the host-enforced timeout. It is NOT an rlimit (it catches
+	// IO-bound hangs that never burn CPU); the launcher records it for context
+	// while the Manager owns the actual timer.
+	WallClock time.Duration
+	// CPUSeconds maps to RLIMIT_CPU.
+	CPUSeconds uint64
+	// AddressSpaceBytes maps to RLIMIT_AS (virtual memory).
+	AddressSpaceBytes uint64
+	// FileSizeBytes maps to RLIMIT_FSIZE.
+	FileSizeBytes uint64
+	// MaxProcs maps to RLIMIT_NPROC (blocks fork bombs).
+	MaxProcs uint64
+	// MaxOpenFiles maps to RLIMIT_NOFILE.
+	MaxOpenFiles uint64
+}
+
+// SandboxSpec is the concrete launch profile, built host-side from the Session
+// and the lifecycle policy. Nothing here originates from kernel input.
+type SandboxSpec struct {
+	// Command is the argv to execute, e.g. ["python3", ".pykernel/bootstrap.py"].
+	Command []string
+	// Workdir is the child's working directory (a 0700 directory on the
+	// persistent volume).
+	Workdir string
+	// Env is the EXACT environment handed to the child — an allowlist with no
+	// DB DSNs or secrets. The launcher never appends the host environment; a
+	// nil Env yields an empty child environment (not the host's).
+	Env []string
+	// Limits are the resource caps applied to the child.
+	Limits ResourceLimits
+	// Nice is an optional scheduling niceness for the child (0 = default).
+	Nice int
+	// Stdout and Stderr, if set, receive the child's standard streams; nil
+	// discards them. (The control protocol uses a separate channel, so stdout
+	// stays a clean user-output stream.)
+	Stdout, Stderr io.Writer
+}
+
+// Process is a handle to a launched sandbox subprocess.
+type Process interface {
+	// PID is the subprocess id.
+	PID() int
+	// Wait blocks until the process exits and returns its exit error.
+	Wait() error
+	// Signal sends sig to the process group.
+	Signal(sig os.Signal) error
+	// Kill SIGKILLs the whole process group; it is idempotent.
+	Kill() error
+}
+
+// Launcher starts sandboxed subprocesses.
+type Launcher interface {
+	Launch(ctx context.Context, spec SandboxSpec) (Process, error)
+}
+
+// NewLauncher returns the platform Launcher.
+func NewLauncher() Launcher { return newLauncher() }
+
+// AllowedEnv returns the os.Environ entries whose key is in keys, for building
+// an explicit allowlist (e.g. PATH, LANG). It never returns a variable that is
+// not named in keys, so secrets stay out unless explicitly allow-listed.
+func AllowedEnv(keys ...string) []string {
+	allow := make(map[string]struct{}, len(keys))
+	for _, k := range keys {
+		allow[k] = struct{}{}
+	}
+	var out []string
+	for _, kv := range os.Environ() {
+		if eq := strings.IndexByte(kv, '='); eq >= 0 {
+			if _, ok := allow[kv[:eq]]; ok {
+				out = append(out, kv)
+			}
+		}
+	}
+	return out
+}

--- a/pkg/pykernel/isolation/sandbox.go
+++ b/pkg/pykernel/isolation/sandbox.go
@@ -62,6 +62,10 @@ type SandboxSpec struct {
 	// discards them. (The control protocol uses a separate channel, so stdout
 	// stays a clean user-output stream.)
 	Stdout, Stderr io.Writer
+	// ExtraFiles are additional open files passed to the child, inherited
+	// starting at fd 3 (matching os/exec.Cmd.ExtraFiles). The kernel control
+	// socket is passed this way so it needs no filesystem path.
+	ExtraFiles []*os.File
 }
 
 // Process is a handle to a launched sandbox subprocess.

--- a/pkg/pykernel/kernel.go
+++ b/pkg/pykernel/kernel.go
@@ -1,0 +1,95 @@
+package pykernel
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Session is the host-bound execution context for a kernel lease. Every
+// security-relevant field is set host-side from the authenticated session/run
+// and is immutable for the life of the lease; the kernel never supplies any of
+// them (see the package doc's host-binds-context invariant).
+type Session interface {
+	// Key is the pool identity — an Ali chat-session id (warm reuse) or a
+	// migration run id (ephemeral). Warm-pool keys must be tenant-scoped so a
+	// kernel is never reused across tenants.
+	Key() string
+	// TenantID scopes every capability call; bound from the session.
+	TenantID() uuid.UUID
+	// Capabilities is the frozen set of host functions exposed into Python.
+	Capabilities() CapabilitySet
+	// Mode is plan vs apply; write capabilities are refused in plan mode.
+	Mode() Mode
+	// Workdir is the per-session/per-run scratch directory on a persistent
+	// volume. It survives a kernel respawn even though the namespace does not.
+	Workdir() string
+}
+
+// Manager owns the lifecycle of Python kernel subprocesses and is the single
+// entry point both consumers share. Implementations are safe for concurrent
+// use. The Manager binds no tenant/permission context itself — that travels on
+// the Session passed to Acquire.
+type Manager interface {
+	// Acquire returns a Kernel bound to sess. Whether it reuses an idle kernel
+	// keyed by sess.Key() or spawns a fresh one is decided by the lifecycle
+	// policy. The capability set and Mode in sess are frozen onto the kernel and
+	// cannot be escalated for the life of the lease. The returned Kernel is
+	// leased: the caller releases it (warm policy) or disposes it (ephemeral).
+	Acquire(ctx context.Context, sess Session) (Kernel, error)
+	// Get returns the already-acquired kernel for key, or (nil, false). A host
+	// reconciler uses it to find an in-flight kernel after a crash or redeploy.
+	Get(key string) (Kernel, bool)
+	// Release returns a kernel to the pool (warm policy) or disposes it
+	// (ephemeral policy).
+	Release(k Kernel) error
+	// Evict forcibly terminates and removes the kernel for key (idle timeout,
+	// LRU cap, tenant teardown). It is safe to call on an unknown key.
+	Evict(key string) error
+	// Shutdown drains the pool: it refuses new Acquire calls, lets in-flight
+	// execs run up to a grace period, then kills survivors. Wire it to SIGTERM.
+	Shutdown(ctx context.Context) error
+}
+
+// Kernel is a handle to one warm Python subprocess. At most one Exec runs at a
+// time per Kernel; a concurrent Exec returns ErrKernelBusy.
+type Kernel interface {
+	// Exec runs code in the kernel's persistent namespace and streams events
+	// (stdout chunks, partial results, metrics, logs, the final result, errors)
+	// until the channel closes with a terminal EventDone. The namespace survives
+	// across Exec calls; the workdir survives across kernel respawns.
+	Exec(ctx context.Context, req ExecRequest) (<-chan ExecEvent, error)
+	// Info reports liveness, last activity, and whether the namespace was reset
+	// since the consumer last saw it (the post-respawn "namespace cleared, files
+	// intact" signal surfaced to the model).
+	Info() KernelInfo
+	// Dispose terminates the subprocess and frees its slot. It is idempotent.
+	Dispose(ctx context.Context) error
+}
+
+// KernelInfo is a liveness snapshot of a kernel.
+type KernelInfo struct {
+	// Key is the kernel's pool identity (the Session key it was acquired with).
+	Key string
+	// PID is the subprocess id, or 0 if not yet spawned / already disposed.
+	PID int
+	// LastActiveAt is when the kernel last started or finished an exec.
+	LastActiveAt time.Time
+	// NamespaceReset is true after a respawn until the consumer acknowledges it.
+	NamespaceReset bool
+	// InFlight is true while an Exec is running.
+	InFlight bool
+}
+
+// Sentinel errors callers branch on.
+var (
+	// ErrKernelBusy is returned by Exec when an exec is already in flight.
+	ErrKernelBusy = errors.New("pykernel: kernel has an in-flight exec")
+	// ErrPoolExhausted is returned by Acquire when the parallel-kernel cap is
+	// reached and no kernel can be evicted to make room.
+	ErrPoolExhausted = errors.New("pykernel: parallel-kernel cap reached")
+	// ErrKernelDisposed is returned when operating on a disposed kernel.
+	ErrKernelDisposed = errors.New("pykernel: kernel disposed")
+)

--- a/pkg/pykernel/lifecycle/ephemeral.go
+++ b/pkg/pykernel/lifecycle/ephemeral.go
@@ -1,0 +1,21 @@
+package lifecycle
+
+import "github.com/iota-uz/iota-sdk/pkg/pykernel"
+
+// Ephemeral is the per-run policy for the data-migration engine: every Acquire
+// spawns a fresh kernel and every Release disposes it. Durable state lives
+// host-side, so a kernel is safe to throw away after its run. The background
+// sweeper never evicts (the run owns disposal).
+func Ephemeral() LifecyclePolicy { return ephemeral{} }
+
+type ephemeral struct{}
+
+func (ephemeral) OnAcquire(string, PoolView) (Decision, error) { return SpawnNew, nil }
+
+func (ephemeral) OnRelease(pykernel.KernelInfo) ReleaseAction { return Dispose }
+
+func (ephemeral) ShouldEvict(pykernel.KernelInfo, PoolView) bool { return false }
+
+func (ephemeral) MaxParallel() int { return 0 } // 0 = unbounded
+
+func (ephemeral) ResetMode() ResetMode { return FreshNamespace }

--- a/pkg/pykernel/lifecycle/policy.go
+++ b/pkg/pykernel/lifecycle/policy.go
@@ -2,8 +2,8 @@
 // kernels. It is the single seam that lets one kernel primitive serve two very
 // different consumers without forking the manager:
 //
-//   - WarmPool — per-session reuse with idle eviction and an LRU cap, for the
-//     interactive Ali REPL;
+//   - WarmPool — per-session reuse with idle-TTL eviction and a MaxParallel
+//     cap, for the interactive Ali REPL;
 //   - Ephemeral — every Acquire spawns and every Release disposes, for the
 //     batch data-migration engine, whose durable state lives host-side so a
 //     kernel is safe to throw away.
@@ -64,11 +64,15 @@ type LifecyclePolicy interface {
 	// OnRelease decides whether to park or dispose a kernel after its exec
 	// completes.
 	OnRelease(info pykernel.KernelInfo) ReleaseAction
-	// ShouldEvict is consulted by the background sweeper (idle TTL, LRU cap).
+	// ShouldEvict is consulted by the background sweeper (idle TTL).
 	ShouldEvict(info pykernel.KernelInfo, pool PoolView) bool
-	// MaxParallel caps the number of concurrently live kernels; the Manager
-	// evicts (LRU) or rejects Acquire beyond it.
+	// MaxParallel caps the number of concurrently live kernels; on Acquire beyond
+	// it the Manager evicts an idle kernel (or rejects with ErrPoolExhausted).
 	MaxParallel() int
 	// ResetMode reports whether reused kernels keep or clear their namespace.
+	//
+	// Currently advisory: namespace reset on reuse is NOT yet enforced (a reused
+	// kernel always keeps its namespace via process reuse) and
+	// pykernel.KernelInfo.NamespaceReset is reserved for when it is.
 	ResetMode() ResetMode
 }

--- a/pkg/pykernel/lifecycle/policy.go
+++ b/pkg/pykernel/lifecycle/policy.go
@@ -1,0 +1,74 @@
+// Package lifecycle defines how a pykernel.Manager pools, reuses, and evicts
+// kernels. It is the single seam that lets one kernel primitive serve two very
+// different consumers without forking the manager:
+//
+//   - WarmPool — per-session reuse with idle eviction and an LRU cap, for the
+//     interactive Ali REPL;
+//   - Ephemeral — every Acquire spawns and every Release disposes, for the
+//     batch data-migration engine, whose durable state lives host-side so a
+//     kernel is safe to throw away.
+//
+// The Manager is policy-agnostic: it consults a LifecyclePolicy for every
+// pooling decision and acts on the result. Concrete policies are provided
+// alongside the Manager implementation.
+package lifecycle
+
+import "github.com/iota-uz/iota-sdk/pkg/pykernel"
+
+// Decision is how OnAcquire wants the Manager to satisfy an Acquire.
+type Decision int
+
+const (
+	// SpawnNew starts a fresh kernel subprocess.
+	SpawnNew Decision = iota
+	// ReuseIdle hands back an existing idle kernel matching the key.
+	ReuseIdle
+)
+
+// ReleaseAction is how OnRelease wants the Manager to treat a released kernel.
+type ReleaseAction int
+
+const (
+	// Dispose terminates the kernel and frees its slot.
+	Dispose ReleaseAction = iota
+	// Park returns the kernel to the idle pool for later reuse.
+	Park
+)
+
+// ResetMode is whether a reused kernel keeps or clears its Python namespace.
+type ResetMode int
+
+const (
+	// FreshNamespace always executes against a clean namespace.
+	FreshNamespace ResetMode = iota
+	// KeepNamespace preserves names/state across execs (interactive REPL).
+	KeepNamespace
+)
+
+// PoolView is a read-only snapshot of the live kernel pool that a policy
+// inspects to make eviction and reuse decisions.
+type PoolView interface {
+	// Len returns the number of live kernels.
+	Len() int
+	// Infos returns liveness snapshots for all live kernels.
+	Infos() []pykernel.KernelInfo
+}
+
+// LifecyclePolicy decides how kernels are pooled, reused, evicted, and reset.
+// Swapping the policy is the only difference between Ali's warm REPL and the
+// migration engine's ephemeral runs. Implementations must be safe for
+// concurrent use.
+type LifecyclePolicy interface {
+	// OnAcquire decides whether to reuse an idle kernel for key or spawn fresh.
+	OnAcquire(key string, pool PoolView) (Decision, error)
+	// OnRelease decides whether to park or dispose a kernel after its exec
+	// completes.
+	OnRelease(info pykernel.KernelInfo) ReleaseAction
+	// ShouldEvict is consulted by the background sweeper (idle TTL, LRU cap).
+	ShouldEvict(info pykernel.KernelInfo, pool PoolView) bool
+	// MaxParallel caps the number of concurrently live kernels; the Manager
+	// evicts (LRU) or rejects Acquire beyond it.
+	MaxParallel() int
+	// ResetMode reports whether reused kernels keep or clear their namespace.
+	ResetMode() ResetMode
+}

--- a/pkg/pykernel/lifecycle/warmpool.go
+++ b/pkg/pykernel/lifecycle/warmpool.go
@@ -1,0 +1,34 @@
+package lifecycle
+
+import (
+	"time"
+
+	"github.com/iota-uz/iota-sdk/pkg/pykernel"
+)
+
+// WarmPool is the per-session policy for the interactive Ali REPL: a kernel is
+// reused across execs (its namespace persists), parked on release, evicted
+// after idleTTL, and the pool is capped at maxParallel live kernels.
+func WarmPool(idleTTL time.Duration, maxParallel int) LifecyclePolicy {
+	return warmPool{idleTTL: idleTTL, maxParallel: maxParallel}
+}
+
+type warmPool struct {
+	idleTTL     time.Duration
+	maxParallel int
+}
+
+func (warmPool) OnAcquire(string, PoolView) (Decision, error) { return ReuseIdle, nil }
+
+func (warmPool) OnRelease(pykernel.KernelInfo) ReleaseAction { return Park }
+
+func (w warmPool) ShouldEvict(info pykernel.KernelInfo, _ PoolView) bool {
+	if info.InFlight {
+		return false
+	}
+	return w.idleTTL > 0 && time.Since(info.LastActiveAt) > w.idleTTL
+}
+
+func (w warmPool) MaxParallel() int { return w.maxParallel }
+
+func (warmPool) ResetMode() ResetMode { return KeepNamespace }

--- a/pkg/pykernel/manager/dispatch.go
+++ b/pkg/pykernel/manager/dispatch.go
@@ -1,0 +1,142 @@
+package manager
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"github.com/iota-uz/iota-sdk/pkg/pykernel"
+	"github.com/iota-uz/iota-sdk/pkg/pykernel/bridge"
+)
+
+// capSpec mirrors one entry the Python shim reads from PYKERNEL_CAPABILITIES to
+// synthesize a callable proxy.
+type capSpec struct {
+	Name    string     `json:"name"`
+	Params  []capParam `json:"params"`
+	Returns string     `json:"returns"`
+	Doc     string     `json:"doc"`
+}
+
+type capParam struct {
+	Name string `json:"name"`
+}
+
+func capSpecsJSON(set pykernel.CapabilitySet) ([]byte, error) {
+	specs := make([]capSpec, 0)
+	for _, c := range set.List() {
+		sig := c.Signature()
+		params := make([]capParam, 0, len(sig.Params))
+		for _, p := range sig.Params {
+			params = append(params, capParam{Name: p.Name})
+		}
+		specs = append(specs, capSpec{Name: c.Name(), Params: params, Returns: sig.Returns, Doc: sig.Doc})
+	}
+	return json.Marshal(specs)
+}
+
+// dispatcher binds a kernel's capability set, run Mode and tenant, and routes
+// every kernel cap.call through the central plan/apply authorization. The
+// kernel supplies only the capability name and arguments; tenant and Mode are
+// bound here from the Session.
+type dispatcher struct {
+	caps   pykernel.CapabilitySet
+	mode   pykernel.Mode
+	tenant uuid.UUID
+}
+
+func (d *dispatcher) Dispatch(ctx context.Context, call bridge.Call) bridge.Reply {
+	ctx = composables.WithTenantID(ctx, d.tenant)
+
+	var args pykernel.CallArgs
+	if len(call.Args) > 0 {
+		if err := json.Unmarshal(call.Args, &args); err != nil {
+			return bridge.Reply{Err: &bridge.CallError{Type: "ValueError", Message: "invalid arguments: " + err.Error()}}
+		}
+	}
+
+	out, err := pykernel.Dispatch(ctx, d.caps, d.mode, call.Name, args)
+	if err != nil {
+		return bridge.Reply{Err: capError(err)}
+	}
+
+	raw, err := json.Marshal(out)
+	if err != nil {
+		return bridge.Reply{Err: &bridge.CallError{Type: "TypeError", Message: "result is not JSON-serializable: " + err.Error()}}
+	}
+	return bridge.Reply{Result: raw}
+}
+
+// capError maps a dispatch error to the Python exception type the shim raises.
+func capError(err error) *bridge.CallError {
+	switch {
+	case errors.Is(err, pykernel.ErrPlanModeWrite):
+		return &bridge.CallError{Type: "PlanModeViolation", Message: err.Error()}
+	case errors.Is(err, pykernel.ErrCapabilityNotFound):
+		return &bridge.CallError{Type: "CapabilityNotFound", Message: err.Error()}
+	default:
+		return &bridge.CallError{Type: "CapabilityError", Message: err.Error()}
+	}
+}
+
+// translate converts a bridge output notification into a pykernel.ExecEvent and
+// reports whether it terminates the stream.
+func translate(ev bridge.RawEvent) (pykernel.ExecEvent, bool) {
+	out := pykernel.ExecEvent{Timestamp: time.Now()}
+	switch ev.Kind {
+	case bridge.KindStdout:
+		var p struct {
+			Chunk string `json:"chunk"`
+		}
+		_ = json.Unmarshal(ev.Params, &p)
+		out.Kind = pykernel.EventStdout
+		out.Stdout = []byte(p.Chunk)
+	case bridge.KindMetric:
+		var p struct {
+			Name  string            `json:"name"`
+			Value float64           `json:"value"`
+			Tags  map[string]string `json:"tags"`
+		}
+		_ = json.Unmarshal(ev.Params, &p)
+		out.Kind = pykernel.EventMetric
+		out.Metric = &pykernel.MetricPayload{Name: p.Name, Value: p.Value, Tags: p.Tags}
+	case bridge.KindLog:
+		var p struct {
+			Level   string         `json:"level"`
+			Message string         `json:"message"`
+			Fields  map[string]any `json:"fields"`
+		}
+		_ = json.Unmarshal(ev.Params, &p)
+		out.Kind = pykernel.EventLog
+		out.Log = &pykernel.LogPayload{Level: p.Level, Message: p.Message, Fields: p.Fields}
+	case bridge.KindResult:
+		var p struct {
+			Text      string `json:"text"`
+			MIME      string `json:"mime"`
+			Data      []byte `json:"data"`
+			Truncated bool   `json:"truncated"`
+		}
+		_ = json.Unmarshal(ev.Params, &p)
+		out.Kind = pykernel.EventResult
+		out.Result = &pykernel.ResultPayload{Text: p.Text, MIME: p.MIME, Data: p.Data, Truncated: p.Truncated}
+	case bridge.KindError:
+		var p struct {
+			Type      string `json:"type"`
+			Message   string `json:"message"`
+			Traceback string `json:"traceback"`
+		}
+		_ = json.Unmarshal(ev.Params, &p)
+		out.Kind = pykernel.EventError
+		out.Err = &pykernel.ExecError{Type: p.Type, Message: p.Message, Traceback: p.Traceback}
+	case bridge.KindDone:
+		out.Kind = pykernel.EventDone
+		return out, true
+	default:
+		out.Kind = pykernel.EventLog
+		out.Log = &pykernel.LogPayload{Level: "debug", Message: "unknown kernel event: " + ev.Kind}
+	}
+	return out, false
+}

--- a/pkg/pykernel/manager/kernel.go
+++ b/pkg/pykernel/manager/kernel.go
@@ -207,11 +207,13 @@ func (k *kernel) watch(ctx context.Context, execID string, timeout time.Duration
 }
 
 // onServeExit runs after the bridge read loop returns (kernel died or was
-// disposed). If an exec was still in flight, the consumer is unblocked with a
-// synthetic error + closed channel.
+// disposed). The kernel is marked disposed so the pool never hands back this
+// corpse on a later Acquire. If an exec was still in flight, the consumer is
+// unblocked with a synthetic error + closed channel.
 func (k *kernel) onServeExit() {
 	k.mu.Lock()
 	defer k.mu.Unlock()
+	k.disposed = true
 	if k.activeCh != nil {
 		k.finishLocked(&pykernel.ExecEvent{
 			Kind:      pykernel.EventError,

--- a/pkg/pykernel/manager/kernel.go
+++ b/pkg/pykernel/manager/kernel.go
@@ -1,0 +1,253 @@
+package manager
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/pkg/pykernel"
+	"github.com/iota-uz/iota-sdk/pkg/pykernel/bridge"
+	"github.com/iota-uz/iota-sdk/pkg/pykernel/isolation"
+)
+
+// kernel is a live Python subprocess plus its bridge. It implements
+// pykernel.Kernel and serves as the bridge.EventSink that fans kernel output
+// into the active Exec's event channel.
+type kernel struct {
+	key       string
+	proc      isolation.Process
+	br        bridge.Bridge
+	disp      *dispatcher
+	outputCap int
+	grace     time.Duration
+
+	serveCancel context.CancelFunc
+	closed      chan struct{}
+	closeOnce   sync.Once
+
+	mu           sync.Mutex
+	disposed     bool
+	inFlight     bool
+	nsReset      bool
+	lastActive   time.Time
+	pid          int
+	activeExecID string
+	activeCh     chan pykernel.ExecEvent
+	activeDone   chan struct{}
+}
+
+var (
+	_ pykernel.Kernel  = (*kernel)(nil)
+	_ bridge.EventSink = (*kernel)(nil)
+)
+
+func newKernel(sess pykernel.Session, proc isolation.Process, br bridge.Bridge, outputCap int, grace time.Duration) *kernel {
+	return &kernel{
+		key:        sess.Key(),
+		proc:       proc,
+		br:         br,
+		disp:       &dispatcher{caps: sess.Capabilities(), mode: sess.Mode(), tenant: sess.TenantID()},
+		outputCap:  outputCap,
+		grace:      grace,
+		closed:     make(chan struct{}),
+		lastActive: time.Now(),
+		pid:        proc.PID(),
+	}
+}
+
+// start runs the bridge read loop for the kernel's lifetime.
+func (k *kernel) start() {
+	ctx, cancel := context.WithCancel(context.Background())
+	k.serveCancel = cancel
+	go func() {
+		_ = k.br.Serve(ctx, k.disp, k)
+		k.onServeExit()
+	}()
+}
+
+func (k *kernel) Info() pykernel.KernelInfo {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	return pykernel.KernelInfo{
+		Key:            k.key,
+		PID:            k.pid,
+		LastActiveAt:   k.lastActive,
+		NamespaceReset: k.nsReset,
+		InFlight:       k.inFlight,
+	}
+}
+
+func (k *kernel) isDisposed() bool {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	return k.disposed
+}
+
+func (k *kernel) Exec(ctx context.Context, req pykernel.ExecRequest) (<-chan pykernel.ExecEvent, error) {
+	k.mu.Lock()
+	if k.disposed {
+		k.mu.Unlock()
+		return nil, pykernel.ErrKernelDisposed
+	}
+	if k.inFlight {
+		k.mu.Unlock()
+		return nil, pykernel.ErrKernelBusy
+	}
+	execID := uuid.NewString()
+	ch := make(chan pykernel.ExecEvent, 256)
+	done := make(chan struct{})
+	k.activeExecID = execID
+	k.activeCh = ch
+	k.activeDone = done
+	k.inFlight = true
+	k.lastActive = time.Now()
+	k.mu.Unlock()
+
+	outCap := req.OutputCap
+	if outCap == 0 {
+		outCap = k.outputCap
+	}
+	limits := bridge.Limits{OutputCap: outCap}
+	if req.Timeout > 0 {
+		limits.WallClockMS = req.Timeout.Milliseconds()
+	}
+
+	if err := k.br.Submit(ctx, execID, req.Code, limits); err != nil {
+		k.mu.Lock()
+		k.finishLocked(nil)
+		k.mu.Unlock()
+		return nil, err
+	}
+
+	go k.watch(ctx, execID, req.Timeout, done)
+	return ch, nil
+}
+
+// Emit receives a kernel output notification (runs in the bridge read loop) and
+// fans it into the active exec's channel, closing the channel on EventDone.
+func (k *kernel) Emit(execID string, ev bridge.RawEvent) {
+	out, terminal := translate(ev)
+
+	k.mu.Lock()
+	if k.activeCh == nil || execID != k.activeExecID {
+		k.mu.Unlock()
+		return
+	}
+	ch := k.activeCh
+	k.mu.Unlock()
+
+	// Buffered send with a closing escape hatch so an abandoned consumer can't
+	// wedge the read loop.
+	select {
+	case ch <- out:
+	case <-k.closed:
+		return
+	}
+
+	if terminal {
+		k.mu.Lock()
+		if k.activeExecID == execID {
+			k.finishLocked(nil)
+		}
+		k.mu.Unlock()
+	}
+}
+
+// finishLocked closes the active exec channel (optionally emitting a final
+// synthetic event first) and clears in-flight state. Caller holds k.mu. The
+// channel is only ever closed here, and only from the bridge goroutine paths
+// (Emit / onServeExit) or the Submit-failure path, so it is closed at most once.
+func (k *kernel) finishLocked(synthetic *pykernel.ExecEvent) {
+	if k.activeCh == nil {
+		return
+	}
+	if synthetic != nil {
+		select {
+		case k.activeCh <- *synthetic:
+		default:
+		}
+	}
+	close(k.activeCh)
+	k.activeCh = nil
+	k.activeExecID = ""
+	k.inFlight = false
+	k.lastActive = time.Now()
+	if k.activeDone != nil {
+		close(k.activeDone)
+		k.activeDone = nil
+	}
+}
+
+// watch enforces ctx cancellation and the wall-clock timeout: cooperative
+// cancel first, then SIGKILL after the dispose grace if the exec hasn't ended.
+func (k *kernel) watch(ctx context.Context, execID string, timeout time.Duration, done <-chan struct{}) {
+	var timer <-chan time.Time
+	if timeout > 0 {
+		t := time.NewTimer(timeout)
+		defer t.Stop()
+		timer = t.C
+	}
+	select {
+	case <-done:
+		return
+	case <-k.closed:
+		return
+	case <-ctx.Done():
+	case <-timer:
+	}
+	// ctx cancelled or timed out: cooperative cancel, then escalate to kill.
+	_ = k.br.Cancel(context.Background(), execID)
+	select {
+	case <-done:
+	case <-k.closed:
+	case <-time.After(k.grace):
+		_ = k.proc.Kill()
+	}
+}
+
+// onServeExit runs after the bridge read loop returns (kernel died or was
+// disposed). If an exec was still in flight, the consumer is unblocked with a
+// synthetic error + closed channel.
+func (k *kernel) onServeExit() {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if k.activeCh != nil {
+		k.finishLocked(&pykernel.ExecEvent{
+			Kind:      pykernel.EventError,
+			Err:       &pykernel.ExecError{Type: "KernelExited", Message: "kernel process exited before completing the exec"},
+			Timestamp: time.Now(),
+		})
+	}
+}
+
+func (k *kernel) Dispose(_ context.Context) error {
+	k.mu.Lock()
+	if k.disposed {
+		k.mu.Unlock()
+		return nil
+	}
+	k.disposed = true
+	k.mu.Unlock()
+
+	// Unblock any in-flight Emit send, stop the read loop, and close the bridge
+	// — closing the control socket makes the shim exit cleanly on EOF.
+	k.closeOnce.Do(func() { close(k.closed) })
+	if k.serveCancel != nil {
+		k.serveCancel()
+	}
+	_ = k.br.Close()
+
+	waitDone := make(chan struct{})
+	go func() {
+		_ = k.proc.Wait()
+		close(waitDone)
+	}()
+	select {
+	case <-waitDone:
+	case <-time.After(k.grace):
+		_ = k.proc.Kill()
+		<-waitDone
+	}
+	return nil
+}

--- a/pkg/pykernel/manager/kernel.go
+++ b/pkg/pykernel/manager/kernel.go
@@ -28,6 +28,7 @@ type kernel struct {
 
 	mu           sync.Mutex
 	disposed     bool
+	serveExited  bool
 	inFlight     bool
 	nsReset      bool
 	lastActive   time.Time
@@ -81,7 +82,7 @@ func (k *kernel) Info() pykernel.KernelInfo {
 func (k *kernel) isDisposed() bool {
 	k.mu.Lock()
 	defer k.mu.Unlock()
-	return k.disposed
+	return k.disposed || k.serveExited
 }
 
 func (k *kernel) Exec(ctx context.Context, req pykernel.ExecRequest) (<-chan pykernel.ExecEvent, error) {
@@ -197,7 +198,9 @@ func (k *kernel) watch(ctx context.Context, execID string, timeout time.Duration
 	case <-timer:
 	}
 	// ctx cancelled or timed out: cooperative cancel, then escalate to kill.
-	_ = k.br.Cancel(context.Background(), execID)
+	// Run the cancel in a goroutine so a stalled Cancel write can't block the
+	// grace/Kill escalation below.
+	go func() { _ = k.br.Cancel(context.Background(), execID) }()
 	select {
 	case <-done:
 	case <-k.closed:
@@ -207,13 +210,15 @@ func (k *kernel) watch(ctx context.Context, execID string, timeout time.Duration
 }
 
 // onServeExit runs after the bridge read loop returns (kernel died or was
-// disposed). The kernel is marked disposed so the pool never hands back this
-// corpse on a later Acquire. If an exec was still in flight, the consumer is
-// unblocked with a synthetic error + closed channel.
+// disposed). It marks the kernel serve-exited (not fully disposed) so the pool
+// treats it as unusable via isDisposed, while leaving full teardown to Dispose
+// — the process may still be alive and must still be reaped. If an exec was
+// still in flight, the consumer is unblocked with a synthetic error + closed
+// channel.
 func (k *kernel) onServeExit() {
 	k.mu.Lock()
 	defer k.mu.Unlock()
-	k.disposed = true
+	k.serveExited = true
 	if k.activeCh != nil {
 		k.finishLocked(&pykernel.ExecEvent{
 			Kind:      pykernel.EventError,

--- a/pkg/pykernel/manager/lifecycle_internal_test.go
+++ b/pkg/pykernel/manager/lifecycle_internal_test.go
@@ -116,7 +116,11 @@ func TestAcquire_DoesNotReturnDeadReuseEntry(t *testing.T) {
 	require.NoError(t, err)
 	gotK := got.(*kernel)
 	assert.NotSame(t, dead, gotK, "Acquire must not return the dead kernel")
-	assert.False(t, gotK.isDisposed(), "Acquire must return a live kernel")
+	// Note: we don't assert gotK is live. spawn() closes the child socket fd, so
+	// with the fake launcher (no real subprocess to inherit it) the freshly-spawned
+	// kernel's serve loop sees EOF and may race to disposed — an artifact of the
+	// fake, not the behavior under test. The invariant here is that Acquire never
+	// returns the dead corpse and replaces it in the map.
 
 	// And the dead entry must have been evicted from the map (replaced by the new
 	// one), not left lingering.

--- a/pkg/pykernel/manager/lifecycle_internal_test.go
+++ b/pkg/pykernel/manager/lifecycle_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"os"
+	"syscall"
 	"testing"
 	"time"
 
@@ -20,7 +21,14 @@ import (
 // lifecycle without spawning real Python: they use a fake launcher/process and a
 // real bridge over net.Pipe, so serve-exit can be simulated by closing the pipe.
 
-type fakeProcess struct{ killed chan struct{} }
+type fakeProcess struct {
+	killed chan struct{}
+	// childFile, if set, is this fake process's retained copy of the inherited
+	// child socket fd. Holding it open keeps the socketpair peer alive so the
+	// spawned kernel's Serve blocks on read (modeling a real inherited child);
+	// it is closed when the process is killed/waited.
+	childFile *os.File
+}
 
 func newFakeProcess() *fakeProcess { return &fakeProcess{killed: make(chan struct{})} }
 
@@ -32,18 +40,38 @@ func (p *fakeProcess) Kill() error {
 	default:
 		close(p.killed)
 	}
+	if p.childFile != nil {
+		_ = p.childFile.Close()
+	}
 	return nil
 }
-func (p *fakeProcess) Wait() error { return nil }
+func (p *fakeProcess) Wait() error {
+	if p.childFile != nil {
+		_ = p.childFile.Close()
+	}
+	return nil
+}
 
 // fakeLauncher returns a fake process so Acquire can spawn a "live" kernel
-// without a real Python subprocess. The kernel's bridge reads from a socketpair
-// nothing writes to, so the serve loop blocks and the kernel stays live — which
-// is all this test needs from a freshly-spawned kernel.
+// without a real Python subprocess. It OWNS the inherited child socket fd
+// (spec.ExtraFiles[0]) so that spawn()'s post-Launch close of the parent's copy
+// doesn't tear down the socketpair peer: the retained fd keeps the peer open, so
+// the spawned kernel's Serve blocks on read and stays live, modeling a real
+// inherited child. The fd is released when the process is killed/waited.
 type fakeLauncher struct{}
 
-func (l *fakeLauncher) Launch(_ context.Context, _ isolation.SandboxSpec) (isolation.Process, error) {
-	return newFakeProcess(), nil
+func (l *fakeLauncher) Launch(_ context.Context, spec isolation.SandboxSpec) (isolation.Process, error) {
+	p := newFakeProcess()
+	if len(spec.ExtraFiles) > 0 && spec.ExtraFiles[0] != nil {
+		// Dup the fd so we own a copy independent of the parent's, which spawn()
+		// closes right after Launch.
+		fd, err := syscall.Dup(int(spec.ExtraFiles[0].Fd()))
+		if err != nil {
+			return nil, err
+		}
+		p.childFile = os.NewFile(uintptr(fd), "fake-child-socket")
+	}
+	return p, nil
 }
 
 func testSess(key, wd string) pykernel.Session {
@@ -116,11 +144,7 @@ func TestAcquire_DoesNotReturnDeadReuseEntry(t *testing.T) {
 	require.NoError(t, err)
 	gotK := got.(*kernel)
 	assert.NotSame(t, dead, gotK, "Acquire must not return the dead kernel")
-	// Note: we don't assert gotK is live. spawn() closes the child socket fd, so
-	// with the fake launcher (no real subprocess to inherit it) the freshly-spawned
-	// kernel's serve loop sees EOF and may race to disposed — an artifact of the
-	// fake, not the behavior under test. The invariant here is that Acquire never
-	// returns the dead corpse and replaces it in the map.
+	assert.False(t, gotK.isDisposed(), "Acquire must return a live kernel")
 
 	// And the dead entry must have been evicted from the map (replaced by the new
 	// one), not left lingering.

--- a/pkg/pykernel/manager/lifecycle_internal_test.go
+++ b/pkg/pykernel/manager/lifecycle_internal_test.go
@@ -1,0 +1,127 @@
+package manager
+
+import (
+	"context"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/pkg/pykernel"
+	"github.com/iota-uz/iota-sdk/pkg/pykernel/bridge"
+	"github.com/iota-uz/iota-sdk/pkg/pykernel/isolation"
+	"github.com/iota-uz/iota-sdk/pkg/pykernel/lifecycle"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These are white-box tests (package manager) that exercise the disposed-kernel
+// lifecycle without spawning real Python: they use a fake launcher/process and a
+// real bridge over net.Pipe, so serve-exit can be simulated by closing the pipe.
+
+type fakeProcess struct{ killed chan struct{} }
+
+func newFakeProcess() *fakeProcess { return &fakeProcess{killed: make(chan struct{})} }
+
+func (*fakeProcess) PID() int                 { return 4242 }
+func (*fakeProcess) Signal(_ os.Signal) error { return nil }
+func (p *fakeProcess) Kill() error {
+	select {
+	case <-p.killed:
+	default:
+		close(p.killed)
+	}
+	return nil
+}
+func (p *fakeProcess) Wait() error { return nil }
+
+// fakeLauncher returns a fake process so Acquire can spawn a "live" kernel
+// without a real Python subprocess. The kernel's bridge reads from a socketpair
+// nothing writes to, so the serve loop blocks and the kernel stays live — which
+// is all this test needs from a freshly-spawned kernel.
+type fakeLauncher struct{}
+
+func (l *fakeLauncher) Launch(_ context.Context, _ isolation.SandboxSpec) (isolation.Process, error) {
+	return newFakeProcess(), nil
+}
+
+func testSess(key, wd string) pykernel.Session {
+	caps, _ := pykernel.NewCapabilitySet()
+	return &fakeSession{key: key, tenant: uuid.New(), caps: caps, mode: pykernel.ModeApply, wd: wd}
+}
+
+type fakeSession struct {
+	key    string
+	tenant uuid.UUID
+	caps   pykernel.CapabilitySet
+	mode   pykernel.Mode
+	wd     string
+}
+
+func (s *fakeSession) Key() string                          { return s.key }
+func (s *fakeSession) TenantID() uuid.UUID                  { return s.tenant }
+func (s *fakeSession) Capabilities() pykernel.CapabilitySet { return s.caps }
+func (s *fakeSession) Mode() pykernel.Mode                  { return s.mode }
+func (s *fakeSession) Workdir() string                      { return s.wd }
+
+// newPipeKernel builds a kernel whose bridge runs over a net.Pipe, starts its
+// serve loop, and returns the kernel plus the kernel-side conn (close it to kill
+// the serve loop and trigger onServeExit).
+func newPipeKernel(t *testing.T, key string) (*kernel, net.Conn) {
+	t.Helper()
+	hostConn, kernConn := net.Pipe()
+	k := newKernel(testSess(key, t.TempDir()), newFakeProcess(), bridge.New(hostConn), defaultOutputCap, 100*time.Millisecond)
+	k.start()
+	return k, kernConn
+}
+
+func TestOnServeExit_MarksKernelDisposed(t *testing.T) {
+	t.Parallel()
+
+	k, kernConn := newPipeKernel(t, "k1")
+	require.False(t, k.isDisposed(), "kernel should start live")
+
+	// Killing the kernel side makes readFrame return EOF, ending Serve and
+	// running onServeExit.
+	require.NoError(t, kernConn.Close())
+
+	require.Eventually(t, k.isDisposed, time.Second, 5*time.Millisecond,
+		"a kernel whose serve loop exited must be marked disposed")
+}
+
+func TestAcquire_DoesNotReturnDeadReuseEntry(t *testing.T) {
+	t.Parallel()
+
+	m, err := New(Config{
+		Policy:       lifecycle.WarmPool(time.Hour, 8), // reuse-idle policy
+		Launcher:     &fakeLauncher{},
+		DisposeGrace: 100 * time.Millisecond,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = m.Shutdown(context.Background()) })
+
+	// Seed a dead kernel under the reuse key, mimicking a crashed-then-evicted-on-
+	// reuse situation.
+	dead, kernConn := newPipeKernel(t, "dead-key")
+	require.NoError(t, kernConn.Close())
+	require.Eventually(t, dead.isDisposed, time.Second, 5*time.Millisecond)
+
+	m.mu.Lock()
+	m.kernels["dead-key"] = dead
+	m.mu.Unlock()
+
+	// Acquire for the same key must NOT hand back the corpse.
+	got, err := m.Acquire(context.Background(), testSess("dead-key", t.TempDir()))
+	require.NoError(t, err)
+	gotK := got.(*kernel)
+	assert.NotSame(t, dead, gotK, "Acquire must not return the dead kernel")
+	assert.False(t, gotK.isDisposed(), "Acquire must return a live kernel")
+
+	// And the dead entry must have been evicted from the map (replaced by the new
+	// one), not left lingering.
+	m.mu.Lock()
+	cur := m.kernels["dead-key"]
+	m.mu.Unlock()
+	assert.Same(t, gotK, cur, "the dead entry must be replaced by the fresh kernel")
+}

--- a/pkg/pykernel/manager/manager.go
+++ b/pkg/pykernel/manager/manager.go
@@ -1,0 +1,283 @@
+// Package manager implements pykernel.Manager over sandboxed Python
+// subprocesses: it spawns a kernel, wires the host↔kernel bridge, applies a
+// lifecycle policy (warm pool or ephemeral), and routes capability calls
+// through the central plan/apply authorization.
+package manager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/iota-uz/iota-sdk/pkg/pykernel"
+	"github.com/iota-uz/iota-sdk/pkg/pykernel/bridge"
+	"github.com/iota-uz/iota-sdk/pkg/pykernel/isolation"
+	"github.com/iota-uz/iota-sdk/pkg/pykernel/lifecycle"
+	"github.com/iota-uz/iota-sdk/pkg/pykernel/runtime"
+)
+
+const (
+	defaultPython       = "python3"
+	defaultOutputCap    = 50 * 1024
+	defaultDisposeGrace = 5 * time.Second
+)
+
+var (
+	errShuttingDown  = errors.New("pykernel/manager: manager is shutting down")
+	errForeignKernel = errors.New("pykernel/manager: kernel not owned by this manager")
+)
+
+// Config configures a Manager. Policy is required; the rest have defaults.
+type Config struct {
+	// PythonPath is the interpreter to launch (default "python3").
+	PythonPath string
+	// Launcher launches the sandbox (default isolation.NewLauncher()).
+	Launcher isolation.Launcher
+	// Policy decides pooling/eviction (lifecycle.WarmPool or lifecycle.Ephemeral).
+	Policy lifecycle.LifecyclePolicy
+	// Limits are the OS resource caps applied to every kernel.
+	Limits isolation.ResourceLimits
+	// DefaultOutputCap bounds captured stdout+result bytes per exec (default 50KB).
+	DefaultOutputCap int
+	// DisposeGrace is how long a kernel may take to exit on dispose before
+	// it is SIGKILLed (default 5s).
+	DisposeGrace time.Duration
+	// EnvAllowlist names host environment variables passed through to the
+	// kernel (e.g. PATH, LANG). Secrets must NOT be listed.
+	EnvAllowlist []string
+	// ExtraEnv adds fixed, non-secret KEY=VALUE entries to the kernel env.
+	ExtraEnv []string
+	// KernelStderr, if set, receives kernel-process stderr (debugging only).
+	KernelStderr io.Writer
+}
+
+// Manager owns the lifecycle of Python kernel subprocesses.
+type Manager struct {
+	cfg     Config
+	mu      sync.Mutex
+	kernels map[string]*kernel
+	closing bool
+}
+
+var _ pykernel.Manager = (*Manager)(nil)
+
+// New validates cfg, applies defaults, and returns a Manager.
+func New(cfg Config) (*Manager, error) {
+	if cfg.Policy == nil {
+		return nil, errors.New("pykernel/manager: Policy is required")
+	}
+	if cfg.PythonPath == "" {
+		cfg.PythonPath = defaultPython
+	}
+	if cfg.Launcher == nil {
+		cfg.Launcher = isolation.NewLauncher()
+	}
+	if cfg.DefaultOutputCap == 0 {
+		cfg.DefaultOutputCap = defaultOutputCap
+	}
+	if cfg.DisposeGrace == 0 {
+		cfg.DisposeGrace = defaultDisposeGrace
+	}
+	return &Manager{cfg: cfg, kernels: make(map[string]*kernel)}, nil
+}
+
+func (m *Manager) Acquire(ctx context.Context, sess pykernel.Session) (pykernel.Kernel, error) {
+	m.mu.Lock()
+	if m.closing {
+		m.mu.Unlock()
+		return nil, errShuttingDown
+	}
+	decision, err := m.cfg.Policy.OnAcquire(sess.Key(), poolView{m.snapshotLocked()})
+	if err != nil {
+		m.mu.Unlock()
+		return nil, err
+	}
+	if decision == lifecycle.ReuseIdle {
+		if k, ok := m.kernels[sess.Key()]; ok && !k.isDisposed() {
+			m.mu.Unlock()
+			return k, nil
+		}
+	}
+	if max := m.cfg.Policy.MaxParallel(); max > 0 && len(m.kernels) >= max {
+		if !m.evictIdleLocked() {
+			m.mu.Unlock()
+			return nil, pykernel.ErrPoolExhausted
+		}
+	}
+	m.mu.Unlock()
+
+	// Spawn outside the lock: Launch + Accept can take time.
+	k, err := m.spawn(ctx, sess)
+	if err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	if m.closing {
+		m.mu.Unlock()
+		_ = k.Dispose(context.Background())
+		return nil, errShuttingDown
+	}
+	if existing, ok := m.kernels[sess.Key()]; ok {
+		// Lost a same-key spawn race: keep the established kernel.
+		m.mu.Unlock()
+		_ = k.Dispose(context.Background())
+		return existing, nil
+	}
+	m.kernels[sess.Key()] = k
+	m.mu.Unlock()
+	return k, nil
+}
+
+func (m *Manager) Get(key string) (pykernel.Kernel, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	k, ok := m.kernels[key]
+	if !ok {
+		return nil, false
+	}
+	return k, true
+}
+
+func (m *Manager) Release(kk pykernel.Kernel) error {
+	k, ok := kk.(*kernel)
+	if !ok {
+		return errForeignKernel
+	}
+	if m.cfg.Policy.OnRelease(k.Info()) == lifecycle.Dispose {
+		m.mu.Lock()
+		if m.kernels[k.key] == k {
+			delete(m.kernels, k.key)
+		}
+		m.mu.Unlock()
+		return k.Dispose(context.Background())
+	}
+	return nil // Park: leave it parked in the pool for reuse.
+}
+
+func (m *Manager) Evict(key string) error {
+	m.mu.Lock()
+	k, ok := m.kernels[key]
+	if ok {
+		delete(m.kernels, key)
+	}
+	m.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	return k.Dispose(context.Background())
+}
+
+func (m *Manager) Shutdown(ctx context.Context) error {
+	m.mu.Lock()
+	m.closing = true
+	victims := make([]*kernel, 0, len(m.kernels))
+	for key, k := range m.kernels {
+		victims = append(victims, k)
+		delete(m.kernels, key)
+	}
+	m.mu.Unlock()
+	for _, k := range victims {
+		_ = k.Dispose(ctx)
+	}
+	return nil
+}
+
+// Sweep disposes kernels the policy considers evictable (idle TTL, etc.).
+// A periodic task can call it; it is a no-op for the ephemeral policy.
+func (m *Manager) Sweep() {
+	m.mu.Lock()
+	view := poolView{m.snapshotLocked()}
+	var victims []*kernel
+	for key, k := range m.kernels {
+		if m.cfg.Policy.ShouldEvict(k.Info(), view) {
+			victims = append(victims, k)
+			delete(m.kernels, key)
+		}
+	}
+	m.mu.Unlock()
+	for _, k := range victims {
+		_ = k.Dispose(context.Background())
+	}
+}
+
+func (m *Manager) snapshotLocked() []pykernel.KernelInfo {
+	out := make([]pykernel.KernelInfo, 0, len(m.kernels))
+	for _, k := range m.kernels {
+		out = append(out, k.Info())
+	}
+	return out
+}
+
+// evictIdleLocked disposes one evictable kernel to make room; caller holds mu.
+func (m *Manager) evictIdleLocked() bool {
+	view := poolView{m.snapshotLocked()}
+	for key, k := range m.kernels {
+		if m.cfg.Policy.ShouldEvict(k.Info(), view) {
+			delete(m.kernels, key)
+			go func(k *kernel) { _ = k.Dispose(context.Background()) }(k)
+			return true
+		}
+	}
+	return false
+}
+
+type poolView struct{ infos []pykernel.KernelInfo }
+
+func (p poolView) Len() int                     { return len(p.infos) }
+func (p poolView) Infos() []pykernel.KernelInfo { return p.infos }
+
+func (m *Manager) spawn(ctx context.Context, sess pykernel.Session) (*kernel, error) {
+	workdir := sess.Workdir()
+	if workdir == "" {
+		return nil, errors.New("pykernel/manager: session workdir is empty")
+	}
+	ctrlDir := filepath.Join(workdir, ".pykernel")
+	shimPath, err := runtime.Write(ctrlDir)
+	if err != nil {
+		return nil, err
+	}
+
+	capsJSON, err := capSpecsJSON(sess.Capabilities())
+	if err != nil {
+		return nil, err
+	}
+
+	// The control socket is an inherited fd (fd 3 in the child), not a path.
+	hostConn, childFile, err := socketPair()
+	if err != nil {
+		return nil, fmt.Errorf("pykernel/manager: socketpair: %w", err)
+	}
+
+	env := append([]string{}, isolation.AllowedEnv(m.cfg.EnvAllowlist...)...)
+	env = append(env,
+		"PYKERNEL_SOCKET_FD=3",
+		"PYKERNEL_CAPABILITIES="+string(capsJSON),
+		"HOME="+workdir,
+	)
+	env = append(env, m.cfg.ExtraEnv...)
+
+	proc, err := m.cfg.Launcher.Launch(ctx, isolation.SandboxSpec{
+		Command:    []string{m.cfg.PythonPath, shimPath},
+		Workdir:    workdir,
+		Env:        env,
+		Limits:     m.cfg.Limits,
+		Stderr:     m.cfg.KernelStderr,
+		ExtraFiles: []*os.File{childFile},
+	})
+	// The child has inherited the fd; the parent closes its copy regardless.
+	_ = childFile.Close()
+	if err != nil {
+		_ = hostConn.Close()
+		return nil, err
+	}
+
+	k := newKernel(sess, proc, bridge.New(hostConn), m.cfg.DefaultOutputCap, m.cfg.DisposeGrace)
+	k.start()
+	return k, nil
+}

--- a/pkg/pykernel/manager/manager.go
+++ b/pkg/pykernel/manager/manager.go
@@ -98,9 +98,14 @@ func (m *Manager) Acquire(ctx context.Context, sess pykernel.Session) (pykernel.
 		return nil, err
 	}
 	if decision == lifecycle.ReuseIdle {
-		if k, ok := m.kernels[sess.Key()]; ok && !k.isDisposed() {
-			m.mu.Unlock()
-			return k, nil
+		if k, ok := m.kernels[sess.Key()]; ok {
+			if !k.isDisposed() {
+				m.mu.Unlock()
+				return k, nil
+			}
+			// The entry is a dead kernel (its serve loop exited); evict it now so
+			// it doesn't linger until Sweep, then fall through to spawn a fresh one.
+			delete(m.kernels, sess.Key())
 		}
 	}
 	if maxParallel := m.cfg.Policy.MaxParallel(); maxParallel > 0 && len(m.kernels) >= maxParallel {
@@ -123,8 +128,9 @@ func (m *Manager) Acquire(ctx context.Context, sess pykernel.Session) (pykernel.
 		_ = k.Dispose(context.Background())
 		return nil, errShuttingDown
 	}
-	if existing, ok := m.kernels[sess.Key()]; ok {
-		// Lost a same-key spawn race: keep the established kernel.
+	if existing, ok := m.kernels[sess.Key()]; ok && !existing.isDisposed() {
+		// Lost a same-key spawn race against a live kernel: keep the established
+		// one and discard our freshly-spawned spare.
 		m.mu.Unlock()
 		_ = k.Dispose(context.Background())
 		return existing, nil

--- a/pkg/pykernel/manager/manager.go
+++ b/pkg/pykernel/manager/manager.go
@@ -105,7 +105,9 @@ func (m *Manager) Acquire(ctx context.Context, sess pykernel.Session) (pykernel.
 			}
 			// The entry is a dead kernel (its serve loop exited); evict it now so
 			// it doesn't linger until Sweep, then fall through to spawn a fresh one.
+			// Dispose it asynchronously so its process is reaped, not leaked.
 			delete(m.kernels, sess.Key())
+			go func(k *kernel) { _ = k.Dispose(context.Background()) }(k)
 		}
 	}
 	if maxParallel := m.cfg.Policy.MaxParallel(); maxParallel > 0 && len(m.kernels) >= maxParallel {
@@ -128,12 +130,17 @@ func (m *Manager) Acquire(ctx context.Context, sess pykernel.Session) (pykernel.
 		_ = k.Dispose(context.Background())
 		return nil, errShuttingDown
 	}
-	if existing, ok := m.kernels[sess.Key()]; ok && !existing.isDisposed() {
-		// Lost a same-key spawn race against a live kernel: keep the established
-		// one and discard our freshly-spawned spare.
-		m.mu.Unlock()
-		_ = k.Dispose(context.Background())
-		return existing, nil
+	if existing, ok := m.kernels[sess.Key()]; ok {
+		if !existing.isDisposed() {
+			// Lost a same-key spawn race against a live kernel: keep the established
+			// one and discard our freshly-spawned spare.
+			m.mu.Unlock()
+			_ = k.Dispose(context.Background())
+			return existing, nil
+		}
+		// The entry is a dead kernel: replace it with our fresh one and dispose
+		// the stale entry asynchronously so its process is reaped, not leaked.
+		go func(k *kernel) { _ = k.Dispose(context.Background()) }(existing)
 	}
 	m.kernels[sess.Key()] = k
 	m.mu.Unlock()
@@ -144,7 +151,7 @@ func (m *Manager) Get(key string) (pykernel.Kernel, bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	k, ok := m.kernels[key]
-	if !ok {
+	if !ok || k.isDisposed() {
 		return nil, false
 	}
 	return k, true

--- a/pkg/pykernel/manager/manager.go
+++ b/pkg/pykernel/manager/manager.go
@@ -103,7 +103,7 @@ func (m *Manager) Acquire(ctx context.Context, sess pykernel.Session) (pykernel.
 			return k, nil
 		}
 	}
-	if max := m.cfg.Policy.MaxParallel(); max > 0 && len(m.kernels) >= max {
+	if maxParallel := m.cfg.Policy.MaxParallel(); maxParallel > 0 && len(m.kernels) >= maxParallel {
 		if !m.evictIdleLocked() {
 			m.mu.Unlock()
 			return nil, pykernel.ErrPoolExhausted

--- a/pkg/pykernel/manager/manager_test.go
+++ b/pkg/pykernel/manager/manager_test.go
@@ -50,9 +50,12 @@ func newManager(t *testing.T) *manager.Manager {
 }
 
 // drain collects events until the channel closes or the deadline passes.
-func drain(t *testing.T, ch <-chan pykernel.ExecEvent, d time.Duration) (stdout string, result string, gotDone bool, errEv *pykernel.ExecError) {
+func drain(t *testing.T, ch <-chan pykernel.ExecEvent, d time.Duration) (string, string, bool, *pykernel.ExecError) {
 	t.Helper()
 	var sb strings.Builder
+	var result string
+	var gotDone bool
+	var errEv *pykernel.ExecError
 	deadline := time.After(d)
 	for {
 		select {
@@ -69,6 +72,8 @@ func drain(t *testing.T, ch <-chan pykernel.ExecEvent, d time.Duration) (stdout 
 				errEv = ev.Err
 			case pykernel.EventDone:
 				gotDone = true
+			case pykernel.EventMetric, pykernel.EventLog, pykernel.EventTruncated:
+				// Not asserted by these tests; ignore.
 			}
 		case <-deadline:
 			t.Fatal("timed out draining exec events")

--- a/pkg/pykernel/manager/manager_test.go
+++ b/pkg/pykernel/manager/manager_test.go
@@ -72,7 +72,7 @@ func drain(t *testing.T, ch <-chan pykernel.ExecEvent, d time.Duration) (string,
 				errEv = ev.Err
 			case pykernel.EventDone:
 				gotDone = true
-			case pykernel.EventMetric, pykernel.EventLog, pykernel.EventTruncated:
+			case pykernel.EventMetric, pykernel.EventLog:
 				// Not asserted by these tests; ignore.
 			}
 		case <-deadline:

--- a/pkg/pykernel/manager/manager_test.go
+++ b/pkg/pykernel/manager/manager_test.go
@@ -1,0 +1,179 @@
+package manager_test
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"github.com/iota-uz/iota-sdk/pkg/pykernel"
+	"github.com/iota-uz/iota-sdk/pkg/pykernel/lifecycle"
+	"github.com/iota-uz/iota-sdk/pkg/pykernel/manager"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testSession struct {
+	key    string
+	tenant uuid.UUID
+	caps   pykernel.CapabilitySet
+	mode   pykernel.Mode
+	wd     string
+}
+
+func (s *testSession) Key() string                        { return s.key }
+func (s *testSession) TenantID() uuid.UUID                { return s.tenant }
+func (s *testSession) Capabilities() pykernel.CapabilitySet { return s.caps }
+func (s *testSession) Mode() pykernel.Mode                { return s.mode }
+func (s *testSession) Workdir() string                    { return s.wd }
+
+func requirePython(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not available")
+	}
+}
+
+func newManager(t *testing.T) *manager.Manager {
+	t.Helper()
+	m, err := manager.New(manager.Config{
+		Policy:       lifecycle.Ephemeral(),
+		EnvAllowlist: []string{"PATH"},
+		DisposeGrace: 2 * time.Second,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = m.Shutdown(context.Background()) })
+	return m
+}
+
+// drain collects events until the channel closes or the deadline passes.
+func drain(t *testing.T, ch <-chan pykernel.ExecEvent, d time.Duration) (stdout string, result string, gotDone bool, errEv *pykernel.ExecError) {
+	t.Helper()
+	var sb strings.Builder
+	deadline := time.After(d)
+	for {
+		select {
+		case ev, ok := <-ch:
+			if !ok {
+				return sb.String(), result, gotDone, errEv
+			}
+			switch ev.Kind {
+			case pykernel.EventStdout:
+				sb.Write(ev.Stdout)
+			case pykernel.EventResult:
+				result = ev.Result.Text
+			case pykernel.EventError:
+				errEv = ev.Err
+			case pykernel.EventDone:
+				gotDone = true
+			}
+		case <-deadline:
+			t.Fatal("timed out draining exec events")
+		}
+	}
+}
+
+func TestManager_ExecStreamsStdoutResultAndCapability(t *testing.T) {
+	requirePython(t)
+
+	var sawTenant uuid.UUID
+	tenant := uuid.New()
+	echo := pykernel.CapabilityFunc("echo", pykernel.AccessRead,
+		pykernel.CapabilitySignature{Params: []pykernel.ParamSpec{{Name: "msg", Type: "str"}}},
+		func(ctx context.Context, args pykernel.CallArgs) (any, error) {
+			if tid, err := composables.UseTenantID(ctx); err == nil {
+				sawTenant = tid
+			}
+			return args["msg"], nil
+		})
+	caps, err := pykernel.NewCapabilitySet(echo)
+	require.NoError(t, err)
+
+	m := newManager(t)
+	sess := &testSession{key: "run-1", tenant: tenant, caps: caps, mode: pykernel.ModeApply, wd: t.TempDir()}
+	k, err := m.Acquire(context.Background(), sess)
+	require.NoError(t, err)
+
+	ch, err := k.Exec(context.Background(), pykernel.ExecRequest{
+		Code: "print('hello')\nr = echo(msg='world')\nprint(r)\nr",
+	})
+	require.NoError(t, err)
+
+	stdout, result, gotDone, errEv := drain(t, ch, 20*time.Second)
+	require.Nil(t, errEv, "exec should not error")
+	assert.True(t, gotDone, "should receive EventDone")
+	assert.Contains(t, stdout, "hello")
+	assert.Contains(t, stdout, "world")
+	assert.Equal(t, "'world'", result, "final expression repr should be returned")
+	assert.Equal(t, tenant, sawTenant, "tenant must be bound host-side into the capability context")
+
+	require.NoError(t, m.Release(k)) // ephemeral → dispose
+}
+
+func TestManager_PlanModeRefusesWrite(t *testing.T) {
+	requirePython(t)
+
+	invoked := false
+	write := pykernel.CapabilityFunc("do_write", pykernel.AccessWrite,
+		pykernel.CapabilitySignature{},
+		func(context.Context, pykernel.CallArgs) (any, error) {
+			invoked = true
+			return "wrote", nil
+		})
+	caps, err := pykernel.NewCapabilitySet(write)
+	require.NoError(t, err)
+
+	m := newManager(t)
+	sess := &testSession{key: "run-2", tenant: uuid.New(), caps: caps, mode: pykernel.ModePlan, wd: t.TempDir()}
+	k, err := m.Acquire(context.Background(), sess)
+	require.NoError(t, err)
+
+	ch, err := k.Exec(context.Background(), pykernel.ExecRequest{
+		Code: "try:\n    do_write()\nexcept Exception as e:\n    print(type(e).__name__)",
+	})
+	require.NoError(t, err)
+
+	stdout, _, gotDone, errEv := drain(t, ch, 20*time.Second)
+	require.Nil(t, errEv)
+	assert.True(t, gotDone)
+	assert.Contains(t, stdout, "PlanModeViolation", "a write in plan mode must raise PlanModeViolation in the kernel")
+	assert.False(t, invoked, "the host capability handler must never run for a refused write")
+
+	require.NoError(t, m.Release(k))
+}
+
+func TestManager_CancelTerminatesExec(t *testing.T) {
+	requirePython(t)
+
+	caps, err := pykernel.NewCapabilitySet()
+	require.NoError(t, err)
+
+	m := newManager(t)
+	sess := &testSession{key: "run-3", tenant: uuid.New(), caps: caps, mode: pykernel.ModeApply, wd: t.TempDir()}
+	k, err := m.Acquire(context.Background(), sess)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := k.Exec(ctx, pykernel.ExecRequest{Code: "while True:\n    pass"})
+	require.NoError(t, err)
+
+	time.Sleep(250 * time.Millisecond)
+	cancel()
+
+	// The channel must close (cooperative cancel, or kill after the grace).
+	deadline := time.After(15 * time.Second)
+	for {
+		select {
+		case _, ok := <-ch:
+			if !ok {
+				require.NoError(t, m.Release(k))
+				return
+			}
+		case <-deadline:
+			t.Fatal("exec did not terminate after cancellation")
+		}
+	}
+}

--- a/pkg/pykernel/manager/manager_test.go
+++ b/pkg/pykernel/manager/manager_test.go
@@ -24,11 +24,11 @@ type testSession struct {
 	wd     string
 }
 
-func (s *testSession) Key() string                        { return s.key }
-func (s *testSession) TenantID() uuid.UUID                { return s.tenant }
+func (s *testSession) Key() string                          { return s.key }
+func (s *testSession) TenantID() uuid.UUID                  { return s.tenant }
 func (s *testSession) Capabilities() pykernel.CapabilitySet { return s.caps }
-func (s *testSession) Mode() pykernel.Mode                { return s.mode }
-func (s *testSession) Workdir() string                    { return s.wd }
+func (s *testSession) Mode() pykernel.Mode                  { return s.mode }
+func (s *testSession) Workdir() string                      { return s.wd }
 
 func requirePython(t *testing.T) {
 	t.Helper()

--- a/pkg/pykernel/manager/socketpair_other.go
+++ b/pkg/pykernel/manager/socketpair_other.go
@@ -1,0 +1,13 @@
+//go:build !unix
+
+package manager
+
+import (
+	"errors"
+	"net"
+	"os"
+)
+
+func socketPair() (net.Conn, *os.File, error) {
+	return nil, nil, errors.New("pykernel/manager: socket pair not supported on this platform")
+}

--- a/pkg/pykernel/manager/socketpair_unix.go
+++ b/pkg/pykernel/manager/socketpair_unix.go
@@ -1,0 +1,30 @@
+//go:build unix
+
+package manager
+
+import (
+	"net"
+	"os"
+	"syscall"
+)
+
+// socketPair returns a connected AF_UNIX stream pair: the host end as a net.Conn
+// and the child end as an *os.File to hand the subprocess as fd 3. Passing the
+// socket by inherited fd avoids the sun_path length limit on filesystem socket
+// paths and keeps no socket file on disk.
+func socketPair() (net.Conn, *os.File, error) {
+	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	hostFile := os.NewFile(uintptr(fds[0]), "pykernel-host")
+	childFile := os.NewFile(uintptr(fds[1]), "pykernel-child")
+
+	conn, err := net.FileConn(hostFile) // dups the host fd into a net.Conn
+	_ = hostFile.Close()
+	if err != nil {
+		_ = childFile.Close()
+		return nil, nil, err
+	}
+	return conn, childFile, nil
+}

--- a/pkg/pykernel/manager/socketpair_unix.go
+++ b/pkg/pykernel/manager/socketpair_unix.go
@@ -13,10 +13,20 @@ import (
 // socket by inherited fd avoids the sun_path length limit on filesystem socket
 // paths and keeps no socket file on disk.
 func socketPair() (net.Conn, *os.File, error) {
+	// Hold ForkLock across Socketpair and set FD_CLOEXEC on both ends before a
+	// concurrent fork+exec elsewhere in the process can observe (and leak) the
+	// raw fds into an unrelated child. The child end is still inherited fine:
+	// exec.Cmd.ExtraFiles dups it and clears CLOEXEC on the child's copy.
+	syscall.ForkLock.RLock()
 	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
 	if err != nil {
+		syscall.ForkLock.RUnlock()
 		return nil, nil, err
 	}
+	syscall.CloseOnExec(fds[0])
+	syscall.CloseOnExec(fds[1])
+	syscall.ForkLock.RUnlock()
+
 	hostFile := os.NewFile(uintptr(fds[0]), "pykernel-host")
 	childFile := os.NewFile(uintptr(fds[1]), "pykernel-child")
 

--- a/pkg/pykernel/runtime/bootstrap.py
+++ b/pkg/pykernel/runtime/bootstrap.py
@@ -143,17 +143,27 @@ class _StreamWriter:
         self.truncated = False
 
     def write(self, s):
+        # The cap is measured in UTF-8 bytes (matching the Go-side OutputCap),
+        # not Python code points, so we encode and budget in bytes and never
+        # split a multibyte sequence when truncating.
         if not s:
             return
         if self._sent >= self._cap:
             self.truncated = True
             return
+        encoded = s.encode("utf-8")
         remaining = self._cap - self._sent
-        chunk = s if len(s) <= remaining else s[:remaining]
-        if len(s) > remaining:
-            self.truncated = True
-        self._sent += len(chunk)
-        _notify("out.stdout", {"exec_id": self._exec_id, "chunk": chunk})
+        if len(encoded) <= remaining:
+            self._sent += len(encoded)
+            _notify("out.stdout", {"exec_id": self._exec_id, "chunk": s})
+            return
+        # Truncate on a valid UTF-8 boundary: take the first `remaining` bytes,
+        # then drop any partial trailing char via errors='ignore'.
+        chunk = encoded[:remaining].decode("utf-8", errors="ignore")
+        self.truncated = True
+        self._sent = self._cap
+        if chunk:
+            _notify("out.stdout", {"exec_id": self._exec_id, "chunk": chunk})
 
     def flush(self):
         pass
@@ -210,15 +220,30 @@ def _worker():
     global _worker_tid
     _worker_tid = threading.get_ident()
     while True:
-        item = _exec_queue.get()
-        if item is None:
-            return
-        exec_id, code, output_cap = item
-        _run_code(exec_id, code, output_cap)
+        try:
+            item = _exec_queue.get()
+            if item is None:
+                return
+            exec_id, code, output_cap = item
+            _run_code(exec_id, code, output_cap)
+        except KeyboardInterrupt:
+            # A cancellation can be delivered late (after the target exec
+            # finished) or while the worker is idle in _exec_queue.get(). Such a
+            # stray async exception must NOT terminate the only execution
+            # thread — swallow it and keep serving the queue. The in-exec case
+            # is handled by _run_code's own KeyboardInterrupt handler.
+            continue
 
 
-def _cancel_worker():
+def _cancel_worker(target_exec_id):
     if ctypes is None or _worker_tid is None:
+        return
+    # Best-effort gate: only interrupt when the requested exec is the one
+    # actually running. A tiny TOCTOU window remains but is far safer than
+    # interrupting unconditionally (which could cancel a different exec or land
+    # in the idle worker loop).
+    current = _current_exec
+    if current is None or current != target_exec_id:
         return
     ctypes.pythonapi.PyThreadState_SetAsyncExc(
         ctypes.c_long(_worker_tid), ctypes.py_object(KeyboardInterrupt)
@@ -227,28 +252,55 @@ def _cancel_worker():
 
 # --- Reader loop ---------------------------------------------------------
 
-def _reader():
-    while True:
+def _fail_pending(message):
+    """Unblock every waiting _invoke when the control socket dies, so capability
+    calls raise instead of wedging the worker thread forever."""
+    sentinel = {"error": {"message": message, "data": {"type": "KernelDisconnected"}}}
+    with _pending_lock:
+        pending = list(_pending.values())
+        _pending.clear()
+    for reply_q in pending:
+        # Reply queues are maxsize=1; clear any stale item, then push without
+        # blocking so a full queue cannot deadlock the reader's teardown.
         try:
-            msg = _read_frame()
-        except Exception:
-            return  # socket closed: let the process exit
-        method = msg.get("method")
-        if method == "exec.submit":
-            params = msg.get("params") or {}
-            limits = params.get("limits") or {}
-            _exec_queue.put((
-                params.get("exec_id"),
-                params.get("code", ""),
-                limits.get("output_cap", 0),
-            ))
-        elif method == "exec.cancel":
-            _cancel_worker()
-        elif method is None and "id" in msg:
-            with _pending_lock:
-                reply_q = _pending.get(msg["id"])
-            if reply_q is not None:
-                reply_q.put(msg)
+            reply_q.put_nowait(sentinel)
+        except _queue.Full:
+            try:
+                reply_q.get_nowait()
+            except _queue.Empty:
+                pass
+            try:
+                reply_q.put_nowait(sentinel)
+            except _queue.Full:
+                pass
+
+
+def _reader():
+    try:
+        while True:
+            try:
+                msg = _read_frame()
+            except Exception:
+                return  # socket closed: let the process exit
+            method = msg.get("method")
+            if method == "exec.submit":
+                params = msg.get("params") or {}
+                limits = params.get("limits") or {}
+                _exec_queue.put((
+                    params.get("exec_id"),
+                    params.get("code", ""),
+                    limits.get("output_cap", 0),
+                ))
+            elif method == "exec.cancel":
+                params = msg.get("params") or {}
+                _cancel_worker(params.get("exec_id"))
+            elif method is None and "id" in msg:
+                with _pending_lock:
+                    reply_q = _pending.get(msg["id"])
+                if reply_q is not None:
+                    reply_q.put(msg)
+    finally:
+        _fail_pending("control socket closed")
 
 
 def _main():

--- a/pkg/pykernel/runtime/bootstrap.py
+++ b/pkg/pykernel/runtime/bootstrap.py
@@ -145,18 +145,21 @@ class _StreamWriter:
     def write(self, s):
         # The cap is measured in UTF-8 bytes (matching the Go-side OutputCap),
         # not Python code points, so we encode and budget in bytes and never
-        # split a multibyte sequence when truncating.
+        # split a multibyte sequence when truncating. A file-like write must
+        # return the number of characters written, so every path returns the
+        # original code-point length of the input.
+        n = len(s)
         if not s:
-            return
+            return 0
         if self._sent >= self._cap:
             self.truncated = True
-            return
+            return n
         encoded = s.encode("utf-8")
         remaining = self._cap - self._sent
         if len(encoded) <= remaining:
             self._sent += len(encoded)
             _notify("out.stdout", {"exec_id": self._exec_id, "chunk": s})
-            return
+            return n
         # Truncate on a valid UTF-8 boundary: take the first `remaining` bytes,
         # then drop any partial trailing char via errors='ignore'.
         chunk = encoded[:remaining].decode("utf-8", errors="ignore")
@@ -164,6 +167,7 @@ class _StreamWriter:
         self._sent = self._cap
         if chunk:
             _notify("out.stdout", {"exec_id": self._exec_id, "chunk": chunk})
+        return n
 
     def flush(self):
         pass
@@ -209,6 +213,21 @@ def _run_code(exec_id, code, output_cap):
     else:
         sys.stdout, sys.stderr = saved_out, saved_err
         if result_text is not None:
+            # Budget the result against the SAME byte cap as stdout so a huge
+            # repr can't exceed the bridge frame cap or balloon memory. Truncate
+            # on a UTF-8 boundary and flag the exec as truncated.
+            remaining = writer._cap - writer._sent
+            encoded = result_text.encode("utf-8")
+            if remaining <= 0:
+                # Budget exhausted by stdout: elide the result entirely.
+                result_text = "… [truncated]"
+                writer.truncated = True
+            elif len(encoded) > remaining:
+                result_text = encoded[:remaining].decode("utf-8", errors="ignore") + "… [truncated]"
+                writer._sent = writer._cap
+                writer.truncated = True
+            else:
+                writer._sent += len(encoded)
             _notify("exec.result", {"exec_id": exec_id, "text": result_text, "mime": "text/plain"})
     finally:
         sys.stdout, sys.stderr = saved_out, saved_err
@@ -245,9 +264,15 @@ def _cancel_worker(target_exec_id):
     current = _current_exec
     if current is None or current != target_exec_id:
         return
-    ctypes.pythonapi.PyThreadState_SetAsyncExc(
+    # PyThreadState_SetAsyncExc returns the number of thread states modified.
+    # 0 = tid not found (nothing to do). >1 = it hit more than the intended
+    # thread, which per CPython requires an immediate revert by calling again
+    # with a NULL exception, and is treated as a failed cancellation.
+    res = ctypes.pythonapi.PyThreadState_SetAsyncExc(
         ctypes.c_long(_worker_tid), ctypes.py_object(KeyboardInterrupt)
     )
+    if res > 1:
+        ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(_worker_tid), None)
 
 
 # --- Reader loop ---------------------------------------------------------
@@ -298,7 +323,20 @@ def _reader():
                 with _pending_lock:
                     reply_q = _pending.get(msg["id"])
                 if reply_q is not None:
-                    reply_q.put(msg)
+                    # Deliver non-blockingly: the reply queue is maxsize=1, so a
+                    # duplicate/late response (or a race with _fail_pending) must
+                    # not wedge the reader. Drop/replace any stale item.
+                    try:
+                        reply_q.put_nowait(msg)
+                    except _queue.Full:
+                        try:
+                            reply_q.get_nowait()
+                        except _queue.Empty:
+                            pass
+                        try:
+                            reply_q.put_nowait(msg)
+                        except _queue.Full:
+                            pass
     finally:
         _fail_pending("control socket closed")
 

--- a/pkg/pykernel/runtime/bootstrap.py
+++ b/pkg/pykernel/runtime/bootstrap.py
@@ -1,0 +1,275 @@
+"""pykernel bootstrap shim.
+
+Runs inside the sandboxed subprocess. Connects to the host control socket,
+exposes host capabilities as callable Python functions, executes submitted code
+in a persistent namespace, and streams stdout/result/metric/log/done back over
+a length-prefixed JSON-RPC channel.
+
+All data access goes through capability calls over the socket: this process has
+no database credentials and (in production) no network egress, so importing a
+DB driver here is inert. The host enforces the plan/apply boundary and refuses a
+write capability in plan mode by returning a JSON-RPC error whose data.type this
+shim raises as a Python exception at the call site.
+"""
+
+import ast
+import json
+import os
+import socket
+import struct
+import sys
+import threading
+import traceback
+import queue as _queue
+
+try:
+    import ctypes  # used for cooperative cancellation
+except Exception:  # pragma: no cover - ctypes is present on CPython
+    ctypes = None
+
+_OUTPUT_CAP_DEFAULT = 50 * 1024
+
+_sock = None
+_write_lock = threading.Lock()
+_pending = {}
+_pending_lock = threading.Lock()
+_id_lock = threading.Lock()
+_next_id = 0
+_ns = {}
+_current_exec = None
+_worker_tid = None
+_exec_queue = _queue.Queue()
+_exc_types = {}
+
+
+# --- Framing -------------------------------------------------------------
+
+def _recv_exact(n):
+    buf = b""
+    while len(buf) < n:
+        chunk = _sock.recv(n - len(buf))
+        if not chunk:
+            raise ConnectionError("control socket closed")
+        buf += chunk
+    return buf
+
+
+def _read_frame():
+    (length,) = struct.unpack(">I", _recv_exact(4))
+    return json.loads(_recv_exact(length))
+
+
+def _write_frame(msg):
+    payload = json.dumps(msg).encode("utf-8")
+    header = struct.pack(">I", len(payload))
+    with _write_lock:
+        _sock.sendall(header + payload)
+
+
+def _notify(method, params):
+    _write_frame({"jsonrpc": "2.0", "method": method, "params": params})
+
+
+def _alloc_id():
+    global _next_id
+    with _id_lock:
+        _next_id += 1
+        return _next_id
+
+
+# --- Capability proxies --------------------------------------------------
+
+class CapabilityError(Exception):
+    """Base class for any error returned by a host capability."""
+
+
+def _exc_for(etype):
+    cls = _exc_types.get(etype)
+    if cls is None:
+        cls = type(str(etype), (CapabilityError,), {})
+        _exc_types[etype] = cls
+    return cls
+
+
+def _invoke(name, args):
+    msg_id = _alloc_id()
+    reply_q = _queue.Queue(maxsize=1)
+    with _pending_lock:
+        _pending[msg_id] = reply_q
+    try:
+        _write_frame({
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "method": "cap.call",
+            "params": {"exec_id": _current_exec, "name": name, "args": args},
+        })
+        resp = reply_q.get()
+    finally:
+        with _pending_lock:
+            _pending.pop(msg_id, None)
+
+    err = resp.get("error")
+    if err is not None:
+        etype = "CapabilityError"
+        data = err.get("data") or {}
+        if isinstance(data, dict) and data.get("type"):
+            etype = data["type"]
+        raise _exc_for(etype)(err.get("message", ""))
+    return resp.get("result")
+
+
+def _make_proxy(name, param_names):
+    def proxy(*args, **kwargs):
+        call_args = dict(kwargs)
+        for i, value in enumerate(args):
+            if i >= len(param_names):
+                raise TypeError(
+                    "%s() takes at most %d positional argument(s)" % (name, len(param_names))
+                )
+            call_args[param_names[i]] = value
+        return _invoke(name, call_args)
+
+    proxy.__name__ = name
+    return proxy
+
+
+# --- Stdout capture ------------------------------------------------------
+
+class _StreamWriter:
+    def __init__(self, exec_id, cap):
+        self._exec_id = exec_id
+        self._cap = cap
+        self._sent = 0
+        self.truncated = False
+
+    def write(self, s):
+        if not s:
+            return
+        if self._sent >= self._cap:
+            self.truncated = True
+            return
+        remaining = self._cap - self._sent
+        chunk = s if len(s) <= remaining else s[:remaining]
+        if len(s) > remaining:
+            self.truncated = True
+        self._sent += len(chunk)
+        _notify("out.stdout", {"exec_id": self._exec_id, "chunk": chunk})
+
+    def flush(self):
+        pass
+
+
+# --- Execution -----------------------------------------------------------
+
+def _exec_with_result(code):
+    """Execute code in the persistent namespace. If the final statement is an
+    expression, return repr(value); otherwise return None."""
+    tree = ast.parse(code, "<cell>", "exec")
+    if tree.body and isinstance(tree.body[-1], ast.Expr):
+        last = tree.body.pop()
+        if tree.body:
+            exec(compile(tree, "<cell>", "exec"), _ns)
+        value = eval(compile(ast.Expression(last.value), "<cell>", "eval"), _ns)
+        return None if value is None else repr(value)
+    exec(compile(tree, "<cell>", "exec"), _ns)
+    return None
+
+
+def _run_code(exec_id, code, output_cap):
+    global _current_exec
+    _current_exec = exec_id
+    writer = _StreamWriter(exec_id, output_cap or _OUTPUT_CAP_DEFAULT)
+    saved_out, saved_err = sys.stdout, sys.stderr
+    sys.stdout = writer
+    sys.stderr = writer
+    try:
+        result_text = _exec_with_result(code)
+    except KeyboardInterrupt:
+        sys.stdout, sys.stderr = saved_out, saved_err
+        _notify("exec.error", {
+            "exec_id": exec_id, "type": "KernelCancelled",
+            "message": "execution cancelled", "traceback": "",
+        })
+    except BaseException as exc:  # report any failure back to the host
+        sys.stdout, sys.stderr = saved_out, saved_err
+        _notify("exec.error", {
+            "exec_id": exec_id, "type": type(exc).__name__,
+            "message": str(exc), "traceback": traceback.format_exc(),
+        })
+    else:
+        sys.stdout, sys.stderr = saved_out, saved_err
+        if result_text is not None:
+            _notify("exec.result", {"exec_id": exec_id, "text": result_text, "mime": "text/plain"})
+    finally:
+        sys.stdout, sys.stderr = saved_out, saved_err
+        _current_exec = None
+    _notify("exec.done", {"exec_id": exec_id, "output_truncated": writer.truncated})
+
+
+def _worker():
+    global _worker_tid
+    _worker_tid = threading.get_ident()
+    while True:
+        item = _exec_queue.get()
+        if item is None:
+            return
+        exec_id, code, output_cap = item
+        _run_code(exec_id, code, output_cap)
+
+
+def _cancel_worker():
+    if ctypes is None or _worker_tid is None:
+        return
+    ctypes.pythonapi.PyThreadState_SetAsyncExc(
+        ctypes.c_long(_worker_tid), ctypes.py_object(KeyboardInterrupt)
+    )
+
+
+# --- Reader loop ---------------------------------------------------------
+
+def _reader():
+    while True:
+        try:
+            msg = _read_frame()
+        except Exception:
+            return  # socket closed: let the process exit
+        method = msg.get("method")
+        if method == "exec.submit":
+            params = msg.get("params") or {}
+            limits = params.get("limits") or {}
+            _exec_queue.put((
+                params.get("exec_id"),
+                params.get("code", ""),
+                limits.get("output_cap", 0),
+            ))
+        elif method == "exec.cancel":
+            _cancel_worker()
+        elif method is None and "id" in msg:
+            with _pending_lock:
+                reply_q = _pending.get(msg["id"])
+            if reply_q is not None:
+                reply_q.put(msg)
+
+
+def _main():
+    global _sock
+    fd_env = os.environ.get("PYKERNEL_SOCKET_FD")
+    if not fd_env:
+        sys.stderr.write("pykernel: PYKERNEL_SOCKET_FD not set\n")
+        sys.exit(1)
+
+    # The host passes the control socket as an inherited fd (no filesystem path,
+    # so no sun_path length limit).
+    _sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM, fileno=int(fd_env))
+    _sock.setblocking(True)
+
+    for spec in json.loads(os.environ.get("PYKERNEL_CAPABILITIES", "[]")):
+        param_names = [p.get("name") for p in (spec.get("params") or [])]
+        _ns[spec["name"]] = _make_proxy(spec["name"], param_names)
+
+    threading.Thread(target=_worker, daemon=True).start()
+    _reader()
+
+
+if __name__ == "__main__":
+    _main()

--- a/pkg/pykernel/runtime/shim.go
+++ b/pkg/pykernel/runtime/shim.go
@@ -1,0 +1,31 @@
+// Package runtime carries the embedded Python kernel shim and materializes it
+// at spawn time. Shipping the shim inside the Go binary (rather than pip-
+// installing it) keeps a single source of truth and guarantees the shim and the
+// host bridge never disagree on the wire protocol.
+package runtime
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+//go:embed bootstrap.py
+var bootstrapPy []byte
+
+// ShimFilename is the materialized shim's filename inside the control directory.
+const ShimFilename = "bootstrap.py"
+
+// Write materializes the embedded shim into dir (created 0700 if absent) and
+// returns the shim's path. It is written fresh on every spawn.
+func Write(dir string) (string, error) {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("pykernel/runtime: mkdir %q: %w", dir, err)
+	}
+	path := filepath.Join(dir, ShimFilename)
+	if err := os.WriteFile(path, bootstrapPy, 0o600); err != nil {
+		return "", fmt.Errorf("pykernel/runtime: write shim %q: %w", path, err)
+	}
+	return path, nil
+}


### PR DESCRIPTION
## pykernel — sandboxed Python kernel primitive (foundation)

> **Draft / WIP.** Foundation slice of a larger effort: a reusable primitive for running AI-agent-authored Python in a sandboxed subprocess. It is built to be shared by two consumers — the **Ali analyst REPL** (warm, read-only `sql()`) and a new **Go data-migration engine** (ephemeral-per-run, write-capable connectors gated by a plan/apply mode). This PR lands the core primitive; the capability adapters (`sqlcap`, `migcap`) and the deployment image follow.

### Why

We're reworking the data-migration engine for the coding-agent era: instead of committing migration files, an agent submits Python over MCP and the engine runs it durably on production. That needs a sandbox to run agent-authored Python where **all data access is host-controlled** and a dry-run can't accidentally corrupt prod. The Ali REPL ([#3109](https://github.com/iota-uz/eai/issues/3109)/[#3110](https://github.com/iota-uz/eai/issues/3110)) needs the same sandbox, so this is one primitive, not two stacks.

### What's in this PR

`pkg/pykernel`:

- **Core contracts** — `Manager` / `Session` / `Kernel`, streamed `ExecEvent`, `Capability` with a per-call read/write `Access` flag.
- **Centralized plan/apply enforcement** — `Authorize` / `Dispatch` refuse a write capability in plan mode (`ErrPlanModeWrite`); the Go analogue of the Python engine's `assert_writable`, one greppable choke point.
- **Host-binds-context invariant** — tenant, capability set and `Mode` are frozen onto a kernel from the `Session` and are never supplied by the kernel. A `cap.call` wire frame carries only name + args.
- **`bridge`** — length-prefixed JSON-RPC host↔kernel channel; `cap.call` blocks for the host reply; refusals surface as a typed Python exception (`PlanModeViolation`) at the call site; output streams back as notifications.
- **`isolation`** — unix launcher: own process group, **env scrub** (no DSN/secret reaches the kernel — the load-bearing control), jailed workdir, Linux rlimits via `prlimit`.
- **`manager` + `runtime/bootstrap.py`** — spawns `python3`, passes the control socket as an inherited fd (socketpair; no `sun_path` length limit, no socket file on disk), binds tenant/Mode into the dispatcher, fans kernel output into a per-`Exec` channel, and enforces ctx-cancel/wall-clock with cooperative-cancel-then-SIGKILL.
- **`lifecycle`** — `WarmPool` (Ali) and `Ephemeral` (migration) policies behind one manager.

### Verification

- `go test -race ./pkg/pykernel/...` green, including an end-to-end test against **real `python3`**: stdout/result streaming, a capability call with the tenant bound host-side, a **plan-mode write refused as `PlanModeViolation`** (the host handler never runs), and cancellation terminating a CPU loop.
- `go vet` passes for both `darwin` and `linux` build tags; env-scrub and process-group kill are tested.

### Follow-ups (later PRs)

- `sqlcap` — read-only `sql()` capability over the existing `SafeQueryExecutor` (Ali adopts via [#3109](https://github.com/iota-uz/eai/issues/3109)/[#3110](https://github.com/iota-uz/eai/issues/3110)).
- `migcap` — write-flagged connector capabilities for the migration engine.
- `pykernel-base` image (glibc `python:3.11-slim`, pandas/numpy/duckdb/openpyxl).

The data-migration engine consuming this lives in `iota-uz/eai` (companion PRs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a host–kernel bridge using length-prefixed JSON-RPC, including capability calls and streamed stdout/metrics/log/result events.
  * Introduced a capabilities framework with plan/apply enforcement, including a new read-only `sql` capability.
  * Implemented sandboxed Python execution with OS isolation, resource limits, and kernel lifecycle pooling (warm/ephemeral).
  * Added a Docker runtime image for analysis workloads with a built-in smoke test.
* **Bug Fixes**
  * Improved message framing robustness (size limits, short-write tolerance) and clearer typed error reporting.
* **Tests**
  * Added unit and integration-style tests covering bridge framing, capability dispatch, SQL, cancel, and launcher isolation.
* **Documentation**
  * Added package documentation describing the sandbox and security model.
* **Chores**
  * Updated a Go module dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->