### PR TITLE
Standardize export download helpers

### DIFF
--- a/components/export/export_dropdown.templ
+++ b/components/export/export_dropdown.templ
@@ -102,6 +102,19 @@ type ExportDropdownProps struct {
 	ParamsFormID string
 }
 
+func exportButtonSizeClass(size button.Size) string {
+	switch size {
+	case button.SizeMD:
+		return "btn-md"
+	case button.SizeSM:
+		return "btn-sm"
+	case button.SizeXS:
+		return "btn-xs"
+	default:
+		return "btn-normal"
+	}
+}
+
 // exportDownloadState is the Alpine component driving GET-download mode: it
 // fetches the GET export route (which streams the file) and saves the response
 // as a Blob via a temporary <a download>. Awaiting the fetch gives a precise
@@ -120,13 +133,13 @@ const exportDownloadState = `{
 			console.error('ExportDropdown: ParamsFormID element is missing or not a form:', formId);
 			return;
 		}
-		let params;
+		let params = new URLSearchParams(window.location.search);
 		if (form instanceof HTMLFormElement) {
-			params = new URLSearchParams(new FormData(form));
-			const fromUrl = new URLSearchParams(window.location.search);
-			['sort', 'order'].forEach(function (k) { if (fromUrl.has(k)) params.set(k, fromUrl.get(k)); });
-		} else {
-			params = new URLSearchParams(window.location.search);
+			const formParams = new URLSearchParams(new FormData(form));
+			const formKeys = new Set();
+			formParams.forEach(function (_value, key) { formKeys.add(key); });
+			formKeys.forEach(function (key) { params.delete(key); });
+			formParams.forEach(function (value, key) { params.append(key, value); });
 		}
 		['page', 'limit', 'per_page'].forEach(function (k) { params.delete(k); });
 		params.set('format', format);
@@ -170,7 +183,7 @@ templ ExportDropdown(props ExportDropdownProps) {
 	} else {
 		<div class="relative">
 			<details class="relative z-10 peer" name="export-dropdown">
-				<summary class="list-none cursor-pointer shrink-0 btn btn-secondary btn-normal btn-with-icon flex items-center gap-2">
+				<summary class={ "list-none cursor-pointer shrink-0 btn btn-secondary btn-with-icon flex items-center gap-2", exportButtonSizeClass(props.Size), props.Class }>
 					@icons.Download(icons.Props{Size: "18"})
 					if props.Label != "" {
 						{ props.Label }
@@ -216,7 +229,7 @@ templ exportDownloadDropdown(props ExportDropdownProps) {
 	>
 		<details class="relative z-10 peer" name="export-dropdown">
 			<summary
-				class="list-none cursor-pointer shrink-0 btn btn-secondary btn-normal btn-with-icon flex items-center gap-2"
+				class={ "list-none cursor-pointer shrink-0 btn btn-secondary btn-with-icon flex items-center gap-2", exportButtonSizeClass(props.Size), props.Class }
 				x-bind:aria-busy="exporting"
 			>
 				<span x-show="!exporting" class="flex items-center">

--- a/components/export/export_dropdown_templ.go
+++ b/components/export/export_dropdown_templ.go
@@ -110,6 +110,19 @@ type ExportDropdownProps struct {
 	ParamsFormID string
 }
 
+func exportButtonSizeClass(size button.Size) string {
+	switch size {
+	case button.SizeMD:
+		return "btn-md"
+	case button.SizeSM:
+		return "btn-sm"
+	case button.SizeXS:
+		return "btn-xs"
+	default:
+		return "btn-normal"
+	}
+}
+
 // exportDownloadState is the Alpine component driving GET-download mode: it
 // fetches the GET export route (which streams the file) and saves the response
 // as a Blob via a temporary <a download>. Awaiting the fetch gives a precise
@@ -128,13 +141,13 @@ const exportDownloadState = `{
 			console.error('ExportDropdown: ParamsFormID element is missing or not a form:', formId);
 			return;
 		}
