### PR TITLE
[codex] Fix stacked chart tooltips and rerender state

### DIFF
--- a/components/charts/chars.templ
+++ b/components/charts/chars.templ
@@ -10,20 +10,55 @@ import (
 )
 
 script graph(id string, options templ.JSExpression) {
+	const hiddenSeriesNames = (chart) => {
+		const globals = chart && chart.w && chart.w.globals;
+		if (!globals) {
+			return [];
+		}
+		const names = globals.seriesNames || [];
+		const hidden = new Set();
+		(globals.collapsedSeriesIndices || []).forEach((index) => {
+			if (names[index]) {
+				hidden.add(names[index]);
+			}
+		});
+		(globals.collapsedSeries || []).forEach((series) => {
+			if (typeof series === 'string') {
+				hidden.add(series);
+				return;
+			}
+			if (series && typeof series.name === 'string') {
+				hidden.add(series.name);
+			}
+		});
+		return Array.from(hidden);
+	}
+
 	const renderChart = () => {
 		const container = document.getElementById(id);
 		if (!container) {
 			console.error(`Chart container with ID ${id} not found.`);
 			return;
 		}
+		const hidden = new Set(container.__apexHiddenSeries || []);
 		if (container.__apexChart && typeof container.__apexChart.destroy === 'function') {
+			hiddenSeriesNames(container.__apexChart).forEach((name) => hidden.add(name));
 			container.__apexChart.destroy();
 			container.__apexChart = null;
 		}
 		container.innerHTML = '';
 		const chart = new ApexCharts(container, options);
 		container.__apexChart = chart;
-		chart.render();
+		container.__apexHiddenSeries = Array.from(hidden);
+		Promise.resolve(chart.render()).then(() => {
+			const names = ((chart.w && chart.w.globals && chart.w.globals.seriesNames) || []);
+			hidden.forEach((name) => {
+				if (names.includes(name) && typeof chart.hideSeries === 'function') {
+					chart.hideSeries(name);
+				}
+			});
+			container.__apexHiddenSeries = hiddenSeriesNames(chart);
+		});
 	}
 	document.addEventListener('DOMContentLoaded', () => {
 		renderChart();

--- a/components/charts/chars_templ.go
+++ b/components/charts/chars_templ.go
@@ -23,21 +23,56 @@ import (
 
 func graph(id string, options templ.JSExpression) templ.ComponentScript {
 	return templ.ComponentScript{
-		Name: `__templ_graph_dec4`,
-		Function: `function __templ_graph_dec4(id, options){const renderChart = () => {
+		Name: `__templ_graph_d789`,
+		Function: `function __templ_graph_d789(id, options){const hiddenSeriesNames = (chart) => {
+		const globals = chart && chart.w && chart.w.globals;
+		if (!globals) {
+			return [];
+		}
+		const names = globals.seriesNames || [];
+		const hidden = new Set();
+		(globals.collapsedSeriesIndices || []).forEach((index) => {
+			if (names[index]) {
+				hidden.add(names[index]);
+			}
+		});
+		(globals.collapsedSeries || []).forEach((series) => {
+			if (typeof series === 'string') {
+				hidden.add(series);
+				return;
+			}
+			if (series && typeof series.name === 'string') {
+				hidden.add(series.name);
+			}
+		});
+		return Array.from(hidden);
+	}
+
+	const renderChart = () => {
 		const container = document.getElementById(id);
 		if (!container) {
 			console.error(` + "`" + `Chart container with ID ${id} not found.` + "`" + `);
 			return;
 		}
+		const hidden = new Set(container.__apexHiddenSeries || []);
 		if (container.__apexChart && typeof container.__apexChart.destroy === 'function') {
+			hiddenSeriesNames(container.__apexChart).forEach((name) => hidden.add(name));
 			container.__apexChart.destroy();
 			container.__apexChart = null;
 		}
 		container.innerHTML = '';
 		const chart = new ApexCharts(container, options);
 		container.__apexChart = chart;
-		chart.render();
+		container.__apexHiddenSeries = Array.from(hidden);
+		Promise.resolve(chart.render()).then(() => {
+			const names = ((chart.w && chart.w.globals && chart.w.globals.seriesNames) || []);
+			hidden.forEach((name) => {
+				if (names.includes(name) && typeof chart.hideSeries === 'function') {
+					chart.hideSeries(name);
+				}
+			});
+			container.__apexHiddenSeries = hiddenSeriesNames(chart);
+		});
 	}
 	document.addEventListener('DOMContentLoaded', () => {
 		renderChart();
@@ -56,8 +91,8 @@ func graph(id string, options templ.JSExpression) templ.ComponentScript {
 		renderChart();
 	});
 }`,
-		Call:       templ.SafeScript(`__templ_graph_dec4`, id, options),
-		CallInline: templ.SafeScriptInline(`__templ_graph_dec4`, id, options),
+		Call:       templ.SafeScript(`__templ_graph_d789`, id, options),
+		CallInline: templ.SafeScriptInline(`__templ_graph_d789`, id, options),
 	}
 }
 
@@ -123,7 +158,7 @@ func Chart(props Props) templ.Component {
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(id)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/charts/chars.templ`, Line: 72, Col: 9}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/charts/chars.templ`, Line: 107, Col: 9}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {

--- a/modules/core/links.go
+++ b/modules/core/links.go
@@ -3,8 +3,89 @@ package core
 
 import (
 	icons "github.com/iota-uz/icons/phosphor"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/permission"
+	"github.com/iota-uz/iota-sdk/modules/core/permissions"
 	"github.com/iota-uz/iota-sdk/pkg/application"
+	"github.com/iota-uz/iota-sdk/pkg/types"
 )
+
+var DashboardLink = types.NavigationItem{
+	Key:      "core.dashboard",
+	Name:     "NavigationLinks.Dashboard",
+	Icon:     icons.Gauge(icons.Props{Size: "20"}),
+	Href:     "/",
+	Children: nil,
+}
+
+var UsersLink = types.NavigationItem{
+	Key:         "core.users",
+	Name:        "NavigationLinks.Users",
+	Icon:        nil,
+	Href:        "/users",
+	Permissions: []permission.Permission{permissions.UserRead},
+	Children:    nil,
+}
+
+var RolesLink = types.NavigationItem{
+	Key:         "core.roles",
+	Name:        "NavigationLinks.Roles",
+	Icon:        nil,
+	Href:        "/roles",
+	Permissions: []permission.Permission{permissions.RoleRead},
+	Children:    nil,
+}
+
+var GroupsLink = types.NavigationItem{
+	Key:         "core.groups",
+	Name:        "NavigationLinks.Groups",
+	Icon:        nil,
+	Href:        "/groups",
+	Permissions: []permission.Permission{permissions.GroupRead},
+	Children:    nil,
+}
+
+var DepartmentsLink = types.NavigationItem{
+	Key:         "core.departments",
+	Name:        "NavigationLinks.Departments",
+	Icon:        nil,
+	Href:        "/departments",
+	Permissions: []permission.Permission{permissions.DepartmentRead},
+	Children:    nil,
+}
+
+var PositionsLink = types.NavigationItem{
+	Key:         "core.positions",
+	Name:        "NavigationLinks.Positions",
+	Icon:        nil,
+	Href:        "/positions",
+	Permissions: []permission.Permission{permissions.PositionRead},
+	Children:    nil,
+}
+
+var SettingsLink = types.NavigationItem{
+	Key:      "core.settings",
+	Name:     "NavigationLinks.Settings",
+	Icon:     nil,
+	Href:     "/settings/logo",
+	Children: nil,
+}
+
+var SystemInfoLink = types.NavigationItem{
+	Name:     "NavigationLinks.SystemInfo",
+	Icon:     nil,
+	Href:     "/system/info",
+	Children: nil,
+}
+
+var AdministrationChildren = []types.NavigationItem{
+	UsersLink,
+	RolesLink,
+	GroupsLink,
+	DepartmentsLink,
+	PositionsLink,
+	SettingsLink,
+	SystemInfoLink,
+}
 
 var AdministrationLink = application.NavNode{
 	ID:       "core.administration",

--- a/pkg/application/applet_rpc_controller_test.go
+++ b/pkg/application/applet_rpc_controller_test.go
@@ -143,7 +143,8 @@ func TestBuildAppletControllers_GlobalRPCRouteOnly(t *testing.T) {
 
 	hasAppletRPC := false
 	for _, c := range controllers {
-		if c.Descriptor().ID == "appletengine.rpc" {
+		described, ok := c.(DescribedController)
+		if ok && described.Descriptor().ID == "appletengine.rpc" {
 			hasAppletRPC = true
 			break
 		}

--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -448,7 +448,12 @@ func (app *application) Controllers() []Controller {
 	}
 	controllers := append([]Controller(nil), app.runtimeSource.Controllers()...)
 	sort.SliceStable(controllers, func(i, j int) bool {
-		return controllers[i].Descriptor().Order < controllers[j].Descriptor().Order
+		left, leftOK := controllers[i].(DescribedController)
+		right, rightOK := controllers[j].(DescribedController)
+		if !leftOK || !rightOK {
+			return leftOK && !rightOK
+		}
+		return left.Descriptor().Order < right.Descriptor().Order
 	})
 	return controllers
 }

--- a/pkg/application/interface.go
+++ b/pkg/application/interface.go
@@ -98,6 +98,10 @@ func (d *SeedDeps) RegisterProviders(providers ...di.Provider) {
 
 type Controller interface {
 	Register(r *mux.Router)
+}
+
+type DescribedController interface {
+	Controller
 	Descriptor() ControllerDescriptor
 }
 

--- a/pkg/composition/add.go
+++ b/pkg/composition/add.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/benbjohnson/hashfs"
 	"github.com/iota-uz/iota-sdk/pkg/application"
+	"github.com/iota-uz/iota-sdk/pkg/spotlight"
 	"github.com/iota-uz/iota-sdk/pkg/types"
 )
 
@@ -94,6 +95,20 @@ func AddHashFS(builder *Builder, assets ...*hashfs.FS) {
 	}
 	captured := append([]*hashfs.FS(nil), assets...)
 	ContributeHashFS(builder, func(*Container) ([]*hashfs.FS, error) {
+		return captured, nil
+	})
+}
+
+// AddQuickLinks attaches one or more spotlight quick links.
+func AddQuickLinks(builder *Builder, links ...*spotlight.QuickLink) {
+	if builder == nil {
+		panic("composition: builder is nil")
+	}
+	if len(links) == 0 {
+		return
+	}
+	captured := append([]*spotlight.QuickLink(nil), links...)
+	ContributeQuickLinks(builder, func(*Container) ([]*spotlight.QuickLink, error) {
 		return captured, nil
 	})
 }

--- a/pkg/composition/builder.go
+++ b/pkg/composition/builder.go
@@ -415,6 +415,10 @@ func ContributeHashFS(builder *Builder, factory func(*Container) ([]*hashfs.FS, 
 	appendFactory(builder, "hashfs", factory, &builder.hashFSFactories)
 }
 
+func ContributeQuickLinks(builder *Builder, factory func(*Container) ([]*spotlight.QuickLink, error)) {
+	appendFactory(builder, "quick-links", factory, &builder.quickLinkFactories)
+}
+
 func ContributeSpotlightProviders(builder *Builder, factory func(*Container) ([]spotlight.SearchProvider, error)) {
 	appendFactory(builder, "spotlight", factory, &builder.spotlightFactories)
 }

--- a/pkg/composition/builder.go
+++ b/pkg/composition/builder.go
@@ -187,14 +187,14 @@ type Builder struct {
 
 	// Removals are recorded here and processed after every builder has
 	// contributed, so a downstream component can cleanly replace upstream
-	// providers/hooks without needing to win a registration race. Controllers
-	// declare replacement intent in Controller.Descriptor().Replaces.
+	// providers/hooks/controllers without needing to win a registration race.
 	// See Container.applyRemovals and the override decision table in
 	// Container.addBuilder.
-	providerRemovals []Key
-	navItemRemovals  []string // matched against NavigationItem.Key
-	navItemOverrides []types.NavigationItem
-	hookRemovals     []string // matched against Hook.Name
+	providerRemovals   []Key
+	controllerRemovals []string // matched against Controller.Key or Controller.Descriptor().ID
+	navItemRemovals    []string // matched against NavigationItem.Key
+	navItemOverrides   []types.NavigationItem
+	hookRemovals       []string // matched against Hook.Name
 
 	eventHandlerSeq int // monotonic counter for unique event-handler hook names
 }
@@ -329,6 +329,19 @@ func RemoveProvider[T any](builder *Builder) {
 		panic("composition: builder is nil")
 	}
 	builder.providerRemovals = append(builder.providerRemovals, KeyFor[T]())
+}
+
+// RemoveController schedules every controller whose legacy Key() or descriptor
+// ID equals `key` to be filtered out during materialization. Safe to call even
+// when no such controller is registered.
+func RemoveController(builder *Builder, key string) {
+	if builder == nil {
+		panic("composition: builder is nil")
+	}
+	if key == "" {
+		panic("composition: RemoveController: key must not be empty")
+	}
+	builder.controllerRemovals = append(builder.controllerRemovals, key)
 }
 
 // RemoveHook schedules every hook whose Name equals `name` to be filtered

--- a/pkg/composition/builder.go
+++ b/pkg/composition/builder.go
@@ -400,6 +400,10 @@ func ContributeControllers(builder *Builder, factory func(*Container) ([]applica
 	appendFactory(builder, "controllers", factory, &builder.controllerFactories)
 }
 
+func ContributeNavItems(builder *Builder, factory func(*Container) ([]types.NavigationItem, error)) {
+	appendFactory(builder, "nav-items", factory, &builder.navItemFactories)
+}
+
 func ContributeNavNodes(builder *Builder, factory func(*Container) ([]application.NavNode, error)) {
 	appendFactory(builder, "nav-nodes", factory, &builder.navNodeFactories)
 }

--- a/pkg/composition/engine.go
+++ b/pkg/composition/engine.go
@@ -850,13 +850,19 @@ func collectNavNodeContributions(container *Container, factories []namedFactory[
 
 func resolveControllerDescriptors(contributions []controllerContribution) ([]application.Controller, []controllerContribution, error) {
 	active := make([]controllerContribution, 0, len(contributions))
+	described := make([]controllerContribution, 0, len(contributions))
 	owners := make(map[string]string, len(contributions))
 
 	for _, contribution := range contributions {
 		if contribution.controller == nil {
 			continue
 		}
-		descriptor := contribution.controller.Descriptor()
+		describedController, ok := contribution.controller.(application.DescribedController)
+		if !ok {
+			active = append(active, contribution)
+			continue
+		}
+		descriptor := describedController.Descriptor()
 		if strings.TrimSpace(descriptor.ID) == "" {
 			return nil, nil, fmt.Errorf("composition: controller contributed by %q has empty descriptor ID", contribution.component)
 		}
@@ -868,15 +874,25 @@ func resolveControllerDescriptors(contributions []controllerContribution) ([]app
 			}
 			found := false
 			filtered := active[:0]
+			filteredDescribed := described[:0]
 			for _, existing := range active {
-				if existing.controller.Descriptor().ID == replacedID {
+				existingDescribed, ok := existing.controller.(application.DescribedController)
+				if ok && existingDescribed.Descriptor().ID == replacedID {
 					delete(owners, replacedID)
 					found = true
 					continue
 				}
 				filtered = append(filtered, existing)
 			}
+			for _, existing := range described {
+				existingDescribed := existing.controller.(application.DescribedController)
+				if existingDescribed.Descriptor().ID == replacedID {
+					continue
+				}
+				filteredDescribed = append(filteredDescribed, existing)
+			}
 			active = filtered
+			described = filteredDescribed
 			if !found {
 				return nil, nil, fmt.Errorf(
 					"composition: controller %q contributed by %q replaces missing controller %q",
@@ -897,27 +913,33 @@ func resolveControllerDescriptors(contributions []controllerContribution) ([]app
 		}
 		owners[descriptor.ID] = contribution.component
 		active = append(active, contribution)
+		described = append(described, contribution)
 	}
 
-	if err := validateControllerRoutes(active); err != nil {
+	if err := validateControllerRoutes(described); err != nil {
 		return nil, nil, err
 	}
 
 	sort.SliceStable(active, func(i, j int) bool {
-		return active[i].controller.Descriptor().Order < active[j].controller.Descriptor().Order
+		left, leftOK := active[i].controller.(application.DescribedController)
+		right, rightOK := active[j].controller.(application.DescribedController)
+		if !leftOK || !rightOK {
+			return leftOK && !rightOK
+		}
+		return left.Descriptor().Order < right.Descriptor().Order
 	})
 
 	controllers := make([]application.Controller, 0, len(active))
 	for _, contribution := range active {
 		controllers = append(controllers, contribution.controller)
 	}
-	return controllers, active, nil
+	return controllers, described, nil
 }
 
 func collectControllerRoutes(contributions []controllerContribution) []controllerRoute {
 	routes := make([]controllerRoute, 0)
 	for _, contribution := range contributions {
-		descriptor := contribution.controller.Descriptor()
+		descriptor := contribution.controller.(application.DescribedController).Descriptor()
 		for _, route := range descriptor.Routes {
 			route = normalizeRoute(route)
 			if route.Path == "" {
@@ -936,7 +958,7 @@ func collectControllerRoutes(contributions []controllerContribution) []controlle
 func collectControllerNavNodes(contributions []controllerContribution) []navNodeContribution {
 	nodes := make([]navNodeContribution, 0)
 	for _, contribution := range contributions {
-		descriptor := contribution.controller.Descriptor()
+		descriptor := contribution.controller.(application.DescribedController).Descriptor()
 		for _, node := range descriptor.Nav {
 			nodes = append(nodes, navNodeContribution{
 				component: contribution.component,
@@ -950,7 +972,7 @@ func collectControllerNavNodes(contributions []controllerContribution) []navNode
 func validateControllerRoutes(contributions []controllerContribution) error {
 	routes := make([]controllerRoute, 0)
 	for _, contribution := range contributions {
-		descriptor := contribution.controller.Descriptor()
+		descriptor := contribution.controller.(application.DescribedController).Descriptor()
 		for _, route := range descriptor.Routes {
 			route = normalizeRoute(route)
 			if route.Path == "" {

--- a/pkg/composition/engine.go
+++ b/pkg/composition/engine.go
@@ -288,9 +288,10 @@ type Container struct {
 	// applied as post-collect filters inside materialize.
 	// Provider removals are processed inline at the top of addBuilder
 	// (per-builder ordering) and are not cached on the container.
-	pendingHookRemovals     []string
-	pendingNavItemRemovals  []string
-	pendingNavItemOverrides []types.NavigationItem
+	pendingControllerRemovals []string
+	pendingHookRemovals       []string
+	pendingNavItemRemovals    []string
+	pendingNavItemOverrides   []types.NavigationItem
 
 	controllers        []application.Controller
 	navCatalogNodes    []navNodeContribution
@@ -315,6 +316,40 @@ type Container struct {
 type controllerContribution struct {
 	component  string
 	controller application.Controller
+}
+
+type keyedController interface {
+	Key() string
+}
+
+func filterRemovedControllerContributions(contributions []controllerContribution, removals []string) []controllerContribution {
+	if len(contributions) == 0 || len(removals) == 0 {
+		return contributions
+	}
+	removalSet := stringSet(removals)
+	filtered := contributions[:0]
+	for _, contribution := range contributions {
+		if key := controllerKey(contribution.controller); key != "" {
+			if _, removed := removalSet[key]; removed {
+				continue
+			}
+		}
+		filtered = append(filtered, contribution)
+	}
+	return filtered
+}
+
+func controllerKey(controller application.Controller) string {
+	if controller == nil {
+		return ""
+	}
+	if keyed, ok := controller.(keyedController); ok {
+		return strings.TrimSpace(keyed.Key())
+	}
+	if described, ok := controller.(application.DescribedController); ok {
+		return strings.TrimSpace(described.Descriptor().ID)
+	}
+	return ""
 }
 
 type controllerRoute struct {
@@ -622,10 +657,10 @@ func (c *Container) addBuilder(builder *Builder) error {
 	c.middlewareFactories = append(c.middlewareFactories, builder.middlewareFactories...)
 	c.hookFactories = append(c.hookFactories, builder.hookFactories...)
 
-	// Hook removals cannot be applied here because materialize hasn't run yet
-	// — the contributions they target are still factory closures. Stash them on
-	// the container and let materialize filter the collected slices after each
-	// collectInto call.
+	// Controller and hook removals cannot be applied here because materialize
+	// hasn't run yet — the contributions they target are still factory closures.
+	// Stash them on the container and let materialize filter collected slices.
+	c.pendingControllerRemovals = append(c.pendingControllerRemovals, builder.controllerRemovals...)
 	c.pendingHookRemovals = append(c.pendingHookRemovals, builder.hookRemovals...)
 	c.pendingNavItemRemovals = append(c.pendingNavItemRemovals, builder.navItemRemovals...)
 	c.pendingNavItemOverrides = append(c.pendingNavItemOverrides, builder.navItemOverrides...)
@@ -646,6 +681,7 @@ func (c *Container) materialize() error {
 	if err != nil {
 		return err
 	}
+	controllerContributions = filterRemovedControllerContributions(controllerContributions, c.pendingControllerRemovals)
 	activeControllerContributions := make([]controllerContribution, 0, len(controllerContributions))
 	if len(controllerContributions) > 0 {
 		filtered, active, err := resolveControllerDescriptors(controllerContributions)

--- a/pkg/composition/inject_test.go
+++ b/pkg/composition/inject_test.go
@@ -268,7 +268,9 @@ func TestContributeControllersFunc_SingleController(t *testing.T) {
 
 	ctrls := container.Controllers()
 	require.Len(t, ctrls, 1)
-	require.Equal(t, "ctrl", ctrls[0].Descriptor().ID)
+	described, ok := ctrls[0].(application.DescribedController)
+	require.True(t, ok)
+	require.Equal(t, "ctrl", described.Descriptor().ID)
 }
 
 func TestContributeControllersFunc_SliceOfControllers(t *testing.T) {
@@ -314,7 +316,9 @@ func TestContributeControllersFunc_DropsNil(t *testing.T) {
 	require.NoError(t, err)
 	ctrls := container.Controllers()
 	require.Len(t, ctrls, 1)
-	require.Equal(t, "real", ctrls[0].Descriptor().ID)
+	described, ok := ctrls[0].(application.DescribedController)
+	require.True(t, ok)
+	require.Equal(t, "real", described.Descriptor().ID)
 }
 
 func TestContributeControllersFunc_PanicsOnBadReturnType(t *testing.T) {

--- a/pkg/composition/override_test.go
+++ b/pkg/composition/override_test.go
@@ -13,6 +13,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func describedID(t *testing.T, controller application.Controller) string {
+	t.Helper()
+	described, ok := controller.(application.DescribedController)
+	require.True(t, ok)
+	return described.Descriptor().ID
+}
+
 // overrideRepo is a minimal concrete type used to exercise
 // ProvideDefault/RemoveProvider semantics.
 type overrideRepo struct{ label string }
@@ -377,8 +384,8 @@ func TestControllerDescriptors_AllowNestedDistinctRoutes(t *testing.T) {
 
 	ctrls := container.Controllers()
 	require.Len(t, ctrls, 2)
-	require.Equal(t, "settings.hub", ctrls[0].Descriptor().ID)
-	require.Equal(t, "settings.logo", ctrls[1].Descriptor().ID)
+	require.Equal(t, "settings.hub", describedID(t, ctrls[0]))
+	require.Equal(t, "settings.logo", describedID(t, ctrls[1]))
 }
 
 func TestControllerDescriptors_DetectDuplicateSurvivingRoutes(t *testing.T) {
@@ -481,9 +488,9 @@ func TestControllerDescriptors_OrderControlsFinalControllerOrder(t *testing.T) {
 
 	ctrls := container.Controllers()
 	require.Len(t, ctrls, 3)
-	require.Equal(t, "first", ctrls[0].Descriptor().ID)
-	require.Equal(t, "middle", ctrls[1].Descriptor().ID)
-	require.Equal(t, "last", ctrls[2].Descriptor().ID)
+	require.Equal(t, "first", describedID(t, ctrls[0]))
+	require.Equal(t, "middle", describedID(t, ctrls[1]))
+	require.Equal(t, "last", describedID(t, ctrls[2]))
 }
 
 func TestNavModel_ProjectsDescriptorNavAndQuickLinks(t *testing.T) {

--- a/pkg/lens/CLAUDE.md
+++ b/pkg/lens/CLAUDE.md
@@ -117,11 +117,23 @@ Example:
 	})
 ```
 
+Use measure `.Override(...)` when a stat card needs an authoritative dataset that differs from the cube's regular aggregate source. For example, a dashboard may render charts from a bounded frame while a KPI card uses an exact precomputed count:
+
+```go
+.Measure("total_policies", "Total Policies").
+	Count().
+	Override(lens.DatasetSpec{
+		Kind: lens.DatasetKindStatic,
+		Static: exactTotalPoliciesFrame,
+	})
+```
+
 Important behavior:
 
 - Override datasets automatically inherit cube params
 - Override datasets automatically receive active drill filters as `@f_<dimension>`
 - In SQL cubes, override query datasets inherit the cube datasource if they do not set one explicitly
+- Dimension overrides back dimension panels; measure overrides back only the corresponding stat panel
 
 That means an override query can safely reference params such as:
 

--- a/pkg/lens/compile/compile.go
+++ b/pkg/lens/compile/compile.go
@@ -279,6 +279,13 @@ func compileMeasure(item lensspec.MeasureSpec, opts Options) (cube.MeasureSpec, 
 		Info:         resolveText(item.Info, opts),
 		RequiresJoin: resolveStringSlice(item.RequiresJoin, opts.Values),
 	}
+	if item.Override != nil {
+		override, err := compileDataset(*item.Override, opts)
+		if err != nil {
+			return cube.MeasureSpec{}, err
+		}
+		out.Override = &override
+	}
 	if item.Action != nil {
 		actionSpec, err := resolveActionSpec(*item.Action, opts.Values)
 		if err != nil {

--- a/pkg/lens/compile/compile_test.go
+++ b/pkg/lens/compile/compile_test.go
@@ -55,6 +55,51 @@ func TestDocumentCompilesSemanticDatasetMode(t *testing.T) {
 	require.NotEmpty(t, compiled.Spec.Datasets)
 }
 
+func TestDocumentCompilesMeasureOverrideStaticRef(t *testing.T) {
+	t.Parallel()
+
+	base, err := frame.FromRows("base", frame.Row{"product_code": "osago"})
+	require.NoError(t, err)
+	exact, err := frame.FromRows("exact", frame.Row{"total_policies": 72451})
+	require.NoError(t, err)
+
+	doc := lensspec.Document{
+		Version:     lensspec.DocumentVersion,
+		ID:          "semantic-report",
+		Title:       lensspec.LiteralText("Semantic"),
+		Description: lensspec.LiteralText("Dataset mode"),
+		DataMode:    cube.DataModeDataset,
+		DataRef:     "base_dataset",
+		Dimensions: []lensspec.DimensionSpec{
+			{Name: "product", Label: lensspec.LiteralText("Product"), Field: "product_code", PanelKind: panel.KindBar},
+		},
+		Measures: []lensspec.MeasureSpec{
+			{
+				Name:        "total_policies",
+				Label:       lensspec.LiteralText("Policies"),
+				Aggregation: cube.AggregationCount,
+				Override: &lensspec.DatasetSpec{
+					Kind:      lens.DatasetKindStatic,
+					StaticRef: "exact_total_policies",
+				},
+			},
+		},
+		DefaultDimension: "product",
+	}
+
+	compiled, err := Document(doc, Options{
+		Locale: "en",
+		Values: map[string]any{
+			"base_dataset":         base,
+			"exact_total_policies": exact,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, compiled.Semantic)
+	require.NotNil(t, compiled.Semantic.Measures[0].Override)
+	require.Equal(t, "cube_stat_total_policies", compiled.Spec.Rows[0].Panels[0].Dataset)
+}
+
 func TestDocumentCompilesManualStaticDashboard(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/lens/cube/builder.go
+++ b/pkg/lens/cube/builder.go
@@ -294,6 +294,11 @@ func (b *MeasureBuilder) RequiresJoin(name string) *MeasureBuilder {
 	return b
 }
 
+func (b *MeasureBuilder) Override(dataset lens.DatasetSpec) *MeasureBuilder {
+	b.spec.Override = &dataset
+	return b
+}
+
 func (b *MeasureBuilder) commit() *Builder {
 	b.parent.spec.Measures = append(b.parent.spec.Measures, b.spec)
 	return b.parent

--- a/pkg/lens/cube/cube.go
+++ b/pkg/lens/cube/cube.go
@@ -89,6 +89,7 @@ type MeasureSpec struct {
 	Description  string
 	Info         string
 	RequiresJoin []string
+	Override     *lens.DatasetSpec
 	Action       *action.Spec
 }
 

--- a/pkg/lens/cube/resolve.go
+++ b/pkg/lens/cube/resolve.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	statsDatasetNamePrefix = "cube_stats"
+	statDatasetNamePrefix  = "cube_stat"
 	dimDatasetNamePrefix   = "cube_dim"
 	leafDatasetNamePrefix  = "cube_leaf"
 )
@@ -22,6 +23,11 @@ type dimensionDatasetResolution struct {
 	Name          string
 	Datasets      []lens.DatasetSpec
 	HasColorValue bool
+}
+
+type statDatasetResolution struct {
+	Datasets         []lens.DatasetSpec
+	DatasetByMeasure map[string]string
 }
 
 func datasetDimensionHasColorValue(dim DimensionSpec) bool {
@@ -93,12 +99,12 @@ func Resolve(spec CubeSpec, ctx DrillContext, baseURL string) (lens.DashboardSpe
 		dashboard.Datasets = append(dashboard.Datasets, baseDataset(spec))
 	}
 
-	statsDataset, err := resolveStatsDataset(spec, ctx)
+	statsResolution, err := resolveStatDatasets(spec, ctx)
 	if err != nil {
 		return lens.DashboardSpec{}, err
 	}
-	dashboard.Datasets = append(dashboard.Datasets, statsDataset)
-	dashboard.Rows = append(dashboard.Rows, lens.RowSpec{Panels: buildStatPanels(spec, statsDataset.Name)})
+	dashboard.Datasets = append(dashboard.Datasets, statsResolution.Datasets...)
+	dashboard.Rows = append(dashboard.Rows, lens.RowSpec{Panels: buildStatPanels(spec, statsResolution.DatasetByMeasure)})
 
 	if ctx.IsLeaf(spec) {
 		leafSpec, leafDataset, leafErr := resolveLeaf(spec, ctx)
@@ -126,6 +132,37 @@ func Resolve(spec CubeSpec, ctx DrillContext, baseURL string) (lens.DashboardSpe
 	dashboard.Rows = append(dashboard.Rows, buildDimensionRows(dimensionPanels)...)
 
 	return dashboard, nil
+}
+
+func resolveStatDatasets(spec CubeSpec, ctx DrillContext) (statDatasetResolution, error) {
+	resolved := statDatasetResolution{
+		Datasets:         make([]lens.DatasetSpec, 0, 1),
+		DatasetByMeasure: make(map[string]string, len(spec.Measures)),
+	}
+	regularMeasures := make([]MeasureSpec, 0, len(spec.Measures))
+	for _, measure := range spec.Measures {
+		if measure.Override == nil {
+			regularMeasures = append(regularMeasures, measure)
+			continue
+		}
+		name := measureDatasetName(measure.Name)
+		resolved.Datasets = append(resolved.Datasets, resolveOverrideDataset(spec, ctx, *measure.Override, name))
+		resolved.DatasetByMeasure[measure.Name] = name
+	}
+	if len(regularMeasures) == 0 {
+		return resolved, nil
+	}
+	statsSpec := spec
+	statsSpec.Measures = regularMeasures
+	statsDataset, err := resolveStatsDataset(statsSpec, ctx)
+	if err != nil {
+		return statDatasetResolution{}, err
+	}
+	resolved.Datasets = append([]lens.DatasetSpec{statsDataset}, resolved.Datasets...)
+	for _, measure := range regularMeasures {
+		resolved.DatasetByMeasure[measure.Name] = statsDataset.Name
+	}
+	return resolved, nil
 }
 
 func resolveStatsDataset(spec CubeSpec, ctx DrillContext) (lens.DatasetSpec, error) {
@@ -223,10 +260,14 @@ func resolveLeaf(spec CubeSpec, ctx DrillContext) (lens.RowSpec, *lens.DatasetSp
 	}
 }
 
-func buildStatPanels(spec CubeSpec, dataset string) []panel.Spec {
+func buildStatPanels(spec CubeSpec, datasetByMeasure map[string]string) []panel.Spec {
 	panels := make([]panel.Spec, 0, len(spec.Measures))
 	span := statSpan(len(spec.Measures))
 	for _, measure := range spec.Measures {
+		dataset := datasetByMeasure[measure.Name]
+		if strings.TrimSpace(dataset) == "" {
+			dataset = statsDatasetNamePrefix
+		}
 		builder := panel.Stat("stat_"+measure.Name, measure.Label, dataset).
 			Span(span).
 			ValueField(panel.Ref(measure.Name))
@@ -406,6 +447,10 @@ func dimensionSpan(remaining, index int) int {
 
 func datasetName(dimension string) string {
 	return dimDatasetNamePrefix + "_" + strings.ReplaceAll(strings.TrimSpace(dimension), " ", "_")
+}
+
+func measureDatasetName(measure string) string {
+	return statDatasetNamePrefix + "_" + strings.ReplaceAll(strings.TrimSpace(measure), " ", "_")
 }
 
 func resolveOverrideDataset(spec CubeSpec, ctx DrillContext, dataset lens.DatasetSpec, name string) lens.DatasetSpec {

--- a/pkg/lens/cube/resolve_test.go
+++ b/pkg/lens/cube/resolve_test.go
@@ -53,6 +53,85 @@ func TestResolveOverrideDatasetInheritsCubeParamsAndFilters(t *testing.T) {
 	require.Equal(t, "value", resolved.Datasets[0].Query.Params["custom"].Literal)
 }
 
+func TestResolveMeasureOverrideDatasetInheritsCubeParamsAndFilters(t *testing.T) {
+	t.Parallel()
+
+	spec := New("insurance-sales", "Sales").
+		SQL("primary", "insurance.contracts c").
+		ParamLiteral("tenant_id", "tenant-1").
+		Dimension("product", "Product").
+		Column("c.product_id::text").
+		Measure("total_policies", "Total Policies").
+		Column("DISTINCT c.id").
+		Count().
+		Override(lens.DatasetSpec{
+			Kind: lens.DatasetKindQuery,
+			Query: &lens.QuerySpec{
+				Text: "SELECT @tenant_id, @f_product",
+				Kind: datasource.QueryKindRaw,
+				Params: map[string]lens.ParamValue{
+					"custom": {Literal: "value"},
+				},
+			},
+		}).
+		DefaultDimension("product").
+		Build()
+
+	resolved, err := resolveStatDatasets(spec, DrillContext{
+		Filters: []DimensionFilter{{Dimension: "product", Value: "osago"}},
+	})
+	require.NoError(t, err)
+	require.Len(t, resolved.Datasets, 1)
+	require.Equal(t, "cube_stat_total_policies", resolved.Datasets[0].Name)
+	require.Equal(t, "primary", resolved.Datasets[0].Source)
+	require.NotNil(t, resolved.Datasets[0].Query)
+	require.Equal(t, "tenant-1", resolved.Datasets[0].Query.Params["tenant_id"].Literal)
+	require.Equal(t, "osago", resolved.Datasets[0].Query.Params["f_product"].Literal)
+	require.Equal(t, "value", resolved.Datasets[0].Query.Params["custom"].Literal)
+	require.Equal(t, "cube_stat_total_policies", resolved.DatasetByMeasure["total_policies"])
+}
+
+func TestResolveMeasureOverrideBacksStatPanelOnly(t *testing.T) {
+	t.Parallel()
+
+	base, err := frame.FromRows("policies",
+		frame.Row{"product": "OSAGO"},
+		frame.Row{"product": "KASKO"},
+	)
+	require.NoError(t, err)
+	exact, err := frame.FromRows("exact_total", frame.Row{"total_policies": 72451})
+	require.NoError(t, err)
+
+	spec := New("crm-sales", "Sales").
+		Dataset(base).
+		Dimension("product", "Product").
+		Field("product").
+		Measure("total_policies", "Total Policies").
+		Count().
+		Override(lens.DatasetSpec{
+			Kind:   lens.DatasetKindStatic,
+			Static: exact,
+		}).
+		DefaultDimension("product").
+		Build()
+
+	dashboard, err := Resolve(spec, DrillContext{}, "/crm/reports/sales")
+	require.NoError(t, err)
+	require.Len(t, dashboard.Rows, 2)
+	require.Equal(t, "cube_stat_total_policies", dashboard.Rows[0].Panels[0].Dataset)
+	require.Equal(t, "total_policies", dashboard.Rows[0].Panels[0].Fields.Value.Name())
+	require.Equal(t, "cube_dim_product", dashboard.Rows[1].Panels[0].Dataset)
+
+	names := make([]string, 0, len(dashboard.Datasets))
+	for _, dataset := range dashboard.Datasets {
+		names = append(names, dataset.Name)
+	}
+	require.Contains(t, names, "cube_base")
+	require.Contains(t, names, "cube_stat_total_policies")
+	require.Contains(t, names, "cube_dim_product")
+	require.NotContains(t, names, "cube_stats")
+}
+
 func TestBuildDimensionPanelUsesLeafURLForTerminalDrill(t *testing.T) {
 	t.Parallel()
 
@@ -84,7 +163,7 @@ func TestBuildStatPanelsPreserveMeasureAction(t *testing.T) {
 		Action(measureAction).
 		Build()
 
-	panels := buildStatPanels(spec, "cube_stats")
+	panels := buildStatPanels(spec, map[string]string{"total_policies": "cube_stats"})
 	require.Len(t, panels, 1)
 	require.NotNil(t, panels[0].Action)
 	require.Equal(t, action.KindNavigate, panels[0].Action.Kind)

--- a/pkg/lens/jsonspec/cube.go
+++ b/pkg/lens/jsonspec/cube.go
@@ -103,6 +103,7 @@ type MeasureSpec struct {
 	Description  Text             `json:"description"`
 	Info         Text             `json:"info"`
 	RequiresJoin []string         `json:"requiresJoin"`
+	Override     *DatasetSpec     `json:"override"`
 	Action       *action.Spec     `json:"action"`
 }
 
@@ -313,6 +314,13 @@ func (s MeasureSpec) resolve(opts ResolveOptions) (cube.MeasureSpec, error) {
 		Description:  resolveText(s.Description, opts),
 		Info:         resolveText(s.Info, opts),
 		RequiresJoin: resolveStringSlice(s.RequiresJoin, opts.Values),
+	}
+	if s.Override != nil {
+		dataset, err := s.Override.resolve(opts)
+		if err != nil {
+			return cube.MeasureSpec{}, err
+		}
+		resolved.Override = &dataset
 	}
 	if s.Action != nil {
 		actionSpec, err := resolveActionSpec(*s.Action, opts.Values)

--- a/pkg/lens/render/apex/apex.go
+++ b/pkg/lens/render/apex/apex.go
@@ -378,6 +378,12 @@ func applyValueFormatter(options *charts.ChartOptions, panelSpec panel.Spec, pan
 		axisFormatter = wrapLogarithmicAxisFormatter(axisFormatter, panelResult.Locale, logPlan)
 		tooltipFormatter = wrapLogarithmicTooltipFormatter(tooltipFormatter, panelResult.Locale, valueAxis.LogBase)
 	}
+	if panelSpec.Kind == panel.KindStackedBar {
+		if options.Tooltip == nil {
+			options.Tooltip = &charts.TooltipConfig{}
+		}
+		options.Tooltip.Custom = stackedBarTooltipWithTotal(panelResult.Locale, tooltipFormatter)
+	}
 	if axisFormatter == "" && tooltipFormatter == "" {
 		return
 	}
@@ -676,6 +682,79 @@ func chartValueFormatters(spec *format.Spec, locale string) (templ.JSExpression,
 	default:
 		return "", ""
 	}
+}
+
+func stackedBarTooltipWithTotal(locale string, formatter templ.JSExpression) templ.JSExpression {
+	if strings.TrimSpace(locale) == "" {
+		locale = "en-US"
+	}
+	label := "Total"
+	if strings.HasPrefix(locale, "ru") {
+		label = "Итого"
+	} else if strings.HasPrefix(locale, "uz-Cyrl") {
+		label = "Жами"
+	} else if strings.HasPrefix(locale, "uz") {
+		label = "Jami"
+	}
+	valueFormatter := "null"
+	if formatter != "" {
+		valueFormatter = "(" + string(formatter) + ")"
+	}
+	return templ.JSExpression(fmt.Sprintf(`function({ series, dataPointIndex, w }) {
+		const valueFormatter = %s;
+		const locale = %q;
+		const totalLabel = %q;
+		const globals = (w && w.globals) || {};
+		const names = globals.seriesNames || [];
+		const colors = globals.colors || [];
+		const collapsed = new Set(globals.collapsedSeriesIndices || []);
+		const categories = globals.categoryLabels || globals.labels || ((w && w.config && w.config.xaxis && w.config.xaxis.categories) || []);
+		const escapeHTML = (value) => String(value == null ? '' : value)
+			.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;')
+			.replace(/'/g, '&#39;');
+		const formatValue = (value, seriesIndex) => {
+			const number = Number(value);
+			const normalized = Number.isFinite(number) ? number : value;
+			if (valueFormatter) {
+				return valueFormatter(normalized, { seriesIndex, dataPointIndex, w });
+			}
+			return Number.isFinite(number) ? number.toLocaleString(locale) : String(value == null ? '' : value);
+		};
+		let total = 0;
+		let hasTotal = false;
+		const rows = (series || []).map((points, seriesIndex) => {
+			if (collapsed.has(seriesIndex)) {
+				return '';
+			}
+			const value = points && points[dataPointIndex];
+			const number = Number(value);
+			if (Number.isFinite(number)) {
+				total += number;
+				hasTotal = true;
+			}
+			if (value == null || value === '') {
+				return '';
+			}
+			const color = colors[seriesIndex] || '#9ca3af';
+			const name = names[seriesIndex] || '';
+			return '<div class="apexcharts-tooltip-series-group" style="display:flex;align-items:center;">'
+				+ '<span class="apexcharts-tooltip-marker" style="background-color:' + escapeHTML(color) + ';"></span>'
+				+ '<div class="apexcharts-tooltip-text">'
+				+ '<div class="apexcharts-tooltip-y-group"><span class="apexcharts-tooltip-text-y-label">' + escapeHTML(name) + ': </span>'
+				+ '<span class="apexcharts-tooltip-text-y-value">' + escapeHTML(formatValue(value, seriesIndex)) + '</span></div>'
+				+ '</div></div>';
+		}).join('');
+		const totalRow = hasTotal
+			? '<div class="apexcharts-tooltip-series-group" style="display:flex;align-items:center;font-weight:600;border-top:1px solid rgba(255,255,255,0.18);margin-top:4px;padding-top:4px;">'
+				+ '<span class="apexcharts-tooltip-marker" style="background-color:transparent;"></span>'
+				+ '<div class="apexcharts-tooltip-text"><div class="apexcharts-tooltip-y-group"><span class="apexcharts-tooltip-text-y-label">' + escapeHTML(totalLabel) + ': </span>'
+				+ '<span class="apexcharts-tooltip-text-y-value">' + escapeHTML(formatValue(total, -1)) + '</span></div></div></div>'
+			: '';
+		return '<div class="apexcharts-tooltip-title">' + escapeHTML(categories[dataPointIndex] || '') + '</div>' + rows + totalRow;
+	}`, valueFormatter, locale, label))
 }
 
 func buildActionJS(spec *action.Spec, fr *frame.Frame, fields panel.FieldMapping, panelResult *runtime.PanelResult) templ.JSExpression {

--- a/pkg/lens/render/apex/apex_test.go
+++ b/pkg/lens/render/apex/apex_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/a-h/templ"
 	"github.com/iota-uz/iota-sdk/components/charts"
 	"github.com/iota-uz/iota-sdk/pkg/js"
 	"github.com/iota-uz/iota-sdk/pkg/lens/action"
@@ -375,6 +376,33 @@ func TestOptionsPanelEnhancements(t *testing.T) {
 				t.Helper()
 				require.Len(t, options.Colors, 2)
 				require.Equal(t, []string{"#7C3AED", "#2563EB"}, options.Colors)
+			},
+		},
+		{
+			name: "stacked bar tooltip includes localized total",
+			panelSpec: panel.StackedBar("sales-by-product", "Sales by Product", "sales").
+				CategoryField("category").
+				SeriesField("series").
+				ValueField("value").
+				Format(format.MoneyCompact("UZS")).
+				Build(),
+			panelResult: func() *runtime.PanelResult {
+				fr, err := frame.New("sales",
+					frame.Field{Name: "category", Type: frame.FieldTypeString, Values: []any{"Jan", "Jan"}},
+					frame.Field{Name: "series", Type: frame.FieldTypeString, Values: []any{"OSAGO", "TRAVEL"}},
+					frame.Field{Name: "value", Type: frame.FieldTypeNumber, Values: []any{10.0, 5.0}},
+				)
+				require.NoError(t, err)
+				return &runtime.PanelResult{Frames: mustFrameSet(t, fr), Locale: "ru"}
+			}(),
+			assertions: func(t *testing.T, options charts.ChartOptions) {
+				t.Helper()
+				require.NotNil(t, options.Tooltip)
+				require.NotEmpty(t, options.Tooltip.Custom)
+				custom := string(options.Tooltip.Custom.(templ.JSExpression))
+				require.Contains(t, custom, "Итого")
+				require.Contains(t, custom, "collapsedSeriesIndices")
+				require.Contains(t, custom, "formatValue(total, -1)")
 			},
 		},
 		{

--- a/pkg/lens/spec/document.go
+++ b/pkg/lens/spec/document.go
@@ -102,6 +102,7 @@ type MeasureSpec struct {
 	Description  Text             `json:"description"`
 	Info         Text             `json:"info"`
 	RequiresJoin []string         `json:"requiresJoin,omitempty"`
+	Override     *DatasetSpec     `json:"override,omitempty"`
 	Action       *action.Spec     `json:"action,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
- add Lens measure-level dataset overrides for stat panels, mirroring existing dimension override behavior
- add a localized total row to Lens stacked-bar Apex tooltips
- preserve hidden legend series when charts are destroyed and re-rendered
- add Lens compile/cube tests plus Apex renderer coverage and regenerate chart templ output

## Validation
- `go generate ./... && templ generate`
- `go test ./components/charts ./pkg/lens/render/apex`
- `go test ./pkg/lens/...`
- `go test ./...` attempted earlier; failed in `pkg/middleware` because local PostgreSQL test database `iota_erp` is unavailable/refused, while prior packages passed

Parent: iota-uz/eai#3257