### PR TITLE
feat(export): GET-download mode for ExportDropdown with busy loader

### DIFF
--- a/components/export/export_dropdown.templ
+++ b/components/export/export_dropdown.templ
@@ -1,8 +1,10 @@
 package export
 
 import (
+	"fmt"
 	icons "github.com/iota-uz/icons/phosphor"
 	"github.com/iota-uz/iota-sdk/components/base/button"
+	"github.com/iota-uz/iota-sdk/components/loaders"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
 	"net/http"
 )
@@ -82,14 +84,143 @@ type ExportDropdownProps struct {
 	Size      button.Size
 	Class     string
 	Attrs     templ.Attributes
+	// Download switches the dropdown from the htmx-POST mode (build server-side,
+	// upload, HX-Redirect) to a direct GET-download mode for handlers that stream
+	// the file in the response body. In this mode a click navigates a hidden
+	// iframe to ExportURL with the current filters, a unique download_token and
+	// the chosen format; the trigger shows a busy spinner and a "preparing"
+	// overlay until the handler echoes download_token back as a cookie
+	// (signalling the download has started). A max-timeout fallback always clears
+	// the busy state. Requires ExportURL registered as a GET route that sets the
+	// download_token cookie. Default (false) preserves the htmx-POST mode.
+	Download bool
+	// ParamsFormID (download mode only) is the id of a filter <form> whose fields
+	// are serialised into the export query string. Use it when filters live in a
+	// form rather than the page URL (e.g. inputs excluded from hx-push-url). When
+	// empty, the current window.location.search is used. sort/order are always
+	// merged from the URL; page/limit/per_page are always dropped (export = all).
+	ParamsFormID string
 }
