### PR TITLE
[codex] Fix Payme retry lookup for terminal transactions

### DIFF
--- a/modules/billing/domain/aggregates/billing/billing.go
+++ b/modules/billing/domain/aggregates/billing/billing.go
@@ -30,6 +30,10 @@ const (
 	RUB Currency = "RUB"
 )
 
+func (s Status) IsActive() bool {
+	return s == Created || s == Pending
+}
+
 // TransactionCallback is a function that gets invoked during transaction processing.
 // It receives the transaction and returns an error.
 // - If error is nil, the transaction processing continues normally

--- a/modules/billing/domain/aggregates/billing/billing_test.go
+++ b/modules/billing/domain/aggregates/billing/billing_test.go
@@ -1,0 +1,35 @@
+package billing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatus_IsActive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		status Status
+		want   bool
+	}{
+		{name: "created", status: Created, want: true},
+		{name: "pending", status: Pending, want: true},
+		{name: "completed", status: Completed, want: false},
+		{name: "failed", status: Failed, want: false},
+		{name: "canceled", status: Canceled, want: false},
+		{name: "refunded", status: Refunded, want: false},
+		{name: "partially refunded", status: PartiallyRefunded, want: false},
+		{name: "expired", status: Expired, want: false},
+		{name: "unknown", status: Status("unknown"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, tt.status.IsActive())
+		})
+	}
+}

--- a/modules/billing/presentation/controllers/payme_controller.go
+++ b/modules/billing/presentation/controllers/payme_controller.go
@@ -272,13 +272,12 @@ func (c *PaymeController) create(ctx context.Context, r *paymeapi.CreateTransact
 		billing.Payme,
 		filters,
 	)
