### PR TITLE
feat(scaffold/table): add WithCellLink CellOpt

### DIFF
--- a/components/scaffold/table/helpers.go
+++ b/components/scaffold/table/helpers.go
@@ -79,7 +79,7 @@ type tableCellImpl struct {
 	classes   templ.CSSClasses
 	attrs     templ.Attributes
 	// link, when non-empty, wraps the cell's display content in an <a href> so the
-	// whole cell acts as a link (e.g. a drill-down). Empty → plain content.
+	// content becomes a link (e.g. a drill-down). Empty → plain content.
 	link string
 }
 
@@ -1266,8 +1266,9 @@ func WithCellAttrs(attrs templ.Attributes) CellOpt {
 	}
 }
 
-// WithCellLink wraps the cell's display content in an <a href> so the whole cell
-// acts as a link (e.g. a report drill-down). Works with any templ.Component
+// WithCellLink wraps the cell's display content in an <a href> so the content
+// becomes a link (e.g. a report drill-down). The link covers the rendered
+// content, not the cell's surrounding padding. Works with any templ.Component
 // content, not just text, and composes with WithCellClasses / WithCellAttrs.
 // An empty href leaves the content unwrapped (plain, non-clickable).
 func WithCellLink(href string) CellOpt {

--- a/components/scaffold/table/helpers.go
+++ b/components/scaffold/table/helpers.go
@@ -78,6 +78,9 @@ type tableCellImpl struct {
 	value     any
 	classes   templ.CSSClasses
 	attrs     templ.Attributes
+	// link, when non-empty, wraps the cell's display content in an <a href> so the
+	// whole cell acts as a link (e.g. a drill-down). Empty → plain content.
+	link string
 }
 
 func (c *tableCellImpl) convertValueToString(value any, fieldType crud.FieldType) string {
@@ -650,6 +653,9 @@ func (c *tableCellImpl) Component(col TableColumn, editMode bool, withValue bool
 			}
 			return builder.Build().Component()
 		}
+	}
+	if c.link != "" {
+		return cellLink(c.link, c.component)
 	}
 	return c.component
 }
@@ -1257,6 +1263,16 @@ func WithCellClasses(classes templ.CSSClasses) CellOpt {
 func WithCellAttrs(attrs templ.Attributes) CellOpt {
 	return func(c *tableCellImpl) {
 		c.attrs = attrs
+	}
+}
+
+// WithCellLink wraps the cell's display content in an <a href> so the whole cell
+// acts as a link (e.g. a report drill-down). Works with any templ.Component
+// content, not just text, and composes with WithCellClasses / WithCellAttrs.
+// An empty href leaves the content unwrapped (plain, non-clickable).
+func WithCellLink(href string) CellOpt {
+	return func(c *tableCellImpl) {
+		c.link = href
 	}
 }
 

--- a/components/scaffold/table/table.templ
+++ b/components/scaffold/table/table.templ
@@ -895,8 +895,8 @@ func toBaseTableColumns(config *TableConfig, pageCtx types.PageContext) []*base.
 	return result
 }
 
-// cellLink wraps a cell's display content in an <a href>, giving the whole cell a
-// clear, persistent clickable affordance (dotted underline that solidifies-off on
+// cellLink wraps a cell's display content in an <a href>, giving the content a
+// clear, persistent clickable affordance (dotted underline that disappears on
 // hover). Used by WithCellLink. href is treated as a dynamic URL (sanitized).
 templ cellLink(href string, content templ.Component) {
 	<a

--- a/components/scaffold/table/table.templ
+++ b/components/scaffold/table/table.templ
@@ -894,3 +894,15 @@ func toBaseTableColumns(config *TableConfig, pageCtx types.PageContext) []*base.
 	}
 	return result
 }
