### PR TITLE
fix(di): inject interface-contract services into handlers

### DIFF
--- a/pkg/di/providers.go
+++ b/pkg/di/providers.go
@@ -77,8 +77,8 @@ func (p *userProvider) Provide(t reflect.Type, ctx context.Context) (reflect.Val
 }
 
 func (p *serviceProvider) Ok(t reflect.Type) bool {
-	// Basic check: must be a pointer type for services
-	return t.Kind() == reflect.Ptr
+	// Services may be registered as concrete pointers or interface contracts.
+	return t.Kind() == reflect.Ptr || t.Kind() == reflect.Interface
 }
 
 func (p *serviceProvider) Provide(t reflect.Type, ctx context.Context) (reflect.Value, error) {

--- a/pkg/di/providers.go
+++ b/pkg/di/providers.go
@@ -94,7 +94,14 @@ func (p *serviceProvider) Provide(t reflect.Type, ctx context.Context) (reflect.
 	if err != nil {
 		return reflect.Value{}, err
 	}
-	return reflect.ValueOf(service), nil
+	if service == nil {
+		return reflect.Value{}, fmt.Errorf("container resolved a nil service for type %v", t)
+	}
+	value := reflect.ValueOf(service)
+	if !value.Type().AssignableTo(t) {
+		return reflect.Value{}, fmt.Errorf("resolved service of type %v is not assignable to %v", value.Type(), t)
+	}
+	return value, nil
 }
 
 func (p *loggerProvider) Ok(t reflect.Type) bool {

--- a/pkg/di/router.go
+++ b/pkg/di/router.go
@@ -85,11 +85,11 @@ func (d *DIContext) provideValue(argType reflect.Type, ctx context.Context) (ref
 	if argType == reflect.TypeOf((*context.Context)(nil)).Elem() {
 		return reflect.ValueOf(ctx), nil
 	}
+	if value, ok := provideAppValue(argType, ctx); ok {
+		return value, nil
+	}
 	provider, err := d.resolveProvider(argType)
 	if err != nil {
-		if value, ok := provideAppValue(argType, ctx); ok {
-			return value, nil
-		}
 		return reflect.Value{}, err
 	}
 	return provider.Provide(argType, ctx)
@@ -163,6 +163,10 @@ func createHandlerFunc(diContext *DIContext, handler interface{}) http.HandlerFu
 		// Check for direct http.ResponseWriter injection
 		if argType == writerInterface || (argType.Kind() == reflect.Interface && writerInterface.Implements(argType)) {
 			hasHTTPWriterArg[i] = true
+			continue
+		}
+
+		if argType.Kind() == reflect.Interface {
 			continue
 		}
 

--- a/pkg/di/router_test.go
+++ b/pkg/di/router_test.go
@@ -268,3 +268,30 @@ func TestH_InjectsInterfaceServiceFromContainer(t *testing.T) {
 	require.Equal(t, http.StatusOK, rr.Code)
 	require.Equal(t, "seed", rr.Body.String())
 }
+
+func TestServiceProvider_Provide_RejectsNilService(t *testing.T) {
+	serviceType := reflect.TypeOf((*sampleInterfaceService)(nil)).Elem()
+	container := &mockServiceResolver{
+		services: map[reflect.Type]any{serviceType: nil},
+	}
+	ctx := context.WithValue(context.Background(), constants.ContainerKey, container)
+
+	_, err := (&serviceProvider{}).Provide(serviceType, ctx)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "nil service")
+}
+
+func TestServiceProvider_Provide_RejectsNonAssignableService(t *testing.T) {
+	serviceType := reflect.TypeOf((*sampleInterfaceService)(nil)).Elem()
+	container := &mockServiceResolver{
+		// A string does not satisfy sampleInterfaceService.
+		services: map[reflect.Type]any{serviceType: "not-a-service"},
+	}
+	ctx := context.WithValue(context.Background(), constants.ContainerKey, container)
+
+	_, err := (&serviceProvider{}).Provide(serviceType, ctx)
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not assignable")
+}

--- a/pkg/di/router_test.go
+++ b/pkg/di/router_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -30,6 +31,28 @@ type mockApp struct{}
 func (m *mockApp) Bundle() *i18n.Bundle {
 	bundle := i18n.NewBundle(language.English)
 	return bundle
+}
+
+type mockServiceResolver struct {
+	services map[reflect.Type]any
+}
+
+func (m *mockServiceResolver) ResolveType(t reflect.Type) (any, error) {
+	service, ok := m.services[t]
+	if !ok {
+		return nil, fmt.Errorf("service not found: %v", t)
+	}
+	return service, nil
+}
+
+type sampleInterfaceService interface {
+	Name() string
+}
+
+type sampleInterfaceServiceImpl struct{}
+
+func (sampleInterfaceServiceImpl) Name() string {
+	return "seed"
 }
 
 // Create a test context with necessary dependencies
@@ -223,4 +246,25 @@ func TestH_InjectsAppValueFromContext(t *testing.T) {
 	handler(rr, req)
 
 	require.Equal(t, http.StatusNoContent, rr.Code)
+}
+
+func TestH_InjectsInterfaceServiceFromContainer(t *testing.T) {
+	serviceType := reflect.TypeOf((*sampleInterfaceService)(nil)).Elem()
+	container := &mockServiceResolver{
+		services: map[reflect.Type]any{
+			serviceType: sampleInterfaceServiceImpl{},
+		},
+	}
+
+	handler := H(func(w http.ResponseWriter, svc sampleInterfaceService) {
+		_, _ = fmt.Fprint(w, svc.Name())
+	})
+
+	ctx := context.WithValue(setupTestContext(), constants.ContainerKey, container)
+	req := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+	rr := httptest.NewRecorder()
+	handler(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	require.Equal(t, "seed", rr.Body.String())
 }


### PR DESCRIPTION
## Problem

`di.H` handlers could not receive services registered as **interface contracts** — only concrete `*T` pointers. Resolving such a handler failed at runtime with:

```
no provider found for type: services.PaymentAllocationService
```

This blocked EAI's payment-allocation feature, whose service is exposed via an interface.

## Fix

`pkg/di`:
- `serviceProvider.Ok` now matches `reflect.Interface` in addition to `reflect.Ptr`, so interface-typed args resolve through the container.
- `provideValue` checks app-provided context values **before** falling through to `resolveProvider` (fixes ordering so app values win).
- `createHandlerFunc` skips eager validation for interface args (they resolve from the container at call time, not registration time).

## Tests

Added `TestH_InjectsInterfaceServiceFromContainer` — a handler taking an interface service resolves it from the container and serves 200. `go test ./pkg/di/...` passes.

## Context

Paired with EAI branch `codex/payment-allocation-transfer` (payment-allocation transfer feature + bank-receipt sync backfill). The EAI submodule pointer bumps to this commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Interface-based dependencies can now be resolved correctly during request handling.
  * Service resolution now validates returned values and shows an error if a service is missing or incompatible.
  * App-level values are checked earlier in the resolution flow for more reliable injection.

* **Tests**
  * Added coverage for interface injection and error cases when services are nil or not assignable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->