### PR TITLE
fix(combobox): keep inline search input usable when values are selected

### DIFF
--- a/components/base/combobox.templ
+++ b/components/base/combobox.templ
@@ -256,8 +256,8 @@ templ Combobox(props ComboboxProps) {
 						"x-on:keydown.enter.prevent": "setValue(activeValue)",
 						"@input.debounce":            "onSearch",
 						"@input":                     "searchQuery = $event.target.value",
-						":size":                      "selectedValues.size > 0 ? (searchQuery.length || 1) : null",
-						":class":                     "selectedValues.size > 0 ? '!w-auto min-w-0 flex-shrink' : 'flex-1'",
+						":size":                      "selectedValues.size > 0 ? Math.max(searchQuery.length, 10) : null",
+						":class":                     "selectedValues.size > 0 ? '!w-auto min-w-[10ch] flex-shrink' : 'flex-1'",
 						":placeholder":               "selectedValues.size > 0 ? '' : '" + props.Placeholder + "'",
 					},
 					AddonRight: &input.Addon{

--- a/components/base/combobox_templ.go
+++ b/components/base/combobox_templ.go
@@ -516,8 +516,8 @@ func Combobox(props ComboboxProps) templ.Component {
 					"x-on:keydown.enter.prevent": "setValue(activeValue)",
 					"@input.debounce":            "onSearch",
 					"@input":                     "searchQuery = $event.target.value",
-					":size":                      "selectedValues.size > 0 ? (searchQuery.length || 1) : null",
-					":class":                     "selectedValues.size > 0 ? '!w-auto min-w-0 flex-shrink' : 'flex-1'",
+					":size":                      "selectedValues.size > 0 ? Math.max(searchQuery.length, 10) : null",
+					":class":                     "selectedValues.size > 0 ? '!w-auto min-w-[10ch] flex-shrink' : 'flex-1'",
 					":placeholder":               "selectedValues.size > 0 ? '' : '" + props.Placeholder + "'",
 				},
 				AddonRight: &input.Addon{


### PR DESCRIPTION
## Problem

The non-searchable `base.Combobox` collapses its inline search input to `size=1` (`min-w-0 flex-shrink`) whenever `selectedValues.size > 0`.

On **edit pages**, where multi/single selects are pre-populated, this shrinks the search input to ~1 character wide:
- users can't click/type to search or add options — the caret appears stuck or "vibrating";
- single-selects effectively can't be changed — the stale pre-selected value is posted on submit.

This affects every non-searchable combobox with pre-selected values (88 `base.Combobox` call sites across 42 files in iota-uz/eai alone). Reported downstream: **iota-uz/eai#3343** (insurance product edit → "Risks" / "Insurance term" unusable).

## Root cause

`components/base/combobox.templ` (non-searchable branch):

```
":size":  "selectedValues.size > 0 ? (searchQuery.length || 1) : null"
":class": "selectedValues.size > 0 ? '!w-auto min-w-0 flex-shrink' : 'flex-1'"
```

`searchQuery.length || 1` → `size=1` at rest; `min-w-0 flex-shrink` lets the flex item collapse below that.

## Fix

Floor the width at ~10 characters and keep a min-width:

```
":size":  "selectedValues.size > 0 ? Math.max(searchQuery.length, 10) : null"
":class": "selectedValues.size > 0 ? '!w-auto min-w-[10ch] flex-shrink' : 'flex-1'"
```

Preserves the grow-with-typing behavior; robust to Tailwind purge (no `min-w-0` → won't collapse even if `min-w-[10ch]` is stripped).

## Verification

- `templ generate -f components/base/combobox.templ` (v0.3.857)
- `go vet ./components/base/...`
- Manual UI check pending on the consuming app (iota-uz/eai product edit).

Refs iota-uz/eai#3343

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved combobox input sizing when items are already selected, so the field keeps a more consistent width.
  * Updated the selected-state layout to prevent the input from shrinking too much and to maintain better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->