-		let params;
+		let params = new URLSearchParams(window.location.search);
 		if (form instanceof HTMLFormElement) {
-			params = new URLSearchParams(new FormData(form));
-			const fromUrl = new URLSearchParams(window.location.search);
-			['sort', 'order'].forEach(function (k) { if (fromUrl.has(k)) params.set(k, fromUrl.get(k)); });
-		} else {
-			params = new URLSearchParams(window.location.search);
+			const formParams = new URLSearchParams(new FormData(form));
+			const formKeys = new Set();
+			formParams.forEach(function (_value, key) { formKeys.add(key); });
+			formKeys.forEach(function (key) { params.delete(key); });
+			formParams.forEach(function (value, key) { params.append(key, value); });
 		}
 		['page', 'limit', 'per_page'].forEach(function (k) { params.delete(k); });
 		params.set('format', format);
@@ -199,7 +212,29 @@ func ExportDropdown(props ExportDropdownProps) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"relative\"><details class=\"relative z-10 peer\" name=\"export-dropdown\"><summary class=\"list-none cursor-pointer shrink-0 btn btn-secondary btn-normal btn-with-icon flex items-center gap-2\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div class=\"relative\"><details class=\"relative z-10 peer\" name=\"export-dropdown\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var2 = []any{"list-none cursor-pointer shrink-0 btn btn-secondary btn-with-icon flex items-center gap-2", exportButtonSizeClass(props.Size), props.Class}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var2...)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<summary class=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var3 string
+			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var2).String())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 1, Col: 0}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -208,22 +243,22 @@ func ExportDropdown(props ExportDropdownProps) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			if props.Label != "" {
-				var templ_7745c5c3_Var2 string
-				templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(props.Label)
+				var templ_7745c5c3_Var4 string
+				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(props.Label)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 176, Col: 19}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 189, Col: 19}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				var templ_7745c5c3_Var3 string
-				templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Export.Title"))
+				var templ_7745c5c3_Var5 string
+				templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Export.Title"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 178, Col: 33}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 191, Col: 33}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -232,26 +267,26 @@ func ExportDropdown(props ExportDropdownProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</summary><ul class=\"flex flex-col gap-1 mt-1 absolute bg-surface-300 right-0 text-sm rounded-md w-44 overflow-hidden shadow-sm border border-secondary p-1\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</summary><ul class=\"flex flex-col gap-1 mt-1 absolute bg-surface-300 right-0 text-sm rounded-md w-44 overflow-hidden shadow-sm border border-secondary p-1\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, format := range props.Formats {
 				details := formatDetails[format]
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<li><button class=\"flex items-center gap-2 w-full text-left p-2 duration-200 hover:bg-surface-400 rounded-md\" hx-post=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<li><button class=\"flex items-center gap-2 w-full text-left p-2 duration-200 hover:bg-surface-400 rounded-md\" hx-post=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var4 string
-				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(props.ExportURL + "?format=" + details.Param)
+				var templ_7745c5c3_Var6 string
+				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(props.ExportURL + "?format=" + details.Param)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 188, Col: 62}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 201, Col: 62}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\" hx-target=\"body\" hx-swap=\"none\" hx-on::after-request=\"this.closest(&#39;details&#39;).removeAttribute(&#39;open&#39;)\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\" hx-target=\"body\" hx-swap=\"none\" hx-on::after-request=\"this.closest(&#39;details&#39;).removeAttribute(&#39;open&#39;)\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -259,7 +294,7 @@ func ExportDropdown(props ExportDropdownProps) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, ">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, ">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -267,21 +302,21 @@ func ExportDropdown(props ExportDropdownProps) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var5 string
-				templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T(details.LabelKey))
+				var templ_7745c5c3_Var7 string
+				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T(details.LabelKey))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 195, Col: 37}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 208, Col: 37}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</button></li>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</button></li>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</ul></details> <details class=\"hidden peer-open:block\" name=\"export-dropdown\"><summary class=\"fixed w-full h-full left-0 top-0\"></summary></details></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</ul></details> <details class=\"hidden peer-open:block\" name=\"export-dropdown\"><summary class=\"fixed w-full h-full left-0 top-0\"></summary></details></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -307,52 +342,74 @@ func exportDownloadDropdown(props ExportDropdownProps) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var6 == nil {
-			templ_7745c5c3_Var6 = templ.NopComponent
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		pageCtx := composables.UsePageCtx(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<div class=\"relative\" x-data=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var7 string
-		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(exportDownloadState)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 213, Col: 30}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\" data-export-url=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var8 string
-		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(props.ExportURL)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 214, Col: 35}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\" data-params-form=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<div class=\"relative\" x-data=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var9 string
-		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(props.ParamsFormID)
+		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(exportDownloadState)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 215, Col: 39}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 226, Col: 30}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\"><details class=\"relative z-10 peer\" name=\"export-dropdown\"><summary class=\"list-none cursor-pointer shrink-0 btn btn-secondary btn-normal btn-with-icon flex items-center gap-2\" x-bind:aria-busy=\"exporting\"><span x-show=\"!exporting\" class=\"flex items-center\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\" data-export-url=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var10 string
+		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(props.ExportURL)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 227, Col: 35}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\" data-params-form=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var11 string
+		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(props.ParamsFormID)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 228, Col: 39}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\"><details class=\"relative z-10 peer\" name=\"export-dropdown\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var12 = []any{"list-none cursor-pointer shrink-0 btn btn-secondary btn-with-icon flex items-center gap-2", exportButtonSizeClass(props.Size), props.Class}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var12...)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<summary class=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var13 string
+		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var12).String())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 1, Col: 0}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\" x-bind:aria-busy=\"exporting\"><span x-show=\"!exporting\" class=\"flex items-center\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -360,7 +417,7 @@ func exportDownloadDropdown(props ExportDropdownProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</span> <span x-show=\"exporting\" x-cloak class=\"flex items-center\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</span> <span x-show=\"exporting\" x-cloak class=\"flex items-center\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -370,27 +427,27 @@ func exportDownloadDropdown(props ExportDropdownProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</span> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if props.Label != "" {
-			var templ_7745c5c3_Var10 string
-			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(props.Label)
+			var templ_7745c5c3_Var14 string
+			templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(props.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 231, Col: 18}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 244, Col: 18}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			var templ_7745c5c3_Var11 string
-			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Export.Title"))
+			var templ_7745c5c3_Var15 string
+			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Export.Title"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 233, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 246, Col: 32}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -399,26 +456,26 @@ func exportDownloadDropdown(props ExportDropdownProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</summary><ul class=\"flex flex-col gap-1 mt-1 absolute bg-surface-300 right-0 text-sm rounded-md w-44 overflow-hidden shadow-sm border border-secondary p-1\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</summary><ul class=\"flex flex-col gap-1 mt-1 absolute bg-surface-300 right-0 text-sm rounded-md w-44 overflow-hidden shadow-sm border border-secondary p-1\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, format := range props.Formats {
 			details := formatDetails[format]
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<li><button type=\"button\" class=\"flex items-center gap-2 w-full text-left p-2 duration-200 hover:bg-surface-400 rounded-md disabled:opacity-50 disabled:cursor-not-allowed\" x-on:click=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<li><button type=\"button\" class=\"flex items-center gap-2 w-full text-left p-2 duration-200 hover:bg-surface-400 rounded-md disabled:opacity-50 disabled:cursor-not-allowed\" x-on:click=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var12 string
-			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("runExport('%s')", details.Param))
+			var templ_7745c5c3_Var16 string
+			templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("runExport('%s')", details.Param))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 244, Col: 65}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 257, Col: 65}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "\" x-bind:disabled=\"exporting\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\" x-bind:disabled=\"exporting\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -426,7 +483,7 @@ func exportDownloadDropdown(props ExportDropdownProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, ">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, ">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -434,21 +491,21 @@ func exportDownloadDropdown(props ExportDropdownProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var13 string
-			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T(details.LabelKey))
+			var templ_7745c5c3_Var17 string
+			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T(details.LabelKey))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 249, Col: 36}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 262, Col: 36}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</button></li>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</button></li>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</ul></details> <details class=\"hidden peer-open:block\" name=\"export-dropdown\"><summary class=\"fixed w-full h-full left-0 top-0\"></summary></details><!-- Busy overlay: visible while the export fetch is in flight. --><div x-show=\"exporting\" x-cloak x-transition.opacity class=\"fixed bottom-4 right-4 z-50 flex items-center gap-3 bg-surface-300 border border-secondary rounded-lg shadow-lg px-4 py-3 text-sm\" role=\"status\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</ul></details> <details class=\"hidden peer-open:block\" name=\"export-dropdown\"><summary class=\"fixed w-full h-full left-0 top-0\"></summary></details><!-- Busy overlay: visible while the export fetch is in flight. --><div x-show=\"exporting\" x-cloak x-transition.opacity class=\"fixed bottom-4 right-4 z-50 flex items-center gap-3 bg-surface-300 border border-secondary rounded-lg shadow-lg px-4 py-3 text-sm\" role=\"status\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -458,20 +515,20 @@ func exportDownloadDropdown(props ExportDropdownProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var14 string
-		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Export.Preparing"))
+		var templ_7745c5c3_Var18 string
+		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Export.Preparing"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 269, Col: 40}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/export/export_dropdown.templ`, Line: 282, Col: 40}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</span></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</span></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/components/export/export_dropdown_test.go
+++ b/components/export/export_dropdown_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/text/language"
 
