### PR TITLE
[codex] Fix Kanban transport params

### DIFF
--- a/components/scaffold/kanban/kanban.templ
+++ b/components/scaffold/kanban/kanban.templ
@@ -21,38 +21,32 @@ templ Content[C Card](cfg *Config[C]) {
 			opacity: 0.4;
 		}
 	</style>
-	{{ currentParams := CurrentQueryParams(ctx) }}
+	{{
+		currentParams := CurrentQueryParams(ctx)
+		columnTriggerID := ColumnTriggerID(cfg.Board.Key())
+		cardTriggerID := CardTriggerID(cfg.Board.Key())
+		columnTriggerFormID := ColumnTriggerFormID(cfg.Board.Key())
+		cardTriggerFormID := CardTriggerFormID(cfg.Board.Key())
+	}}
 	<div x-data="kanban" class="contents">
-		<div class="hidden" id="column-trigger" hx-post={ cfg.ColumnChangeURL } hx-trigger="columnChanged" hx-swap="none" hx-push-url="false" hx-include="this">
-			<input type="hidden" name="colKey" x-model="col.key"/>
-			<input type="hidden" name="colOldIndex" x-model="col.oldIndex"/>
-			<input type="hidden" name="colNewIndex" x-model="col.newIndex"/>
+		<div class="hidden" id={ columnTriggerID } hx-post={ cfg.ColumnChangeURL } hx-trigger="columnChanged" hx-swap="none" hx-push-url="false" hx-include="this">
+			<input type="hidden" name={ FormParamColumnKey } form={ columnTriggerFormID } x-model="col.key"/>
+			<input type="hidden" name={ FormParamColumnOldIndex } form={ columnTriggerFormID } x-model="col.oldIndex"/>
+			<input type="hidden" name={ FormParamColumnNewIndex } form={ columnTriggerFormID } x-model="col.newIndex"/>
 		</div>
-		<div class="hidden" id="card-trigger" hx-post={ cfg.CardChangeURL } hx-trigger="cardChanged" hx-swap="none" hx-push-url="false" hx-include="this">
-			<input type="hidden" name="cardKey" x-model="card.key"/>
-			<input type="hidden" name="cardOldCol" x-model="card.oldCol"/>
-			<input type="hidden" name="cardNewCol" x-model="card.newCol"/>
-			<input type="hidden" name="cardOldIndex" x-model="card.oldIndex"/>
-			<input type="hidden" name="cardNewIndex" x-model="card.newIndex"/>
+		<div class="hidden" id={ cardTriggerID } hx-post={ cfg.CardChangeURL } hx-trigger="cardChanged" hx-swap="none" hx-push-url="false" hx-include="this">
+			<input type="hidden" name={ FormParamCardKey } form={ cardTriggerFormID } x-model="card.key"/>
+			<input type="hidden" name={ FormParamCardOldColumn } form={ cardTriggerFormID } x-model="card.oldCol"/>
+			<input type="hidden" name={ FormParamCardNewColumn } form={ cardTriggerFormID } x-model="card.newCol"/>
+			<input type="hidden" name={ FormParamCardOldIndex } form={ cardTriggerFormID } x-model="card.oldIndex"/>
+			<input type="hidden" name={ FormParamCardNewIndex } form={ cardTriggerFormID } x-model="card.newIndex"/>
 		</div>
 		<div class="flex bg-gray-200 rounded-lg h-full overflow-hidden">
 			<div class="w-full overflow-x-auto overscroll-x-contain [touch-action:pan-x_pinch-zoom] [-webkit-overflow-scrolling:touch]">
 				<ol
 					class="flex w-max min-w-full divide-x divide-gray-300"
 					x-sort.ghost
