### PR TITLE
fix: copy-button crossfade + combobox popover full-width bug

### DIFF
--- a/components/copy_button/copy_button.templ
+++ b/components/copy_button/copy_button.templ
@@ -69,10 +69,11 @@ templ CopyButton(props Props) {
 	if variant == "" {
 		{{ variant = VariantDefault }}
 	}
+	{{ dim := size + "px" }}
 	<button
 		type="button"
 		class={
-			"inline-flex items-center gap-1 transition-all duration-200 text-gray-300 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 rounded cursor-pointer",
+			"inline-flex items-center gap-1.5 transition-colors duration-150 text-gray-300 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 rounded cursor-pointer",
 			templ.KV("bg-gray-100 hover:bg-gray-200 px-2 py-1", variant == VariantDefault),
 			templ.KV("hover:bg-gray-100 p-1", variant == VariantMinimal),
 			props.Class,
@@ -80,13 +81,25 @@ templ CopyButton(props Props) {
 		data-copy-text={ props.Text }
 		x-data={ clipboardData }
 		@click="copyText()"
-		x-bind:class="copied ? 'text-green-600' : ''"
+		:class="copied ? 'text-green-600' : ''"
 	>
-		<span x-show="!copied" x-transition>
-			@icons.Copy(icons.Props{Size: size})
-		</span>
-		<span x-show="copied" x-transition>
-			@icons.CheckCircle(icons.Props{Size: size})
+		// Both icons are stacked in the same cell (rather than x-show'd in/out of
+		// flow) and crossfade+scale via :class. Toggling display with x-show left
+		// both icons in flow for the duration of the transition, so the button
+		// visibly widened then snapped back on every copy click.
+		<span class="relative inline-block shrink-0" style={ "width:" + dim + ";height:" + dim }>
+			<span
+				class="absolute inset-0 flex items-center justify-center transition-all duration-150 ease-out"
+				:class="copied ? 'opacity-0 scale-50' : 'opacity-100 scale-100'"
+			>
+				@icons.Copy(icons.Props{Size: size})
+			</span>
+			<span
+				class="absolute inset-0 flex items-center justify-center transition-all duration-200 ease-out"
+				:class="copied ? 'opacity-100 scale-100' : 'opacity-0 scale-50'"
+			>
+				@icons.CheckCircle(icons.Props{Size: size})
+			</span>
 		</span>
 		if props.ShowText {
 			<span class="text-xs font-medium" x-text="copied ? 'Copied!' : 'Copy'"></span>
@@ -127,11 +140,19 @@ templ CopyableText(props TextProps) {
 			@keydown.space.stop.prevent="copy()"
 		>
 			<span class="truncate">{ props.Text }</span>
-			<span x-show="!copied" class="shrink-0 text-current opacity-0 group-hover:opacity-100 transition-opacity">
-				@icons.Copy(icons.Props{Size: size})
-			</span>
-			<span x-show="copied" class="shrink-0 text-green-500">
-				@icons.CheckCircle(icons.Props{Size: size})
+			<span class="relative inline-block shrink-0" style={ "width:" + size + "px;height:" + size + "px" }>
+				<span
+					class="absolute inset-0 flex items-center justify-center text-current opacity-0 transition-all duration-150 ease-out group-hover:opacity-100"
+					:class="copied ? '!opacity-0 scale-50' : 'scale-100'"
+				>
+					@icons.Copy(icons.Props{Size: size})
+				</span>
+				<span
+					class="absolute inset-0 flex items-center justify-center text-green-500 opacity-0 scale-50 transition-all duration-200 ease-out"
+					:class="copied ? 'opacity-100 scale-100' : ''"
+				>
+					@icons.CheckCircle(icons.Props{Size: size})
+				</span>
 			</span>
 		</span>
 	}

--- a/components/copy_button/copy_button_templ.go
+++ b/components/copy_button/copy_button_templ.go
@@ -97,8 +97,9 @@ func CopyButton(props Props) templ.Component {
 		if variant == "" {
 			variant = VariantDefault
 		}
+		dim := size + "px"
 		var templ_7745c5c3_Var2 = []any{
-			"inline-flex items-center gap-1 transition-all duration-200 text-gray-300 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 rounded cursor-pointer",
+			"inline-flex items-center gap-1.5 transition-colors duration-150 text-gray-300 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 rounded cursor-pointer",
 			templ.KV("bg-gray-100 hover:bg-gray-200 px-2 py-1", variant == VariantDefault),
 			templ.KV("hover:bg-gray-100 p-1", variant == VariantMinimal),
 			props.Class,
@@ -127,7 +128,7 @@ func CopyButton(props Props) templ.Component {
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(props.Text)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 80, Col: 29}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 81, Col: 29}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -140,13 +141,26 @@ func CopyButton(props Props) templ.Component {
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(clipboardData)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 81, Col: 24}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 82, Col: 24}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\" @click=\"copyText()\" x-bind:class=\"copied ? &#39;text-green-600&#39; : &#39;&#39;\"><span x-show=\"!copied\" x-transition>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "\" @click=\"copyText()\" :class=\"copied ? &#39;text-green-600&#39; : &#39;&#39;\"><span class=\"relative inline-block shrink-0\" style=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var6 string
+		templ_7745c5c3_Var6, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues("width:" + dim + ";height:" + dim)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 90, Col: 88}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\"><span class=\"absolute inset-0 flex items-center justify-center transition-all duration-150 ease-out\" :class=\"copied ? &#39;opacity-0 scale-50&#39; : &#39;opacity-100 scale-100&#39;\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -154,7 +168,7 @@ func CopyButton(props Props) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</span> <span x-show=\"copied\" x-transition>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</span> <span class=\"absolute inset-0 flex items-center justify-center transition-all duration-200 ease-out\" :class=\"copied ? &#39;opacity-100 scale-100&#39; : &#39;opacity-0 scale-50&#39;\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -162,17 +176,17 @@ func CopyButton(props Props) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</span> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</span></span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if props.ShowText {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<span class=\"text-xs font-medium\" x-text=\"copied ? &#39;Copied!&#39; : &#39;Copy&#39;\"></span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<span class=\"text-xs font-medium\" x-text=\"copied ? &#39;Copied!&#39; : &#39;Copy&#39;\"></span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "</button>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</button>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -206,9 +220,9 @@ func CopyableText(props TextProps) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var6 == nil {
-			templ_7745c5c3_Var6 = templ.NopComponent
+		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var7 == nil {
+			templ_7745c5c3_Var7 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		size := props.Size
@@ -216,110 +230,123 @@ func CopyableText(props TextProps) templ.Component {
 			size = "16"
 		}
 		if props.Text == "" {
-			var templ_7745c5c3_Var7 string
-			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs("-")
+			var templ_7745c5c3_Var8 string
+			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs("-")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 113, Col: 7}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 126, Col: 7}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			var templ_7745c5c3_Var8 = []any{"inline-flex items-center gap-1 cursor-pointer group whitespace-nowrap max-w-full focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded", props.Class}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var8...)
+			var templ_7745c5c3_Var9 = []any{"inline-flex items-center gap-1 cursor-pointer group whitespace-nowrap max-w-full focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded", props.Class}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var9...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<span role=\"button\" tabindex=\"0\" class=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var9 string
-			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var8).String())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 1, Col: 0}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\" data-copy-text=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<span role=\"button\" tabindex=\"0\" class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var10 string
-			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(props.Text)
+			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var9).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 119, Col: 30}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "\" data-copy-text=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var11 string
+			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(props.Text)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 132, Col: 30}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if props.Label != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, " title=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var11 string
-				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(props.Label)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 121, Col: 23}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\" aria-label=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, " title=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var12 string
 				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(props.Label)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 122, Col: 28}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 134, Col: 23}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\" aria-label=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var13 string