-	if err != nil || len(entities) != 1 {
+	entity, ok := activePaymeTransaction(entities)
+	if err != nil || !ok {
 		logger.WithError(err).WithField("transaction_id", r.Id).Error("Invalid account in CreateTransaction")
 		errRPC := paymeapi.InvalidAccountError()
 		return nil, &errRPC
 	}
-
-	entity := entities[0]
 
 	amount := r.Amount / 100
 	if math.Abs(entity.Amount().Quantity()-amount) >= 1e-9 {
@@ -454,13 +453,12 @@ func (c *PaymeController) checkPerform(ctx context.Context, r *paymeapi.CheckPer
 		billing.Payme,
 		filters,
 	)
-	if err != nil || len(entities) != 1 {
+	entity, ok := activePaymeTransaction(entities)
+	if err != nil || !ok {
 		logger.WithError(err).Error("Invalid account in CheckPerformTransaction")
 		errRPC := paymeapi.CheckPerformTransactionInvalidAccountError()
 		return nil, &errRPC
 	}
-
-	entity := entities[0]
 
 	amount := r.Amount / 100
 	if math.Abs(entity.Amount().Quantity()-amount) >= 1e-9 {
@@ -507,6 +505,21 @@ func (c *PaymeController) checkPerform(ctx context.Context, r *paymeapi.CheckPer
 	return &paymeapi.CheckPerformTransactionResponse{
 		Allow: true,
 	}, nil
+}
+
+func activePaymeTransaction(entities []billing.Transaction) (billing.Transaction, bool) {
+	var selected billing.Transaction
+	for _, entity := range entities {
+		if !entity.Status().IsActive() {
+			continue
+		}
+		if selected != nil {
+			return nil, false
+		}
+		selected = entity
+	}
+
+	return selected, selected != nil
 }
 
 func (c *PaymeController) perform(ctx context.Context, r *paymeapi.PerformTransactionRequest, logger *logrus.Entry) (*paymeapi.PerformTransactionResponse, *paymeapi.JSONRPCErrorResponseError) {

--- a/modules/billing/presentation/controllers/payme_controller_test.go
+++ b/modules/billing/presentation/controllers/payme_controller_test.go
@@ -1,0 +1,230 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/modules/billing/domain/aggregates/billing"
+	"github.com/iota-uz/iota-sdk/modules/billing/domain/aggregates/details"
+	"github.com/iota-uz/iota-sdk/modules/billing/services"
+	"github.com/iota-uz/iota-sdk/pkg/constants"
+	paymeapi "github.com/iota-uz/payme"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPaymeController_Create_UsesActiveTransactionWhenTerminalRowsMatchAccount(t *testing.T) {
+	t.Parallel()
+
+	account := map[string]any{"order_id": "order-123"}
+	terminal := newPaymeControllerTestTransaction(
+		billing.Failed,
+		"failed-row",
+		details.PaymeWithAccount(account),
+		details.PaymeWithState(paymeapi.TransactionStateCancelledBeforeCompletion),
+	)
+	active := newPaymeControllerTestTransaction(
+		billing.Created,
+		"created-row",
+		details.PaymeWithAccount(account),
+		details.PaymeWithCreatedTime(1710000000000),
+	)
+	var saved billing.Transaction
+
+	controller := newTestPaymeController(t, account, []billing.Transaction{terminal, active}, func(tx billing.Transaction) {
+		saved = tx
+	})
+
+	ctx := context.WithValue(context.Background(), constants.TxKey, struct{}{})
+	resp, errRPC := controller.create(ctx, &paymeapi.CreateTransactionRequest{
+		Id:      "payme-tx-1",
+		Time:    1710000001000,
+		Amount:  12500,
+		Account: account,
+	}, logrus.New().WithField("test", true))
+
+	require.Nil(t, errRPC)
+	require.NotNil(t, resp)
+	assert.Equal(t, "created-row", resp.Transaction)
+	assert.EqualValues(t, paymeapi.TransactionStateCreated, resp.State)
+	assert.Equal(t, int64(1710000000000), resp.CreateTime)
+
+	require.NotNil(t, saved)
+	paymeDetails, ok := saved.Details().(details.PaymeDetails)
+	require.True(t, ok)
+	assert.Equal(t, "payme-tx-1", paymeDetails.ID())
+	assert.Equal(t, billing.Created, saved.Status())
+}
+
+func TestPaymeController_CheckPerform_UsesActiveTransactionWhenTerminalRowsMatchAccount(t *testing.T) {
+	t.Parallel()
+
+	account := map[string]any{"order_id": "order-123"}
+	terminal := newPaymeControllerTestTransaction(
+		billing.Canceled,
+		"canceled-row",
+		details.PaymeWithAccount(account),
+		details.PaymeWithState(paymeapi.TransactionStateCancelledBeforeCompletion),
+	)
+	active := newPaymeControllerTestTransaction(
+		billing.Created,
+		"created-row",
+		details.PaymeWithAccount(account),
+	)
+	var saved billing.Transaction
+
+	controller := newTestPaymeController(t, account, []billing.Transaction{terminal, active}, func(tx billing.Transaction) {
+		saved = tx
+	})
+
+	ctx := context.WithValue(context.Background(), constants.TxKey, struct{}{})
+	resp, errRPC := controller.checkPerform(ctx, &paymeapi.CheckPerformTransactionRequest{
+		Amount:  12500,
+		Account: account,
+	}, logrus.New().WithField("test", true))
+
+	require.Nil(t, errRPC)
+	require.NotNil(t, resp)
+	assert.True(t, resp.Allow)
+
+	require.NotNil(t, saved)
+	assert.Equal(t, billing.Pending, saved.Status())
+
+	paymeDetails, ok := saved.Details().(details.PaymeDetails)
+	require.True(t, ok)
+	assert.Equal(t, "created-row", paymeDetails.Transaction())
+	assert.Equal(t, account, paymeDetails.Account())
+}
+
+func TestPaymeController_Create_RejectsDuplicateActiveTransactions(t *testing.T) {
+	t.Parallel()
+
+	account := map[string]any{"order_id": "order-123"}
+	controller := newTestPaymeController(t, account, []billing.Transaction{
+		newPaymeControllerTestTransaction(
+			billing.Created,
+			"created-row",
+			details.PaymeWithAccount(account),
+		),
+		newPaymeControllerTestTransaction(
+			billing.Pending,
+			"pending-row",
+			details.PaymeWithAccount(account),
+		),
+	}, nil)
+
+	ctx := context.WithValue(context.Background(), constants.TxKey, struct{}{})
+	resp, errRPC := controller.create(ctx, &paymeapi.CreateTransactionRequest{
+		Id:      "payme-tx-1",
+		Time:    1710000001000,
+		Amount:  12500,
+		Account: account,
+	}, logrus.New().WithField("test", true))
+
+	require.Nil(t, resp)
+	require.NotNil(t, errRPC)
+	assert.Equal(t, paymeapi.InvalidAccountError().Code, errRPC.Code)
+}
+
+func TestPaymeController_CheckPerform_RejectsDuplicateActiveTransactions(t *testing.T) {
+	t.Parallel()
+
+	account := map[string]any{"order_id": "order-123"}
+	controller := newTestPaymeController(t, account, []billing.Transaction{
+		newPaymeControllerTestTransaction(
+			billing.Created,
+			"created-row",
+			details.PaymeWithAccount(account),
+		),
+		newPaymeControllerTestTransaction(
+			billing.Pending,
+			"pending-row",
+			details.PaymeWithAccount(account),
+		),
+	}, nil)
+
+	ctx := context.WithValue(context.Background(), constants.TxKey, struct{}{})
+	resp, errRPC := controller.checkPerform(ctx, &paymeapi.CheckPerformTransactionRequest{
+		Amount:  12500,
+		Account: account,
+	}, logrus.New().WithField("test", true))
+
+	require.Nil(t, resp)
+	require.NotNil(t, errRPC)
+	assert.Equal(t, paymeapi.CheckPerformTransactionInvalidAccountError().Code, errRPC.Code)
+}
+
+func newTestPaymeController(
+	t *testing.T,
+	account map[string]any,
+	transactions []billing.Transaction,
+	onSave func(billing.Transaction),
+) *PaymeController {
+	t.Helper()
+
+	repo := &testBillingRepo{
+		getByDetailsFields: func(_ context.Context, gateway billing.Gateway, filters []billing.DetailsFieldFilter) ([]billing.Transaction, error) {
+			require.Equal(t, billing.Payme, gateway)
+			require.ElementsMatch(t, paymeAccountFilters(account), filters)
+
+			return transactions, nil
+		},
+		save: func(_ context.Context, tx billing.Transaction) (billing.Transaction, error) {
+			if onSave != nil {
+				onSave(tx)
+			}
+			return tx, nil
+		},
+	}
+
+	return &PaymeController{
+		billingService: services.NewBillingService(repo, nil, noopEventBus{}),
+	}
+}
+
+type noopEventBus struct{}
+
+func (noopEventBus) Publish(...interface{}) {}
+
+func (noopEventBus) Subscribe(interface{}) func() {
+	return func() {}
+}
+
+func (noopEventBus) Clear() {}
+
+func (noopEventBus) SubscribersCount() int {
+	return 0
+}
+
+func paymeAccountFilters(account map[string]any) []billing.DetailsFieldFilter {
+	filters := make([]billing.DetailsFieldFilter, 0, len(account))
+	for k, v := range account {
+		filters = append(filters, billing.DetailsFieldFilter{
+			Path:     []string{"account", k},
+			Operator: billing.OpEqual,
+			Value:    v,
+		})
+	}
+	return filters
+}
+
+func newPaymeControllerTestTransaction(
+	status billing.Status,
+	transactionID string,
+	options ...details.PaymeOption,
+) billing.Transaction {
+	options = append([]details.PaymeOption{
+		details.PaymeWithState(paymeapi.TransactionStateCreated),
+	}, options...)
+
+	return billing.New(
+		125,
+		billing.UZS,
+		billing.Payme,
+		details.NewPaymeDetails(transactionID, options...),
+		billing.WithID(uuid.New()),
+		billing.WithStatus(status),
+	)
+}

--- a/modules/billing/presentation/controllers/stripe_controller_test.go
+++ b/modules/billing/presentation/controllers/stripe_controller_test.go
@@ -41,6 +41,7 @@ type testBillingRepo struct {
 		gateway billing.Gateway,
 		filters []billing.DetailsFieldFilter,
 	) ([]billing.Transaction, error)
+	save func(ctx context.Context, tx billing.Transaction) (billing.Transaction, error)
 }
 
 func (r *testBillingRepo) Count(_ context.Context, _ *billing.FindParams) (int64, error) {
@@ -70,7 +71,10 @@ func (r *testBillingRepo) GetAll(_ context.Context) ([]billing.Transaction, erro
 	return nil, nil
 }
 
-func (r *testBillingRepo) Save(_ context.Context, tx billing.Transaction) (billing.Transaction, error) {
+func (r *testBillingRepo) Save(ctx context.Context, tx billing.Transaction) (billing.Transaction, error) {
+	if r.save != nil {
+		return r.save(ctx, tx)
+	}
 	return tx, nil
 }
 


### PR DESCRIPTION
## Summary
- add a domain-level `billing.Status.IsActive()` helper for reusable active transaction semantics
- resolve Payme account lookups to the single active transaction instead of failing when terminal rows share the same `order_id`
- keep ambiguous active duplicates rejected
- add domain and controller regressions for `CreateTransaction` and `CheckPerformTransaction` when a terminal row and fresh `Created` row both match the account

Fixes #805.

## Validation
- `go test -v ./modules/billing/domain/aggregates/billing ./modules/billing/presentation/controllers`
- `go vet ./modules/billing/...`

## Notes
- `go vet ./...` still fails outside this change in `pkg/composition/applet/builder.go:472` because `api.AppletController` does not implement `Controller` (`Key` missing).
- `go test -v ./modules/billing/...` needs the local Postgres test harness on `127.0.0.1:5438`; those integration tests could not connect in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Payme transaction handling to reliably select the correct active billing transaction when multiple matching records exist.
  * Updated create and payment-check flows to fail only when an active transaction can’t be uniquely determined (zero or multiple active matches).
* **Tests**
  * Added/updated unit tests to cover scenarios where both terminal and active transactions match the same account context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->