-					x-sort:config="{
-					delayOnTouchOnly: true,
-					delay: 150,
-					touchStartThreshold: 8,
-					onEnd: (event) => {
-						changeCol({
-							key: event.item.dataset.colKey,
-							oldIndex: event.oldIndex,
-							newIndex: event.newIndex
-						});
-						$nextTick(() => htmx.trigger('#column-trigger', 'columnChanged'));
-					}
-				}"
+					x-sort:config={ columnSortConfig(columnTriggerID) }
 				>
 					for _, c := range cfg.Board.Columns() {
 						<li data-col-key={ c.Key() } x-sort:item class="flex w-72 shrink-0 flex-col gap-2 p-3">
@@ -65,20 +59,7 @@ templ Content[C Card](cfg *Config[C]) {
 								data-col-key={ c.Key() }
 								x-sort.ghost
 								x-sort:group="cards"
-								x-sort:config="{
-								delayOnTouchOnly: true,
-								delay: 150,
-								touchStartThreshold: 8,
-								onEnd: (event) => {
-								changeCard({
-									key: event.item.dataset.cardKey,
-									newCol: event.to.dataset.colKey,
-									oldCol: event.from.dataset.colKey,
-									oldIndex: event.oldIndex,
-									newIndex: event.newIndex
-								})
-								$nextTick(() => htmx.trigger('#card-trigger', 'cardChanged'));
-							}}"
+								x-sort:config={ cardSortConfig(cardTriggerID) }
 							>
 								@ColumnCards(cfg, c, currentParams)
 							</ol>

--- a/components/scaffold/kanban/kanban_templ.go
+++ b/components/scaffold/kanban/kanban_templ.go
@@ -89,52 +89,304 @@ func Content[C Card](cfg *Config[C]) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+
 		currentParams := CurrentQueryParams(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div x-data=\"kanban\" class=\"contents\"><div class=\"hidden\" id=\"column-trigger\" hx-post=\"")
+		columnTriggerID := ColumnTriggerID(cfg.Board.Key())
+		cardTriggerID := CardTriggerID(cfg.Board.Key())
+		columnTriggerFormID := ColumnTriggerFormID(cfg.Board.Key())
+		cardTriggerFormID := CardTriggerFormID(cfg.Board.Key())
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div x-data=\"kanban\" class=\"contents\"><div class=\"hidden\" id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var4 string
-		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.ColumnChangeURL)
+		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(columnTriggerID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 26, Col: 71}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 32, Col: 42}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\" hx-trigger=\"columnChanged\" hx-swap=\"none\" hx-push-url=\"false\" hx-include=\"this\"><input type=\"hidden\" name=\"colKey\" x-model=\"col.key\"> <input type=\"hidden\" name=\"colOldIndex\" x-model=\"col.oldIndex\"> <input type=\"hidden\" name=\"colNewIndex\" x-model=\"col.newIndex\"></div><div class=\"hidden\" id=\"card-trigger\" hx-post=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\" hx-post=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var5 string
-		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.CardChangeURL)
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.ColumnChangeURL)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 31, Col: 67}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 32, Col: 74}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\" hx-trigger=\"cardChanged\" hx-swap=\"none\" hx-push-url=\"false\" hx-include=\"this\"><input type=\"hidden\" name=\"cardKey\" x-model=\"card.key\"> <input type=\"hidden\" name=\"cardOldCol\" x-model=\"card.oldCol\"> <input type=\"hidden\" name=\"cardNewCol\" x-model=\"card.newCol\"> <input type=\"hidden\" name=\"cardOldIndex\" x-model=\"card.oldIndex\"> <input type=\"hidden\" name=\"cardNewIndex\" x-model=\"card.newIndex\"></div><div class=\"flex bg-gray-200 rounded-lg h-full overflow-hidden\"><div class=\"w-full overflow-x-auto overscroll-x-contain [touch-action:pan-x_pinch-zoom] [-webkit-overflow-scrolling:touch]\"><ol class=\"flex w-max min-w-full divide-x divide-gray-300\" x-sort.ghost x-sort:config=\"{\n\t\t\t\t\tdelayOnTouchOnly: true,\n\t\t\t\t\tdelay: 150,\n\t\t\t\t\ttouchStartThreshold: 8,\n\t\t\t\t\tonEnd: (event) =&gt; {\n\t\t\t\t\t\tchangeCol({\n\t\t\t\t\t\t\tkey: event.item.dataset.colKey,\n\t\t\t\t\t\t\toldIndex: event.oldIndex,\n\t\t\t\t\t\t\tnewIndex: event.newIndex\n\t\t\t\t\t\t});\n\t\t\t\t\t\t$nextTick(() =&gt; htmx.trigger(&#39;#column-trigger&#39;, &#39;columnChanged&#39;));\n\t\t\t\t\t}\n\t\t\t\t}\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\" hx-trigger=\"columnChanged\" hx-swap=\"none\" hx-push-url=\"false\" hx-include=\"this\"><input type=\"hidden\" name=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var6 string
+		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(FormParamColumnKey)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 33, Col: 49}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" form=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var7 string
+		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(columnTriggerFormID)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 33, Col: 78}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\" x-model=\"col.key\"> <input type=\"hidden\" name=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var8 string
+		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(FormParamColumnOldIndex)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 34, Col: 54}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\" form=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var9 string
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(columnTriggerFormID)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 34, Col: 83}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\" x-model=\"col.oldIndex\"> <input type=\"hidden\" name=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var10 string
+		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(FormParamColumnNewIndex)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 35, Col: 54}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\" form=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var11 string
+		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(columnTriggerFormID)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 35, Col: 83}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\" x-model=\"col.newIndex\"></div><div class=\"hidden\" id=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var12 string
+		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(cardTriggerID)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 37, Col: 40}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\" hx-post=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var13 string
+		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(cfg.CardChangeURL)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 37, Col: 70}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\" hx-trigger=\"cardChanged\" hx-swap=\"none\" hx-push-url=\"false\" hx-include=\"this\"><input type=\"hidden\" name=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var14 string
+		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(FormParamCardKey)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 38, Col: 47}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\" form=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var15 string
+		templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(cardTriggerFormID)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 38, Col: 74}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\" x-model=\"card.key\"> <input type=\"hidden\" name=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var16 string
+		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(FormParamCardOldColumn)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 39, Col: 53}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\" form=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var17 string
+		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(cardTriggerFormID)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 39, Col: 80}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "\" x-model=\"card.oldCol\"> <input type=\"hidden\" name=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var18 string
+		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(FormParamCardNewColumn)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 40, Col: 53}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\" form=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var19 string
+		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(cardTriggerFormID)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 40, Col: 80}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\" x-model=\"card.newCol\"> <input type=\"hidden\" name=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var20 string
+		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(FormParamCardOldIndex)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 41, Col: 52}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\" form=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var21 string
+		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(cardTriggerFormID)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 41, Col: 79}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\" x-model=\"card.oldIndex\"> <input type=\"hidden\" name=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var22 string
+		templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(FormParamCardNewIndex)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 42, Col: 52}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "\" form=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var23 string
+		templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(cardTriggerFormID)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 42, Col: 79}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "\" x-model=\"card.newIndex\"></div><div class=\"flex bg-gray-200 rounded-lg h-full overflow-hidden\"><div class=\"w-full overflow-x-auto overscroll-x-contain [touch-action:pan-x_pinch-zoom] [-webkit-overflow-scrolling:touch]\"><ol class=\"flex w-max min-w-full divide-x divide-gray-300\" x-sort.ghost x-sort:config=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var24 string
+		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(columnSortConfig(columnTriggerID))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 49, Col: 54}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, c := range cfg.Board.Columns() {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<li data-col-key=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<li data-col-key=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var6 string
-			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(c.Key())
+			var templ_7745c5c3_Var25 string
+			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(c.Key())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 58, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 52, Col: 32}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\" x-sort:item class=\"flex w-72 shrink-0 flex-col gap-2 p-3\"><header class=\"font-medium\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "\" x-sort:item class=\"flex w-72 shrink-0 flex-col gap-2 p-3\"><header class=\"font-medium\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -142,33 +394,46 @@ func Content[C Card](cfg *Config[C]) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</header><ol class=\"flex min-h-6 flex-col gap-2\" id=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</header><ol class=\"flex min-h-6 flex-col gap-2\" id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var7 string
-			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(ColumnCardsTargetID(c.Key()))
+			var templ_7745c5c3_Var26 string
+			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(ColumnCardsTargetID(c.Key()))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 64, Col: 41}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 58, Col: 41}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\" data-col-key=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var8 string
-			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(c.Key())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 65, Col: 30}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "\" data-col-key=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\" x-sort.ghost x-sort:group=\"cards\" x-sort:config=\"{\n\t\t\t\t\t\t\t\tdelayOnTouchOnly: true,\n\t\t\t\t\t\t\t\tdelay: 150,\n\t\t\t\t\t\t\t\ttouchStartThreshold: 8,\n\t\t\t\t\t\t\t\tonEnd: (event) =&gt; {\n\t\t\t\t\t\t\t\tchangeCard({\n\t\t\t\t\t\t\t\t\tkey: event.item.dataset.cardKey,\n\t\t\t\t\t\t\t\t\tnewCol: event.to.dataset.colKey,\n\t\t\t\t\t\t\t\t\toldCol: event.from.dataset.colKey,\n\t\t\t\t\t\t\t\t\toldIndex: event.oldIndex,\n\t\t\t\t\t\t\t\t\tnewIndex: event.newIndex\n\t\t\t\t\t\t\t\t})\n\t\t\t\t\t\t\t\t$nextTick(() =&gt; htmx.trigger(&#39;#card-trigger&#39;, &#39;cardChanged&#39;));\n\t\t\t\t\t\t\t}}\">")
+			var templ_7745c5c3_Var27 string
+			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(c.Key())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 59, Col: 30}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\" x-sort.ghost x-sort:group=\"cards\" x-sort:config=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var28 string
+			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(cardSortConfig(cardTriggerID))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 62, Col: 53}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -176,12 +441,12 @@ func Content[C Card](cfg *Config[C]) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</ol></li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</ol></li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</ol></div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</ol></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -205,26 +470,26 @@ func ColumnCards[C Card](cfg *Config[C], column Column[C], currentParams url.Val
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var9 == nil {
-			templ_7745c5c3_Var9 = templ.NopComponent
+		templ_7745c5c3_Var29 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var29 == nil {
+			templ_7745c5c3_Var29 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		for _, card := range column.Cards() {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<li class=\"cursor-pointer\" data-card-key=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "<li class=\"cursor-pointer\" data-card-key=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var10 string
-			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(card.Key())
+			var templ_7745c5c3_Var30 string
+			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(card.Key())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 95, Col: 55}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 76, Col: 55}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\" x-sort:item>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\" x-sort:item>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -232,39 +497,39 @@ func ColumnCards[C Card](cfg *Config[C], column Column[C], currentParams url.Val
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		if loadState := cfg.ColumnLoad(column.Key()); cfg.CardLoadURL != "" && loadState != nil {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<li class=\"pointer-events-none flex justify-center py-2\" id=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "<li class=\"pointer-events-none flex justify-center py-2\" id=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var11 string
-			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(ColumnSpinnerID(column.Key()))
+			var templ_7745c5c3_Var31 string
+			templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(ColumnSpinnerID(column.Key()))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 102, Col: 37}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 83, Col: 37}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "\" hx-get=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var12 string
-			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(nextColumnChunkURL(cfg.CardLoadURL, column.Key(), loadState, currentParams))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 103, Col: 87}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "\" hx-get=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\" hx-trigger=\"intersect once\" hx-target=\"this\" hx-swap=\"outerHTML\">")
+			var templ_7745c5c3_Var32 string
+			templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(nextColumnChunkURL(cfg.CardLoadURL, column.Key(), loadState, currentParams))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/scaffold/kanban/kanban.templ`, Line: 84, Col: 87}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "\" hx-trigger=\"intersect once\" hx-target=\"this\" hx-swap=\"outerHTML\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -274,7 +539,7 @@ func ColumnCards[C Card](cfg *Config[C], column Column[C], currentParams url.Val
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/components/scaffold/kanban/types.go
+++ b/components/scaffold/kanban/types.go
@@ -2,6 +2,7 @@ package kanban
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"slices"
 	"strconv"
@@ -27,12 +28,40 @@ func NewConfig[C Card](board Board[C], columnChangeURL, cardChangeURL string) *C
 	}
 }
 
-const QueryParamColumn = "kanbanColumn"
+const (
+	QueryParamColumn       = "kanbanColumn"
+	LegacyQueryParamColumn = "colKey"
+)
 
 const (
 	queryParamPage  = "page"
 	queryParamLimit = "limit"
 )
+
+const (
+	FormParamColumnKey      = "colKey"
+	FormParamColumnOldIndex = "colOldIndex"
+	FormParamColumnNewIndex = "colNewIndex"
+	FormParamCardKey        = "cardKey"
+	FormParamCardOldColumn  = "cardOldCol"
+	FormParamCardNewColumn  = "cardNewCol"
+	FormParamCardOldIndex   = "cardOldIndex"
+	FormParamCardNewIndex   = "cardNewIndex"
+)
+
+var transportQueryParams = []string{
+	QueryParamColumn,
+	LegacyQueryParamColumn,
+	queryParamPage,
+	queryParamLimit,
+	FormParamColumnOldIndex,
+	FormParamColumnNewIndex,
+	FormParamCardKey,
+	FormParamCardOldColumn,
+	FormParamCardNewColumn,
+	FormParamCardOldIndex,
+	FormParamCardNewIndex,
+}
 
 type ColumnLoadState struct {
 	NextPage int
@@ -87,10 +116,33 @@ func CurrentQueryParams(ctx context.Context) url.Values {
 	params, _ := composables.UseParams(ctx)
 	currentParams := url.Values{}
 	if params != nil && params.Request != nil {
-		currentParams = params.Request.URL.Query()
+		currentParams = CleanQueryParams(params.Request.URL.Query())
 	}
 
 	return currentParams
+}
+
+func ColumnKey(values url.Values) string {
+	if colKey := values.Get(QueryParamColumn); colKey != "" {
+		return colKey
+	}
+
+	return values.Get(LegacyQueryParamColumn)
+}
+
+func CleanQueryParams(values url.Values) url.Values {
+	params := url.Values{}
+	for key, vals := range values {
+		for _, value := range vals {
+			params.Add(key, value)
+		}
+	}
+
+	for _, key := range transportQueryParams {
+		params.Del(key)
+	}
+
+	return params
 }
 
 func ColumnCardsTargetID(columnKey string) string {
@@ -101,23 +153,68 @@ func ColumnSpinnerID(columnKey string) string {
 	return "kanban-column-spinner-" + columnKey
 }
 
+func ColumnTriggerID(boardKey string) string {
+	return "kanban-column-trigger-" + boardKey
+}
+
+func CardTriggerID(boardKey string) string {
+	return "kanban-card-trigger-" + boardKey
+}
+
+func ColumnTriggerFormID(boardKey string) string {
+	return "kanban-column-trigger-form-" + boardKey
+}
+
+func CardTriggerFormID(boardKey string) string {
+	return "kanban-card-trigger-form-" + boardKey
+}
+
 func nextColumnChunkURL(baseURL, columnKey string, state *ColumnLoadState, currentParams url.Values) string {
 	if state == nil {
 		return baseURL
 	}
 
-	params := url.Values{}
-	for key, values := range currentParams {
-		for _, value := range values {
-			params.Add(key, value)
-		}
-	}
+	params := CleanQueryParams(currentParams)
 
 	params.Set(QueryParamColumn, columnKey)
 	params.Set(queryParamPage, strconv.Itoa(state.NextPage))
 	params.Set(queryParamLimit, strconv.Itoa(state.PerPage))
 
 	return baseURL + "?" + params.Encode()
+}
+
+func columnSortConfig(triggerID string) string {
+	return fmt.Sprintf(`{
+		delayOnTouchOnly: true,
+		delay: 150,
+		touchStartThreshold: 8,
+		onEnd: (event) => {
+			changeCol({
+				key: event.item.dataset.colKey,
+				oldIndex: event.oldIndex,
+				newIndex: event.newIndex
+			});
+			$nextTick(() => htmx.trigger(%q, 'columnChanged'));
+		}
+	}`, "#"+triggerID)
+}
+
+func cardSortConfig(triggerID string) string {
+	return fmt.Sprintf(`{
+		delayOnTouchOnly: true,
+		delay: 150,
+		touchStartThreshold: 8,
+		onEnd: (event) => {
+			changeCard({
+				key: event.item.dataset.cardKey,
+				newCol: event.to.dataset.colKey,
+				oldCol: event.from.dataset.colKey,
+				oldIndex: event.oldIndex,
+				newIndex: event.newIndex
+			})
+			$nextTick(() => htmx.trigger(%q, 'cardChanged'));
+		}
+	}`, "#"+triggerID)
 }
 
 type Card interface {

--- a/components/scaffold/kanban/types_test.go
+++ b/components/scaffold/kanban/types_test.go
@@ -1,0 +1,124 @@
+package kanban
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestColumnKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		values url.Values
+		want   string
+	}{
+		{
+			name: "prefers canonical query param",
+			values: url.Values{
+				QueryParamColumn:       []string{"approved"},
+				LegacyQueryParamColumn: []string{"rejected"},
+			},
+			want: "approved",
+		},
+		{
+			name: "falls back to legacy drag param",
+			values: url.Values{
+				LegacyQueryParamColumn: []string{"waiting-approval"},
+			},
+			want: "waiting-approval",
+		},
+		{
+			name: "empty when no column key is present",
+			values: url.Values{
+				FormParamCardKey: []string{"card-1"},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := ColumnKey(tt.values); got != tt.want {
+				t.Fatalf("ColumnKey() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCleanQueryParams(t *testing.T) {
+	t.Parallel()
+
+	values := url.Values{
+		"Search":                []string{"GULCHEHRA"},
+		"view":                  []string{"kanban"},
+		QueryParamColumn:        []string{"approved"},
+		LegacyQueryParamColumn:  []string{"rejected"},
+		queryParamPage:          []string{"4"},
+		queryParamLimit:         []string{"20"},
+		FormParamColumnOldIndex: []string{"0"},
+		FormParamColumnNewIndex: []string{"1"},
+		FormParamCardKey:        []string{"card-1"},
+		FormParamCardOldColumn:  []string{"draft"},
+		FormParamCardNewColumn:  []string{"approved"},
+		FormParamCardOldIndex:   []string{"2"},
+		FormParamCardNewIndex:   []string{"3"},
+		"Statuses":              []string{"1", "2"},
+	}
+
+	got := CleanQueryParams(values)
+	for _, key := range transportQueryParams {
+		if _, ok := got[key]; ok {
+			t.Fatalf("CleanQueryParams() kept transport param %q in %v", key, got)
+		}
+	}
+	if got.Get("Search") != "GULCHEHRA" {
+		t.Fatalf("CleanQueryParams() dropped Search: %v", got)
+	}
+	if got.Get("view") != "kanban" {
+		t.Fatalf("CleanQueryParams() dropped view: %v", got)
+	}
+	if vals := got["Statuses"]; len(vals) != 2 || vals[0] != "1" || vals[1] != "2" {
+		t.Fatalf("CleanQueryParams() changed multi-value filter: %v", got)
+	}
+	if values.Get(QueryParamColumn) != "approved" {
+		t.Fatalf("CleanQueryParams() mutated input values: %v", values)
+	}
+}
+
+func TestNextColumnChunkURLCleansTransportParams(t *testing.T) {
+	t.Parallel()
+
+	got := nextColumnChunkURL("/kanban/cards", "approved", &ColumnLoadState{
+		NextPage: 2,
+		PerPage:  20,
+	}, url.Values{
+		"Search":               []string{"GULCHEHRA"},
+		LegacyQueryParamColumn: []string{""},
+		FormParamCardKey:       []string{""},
+		FormParamCardOldColumn: []string{"draft"},
+		queryParamPage:         []string{"1"},
+		queryParamLimit:        []string{"10"},
+	})
+
+	parsed, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("nextColumnChunkURL() returned invalid URL %q: %v", got, err)
+	}
+
+	query := parsed.Query()
+	if query.Get("Search") != "GULCHEHRA" {
+		t.Fatalf("nextColumnChunkURL() dropped Search: %s", got)
+	}
+	if query.Get(QueryParamColumn) != "approved" {
+		t.Fatalf("nextColumnChunkURL() did not set column: %s", got)
+	}
+	if query.Get(queryParamPage) != "2" || query.Get(queryParamLimit) != "20" {
+		t.Fatalf("nextColumnChunkURL() did not set pagination: %s", got)
+	}
+	if query.Has(LegacyQueryParamColumn) || query.Has(FormParamCardKey) || query.Has(FormParamCardOldColumn) {
+		t.Fatalf("nextColumnChunkURL() kept drag params: %s", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add shared Kanban helpers for canonical/legacy column-key parsing and query-param cleanup
- scrub drag/pagination transport params from lazy-load URLs while preserving filters/search
- scope hidden trigger IDs per board and prevent drag hidden inputs from being submitted by surrounding forms
- add unit coverage for column-key parsing, query cleanup, and lazy-load URL construction

## Validation
- `go test ./components/scaffold/kanban`
- `go test ./components/scaffold/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved kanban board drag-and-drop behavior with more reliable per-board interactions.
  * Updated board navigation and loading to preserve the right filters and search terms.

* **Bug Fixes**
  * Fixed issues caused by shared trigger identifiers across boards.
  * Prevented drag-and-drop state from leaking into visible URL/query settings.
  * Improved handling of older board links so existing URLs continue to work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->