+
+// exportDownloadState is the Alpine component driving GET-download mode: it
+// triggers the download via a hidden iframe carrying a unique download_token,
+// then polls document.cookie for that token to clear the busy state (the server
+// echoes the token as a cookie once it starts streaming the response). A
+// 10-minute deadline guarantees the spinner can never hang.
+const exportDownloadState = `{
+	exporting: false,
+	_timer: null,
+	runExport(format) {
+		if (this.exporting) return;
+		const token = 'dl-' + Date.now() + '-' + Math.random().toString(36).slice(2);
+		const formId = this.$root.dataset.paramsForm;
+		const form = formId ? document.getElementById(formId) : null;
+		if (formId && !(form instanceof HTMLFormElement)) {
+			// Fail loud rather than silently falling back to the URL, which for
+			// form-only filters could export a broader dataset than is shown.
+			console.error('ExportDropdown: ParamsFormID element is missing or not a form:', formId);
+			return;
+		}
+		let params;
+		if (form instanceof HTMLFormElement) {
+			params = new URLSearchParams(new FormData(form));
+			const fromUrl = new URLSearchParams(window.location.search);
+			['sort', 'order'].forEach(function (k) { if (fromUrl.has(k)) params.set(k, fromUrl.get(k)); });
+		} else {
+			params = new URLSearchParams(window.location.search);
+		}
+		['page', 'limit', 'per_page'].forEach(function (k) { params.delete(k); });
+		params.set('format', format);
+		params.set('download_token', token);
+		// Append (not overwrite) so an ExportURL that already carries a query
+		// string keeps it, and multi-valued filter keys (e.g. repeated f=) survive.
+		const sep = this.$root.dataset.exportUrl.indexOf('?') === -1 ? '?' : '&';
+		const target = this.$root.dataset.exportUrl + sep + params.toString();
+		document.cookie = 'download_token=; path=/; max-age=0';
+		this.$root.querySelectorAll('details').forEach(function (d) { d.removeAttribute('open'); });
+		this.exporting = true;
+		const iframe = document.createElement('iframe');
+		iframe.style.display = 'none';
+		iframe.src = target;
+		document.body.appendChild(iframe);
+		const start = Date.now(), maxMs = 600000, self = this;
+		this._timer = setInterval(function () {
+			const started = document.cookie.split(';').some(function (c) { return c.trim() === 'download_token=' + token; });
+			if (started || Date.now() - start > maxMs) {
+				clearInterval(self._timer);
+				self._timer = null;
+				self.exporting = false;
+				document.cookie = 'download_token=; path=/; max-age=0';
+				setTimeout(function () { iframe.remove(); }, 60000);
+			}
+		}, 250);
+	}
+}`
 
 templ ExportDropdown(props ExportDropdownProps) {
 	{{ pageCtx := composables.UsePageCtx(ctx) }}
-	<div class="relative">
+	if props.Download {
+		@exportDownloadDropdown(props)
+	} else {
+		<div class="relative">
+			<details class="relative z-10 peer" name="export-dropdown">
+				<summary class="list-none cursor-pointer shrink-0 btn btn-secondary btn-normal btn-with-icon flex items-center gap-2">
+					@icons.Download(icons.Props{Size: "18"})
+					if props.Label != "" {
+						{ props.Label }
+					} else {
+						{ pageCtx.T("Export.Title") }
+					}
+					@icons.CaretDown(icons.Props{Size: "16", Class: "ml-1"})
+				</summary>
+				<ul class="flex flex-col gap-1 mt-1 absolute bg-surface-300 right-0 text-sm rounded-md w-44 overflow-hidden shadow-sm border border-secondary p-1">
+					for _, format := range props.Formats {
+						{{ details := formatDetails[format] }}
+						<li>
+							<button
+								class="flex items-center gap-2 w-full text-left p-2 duration-200 hover:bg-surface-400 rounded-md"
+								hx-post={ props.ExportURL + "?format=" + details.Param }
+								hx-target="body"
+								hx-swap="none"
+								hx-on::after-request="this.closest('details').removeAttribute('open')"
+								{ props.Attrs... }
+							>
+								@details.Icon
+								{ pageCtx.T(details.LabelKey) }
+							</button>
+						</li>
+					}
+				</ul>
+			</details>
+			<details class="hidden peer-open:block" name="export-dropdown">
+				<summary class="fixed w-full h-full left-0 top-0"></summary>
+			</details>
+		</div>
+	}
+}
+
+// exportDownloadDropdown renders the GET-download + busy-loader variant.
+templ exportDownloadDropdown(props ExportDropdownProps) {
+	{{ pageCtx := composables.UsePageCtx(ctx) }}
+	<div
+		class="relative"
+		x-data={ exportDownloadState }
+		data-export-url={ props.ExportURL }
+		data-params-form={ props.ParamsFormID }
+	>
 		<details class="relative z-10 peer" name="export-dropdown">
-			<summary class="list-none cursor-pointer shrink-0 btn btn-secondary btn-normal btn-with-icon flex items-center gap-2">
-				@icons.Download(icons.Props{Size: "18"})
+			<summary
+				class="list-none cursor-pointer shrink-0 btn btn-secondary btn-normal btn-with-icon flex items-center gap-2"
+				x-bind:aria-busy="exporting"
+			>
+				<span x-show="!exporting" class="flex items-center">
+					@icons.Download(icons.Props{Size: "18"})
+				</span>
+				<span x-show="exporting" x-cloak class="flex items-center">
+					@loaders.Spinner(loaders.SpinnerProps{
+						SpinnerClass: templ.Classes("w-[18px] h-[18px]"),
+					})
+				</span>
 				if props.Label != "" {
 					{ props.Label }
 				} else {
@@ -102,11 +233,10 @@ templ ExportDropdown(props ExportDropdownProps) {
 					{{ details := formatDetails[format] }}
 					<li>
 						<button
-							class="flex items-center gap-2 w-full text-left p-2 duration-200 hover:bg-surface-400 rounded-md"
-							hx-post={ props.ExportURL + "?format=" + details.Param }
-							hx-target="body"
-							hx-swap="none"
-							hx-on::after-request="this.closest('details').removeAttribute('open')"
+							type="button"
+							class="flex items-center gap-2 w-full text-left p-2 duration-200 hover:bg-surface-400 rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
+							x-on:click={ fmt.Sprintf("runExport('%s')", details.Param) }
+							x-bind:disabled="exporting"
 							{ props.Attrs... }
 						>
 							@details.Icon
@@ -119,5 +249,18 @@ templ ExportDropdown(props ExportDropdownProps) {
 		<details class="hidden peer-open:block" name="export-dropdown">
 			<summary class="fixed w-full h-full left-0 top-0"></summary>
 		</details>
+		<!-- Busy overlay: clears when the handler echoes the download_token cookie. -->
+		<div
+			x-show="exporting"
+			x-cloak
+			x-transition.opacity
+			class="fixed bottom-4 right-4 z-50 flex items-center gap-3 bg-surface-300 border border-secondary rounded-lg shadow-lg px-4 py-3 text-sm"
+			role="status"
+		>
+			@loaders.Spinner(loaders.SpinnerProps{
+				SpinnerClass: templ.Classes("w-5 h-5"),
+			})
+			<span>{ pageCtx.T("Export.Preparing") }</span>
+		</div>
 	</div>
 }

--- a/components/export/export_dropdown_templ.go
+++ b/components/export/export_dropdown_templ.go
@@ -9,8 +9,10 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
+	"fmt"
 	icons "github.com/iota-uz/icons/phosphor"
 	"github.com/iota-uz/iota-sdk/components/base/button"
+	"github.com/iota-uz/iota-sdk/components/loaders"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
 	"net/http"
 )
@@ -90,7 +92,78 @@ type ExportDropdownProps struct {
 	Size      button.Size
 	Class     string
 	Attrs     templ.Attributes
+	// Download switches the dropdown from the htmx-POST mode (build server-side,
+	// upload, HX-Redirect) to a direct GET-download mode for handlers that stream
+	// the file in the response body. In this mode a click navigates a hidden
+	// iframe to ExportURL with the current filters, a unique download_token and
+	// the chosen format; the trigger shows a busy spinner and a "preparing"
+	// overlay until the handler echoes download_token back as a cookie
+	// (signalling the download has started). A max-timeout fallback always clears
+	// the busy state. Requires ExportURL registered as a GET route that sets the
+	// download_token cookie. Default (false) preserves the htmx-POST mode.
+	Download bool
+	// ParamsFormID (download mode only) is the id of a filter <form> whose fields
+	// are serialised into the export query string. Use it when filters live in a
+	// form rather than the page URL (e.g. inputs excluded from hx-push-url). When
+	// empty, the current window.location.search is used. sort/order are always
+	// merged from the URL; page/limit/per_page are always dropped (export = all).
+	ParamsFormID string
 }
+
+// exportDownloadState is the Alpine component driving GET-download mode: it
+// triggers the download via a hidden iframe carrying a unique download_token,
+// then polls document.cookie for that token to clear the busy state (the server
+// echoes the token as a cookie once it starts streaming the response). A
+// 10-minute deadline guarantees the spinner can never hang.
+const exportDownloadState = `{
+	exporting: false,
+	_timer: null,
+	runExport(format) {
+		if (this.exporting) return;
+		const token = 'dl-' + Date.now() + '-' + Math.random().toString(36).slice(2);
+		const formId = this.$root.dataset.paramsForm;
+		const form = formId ? document.getElementById(formId) : null;
+		if (formId && !(form instanceof HTMLFormElement)) {
+			// Fail loud rather than silently falling back to the URL, which for
+			// form-only filters could export a broader dataset than is shown.
+			console.error('ExportDropdown: ParamsFormID element is missing or not a form:', formId);
+			return;
+		}
+		let params;
+		if (form instanceof HTMLFormElement) {
+			params = new URLSearchParams(new FormData(form));
+			const fromUrl = new URLSearchParams(window.location.search);
+			['sort', 'order'].forEach(function (k) { if (fromUrl.has(k)) params.set(k, fromUrl.get(k)); });
+		} else {
+			params = new URLSearchParams(window.location.search);
+		}
+		['page', 'limit', 'per_page'].forEach(function (k) { params.delete(k); });
+		params.set('format', format);
+		params.set('download_token', token);
+		// Append (not overwrite) so an ExportURL that already carries a query
+		// string keeps it, and multi-valued filter keys (e.g. repeated f=) survive.
+		const sep = this.$root.dataset.exportUrl.indexOf('?') === -1 ? '?' : '&';
+		const target = this.$root.dataset.exportUrl + sep + params.toString();
+		document.cookie = 'download_token=; path=/; max-age=0';
+		this.$root.querySelectorAll('details').forEach(function (d) { d.removeAttribute('open'); });
+		this.exporting = true;
+		const iframe = document.createElement('iframe');
+		iframe.style.display = 'none';
+		iframe.src = target;
+		document.body.appendChild(iframe);
+		const start = Date.now(), maxMs = 600000, self = this;
+		this._timer = setInterval(function () {
+			const started = document.cookie.split(';').some(function (c) { return c.trim() === 'download_token=' + token; });
+			if (started || Date.now() - start > maxMs) {
+				clearInterval(self._timer);
+				self._timer = null;
+				self.exporting = false;
+				document.cookie = 'download_token=; path=/; max-age=0';
+				setTimeout(function () { iframe.remove(); }, 60000);
+			}
+		}, 250);
+	}
+}`
 
 func ExportDropdown(props ExportDropdownProps) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
@@ -114,7 +187,166 @@ func ExportDropdown(props ExportDropdownProps) templ.Component {
 		}
 		ctx = templ.ClearChildren(ctx)
 		pageCtx := composables.UsePageCtx(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"relative\"><details class=\"relative z-10 peer\" name=\"export-dropdown\"><summary class=\"list-none cursor-pointer shrink-0 btn btn-secondary btn-normal btn-with-icon flex items-center gap-2\">")
+		if props.Download {
+			templ_7745c5c3_Err = exportDownloadDropdown(props).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		} else {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"relative\"><details class=\"relative z-10 peer\" name=\"export-dropdown\"><summary class=\"list-none cursor-pointer shrink-0 btn btn-secondary btn-normal btn-with-icon flex items-center gap-2\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = icons.Download(icons.Props{Size: "18"}).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if props.Label != "" {
+				var templ_7745c5c3_Var2 string
+				templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(props.Label)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 170, Col: 19}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			} else {
+				var templ_7745c5c3_Var3 string
+				templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Export.Title"))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 172, Col: 33}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = icons.CaretDown(icons.Props{Size: "16", Class: "ml-1"}).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</summary><ul class=\"flex flex-col gap-1 mt-1 absolute bg-surface-300 right-0 text-sm rounded-md w-44 overflow-hidden shadow-sm border border-secondary p-1\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			for _, format := range props.Formats {
+				details := formatDetails[format]
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<li><button class=\"flex items-center gap-2 w-full text-left p-2 duration-200 hover:bg-surface-400 rounded-md\" hx-post=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var4 string
+				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(props.ExportURL + "?format=" + details.Param)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 182, Col: 62}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\" hx-target=\"body\" hx-swap=\"none\" hx-on::after-request=\"this.closest(&#39;details&#39;).removeAttribute(&#39;open&#39;)\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, props.Attrs)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, ">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = details.Icon.Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var5 string
+				templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T(details.LabelKey))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 189, Col: 37}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</button></li>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</ul></details> <details class=\"hidden peer-open:block\" name=\"export-dropdown\"><summary class=\"fixed w-full h-full left-0 top-0\"></summary></details></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		return nil
+	})
+}
+
+// exportDownloadDropdown renders the GET-download + busy-loader variant.
+func exportDownloadDropdown(props ExportDropdownProps) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var6 == nil {
+			templ_7745c5c3_Var6 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		pageCtx := composables.UsePageCtx(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div class=\"relative\" x-data=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var7 string
+		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(exportDownloadState)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 207, Col: 30}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\" data-export-url=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var8 string
+		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(props.ExportURL)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 208, Col: 35}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\" data-params-form=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var9 string
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(props.ParamsFormID)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 209, Col: 39}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\"><details class=\"relative z-10 peer\" name=\"export-dropdown\"><summary class=\"list-none cursor-pointer shrink-0 btn btn-secondary btn-normal btn-with-icon flex items-center gap-2\" x-bind:aria-busy=\"exporting\"><span x-show=\"!exporting\" class=\"flex items-center\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -122,23 +354,37 @@ func ExportDropdown(props ExportDropdownProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</span> <span x-show=\"exporting\" x-cloak class=\"flex items-center\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = loaders.Spinner(loaders.SpinnerProps{
+			SpinnerClass: templ.Classes("w-[18px] h-[18px]"),
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</span> ")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
 		if props.Label != "" {
-			var templ_7745c5c3_Var2 string
-			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(props.Label)
+			var templ_7745c5c3_Var10 string
+			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(props.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 94, Col: 18}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 225, Col: 18}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			var templ_7745c5c3_Var3 string
-			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Export.Title"))
+			var templ_7745c5c3_Var11 string
+			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Export.Title"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 96, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 227, Col: 32}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -147,26 +393,26 @@ func ExportDropdown(props ExportDropdownProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</summary><ul class=\"flex flex-col gap-1 mt-1 absolute bg-surface-300 right-0 text-sm rounded-md w-44 overflow-hidden shadow-sm border border-secondary p-1\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</summary><ul class=\"flex flex-col gap-1 mt-1 absolute bg-surface-300 right-0 text-sm rounded-md w-44 overflow-hidden shadow-sm border border-secondary p-1\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, format := range props.Formats {
 			details := formatDetails[format]
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<li><button class=\"flex items-center gap-2 w-full text-left p-2 duration-200 hover:bg-surface-400 rounded-md\" hx-post=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<li><button type=\"button\" class=\"flex items-center gap-2 w-full text-left p-2 duration-200 hover:bg-surface-400 rounded-md disabled:opacity-50 disabled:cursor-not-allowed\" x-on:click=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var4 string
-			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(props.ExportURL + "?format=" + details.Param)
+			var templ_7745c5c3_Var12 string
+			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("runExport('%s')", details.Param))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 106, Col: 61}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 238, Col: 65}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\" hx-target=\"body\" hx-swap=\"none\" hx-on::after-request=\"this.closest(&#39;details&#39;).removeAttribute(&#39;open&#39;)\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "\" x-bind:disabled=\"exporting\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -174,7 +420,7 @@ func ExportDropdown(props ExportDropdownProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, ">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, ">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -182,21 +428,44 @@ func ExportDropdown(props ExportDropdownProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var5 string
-			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T(details.LabelKey))
+			var templ_7745c5c3_Var13 string
+			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T(details.LabelKey))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 113, Col: 36}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 243, Col: 36}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</button></li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</button></li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</ul></details> <details class=\"hidden peer-open:block\" name=\"export-dropdown\"><summary class=\"fixed w-full h-full left-0 top-0\"></summary></details></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</ul></details> <details class=\"hidden peer-open:block\" name=\"export-dropdown\"><summary class=\"fixed w-full h-full left-0 top-0\"></summary></details><!-- Busy overlay: clears when the handler echoes the download_token cookie. --><div x-show=\"exporting\" x-cloak x-transition.opacity class=\"fixed bottom-4 right-4 z-50 flex items-center gap-3 bg-surface-300 border border-secondary rounded-lg shadow-lg px-4 py-3 text-sm\" role=\"status\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = loaders.Spinner(loaders.SpinnerProps{
+			SpinnerClass: templ.Classes("w-5 h-5"),
+		}).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<span>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var14 string
+		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Export.Preparing"))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 263, Col: 40}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</span></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/components/export/export_dropdown_test.go
+++ b/components/export/export_dropdown_test.go
@@ -1,0 +1,85 @@
+package export_test
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/iota-uz/go-i18n/v2/i18n"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/text/language"
+
+	"github.com/iota-uz/iota-sdk/components/export"
+	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"github.com/iota-uz/iota-sdk/pkg/types"
+)
+
+// fakePageCtx is a minimal types.PageContext for rendering the dropdown in
+// isolation; T echoes the key so assertions don't depend on a loaded bundle.
+type fakePageCtx struct{}
+
+func (fakePageCtx) T(key string, _ ...map[string]interface{}) string     { return key }
+func (fakePageCtx) TSafe(key string, _ ...map[string]interface{}) string { return key }
+func (f fakePageCtx) Namespace(string) types.PageContext                 { return f }
+func (fakePageCtx) ToJSLocale() string                                   { return "en-US" }
+func (fakePageCtx) GetLocale() language.Tag                              { return language.English }
+func (fakePageCtx) GetURL() *url.URL                                     { return &url.URL{} }
+func (fakePageCtx) GetLocalizer() *i18n.Localizer                        { return nil }
+
+func renderDropdown(t *testing.T, props export.ExportDropdownProps) string {
+	t.Helper()
+	ctx := composables.WithPageCtx(context.Background(), fakePageCtx{})
+	var sb strings.Builder
+	require.NoError(t, export.ExportDropdown(props).Render(ctx, &sb))
+	return sb.String()
+}
+
+// TestExportDropdown_DownloadMode verifies the GET-download variant: a real
+// download trigger (no htmx POST, which is what 404'd against GET export
+// routes), the export URL + params-form wiring, and the busy overlay.
+func TestExportDropdown_DownloadMode(t *testing.T) {
+	t.Parallel()
+
+	html := renderDropdown(t, export.ExportDropdownProps{
+		Formats:      []export.ExportFormat{export.ExportFormatExcel, export.ExportFormatCSV},
+		ExportURL:    "/portfolio/policies/export",
+		Download:     true,
+		ParamsFormID: "filters-form",
+	})
+
+	// Download mode must NOT emit htmx attributes — those POST to the export URL
+	// and 404 against GET-streaming routes, and can't save a binary body anyway.
+	assert.NotContains(t, html, "hx-post", "download mode must not use htmx POST")
+	assert.NotContains(t, html, `hx-swap="none"`)
+
+	// GET-download wiring + token-cookie loader.
+	assert.Contains(t, html, `data-export-url="/portfolio/policies/export"`)
+	assert.Contains(t, html, `data-params-form="filters-form"`)
+	assert.Contains(t, html, "runExport(")
+	assert.Contains(t, html, "download_token")
+	assert.Contains(t, html, "Export.Preparing", "busy overlay label must render")
+	// Per-format triggers wired to runExport with each format param. Assert the
+	// format args are present without pinning the exact HTML-entity encoding of
+	// the surrounding quotes (an implementation artifact).
+	assert.Regexp(t, `runExport\(\S*excel`, html)
+	assert.Regexp(t, `runExport\(\S*csv`, html)
+}
+
+// TestExportDropdown_LegacyHtmxMode guards backward compatibility: the default
+// (Download=false) still emits the htmx-POST behavior the MinIO/HX-Redirect
+// export pages rely on.
+func TestExportDropdown_LegacyHtmxMode(t *testing.T) {
+	t.Parallel()
+
+	html := renderDropdown(t, export.ExportDropdownProps{
+		Formats:   []export.ExportFormat{export.ExportFormatExcel},
+		ExportURL: "/clients/export",
+	})
+
+	assert.Contains(t, html, `hx-post="/clients/export?format=excel"`)
+	assert.Contains(t, html, `hx-swap="none"`)
+	assert.NotContains(t, html, "runExport(")
+	assert.NotContains(t, html, "data-export-url")
+}

