### PR TITLE
[codex] Add scaffold table cell link option

### DIFF
--- a/components/scaffold/table/helpers.go
+++ b/components/scaffold/table/helpers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"maps"
 	"net/http"
 	"net/url"
@@ -78,6 +79,7 @@ type tableCellImpl struct {
 	value     any
 	classes   templ.CSSClasses
 	attrs     templ.Attributes
+	linkHref  string
 }
 
 func (c *tableCellImpl) convertValueToString(value any, fieldType crud.FieldType) string {
@@ -651,7 +653,31 @@ func (c *tableCellImpl) Component(col TableColumn, editMode bool, withValue bool
 			return builder.Build().Component()
 		}
 	}
+	if c.linkHref != "" {
+		return cellLink(c.linkHref, c.component)
+	}
 	return c.component
+}
+
+func cellLink(href string, component templ.Component) templ.Component {
+	return templ.ComponentFunc(func(ctx context.Context, w io.Writer) error {
+		if _, err := io.WriteString(w, `<a class="hover:underline" href="`); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(w, templ.EscapeString(string(templ.URL(href)))); err != nil {
+			return err
+		}
+		if _, err := io.WriteString(w, `">`); err != nil {
+			return err
+		}
+		if component != nil {
+			if err := component.Render(ctx, w); err != nil {
+				return err
+			}
+		}
+		_, err := io.WriteString(w, "</a>")
+		return err
+	})
 }
 
 type TableRow interface {
@@ -1257,6 +1283,12 @@ func WithCellClasses(classes templ.CSSClasses) CellOpt {
 func WithCellAttrs(attrs templ.Attributes) CellOpt {
 	return func(c *tableCellImpl) {
 		c.attrs = attrs
+	}
+}
+
+func WithCellLink(href string) CellOpt {
+	return func(c *tableCellImpl) {
+		c.linkHref = href
 	}
 }
 

--- a/components/scaffold/table/helpers_test.go
+++ b/components/scaffold/table/helpers_test.go
@@ -1,13 +1,23 @@
 package table
 
 import (
+	"context"
 	"net/url"
 	"testing"
 
+	"github.com/a-h/templ"
 	"github.com/iota-uz/iota-sdk/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func renderTableCellComponent(t *testing.T, cell TableCell) string {
+	t.Helper()
+
+	html, err := templ.ToGoHTML(context.Background(), cell.Component(Column("name", "Name"), false, true, templ.Attributes{}))
+	require.NoError(t, err)
+	return string(html)
+}
 
 func TestGenerateSortURL(t *testing.T) {
 	tests := []struct {
@@ -187,6 +197,34 @@ func TestColumnDefaultBehavior(t *testing.T) {
 	assert.False(t, col.Sortable()) // Should be false by default
 	assert.Equal(t, SortDirectionNone, col.SortDir())
 	assert.Empty(t, col.SortURL())
+}
+
+func TestCellWithLinkWrapsComponent(t *testing.T) {
+	cell := Cell(
+		templ.Raw(`<span class="font-medium">Reserve #1</span>`),
+		nil,
+		WithCellLink(`/reserves/1?name=a&b="x"`),
+		WithCellClasses(templ.Classes("text-primary")),
+		WithCellAttrs(templ.Attributes{"data-id": "1"}),
+	)
+
+	html := renderTableCellComponent(t, cell)
+
+	assert.Equal(t, `<a class="hover:underline" href="/reserves/1?name=a&amp;b=&#34;x&#34;"><span class="font-medium">Reserve #1</span></a>`, html)
+	assert.Equal(t, "text-primary", cell.Classes().String())
+	assert.Equal(t, templ.Attributes{"data-id": "1"}, cell.Attrs())
+}
+
+func TestCellWithEmptyLinkRendersOriginalComponent(t *testing.T) {
+	cell := Cell(
+		templ.Raw(`<span>Reserve #1</span>`),
+		nil,
+		WithCellLink(""),
+	)
+
+	html := renderTableCellComponent(t, cell)
+
+	assert.Equal(t, `<span>Reserve #1</span>`, html)
 }
 
 func TestColumnWithSortable(t *testing.T) {


### PR DESCRIPTION
## What changed

Adds `WithCellLink(href string) CellOpt` to `components/scaffold/table` so scaffold table cell content can be wrapped in an anchor without replacing the cell component or moving classes/attrs off the `<td>`.

## Why

This provides the SDK primitive requested by iota-uz/eai#3252 for reusable drill-down table cells. Empty href values render the original cell content without a link.

## Details

- Wraps arbitrary `templ.Component` display content in `<a class="hover:underline" href="...">` when `href` is non-empty.
- Sanitizes and escapes the href before rendering.
- Leaves `WithCellClasses` and `WithCellAttrs` behavior unchanged for the table cell.

## Validation

- `go test -v ./components/scaffold/table`
- `go vet ./...`

## Follow-up

The downstream `eai` reserves template can switch from its local `DrillCell` helper to `sfui.Cell(content, value, sfui.WithCellLink(url))` after this SDK change is available.