+				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(props.Label)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 135, Col: 28}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, " x-data=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var13 string
-			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(copyableTextData)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 124, Col: 28}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "\" @click.stop=\"copy()\" @keydown.enter.stop.prevent=\"copy()\" @keydown.space.stop.prevent=\"copy()\"><span class=\"truncate\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, " x-data=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var14 string
-			templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(props.Text)
+			templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(copyableTextData)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 129, Col: 38}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 137, Col: 28}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</span> <span x-show=\"!copied\" class=\"shrink-0 text-current opacity-0 group-hover:opacity-100 transition-opacity\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\" @click.stop=\"copy()\" @keydown.enter.stop.prevent=\"copy()\" @keydown.space.stop.prevent=\"copy()\"><span class=\"truncate\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var15 string
+			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(props.Text)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 142, Col: 38}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</span> <span class=\"relative inline-block shrink-0\" style=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var16 string
+			templ_7745c5c3_Var16, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues("width:" + size + "px;height:" + size + "px")
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/copy_button/copy_button.templ`, Line: 143, Col: 100}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\"><span class=\"absolute inset-0 flex items-center justify-center text-current opacity-0 transition-all duration-150 ease-out group-hover:opacity-100\" :class=\"copied ? &#39;!opacity-0 scale-50&#39; : &#39;scale-100&#39;\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -327,7 +354,7 @@ func CopyableText(props TextProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</span> <span x-show=\"copied\" class=\"shrink-0 text-green-500\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</span> <span class=\"absolute inset-0 flex items-center justify-center text-green-500 opacity-0 scale-50 transition-all duration-200 ease-out\" :class=\"copied ? &#39;opacity-100 scale-100&#39; : &#39;&#39;\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -335,7 +362,7 @@ func CopyableText(props TextProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</span></span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</span></span></span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/modules/core/presentation/assets/js/alpine.js
+++ b/modules/core/presentation/assets/js/alpine.js
@@ -265,6 +265,21 @@ let combobox = (searchable = false, canCreateNew = false) => ({
     let rect = trigger.getBoundingClientRect();
     let gap = 4;
     let edge = 8; // keep the menu clear of the viewport edge
+    let isPopover = this.supportsPopover(list) && list.matches(':popover-open');
+    // Reset the UA-default top-layer box (`inset:0; margin:auto`) BEFORE measuring
+    // scrollWidth below: with inset:0 still active, `left`/`right` are both pinned
+    // to 0 so the box (and therefore its scrollWidth) is forced to full viewport
+    // width regardless of content — that previously made every popover render
+    // screen-wide the instant it opened.
+    if (isPopover) {
+      list.style.margin = '0';
+      list.style.inset = 'auto';
+      list.style.position = 'fixed';
+    } else {
+      list.style.position = 'absolute';
+      list.style.left = '0px';
+      list.style.top = '100%';
+    }
     // Width: at least the field width, but grow to fit the widest option so long
     // labels aren't clipped — capped to the viewport so it never overflows. Measure
     // the natural content width with the constraint cleared first. Callers passing
@@ -274,12 +289,7 @@ let combobox = (searchable = false, canCreateNew = false) => ({
     list.style.maxWidth = viewportWidth + 'px';
     let width = Math.min(Math.max(rect.width, list.scrollWidth), viewportWidth);
     list.style.width = width + 'px';
-    if (this.supportsPopover(list) && list.matches(':popover-open')) {
-      // Top-layer popover: position against the viewport (fixed coordinates)
-      // and reset the UA-default `inset:0; margin:auto` centering.
-      list.style.margin = '0';
-      list.style.inset = 'auto';
-      list.style.position = 'fixed';
+    if (isPopover) {
       // Size the menu to the available space rather than a fixed cap: measure the
       // natural content height (bounded by any caller-supplied cap such as
       // `!max-h-60`), then clamp to whichever side of the trigger has more room.
@@ -298,10 +308,8 @@ let combobox = (searchable = false, canCreateNew = false) => ({
       list.style.left = Math.max(edge, Math.min(rect.left, window.innerWidth - width - edge)) + 'px';
       list.style.top = (flipUp ? rect.top - height - gap : rect.bottom + gap) + 'px';
     } else {
-      // Fallback (no Popover API): sit just below the field, in flow.
-      list.style.position = 'absolute';
-      list.style.left = '0px';
-      list.style.top = '100%';
+      // Fallback (no Popover API): sit just below the field, in flow (position/left/top
+      // already set above).
       list.style.removeProperty('max-height');
       let avail = Math.max(0, window.innerHeight - rect.bottom - gap - edge);
       let height = Math.min(this.dropdownMaxHeightCap(list), list.scrollHeight + 2, avail);


### PR DESCRIPTION
## Summary
- `CopyButton`/`CopyableText` (components/copy_button/copy_button.templ): the copy→checkmark icon swap used `x-show`, which keeps both icons in flow for the duration of the transition — the button visibly widened then snapped back on every click. Icons now sit stacked in the same cell and crossfade+scale via reactive `:class` bindings instead. Also switched the focus ring from `focus:` to `focus-visible:` on `CopyButton` so it no longer persists after a mouse click (matches the pattern already used on `CopyableText`).
- `combobox` popover (modules/core/presentation/assets/js/alpine.js, `positionDropdown()`): measured `list.scrollWidth` *before* resetting the popover's UA-default `inset:0` top-layer box, so every option list (which sizes itself off that scrollWidth) rendered full viewport width the instant it opened, regardless of how little content it had. Reset `position`/`inset`/`margin` first, then measure content width.

## Test plan
- [x] `go vet ./components/copy_button/...` and `go vet ./...` clean
- [x] `templ generate` regenerated only the touched files
- [x] Verified live via `eai/back` (consumer of this submodule) at `/integration/webhooks/:id`:
  - Opened the "Статус" filter combobox — popover now sizes to the field/content (`width: 294px`) instead of the full viewport (`width: 1702px` before the fix)
  - Forced `copied = true` on the secret-row copy button via Alpine devtools — button `getBoundingClientRect()` width is identical before/after (no layout jump), checkmark crossfades in place