--- a/modules/core/presentation/locales/en.json
+++ b/modules/core/presentation/locales/en.json
@@ -366,7 +366,8 @@
     "ToExcel": "Export to Excel",
     "ToCSV": "Export to CSV",
     "ToJSON": "Export to JSON",
-    "ToTXT": "Export to TXT"
+    "ToTXT": "Export to TXT",
+    "Preparing": "Preparing your file…"
   },
   "Filters": {
     "CreatedAt": {

--- a/modules/core/presentation/locales/ru.json
+++ b/modules/core/presentation/locales/ru.json
@@ -366,7 +366,8 @@
     "ToExcel": "Экспорт в Excel",
     "ToCSV": "Экспорт в CSV",
     "ToJSON": "Экспорт в JSON",
-    "ToTXT": "Экспорт в TXT"
+    "ToTXT": "Экспорт в TXT",
+    "Preparing": "Файл готовится…"
   },
   "Filters": {
     "CreatedAt": {

--- a/modules/core/presentation/locales/uz-Cyrl.json
+++ b/modules/core/presentation/locales/uz-Cyrl.json
@@ -366,7 +366,8 @@
     "ToExcel": "Excel ga eksport",
     "ToCSV": "CSV ga eksport",
     "ToJSON": "JSON ga eksport",
-    "ToTXT": "TXT ga eksport"
+    "ToTXT": "TXT ga eksport",
+    "Preparing": "Файл тайёрланмоқда…"
   },
   "Filters": {
     "CreatedAt": {

--- a/modules/core/presentation/locales/uz.json
+++ b/modules/core/presentation/locales/uz.json
@@ -366,7 +366,8 @@
     "ToExcel": "Excel ga eksport",
     "ToCSV": "CSV ga eksport",
     "ToJSON": "JSON ga eksport",
-    "ToTXT": "TXT ga eksport"
+    "ToTXT": "TXT ga eksport",
+    "Preparing": "Fayl tayyorlanmoqda…"
   },
   "Filters": {
     "CreatedAt": {

--- a/modules/core/presentation/locales/zh.json
+++ b/modules/core/presentation/locales/zh.json
@@ -366,7 +366,8 @@
     "ToExcel": "导出到 Excel",
     "ToCSV": "导出到 CSV",
     "ToJSON": "导出到 JSON",
-    "ToTXT": "导出到 TXT"
+    "ToTXT": "导出到 TXT",
+    "Preparing": "正在准备文件…"
   },
   "Filters": {
     "CreatedAt": {


### PR DESCRIPTION
## What

Adds an opt-in **GET-download mode** to the shared `ExportDropdown` component, for export handlers that **stream the file directly in the response body on a GET route** — as opposed to the existing htmx-POST → build → upload-to-MinIO → `HX-Redirect` mode.

### Why
The single htmx-POST design doesn't fit handlers that stream a file on a GET route (e.g. EAI's portfolio policies/admissions exports): the `hx-post` 404s against a GET route, and an `hx-swap="none"` htmx response can't save a binary body to disk. Consumers worked around it with brittle per-page Alpine overrides that race htmx's own click listener.

### Behavior (`Download: true`)
- Click navigates a hidden `<iframe>` to `ExportURL` with the current filters, a unique `download_token`, and the chosen `format` (a real GET download — no htmx).
- Trigger shows a busy spinner; a light `"preparing"` overlay (`Export.Preparing`) is shown until the handler **echoes `download_token` back as a cookie** (signalling the download has started). A 10-minute deadline always clears the busy state.
- `ParamsFormID` (optional): serialise a filter `<form>` into the export query when filters live outside the page URL. `sort`/`order` are merged from the URL; `page`/`limit`/`per_page` are dropped (export = all rows).

### Backward compatibility
- `Download` defaults to **false** → the existing htmx-POST behavior is byte-for-byte unchanged (guarded by a test). CRM clients / OSAGO / NAPP exports are unaffected.

### Tests
- `TestExportDropdown_DownloadMode` — GET-download markup, no `hx-post`, token-cookie loader wiring, per-format triggers.
- `TestExportDropdown_LegacyHtmxMode` — default mode still emits `hx-post` / `hx-swap="none"`.

Adds `Export.Preparing` to core locales (en/ru/uz/uz-Cyrl/zh).

Consumed by iota-uz/eai (portfolio export 404 fix); EAI pins this via the interim SDK lineage until back/ migrates to the descriptor-nav change on main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a direct download flow for export with a visible “Preparing your file…” overlay and loading spinner.
  * Export actions now support building export parameters from the current page query (and, when configured, from a selected filter form) instead of the legacy request approach.
* **Bug Fixes**
  * Export format buttons are disabled during file preparation and the UI reliably clears the preparing state when the download starts.
* **Documentation**
  * Updated export localization in multiple languages to include the new “Preparing” message.
* **Tests**
  * Added rendering tests for both the new download mode and the legacy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->