+
+// cellLink wraps a cell's display content in an <a href>, giving the whole cell a
+// clear, persistent clickable affordance (dotted underline that solidifies-off on
+// hover). Used by WithCellLink. href is treated as a dynamic URL (sanitized).
+templ cellLink(href string, content templ.Component) {
+	<a
+		href={ templ.URL(href) }
+		class="text-primary font-medium underline decoration-dotted decoration-1 underline-offset-2 hover:no-underline cursor-pointer"
+	>
+		@content
+	</a>
+}

--- a/components/scaffold/table/table_templ.go
+++ b/components/scaffold/table/table_templ.go
@@ -2372,8 +2372,8 @@ func toBaseTableColumns(config *TableConfig, pageCtx types.PageContext) []*base.
 	return result
 }
 
-// cellLink wraps a cell's display content in an <a href>, giving the whole cell a
-// clear, persistent clickable affordance (dotted underline that solidifies-off on
+// cellLink wraps a cell's display content in an <a href>, giving the content a
+// clear, persistent clickable affordance (dotted underline that disappears on
 // hover). Used by WithCellLink. href is treated as a dynamic URL (sanitized).
 func cellLink(href string, content templ.Component) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {

--- a/components/scaffold/table/table_templ.go
+++ b/components/scaffold/table/table_templ.go
@@ -2372,4 +2372,53 @@ func toBaseTableColumns(config *TableConfig, pageCtx types.PageContext) []*base.
 	return result
 }
 
+// cellLink wraps a cell's display content in an <a href>, giving the whole cell a
+// clear, persistent clickable affordance (dotted underline that solidifies-off on
+// hover). Used by WithCellLink. href is treated as a dynamic URL (sanitized).
+func cellLink(href string, content templ.Component) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var85 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var85 == nil {
+			templ_7745c5c3_Var85 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 116, "<a href=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var86 templ.SafeURL = templ.URL(href)
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var86)))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 117, "\" class=\"text-primary font-medium underline decoration-dotted decoration-1 underline-offset-2 hover:no-underline cursor-pointer\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = content.Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 118, "</a>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
 var _ = templruntime.GeneratedTemplate


### PR DESCRIPTION
## Summary
Adds `WithCellLink(href string) CellOpt` to `components/scaffold/table`. It wraps a cell's display **content** in an `<a href>` so the rendered content acts as a link (e.g. a report drill-down), composing with the existing `WithCellClasses` / `WithCellAttrs`. Works with any `templ.Component` content (not just strings); an empty `href` leaves the content unwrapped.

The link covers the cell's rendered content (not the cell's surrounding `p-4` padding) and carries a clear, persistent clickable affordance (dotted underline that disappears on hover). The URL is routed through `templ.URL` (sanitized).

## Why
Generalizes a per-app `DrillCell(url, text)` helper that exists in `iota-uz/eai` reserves (the reserves report drill-down). Requested by iota-uz/eai#3252 — moves the pattern into the SDK so any scaffold table can make cells clickable without re-implementing the `<a>` wrapper.

## API
```go
sfui.Cell(content, value, sfui.WithCellLink(url)) // url=="" -> plain, non-clickable
```

## Scope
This PR is **only** the `components/scaffold/table` change (3 files). An earlier revision of this branch also carried the `pkg/pykernel` stack; that has been removed from this PR — the Copilot review comments referencing `pkg/pykernel/*` are stale and do not apply to the current diff.

## Changes
- `components/scaffold/table/helpers.go`: `link` field on `tableCellImpl`, `WithCellLink` constructor, wrap in `Component()` display path.
- `components/scaffold/table/table.templ`: `cellLink(href, content)` templ component (regenerated `table_templ.go`).

## Verification
- `templ generate ./components/scaffold/table/...` (templ v0.3.857) OK
- `go vet ./components/scaffold/table/...` OK

Consumed by iota-uz/eai#3260 (bumps `go.mod` to this commit, refactors reserves onto `WithCellLink`, drops the local `DrillCell`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table cells can now be made clickable with linked content.
  * Added a new option to attach a link to individual cells while keeping plain text cells unchanged when no link is set.
  * Linked cells use consistent visual styling, including a pointer cursor and underlined link appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->