### PR TITLE
fix(combobox): keep long dropdown scrollable — stop scrollTop reset on reposition

### DIFF
--- a/modules/core/presentation/assets/js/alpine.js
+++ b/modules/core/presentation/assets/js/alpine.js
@@ -207,7 +207,13 @@ let combobox = (searchable = false, canCreateNew = false) => ({
   canCreateNew,
   init() {
     // Reposition the (top-layer) dropdown when the page scrolls/resizes while open.
-    this._reflow = () => {
+    this._reflow = (e) => {
+      // A scroll *inside* the open dropdown must not trigger a reposition:
+      // positionDropdown() clears then re-applies max-height, which resets the
+      // list's scrollTop to 0. Repositioning on the list's own scroll would snap
+      // the user back to the top on every wheel tick, making a long menu
+      // impossible to scroll. Only reposition when an ancestor/the page scrolls.
+      if (e && e.target instanceof Node && this.$refs.list && this.$refs.list.contains(e.target)) return;
       if (this.open || this.openedWithKeyboard) this.positionDropdown();
     };
     this.$watch('open', () => this.syncDropdown());
@@ -262,6 +268,10 @@ let combobox = (searchable = false, canCreateNew = false) => ({
     let list = this.$refs.list;
     let trigger = this.$refs.trigger;
     if (!list || !trigger) return;
+    // Clearing `max-height` below momentarily makes the list non-scrollable,
+    // which resets its scrollTop to 0. Snapshot and restore it so a reposition
+    // (resize, chip add, or an ancestor scroll) never loses the user's place.
+    let prevScrollTop = list.scrollTop;
     let rect = trigger.getBoundingClientRect();
     let gap = 4;
     let edge = 8; // keep the menu clear of the viewport edge
@@ -315,6 +325,8 @@ let combobox = (searchable = false, canCreateNew = false) => ({
       let height = Math.min(this.dropdownMaxHeightCap(list), list.scrollHeight + 2, avail);
       list.style.setProperty('max-height', height + 'px', 'important');
     }
+    // Restore the scroll position lost when max-height was cleared above.
+    list.scrollTop = prevScrollTop;
   },
   dropdownMaxHeightCap(list) {
     // Caller-supplied max-height cap (e.g. ListClass `!max-h-60`) in pixels, or


### PR DESCRIPTION
## Problem

A long combobox option list (top-layer popover) could not be scrolled with the wheel/trackpad. Depending on where the field sat on the page the symptom looked like one of two things:

- **Snaps back to the top / freezes** — most visible with a very long list that opens with room below (e.g. product **Risks**, 100+ options).
- **Won't move down at all** — most visible when the field sits low on the page so the menu's bottom is near the viewport edge (e.g. product **Terms / «Срок»**).

Both were reproduced live on production (`erp.eai.uz`, product create/edit) and confirmed to be the same underlying cause.

## Root cause

The option list is a `popover` in the top layer whose height is sized by `positionDropdown()`, which **clears then re-applies** an inline `max-height`:

```js
list.style.removeProperty('max-height');   // list is momentarily NOT overflowing → browser resets scrollTop to 0
...
list.style.setProperty('max-height', height + 'px', 'important');
```

`init()` registers a **capture-phase** `scroll` listener on `window`:

```js
window.addEventListener('scroll', this._reflow, true);   // fires for the dropdown's OWN internal scroll too
```

So every wheel tick **inside** the open menu bubbles a `scroll` event that the capture listener catches → `positionDropdown()` re-runs on each tick:

- It resets `scrollTop` to 0 (via the `max-height` clear) → the list snaps back up.
- When the menu sits low, the reflow also re-evaluates available space, decides there's no room below and **flips/re-anchors** the popover mid-scroll → the list won't advance at all.

Net effect: a long menu is effectively impossible to scroll. Verified live by neutralising `positionDropdown` on the open dropdown — scrolling then works perfectly, isolating the reposition-on-scroll as the cause.

## Fix

Two small, complementary changes in `combobox()` (`modules/core/presentation/assets/js/alpine.js`):

1. **`_reflow` ignores the dropdown's own scroll.** A reposition is only meaningful when an ancestor/the page scrolls (the trigger moves); a scroll *inside* the list must not trigger one. Skip events whose target is inside `$refs.list`.

2. **`positionDropdown` preserves `scrollTop`.** Snapshot before clearing `max-height` and restore after re-applying it, so any reposition (resize, multi-select chip add, ancestor scroll) never loses the user's place.

Either change fixes both symptoms; together they are belt-and-suspenders. No height cap is imposed — the menu still grows to available space.

## Verification

Reproduced live on prod and verified each fix half in DevTools on the actual page:
- **Risks** — fixed by the scrollTop restore (menu opens with room, no flip; only the reset mattered).
- **Terms/«Срок»** — fixed by not repositioning on self-scroll (menu sits low, was flipping mid-scroll).

`node --check` passes on the ES module. No API/interface change; asset-only.

Context: EAI issue iota-uz/eai#3444 (product create/edit «Срок»/«Риски» dropdowns).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dropdown scrolling behavior so internal list scrolling no longer forces the list back to the top.
  * Preserved the dropdown’s scroll position when it is repositioned, preventing users from losing their place during resize, scroll, or selection changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->