+	"github.com/iota-uz/iota-sdk/components/base/button"
 	"github.com/iota-uz/iota-sdk/components/export"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
 	"github.com/iota-uz/iota-sdk/pkg/types"
@@ -47,6 +48,8 @@ func TestExportDropdown_DownloadMode(t *testing.T) {
 		ExportURL:    "/portfolio/policies/export",
 		Download:     true,
 		ParamsFormID: "filters-form",
+		Size:         button.SizeSM,
+		Class:        "w-full",
 	})
 
 	// Download mode must NOT emit htmx attributes — those POST to the export URL
@@ -63,6 +66,11 @@ func TestExportDropdown_DownloadMode(t *testing.T) {
 	assert.NotContains(t, html, "download_token", "cookie-poll mechanism removed")
 	assert.NotContains(t, html, "createElement(&#39;iframe&#39;)", "iframe mechanism removed")
 	assert.Contains(t, html, "Export.Preparing", "busy overlay label must render")
+	assert.Contains(t, html, "btn-sm", "download trigger must honor Size")
+	assert.Contains(t, html, "w-full", "download trigger must honor Class")
+	assert.Contains(t, html, "new URLSearchParams(window.location.search)")
+	assert.Contains(t, html, "new URLSearchParams(new FormData(form))")
+	assert.Contains(t, html, "params.delete(key)")
 	// Per-format triggers wired to runExport with each format param. Assert the
 	// format args are present without pinning the exact HTML-entity encoding of
 	// the surrounding quotes (an implementation artifact).
@@ -79,10 +87,14 @@ func TestExportDropdown_LegacyHtmxMode(t *testing.T) {
 	html := renderDropdown(t, export.ExportDropdownProps{
 		Formats:   []export.ExportFormat{export.ExportFormatExcel},
 		ExportURL: "/clients/export",
+		Size:      button.SizeXS,
+		Class:     "min-w-32",
 	})
 
 	assert.Contains(t, html, `hx-post="/clients/export?format=excel"`)
 	assert.Contains(t, html, `hx-swap="none"`)
+	assert.Contains(t, html, "btn-xs", "legacy trigger must honor Size")
+	assert.Contains(t, html, "min-w-32", "legacy trigger must honor Class")
 	assert.NotContains(t, html, "runExport(")
 	assert.NotContains(t, html, "data-export-url")
 }

--- a/modules/core/services/excel_export_service.go
+++ b/modules/core/services/excel_export_service.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -65,6 +66,19 @@ func (s *ExcelExportService) ExportFromQuery(ctx context.Context, query exportco
 	return uploadEntity, nil
 }
 
+// ExportQueryToWriter exports SQL query results to Excel and streams them to w.
+func (s *ExcelExportService) ExportQueryToWriter(ctx context.Context, w io.Writer, query exportconfig.Query, config exportconfig.ExportConfig) error {
+	datasource := excel.NewPgxDataSource(s.db, query.SQL(), query.Args()...)
+	if config.Filename() != "" {
+		sheetName := config.Filename()
+		if len(sheetName) > 31 {
+			sheetName = sheetName[:31]
+		}
+		datasource.WithSheetName(sheetName)
+	}
+	return s.ExportDataSourceToWriter(ctx, w, datasource, config)
+}
+
 // ExportFromDataSource exports from a custom data source to Excel
 func (s *ExcelExportService) ExportFromDataSource(
 	ctx context.Context,
@@ -94,4 +108,18 @@ func (s *ExcelExportService) ExportFromDataSource(
 	}
 
 	return uploadEntity, nil
+}
+
+// ExportDataSourceToWriter exports from a custom data source to Excel and streams it to w.
+func (s *ExcelExportService) ExportDataSourceToWriter(
+	ctx context.Context,
+	w io.Writer,
+	datasource excel.DataSource,
+	config exportconfig.ExportConfig,
+) error {
+	exporter := excel.NewExcelExporter(config.ExportOptions(), config.StyleOptions())
+	if err := exporter.ExportToWriter(ctx, w, datasource); err != nil {
+		return fmt.Errorf("failed to export to Excel: %w", err)
+	}
+	return nil
 }

--- a/modules/core/services/excel_export_service_test.go
+++ b/modules/core/services/excel_export_service_test.go
@@ -1,6 +1,7 @@
 package services_test
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
@@ -365,6 +366,26 @@ func TestExcelExportService_ExportFromDataSourceWithOptions(t *testing.T) {
 	// Verify expectations
 	mockRepo.AssertExpectations(t)
 	mockStorage.AssertExpectations(t)
+}
+
+func TestExcelExportService_ExportDataSourceToWriter(t *testing.T) {
+	uploadService := services.NewUploadService(new(MockUploadRepository), new(MockUploadStorage), eventbus.NewEventPublisher(logrus.New()))
+	excelService := services.NewExcelExportService(nil, uploadService)
+
+	datasource := &mockDataSource{
+		headers: []string{"id", "name"},
+		rows: [][]interface{}{
+			{1, "John"},
+			{2, "Jane"},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := excelService.ExportDataSourceToWriter(context.Background(), &buf, datasource, exportconfig.New(exportconfig.WithFilename("users")))
+
+	require.NoError(t, err)
+	assert.Positive(t, buf.Len())
+	assert.Equal(t, []byte{'P', 'K'}, buf.Bytes()[:2], "xlsx output should be a zip payload")
 }
 
 func TestExcelExportService_ExportFromDataSource_EmptyFilename(t *testing.T) {


### PR DESCRIPTION
Adds consistent download-mode parameter merging for ExportDropdown and writer APIs for ExcelExportService so Granite exports can stream directly.\n\nChecks:\n- go test ./components/export\n- go test ./modules/core/services

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export dropdown trigger styling now honors the selected button size and any custom classes in both legacy and download flows.
  * Excel exports can now stream output directly during export generation.
* **Bug Fixes**
  * Export downloads now build the request query more predictably: paging params are removed, existing export URL parameters are preserved, and form values take precedence over URL parameters.
  * While an export is preparing, the UI shows a busy state and disables format options.
* **Tests**
  * Updated/added assertions for download and legacy dropdown trigger behavior and Excel streaming output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->