### PR TITLE
bichat: add mid-loop system reminders

### DIFF
--- a/modules/bichat/config.go
+++ b/modules/bichat/config.go
@@ -222,6 +222,8 @@ type ModuleConfig struct {
 	// Optional: Token Estimator for cost tracking and budget management
 	// If not provided, a no-op estimator will be used
 	TokenEstimator agents.TokenEstimator
+	// Optional: additional executor options applied to each parent agent run.
+	ExecutorOptions []agents.ExecutorOption
 
 	// Optional: Observability
 	Logger                 *logrus.Logger

--- a/modules/bichat/config_build.go
+++ b/modules/bichat/config_build.go
@@ -155,6 +155,7 @@ func (c *ModuleConfig) BuildServices() (*ServiceContainer, error) {
 		SkillsCatalogLimit:     c.SkillsCatalogLimit,
 		SkillsMaxChars:         c.SkillsMaxChars,
 		RuntimeTools:           runtimeTools,
+		ExecutorOptions:        c.ExecutorOptions,
 		Logger:                 c.Logger,
 		FormatterRegistry:      formatters.DefaultFormatterRegistry(),
 	})

--- a/modules/bichat/config_options.go
+++ b/modules/bichat/config_options.go
@@ -208,6 +208,13 @@ func WithTokenEstimator(estimator agents.TokenEstimator) ConfigOption {
 	}
 }
 
+// WithExecutorOptions appends executor options used for each parent agent run.
+func WithExecutorOptions(options ...agents.ExecutorOption) ConfigOption {
+	return func(c *ModuleConfig) {
+		c.ExecutorOptions = append(c.ExecutorOptions, options...)
+	}
+}
+
 // WithObservability adds an observability provider for tracing, metrics, and cost tracking.
 // Providers are wrapped in AsyncHandler to prevent blocking the main execution path.
 // Multiple providers can be registered by calling this option multiple times.

--- a/modules/bichat/services/agent_service_impl.go
+++ b/modules/bichat/services/agent_service_impl.go
@@ -45,6 +45,7 @@ type agentServiceImpl struct {
 	skillsCatalogLimit     int
 	skillsMaxChars         int
 	runtimeTools           []agents.Tool
+	executorOptions        []agents.ExecutorOption
 	logger                 *logrus.Logger
 	formatterRegistry      *bichatctx.FormatterRegistry // Optional for StructuredTool support
 }
@@ -66,6 +67,7 @@ type AgentServiceConfig struct {
 	SkillsCatalogLimit     int
 	SkillsMaxChars         int
 	RuntimeTools           []agents.Tool
+	ExecutorOptions        []agents.ExecutorOption
 	Logger                 *logrus.Logger
 	FormatterRegistry      *bichatctx.FormatterRegistry // Optional for StructuredTool support
 }
@@ -118,6 +120,7 @@ func NewAgentService(cfg AgentServiceConfig) services.AgentService {
 		skillsCatalogLimit:     limit,
 		skillsMaxChars:         maxChars,
 		runtimeTools:           append([]agents.Tool(nil), cfg.RuntimeTools...),
+		executorOptions:        append([]agents.ExecutorOption(nil), cfg.ExecutorOptions...),
 		logger:                 logger,
 		formatterRegistry:      cfg.FormatterRegistry,
 	}
@@ -324,6 +327,7 @@ func (s *agentServiceImpl) buildExecutor(ctx context.Context, sessionID, tenantI
 	if s.formatterRegistry != nil {
 		opts = append(opts, agents.WithFormatterRegistry(s.formatterRegistry))
 	}
+	opts = append(opts, s.executorOptions...)
 
 	if tools := s.composeExecutorTools(sessionID, tenantID); len(tools) > 0 {
 		opts = append(opts, agents.WithExecutorTools(tools))

--- a/pkg/bichat/agents/executor.go
+++ b/pkg/bichat/agents/executor.go
@@ -741,7 +741,7 @@ func (e *Executor) Execute(ctx context.Context, input Input) types.Generator[Exe
 
 				// Store for ordered message append later.
 				specResults[tr.call.ID] = types.ToolResponse(tr.call.ID, toolOutput)
-				specOutcomes[tr.call.ID] = toolCallOutcomeFromResult(tr.call, tr.result, tr.err, tr.durationMs)
+				specOutcomes[tr.call.ID] = toolCallOutcomeFromResult(tr.call, toolOutput, tr.result, tr.err, tr.durationMs)
 				return true
 			}
 
@@ -1560,7 +1560,7 @@ func (e *Executor) executeToolCalls(
 		}
 
 		ordered[tr.idx] = types.ToolResponse(tr.call.ID, toolOutput)
-		outcomes[tr.idx] = toolCallOutcomeFromResult(tr.call, tr.result, tr.err, tr.durationMs)
+		outcomes[tr.idx] = toolCallOutcomeFromResult(tr.call, toolOutput, tr.result, tr.err, tr.durationMs)
 	}
 
 	results := make([]types.Message, 0, len(ordered))

--- a/pkg/bichat/agents/executor.go
+++ b/pkg/bichat/agents/executor.go
@@ -221,6 +221,8 @@ type ToolEvent struct {
 type toolExecutionResult struct {
 	output    string
 	artifacts []types.ToolArtifact
+	truncated bool
+	rowCount  int
 }
 
 // Executor executes the ReAct (Reason + Act) loop for an agent.
@@ -265,6 +267,7 @@ type Executor struct {
 	tokenEstimator    TokenEstimator          // Optional token estimator for cost tracking
 	speculativeTools  bool                    // Start executing ready tool calls during streaming (best-effort)
 	formatterRegistry types.FormatterRegistry // Optional formatter registry for StructuredTool support
+	reminderRules     []ReminderRule          // Optional mid-loop behavioral steering rules
 }
 
 // Input represents the input to Execute or Resume.
@@ -380,6 +383,13 @@ func WithFormatterRegistry(registry types.FormatterRegistry) ExecutorOption {
 	}
 }
 
+// WithReminderRules registers opt-in mid-loop reminders emitted after tool batches.
+func WithReminderRules(rules ...ReminderRule) ExecutorOption {
+	return func(e *Executor) {
+		e.reminderRules = append(e.reminderRules, rules...)
+	}
+}
+
 // NewExecutor creates a new Executor with the given agent and model.
 func NewExecutor(agent ExtendedAgent, model Model, opts ...ExecutorOption) *Executor {
 	executor := &Executor{
@@ -403,6 +413,7 @@ func NewExecutor(agent ExtendedAgent, model Model, opts ...ExecutorOption) *Exec
 // falls back to agent.OnToolCall for backward compatibility.
 // After invoking StructuredTool.CallStructured we always return and never fall through to Tool.Call() to avoid double execution.
 func (e *Executor) callTool(ctx context.Context, tool Tool, toolName, arguments string) (toolExecutionResult, error) {
+	execResult := toolExecutionResult{rowCount: -1}
 	if e.formatterRegistry != nil && tool != nil {
 		if st, ok := tool.(StructuredTool); ok {
 			result, err := st.CallStructured(ctx, arguments)
@@ -410,11 +421,10 @@ func (e *Executor) callTool(ctx context.Context, tool Tool, toolName, arguments 
 				return toolExecutionResult{}, err
 			}
 			if result == nil {
-				return toolExecutionResult{}, nil
+				return execResult, nil
 			}
-			execResult := toolExecutionResult{
-				artifacts: result.Artifacts,
-			}
+			execResult.artifacts = result.Artifacts
+			execResult.truncated, execResult.rowCount = reminderMetadataFromPayload(result.Payload)
 			// result != nil: format or fallback, then return (never fall through to tool.Call())
 			if f := e.formatterRegistry.Get(result.CodecID); f != nil {
 				formatted, fmtErr := f.Format(result.Payload, types.DefaultFormatOptions())
@@ -443,13 +453,16 @@ func (e *Executor) callTool(ctx context.Context, tool Tool, toolName, arguments 
 	if tool != nil {
 		if tf, ok := tool.(*ToolFunc); ok && tf.Fn == nil {
 			output, err := e.agent.OnToolCall(ctx, toolName, arguments)
-			return toolExecutionResult{output: output}, err
+			execResult.output = output
+			return execResult, err
 		}
 		output, err := tool.Call(ctx, arguments)
-		return toolExecutionResult{output: output}, err
+		execResult.output = output
+		return execResult, err
 	}
 	output, err := e.agent.OnToolCall(ctx, toolName, arguments)
-	return toolExecutionResult{output: output}, err
+	execResult.output = output
+	return execResult, err
 }
 
 // Execute runs the ReAct loop and returns a Generator that yields ExecutorEvent objects.
@@ -481,6 +494,8 @@ func (e *Executor) Execute(ctx context.Context, input Input) types.Generator[Exe
 
 		// Track provider continuity across iterations in a single execution.
 		previousResponseID := input.PreviousResponseID
+		reminderTracker := newReminderTracker()
+		turnToolCounts := make(map[string]int)
 
 		// Agent lifecycle tracking
 		agentStartTime := time.Now()
@@ -524,6 +539,7 @@ func (e *Executor) Execute(ctx context.Context, input Input) types.Generator[Exe
 			if tools == nil {
 				tools = e.agent.Tools()
 			}
+			batchToolNames := buildBatchToolNames(tools)
 
 			// Build model request
 			req := Request{
@@ -615,6 +631,7 @@ func (e *Executor) Execute(ctx context.Context, input Input) types.Generator[Exe
 			specCancelled := false
 			specStarted := make(map[string]struct{})
 			specResults := make(map[string]types.Message)
+			specOutcomes := make(map[string]ToolCallOutcome)
 			specPending := 0
 			// Do not rely on a large buffer here: tool calls can exceed small fixed sizes.
 			// We drain results opportunistically during streaming to avoid backpressure.
@@ -724,6 +741,7 @@ func (e *Executor) Execute(ctx context.Context, input Input) types.Generator[Exe
 
 				// Store for ordered message append later.
 				specResults[tr.call.ID] = types.ToolResponse(tr.call.ID, toolOutput)
+				specOutcomes[tr.call.ID] = toolCallOutcomeFromResult(tr.call, tr.result, tr.err, tr.durationMs)
 				return true
 			}
 
@@ -1041,6 +1059,7 @@ func (e *Executor) Execute(ctx context.Context, input Input) types.Generator[Exe
 
 			// Execute tool calls
 			var toolResults []types.Message
+			var toolOutcomes []ToolCallOutcome
 			var interrupt *InterruptEvent
 			var toolErr error
 
@@ -1069,9 +1088,13 @@ func (e *Executor) Execute(ctx context.Context, input Input) types.Generator[Exe
 				}
 
 				toolResults = make([]types.Message, 0, len(toolCalls))
+				toolOutcomes = make([]ToolCallOutcome, 0, len(toolCalls))
 				for _, tc := range toolCalls {
 					if msg, ok := specResults[tc.ID]; ok && msg != nil {
 						toolResults = append(toolResults, msg)
+					}
+					if outcome, ok := specOutcomes[tc.ID]; ok {
+						toolOutcomes = append(toolOutcomes, outcome)
 					}
 				}
 			} else {
@@ -1080,7 +1103,7 @@ func (e *Executor) Execute(ctx context.Context, input Input) types.Generator[Exe
 				if !emitTextBlockEndIfNeeded() {
 					return nil
 				}
-				toolResults, interrupt, toolErr = e.executeToolCalls(ctx, input.SessionID, input.TenantID, traceID, tools, toolCalls, yield)
+				toolResults, toolOutcomes, interrupt, toolErr = e.executeToolCalls(ctx, input.SessionID, input.TenantID, traceID, tools, toolCalls, yield)
 			}
 
 			if toolErr != nil {
@@ -1158,6 +1181,12 @@ func (e *Executor) Execute(ctx context.Context, input Input) types.Generator[Exe
 
 			// Add tool results to messages
 			messages = append(messages, toolResults...)
+			for _, outcome := range toolOutcomes {
+				turnToolCounts[outcome.Name]++
+			}
+			if reminder := e.reminderMessage(ctx, iteration, e.maxIterations, toolOutcomes, turnToolCounts, batchToolNames, reminderTracker); reminder != nil {
+				messages = append(messages, reminder)
+			}
 
 			// Continue to next iteration
 		}
@@ -1299,11 +1328,11 @@ func (e *Executor) executeToolCalls(
 	tools []Tool,
 	toolCalls []types.ToolCall,
 	yield func(ExecutorEvent) bool,
-) ([]types.Message, *InterruptEvent, error) {
+) ([]types.Message, []ToolCallOutcome, *InterruptEvent, error) {
 	const op serrors.Op = "Executor.executeToolCalls"
 
 	if len(toolCalls) == 0 {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
 	// Interrupt tool handling is exclusive (do not execute other tools in the same batch).
@@ -1311,7 +1340,7 @@ func (e *Executor) executeToolCalls(
 	for i, tc := range toolCalls {
 		if tc.Name == ToolAskUserQuestion {
 			if interruptIdx != -1 {
-				return nil, nil, serrors.E(op, serrors.KindValidation, "multiple interrupt tool calls in one batch are not supported")
+				return nil, nil, nil, serrors.E(op, serrors.KindValidation, "multiple interrupt tool calls in one batch are not supported")
 			}
 			interruptIdx = i
 		}
@@ -1338,17 +1367,17 @@ func (e *Executor) executeToolCalls(
 				Arguments: tc.Arguments,
 			},
 		}) {
-			return nil, nil, nil // Consumer stopped
+			return nil, nil, nil, nil // Consumer stopped
 		}
 
 		payload, err := parseAndCanonicalizeAskUserQuestionArgs(tc.Arguments)
 		if err != nil {
-			return nil, nil, serrors.E(op, err)
+			return nil, nil, nil, serrors.E(op, err)
 		}
 
 		interruptData, err := json.Marshal(payload)
 		if err != nil {
-			return nil, nil, serrors.E(op, err, "failed to marshal interrupt payload")
+			return nil, nil, nil, serrors.E(op, err, "failed to marshal interrupt payload")
 		}
 
 		interrupt := &InterruptEvent{
@@ -1356,7 +1385,7 @@ func (e *Executor) executeToolCalls(
 			Data: interruptData,
 		}
 
-		return nil, interrupt, nil
+		return nil, nil, interrupt, nil
 	}
 
 	toolByName := make(map[string]Tool, len(tools))
@@ -1418,7 +1447,7 @@ func (e *Executor) executeToolCalls(
 			},
 		}) {
 			cancel()
-			return nil, nil, nil // Consumer stopped
+			return nil, nil, nil, nil // Consumer stopped
 		}
 
 		// Determine concurrency key (optional).
@@ -1469,6 +1498,7 @@ func (e *Executor) executeToolCalls(
 	}
 
 	ordered := make([]types.Message, len(toolCalls))
+	outcomes := make([]ToolCallOutcome, len(toolCalls))
 	received := 0
 
 	for received < len(toolCalls) {
@@ -1476,7 +1506,7 @@ func (e *Executor) executeToolCalls(
 		select {
 		case tr = <-resultsCh:
 		case <-toolCtx.Done():
-			return nil, nil, serrors.E(op, toolCtx.Err())
+			return nil, nil, nil, serrors.E(op, toolCtx.Err())
 		}
 
 		received++
@@ -1526,20 +1556,27 @@ func (e *Executor) executeToolCalls(
 			},
 		}) {
 			cancel()
-			return nil, nil, nil // Consumer stopped
+			return nil, nil, nil, nil // Consumer stopped
 		}
 
 		ordered[tr.idx] = types.ToolResponse(tr.call.ID, toolOutput)
+		outcomes[tr.idx] = toolCallOutcomeFromResult(tr.call, tr.result, tr.err, tr.durationMs)
 	}
 
 	results := make([]types.Message, 0, len(ordered))
+	orderedOutcomes := make([]ToolCallOutcome, 0, len(outcomes))
 	for _, msg := range ordered {
 		if msg != nil {
 			results = append(results, msg)
 		}
 	}
+	for _, outcome := range outcomes {
+		if outcome.Name != "" {
+			orderedOutcomes = append(orderedOutcomes, outcome)
+		}
+	}
 
-	return results, nil, nil
+	return results, orderedOutcomes, nil, nil
 }
 
 func parseAndCanonicalizeAskUserQuestionArgs(args string) (types.AskUserQuestionPayload, error) {

--- a/pkg/bichat/agents/executor_test.go
+++ b/pkg/bichat/agents/executor_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -17,10 +18,12 @@ import (
 
 // mockModel is a test model that returns predefined responses.
 type mockModel struct {
+	mu            sync.Mutex
 	responses     []mockResponse
 	currentIndex  int
 	streamingMode bool
 	info          agents.ModelInfo
+	requests      []agents.Request
 }
 
 type mockResponse struct {
@@ -46,6 +49,7 @@ func newMockModel(responses ...mockResponse) *mockModel {
 }
 
 func (m *mockModel) Generate(ctx context.Context, req agents.Request, opts ...agents.GenerateOption) (*agents.Response, error) {
+	m.recordRequest(req)
 	if m.currentIndex >= len(m.responses) {
 		return nil, fmt.Errorf("no more mock responses")
 	}
@@ -69,6 +73,7 @@ func (m *mockModel) Generate(ctx context.Context, req agents.Request, opts ...ag
 }
 
 func (m *mockModel) Stream(ctx context.Context, req agents.Request, opts ...agents.GenerateOption) (types.Generator[agents.Chunk], error) {
+	m.recordRequest(req)
 	return types.NewGenerator(ctx, func(ctx context.Context, yield func(agents.Chunk) bool) error {
 		if m.currentIndex >= len(m.responses) {
 			return fmt.Errorf("no more mock responses")
@@ -116,6 +121,21 @@ func (m *mockModel) Stream(ctx context.Context, req agents.Request, opts ...agen
 
 		return nil
 	}), nil
+}
+
+func (m *mockModel) recordRequest(req agents.Request) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	copied := req
+	copied.Messages = append([]types.Message(nil), req.Messages...)
+	copied.Tools = append([]agents.Tool(nil), req.Tools...)
+	m.requests = append(m.requests, copied)
+}
+
+func (m *mockModel) capturedRequests() []agents.Request {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]agents.Request(nil), m.requests...)
 }
 
 func (m *mockModel) Info() agents.ModelInfo {

--- a/pkg/bichat/agents/reminders.go
+++ b/pkg/bichat/agents/reminders.go
@@ -1,0 +1,300 @@
+package agents
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/iota-uz/iota-sdk/pkg/bichat/types"
+)
+
+const (
+	defaultSlowToolThresholdMs = int64(10_000)
+	defaultMaxRemindersPerTurn = 8
+)
+
+// ReminderRule emits an optional mid-loop behavioral reminder after a tool batch.
+type ReminderRule interface {
+	Name() string
+	Eval(ctx context.Context, s ReminderState) string
+}
+
+// ReminderState captures the executor state visible to a reminder rule.
+type ReminderState struct {
+	Iteration      int
+	MaxIterations  int
+	Batch          []ToolCallOutcome
+	TurnToolCounts map[string]int
+	BatchToolNames map[string]string
+}
+
+// ToolCallOutcome describes one completed tool call in the latest batch.
+type ToolCallOutcome struct {
+	Name       string
+	Arguments  string
+	DurationMs int64
+	Err        error
+	Truncated  bool
+	RowCount   int
+}
+
+// NewDefaultReminderRules returns the generic reminder rules shipped by the SDK.
+func NewDefaultReminderRules() []ReminderRule {
+	return []ReminderRule{
+		NewSingleToolBatchReminderRule(),
+		NewIterationBudgetReminderRule(),
+		NewSQLTruncationReminderRule(),
+		NewEmptyResultReminderRule(),
+		NewSlowToolReminderRule(defaultSlowToolThresholdMs, "web_fetch", "web_search", "sql_execute"),
+		NewToolErrorReminderRule(),
+	}
+}
+
+// NewSingleToolBatchReminderRule nudges single-call turns toward available batch tools.
+func NewSingleToolBatchReminderRule() ReminderRule {
+	return reminderRule{
+		name: "single_tool_batch",
+		eval: func(ctx context.Context, s ReminderState) string {
+			if len(s.Batch) != 1 || totalToolCalls(s.TurnToolCounts) != 1 {
+				return ""
+			}
+			toolName := s.Batch[0].Name
+			batchName := s.BatchToolNames[toolName]
+			if batchName == "" {
+				return ""
+			}
+			return fmt.Sprintf("This turn used one %s call, but %s is available. When you need related lookups, prefer batching them in one call.", toolName, batchName)
+		},
+	}
+}
+
+// NewIterationBudgetReminderRule nudges the model to converge near the iteration cap.
+func NewIterationBudgetReminderRule() ReminderRule {
+	return reminderRule{
+		name: "iteration_budget",
+		eval: func(ctx context.Context, s ReminderState) string {
+			if s.MaxIterations <= 0 {
+				return ""
+			}
+			ratio := float64(s.Iteration) / float64(s.MaxIterations)
+			if ratio >= 0.95 {
+				return fmt.Sprintf("You've used %d/%d steps. Stop exploring, converge on the best supported answer, and clearly state any remaining uncertainty.", s.Iteration, s.MaxIterations)
+			}
+			if ratio >= 0.80 {
+				return fmt.Sprintf("You've used %d/%d steps. Prioritize the shortest path to a final answer over more exploratory tool calls.", s.Iteration, s.MaxIterations)
+			}
+			return ""
+		},
+	}
+}
+
+// NewSQLTruncationReminderRule nudges the model to narrow truncated SQL results.
+func NewSQLTruncationReminderRule() ReminderRule {
+	return reminderRule{
+		name: "sql_truncation",
+		eval: func(ctx context.Context, s ReminderState) string {
+			for _, outcome := range s.Batch {
+				if outcome.Truncated {
+					return "The SQL result was truncated. Tighten the WHERE clause, aggregate at the needed grain, or select fewer columns instead of rerunning the same broad query."
+				}
+			}
+			return ""
+		},
+	}
+}
+
+// NewEmptyResultReminderRule nudges the model to revisit filters after empty results.
+func NewEmptyResultReminderRule() ReminderRule {
+	return reminderRule{
+		name: "empty_result",
+		eval: func(ctx context.Context, s ReminderState) string {
+			for _, outcome := range s.Batch {
+				if outcome.RowCount == 0 {
+					return "The result returned 0 rows. Recheck filters, broaden exact matches, or inspect candidate values before concluding nothing exists."
+				}
+			}
+			return ""
+		},
+	}
+}
+
+// NewSlowToolReminderRule nudges the model to avoid redundant slow calls.
+func NewSlowToolReminderRule(thresholdMs int64, toolNames ...string) ReminderRule {
+	if thresholdMs <= 0 {
+		thresholdMs = defaultSlowToolThresholdMs
+	}
+	tools := make(map[string]struct{}, len(toolNames))
+	for _, name := range toolNames {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			tools[name] = struct{}{}
+		}
+	}
+	return reminderRule{
+		name: "slow_tool",
+		eval: func(ctx context.Context, s ReminderState) string {
+			for _, outcome := range s.Batch {
+				if len(tools) > 0 {
+					if _, ok := tools[outcome.Name]; !ok {
+						continue
+					}
+				}
+				if outcome.DurationMs > thresholdMs {
+					return fmt.Sprintf("The last %s call was slow. Avoid repeating identical calls; reuse that result or narrow the next request.", outcome.Name)
+				}
+			}
+			return ""
+		},
+	}
+}
+
+// NewToolErrorReminderRule nudges the model to correct failed tool calls before retrying.
+func NewToolErrorReminderRule() ReminderRule {
+	return reminderRule{
+		name: "tool_error",
+		eval: func(ctx context.Context, s ReminderState) string {
+			for _, outcome := range s.Batch {
+				if outcome.Err != nil {
+					return "A tool call failed. Use the error details to correct arguments, syntax, or filters before retrying; avoid repeating the same failing call unchanged."
+				}
+			}
+			return ""
+		},
+	}
+}
+
+type reminderRule struct {
+	name string
+	eval func(context.Context, ReminderState) string
+}
+
+func (r reminderRule) Name() string {
+	return r.name
+}
+
+func (r reminderRule) Eval(ctx context.Context, s ReminderState) string {
+	if r.eval == nil {
+		return ""
+	}
+	return strings.TrimSpace(r.eval(ctx, s))
+}
+
+type reminderTracker struct {
+	emitted  map[string]struct{}
+	lastRule string
+	count    int
+}
+
+func newReminderTracker() *reminderTracker {
+	return &reminderTracker{
+		emitted: make(map[string]struct{}),
+	}
+}
+
+func (t *reminderTracker) allow(ruleName, reminder string) bool {
+	reminder = strings.TrimSpace(reminder)
+	if reminder == "" || t.count >= defaultMaxRemindersPerTurn {
+		return false
+	}
+	if _, exists := t.emitted[reminder]; exists {
+		return false
+	}
+	if ruleName != "" && ruleName == t.lastRule {
+		return false
+	}
+	t.emitted[reminder] = struct{}{}
+	t.lastRule = ruleName
+	t.count++
+	return true
+}
+
+func (e *Executor) reminderMessage(ctx context.Context, iteration, maxIterations int, batch []ToolCallOutcome, counts map[string]int, batchForms map[string]string, tracker *reminderTracker) types.Message {
+	if len(e.reminderRules) == 0 || len(batch) == 0 || tracker == nil {
+		return nil
+	}
+	state := ReminderState{
+		Iteration:      iteration,
+		MaxIterations:  maxIterations,
+		Batch:          slices.Clone(batch),
+		TurnToolCounts: maps.Clone(counts),
+		BatchToolNames: maps.Clone(batchForms),
+	}
+
+	reminders := make([]string, 0, len(e.reminderRules))
+	for _, rule := range e.reminderRules {
+		if rule == nil {
+			continue
+		}
+		text := strings.TrimSpace(rule.Eval(ctx, state))
+		if tracker.allow(rule.Name(), text) {
+			reminders = append(reminders, text)
+		}
+	}
+	if len(reminders) == 0 {
+		return nil
+	}
+	return types.SystemMessage("<system-reminder>\n" + strings.Join(reminders, "\n") + "\n</system-reminder>")
+}
+
+func reminderMetadataFromPayload(payload any) (bool, int) {
+	switch p := payload.(type) {
+	case types.QueryResultFormatPayload:
+		return p.Truncated, p.RowCount
+	case *types.QueryResultFormatPayload:
+		if p == nil {
+			return false, -1
+		}
+		return p.Truncated, p.RowCount
+	case types.ExplainPlanPayload:
+		return p.Truncated, -1
+	case *types.ExplainPlanPayload:
+		if p == nil {
+			return false, -1
+		}
+		return p.Truncated, -1
+	default:
+		return false, -1
+	}
+}
+
+func toolCallOutcomeFromResult(call types.ToolCall, result toolExecutionResult, err error, durationMs int64) ToolCallOutcome {
+	return ToolCallOutcome{
+		Name:       call.Name,
+		Arguments:  call.Arguments,
+		DurationMs: durationMs,
+		Err:        err,
+		Truncated:  result.truncated,
+		RowCount:   result.rowCount,
+	}
+}
+
+func totalToolCalls(counts map[string]int) int {
+	total := 0
+	for _, count := range counts {
+		total += count
+	}
+	return total
+}
+
+func buildBatchToolNames(tools []Tool) map[string]string {
+	available := make(map[string]struct{}, len(tools))
+	for _, tool := range tools {
+		if tool == nil {
+			continue
+		}
+		available[tool.Name()] = struct{}{}
+	}
+	batchForms := make(map[string]string)
+	for name := range available {
+		if strings.HasSuffix(name, "_batch") {
+			continue
+		}
+		batchName := name + "_batch"
+		if _, ok := available[batchName]; ok {
+			batchForms[name] = batchName
+		}
+	}
+	return batchForms
+}

--- a/pkg/bichat/agents/reminders.go
+++ b/pkg/bichat/agents/reminders.go
@@ -34,6 +34,7 @@ type ReminderState struct {
 type ToolCallOutcome struct {
 	Name       string
 	Arguments  string
+	Output     string
 	DurationMs int64
 	Err        error
 	Truncated  bool
@@ -259,10 +260,11 @@ func reminderMetadataFromPayload(payload any) (bool, int) {
 	}
 }
 
-func toolCallOutcomeFromResult(call types.ToolCall, result toolExecutionResult, err error, durationMs int64) ToolCallOutcome {
+func toolCallOutcomeFromResult(call types.ToolCall, output string, result toolExecutionResult, err error, durationMs int64) ToolCallOutcome {
 	return ToolCallOutcome{
 		Name:       call.Name,
 		Arguments:  call.Arguments,
+		Output:     output,
 		DurationMs: durationMs,
 		Err:        err,
 		Truncated:  result.truncated,

--- a/pkg/bichat/agents/reminders_test.go
+++ b/pkg/bichat/agents/reminders_test.go
@@ -1,0 +1,221 @@
+package agents_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/pkg/bichat/agents"
+	"github.com/iota-uz/iota-sdk/pkg/bichat/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultReminderRules(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		rule  agents.ReminderRule
+		state agents.ReminderState
+		want  string
+	}{
+		{
+			name: "single tool batch",
+			rule: agents.NewSingleToolBatchReminderRule(),
+			state: agents.ReminderState{
+				Batch: []agents.ToolCallOutcome{{Name: "schema_describe"}},
+				TurnToolCounts: map[string]int{
+					"schema_describe": 1,
+				},
+				BatchToolNames: map[string]string{
+					"schema_describe": "schema_describe_batch",
+				},
+			},
+			want: "This turn used one schema_describe call, but schema_describe_batch is available. When you need related lookups, prefer batching them in one call.",
+		},
+		{
+			name: "iteration budget pressure",
+			rule: agents.NewIterationBudgetReminderRule(),
+			state: agents.ReminderState{
+				Iteration:     80,
+				MaxIterations: 100,
+			},
+			want: "You've used 80/100 steps. Prioritize the shortest path to a final answer over more exploratory tool calls.",
+		},
+		{
+			name: "sql truncation",
+			rule: agents.NewSQLTruncationReminderRule(),
+			state: agents.ReminderState{
+				Batch: []agents.ToolCallOutcome{{Name: "sql_execute", Truncated: true}},
+			},
+			want: "The SQL result was truncated. Tighten the WHERE clause, aggregate at the needed grain, or select fewer columns instead of rerunning the same broad query.",
+		},
+		{
+			name: "empty result",
+			rule: agents.NewEmptyResultReminderRule(),
+			state: agents.ReminderState{
+				Batch: []agents.ToolCallOutcome{{Name: "sql_execute", RowCount: 0}},
+			},
+			want: "The result returned 0 rows. Recheck filters, broaden exact matches, or inspect candidate values before concluding nothing exists.",
+		},
+		{
+			name: "slow tool",
+			rule: agents.NewSlowToolReminderRule(100, "web_fetch"),
+			state: agents.ReminderState{
+				Batch: []agents.ToolCallOutcome{{Name: "web_fetch", DurationMs: 101}},
+			},
+			want: "The last web_fetch call was slow. Avoid repeating identical calls; reuse that result or narrow the next request.",
+		},
+		{
+			name: "tool error",
+			rule: agents.NewToolErrorReminderRule(),
+			state: agents.ReminderState{
+				Batch: []agents.ToolCallOutcome{{Name: "web_fetch", Err: errors.New("boom")}},
+			},
+			want: "A tool call failed. Use the error details to correct arguments, syntax, or filters before retrying; avoid repeating the same failing call unchanged.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tt.want, tt.rule.Eval(context.Background(), tt.state))
+		})
+	}
+}
+
+func TestExecutor_ReminderMessageAfterToolBatch(t *testing.T) {
+	t.Parallel()
+
+	for _, specEnabled := range []bool{false, true} {
+		t.Run(map[bool]string{false: "sync", true: "speculative"}[specEnabled], func(t *testing.T) {
+			ctx := context.Background()
+			tool := agents.NewTool(
+				"do_thing",
+				"do_thing",
+				map[string]any{},
+				func(ctx context.Context, input string) (string, error) { return "ok", nil },
+			)
+			agent := newMockAgent("reminder-agent", tool)
+			model := newMockModel(
+				mockResponse{
+					content:      "Checking.",
+					toolCalls:    []types.ToolCall{{ID: "c1", Name: "do_thing", Arguments: "{}"}},
+					finishReason: "tool_calls",
+				},
+				mockResponse{
+					content:      "Done.",
+					finishReason: "stop",
+				},
+			)
+
+			executor := agents.NewExecutor(
+				agent,
+				model,
+				agents.WithSpeculativeTools(specEnabled),
+				agents.WithReminderRules(staticReminderRule{name: "test", text: "remember this"}),
+			)
+			gen := executor.Execute(ctx, agents.Input{
+				Messages:  []types.Message{types.UserMessage("go")},
+				SessionID: uuidForTest(t),
+				TenantID:  uuidForTest(t),
+			})
+			defer gen.Close()
+			drainExecutor(t, ctx, gen)
+
+			requests := model.capturedRequests()
+			require.Len(t, requests, 2)
+			secondMessages := requests[1].Messages
+			require.GreaterOrEqual(t, len(secondMessages), 4)
+			require.Equal(t, types.RoleTool, secondMessages[len(secondMessages)-2].Role())
+			require.Equal(t, types.RoleSystem, secondMessages[len(secondMessages)-1].Role())
+			require.Equal(t, "<system-reminder>\nremember this\n</system-reminder>", secondMessages[len(secondMessages)-1].Content())
+		})
+	}
+}
+
+func TestExecutor_RemindersDeduplicateWithinTurn(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tool := agents.NewTool(
+		"do_thing",
+		"do_thing",
+		map[string]any{},
+		func(ctx context.Context, input string) (string, error) { return "ok", nil },
+	)
+	agent := newMockAgent("dedupe-agent", tool)
+	model := newMockModel(
+		mockResponse{
+			toolCalls:    []types.ToolCall{{ID: "c1", Name: "do_thing", Arguments: "{}"}},
+			finishReason: "tool_calls",
+		},
+		mockResponse{
+			toolCalls:    []types.ToolCall{{ID: "c2", Name: "do_thing", Arguments: "{}"}},
+			finishReason: "tool_calls",
+		},
+		mockResponse{
+			content:      "Done.",
+			finishReason: "stop",
+		},
+	)
+
+	executor := agents.NewExecutor(
+		agent,
+		model,
+		agents.WithSpeculativeTools(false),
+		agents.WithReminderRules(staticReminderRule{name: "test", text: "remember this"}),
+	)
+	gen := executor.Execute(ctx, agents.Input{
+		Messages:  []types.Message{types.UserMessage("go")},
+		SessionID: uuidForTest(t),
+		TenantID:  uuidForTest(t),
+	})
+	defer gen.Close()
+	drainExecutor(t, ctx, gen)
+
+	requests := model.capturedRequests()
+	require.Len(t, requests, 3)
+	count := 0
+	for _, msg := range requests[2].Messages {
+		if msg.Role() == types.RoleSystem && msg.Content() == "<system-reminder>\nremember this\n</system-reminder>" {
+			count++
+		}
+	}
+	require.Equal(t, 1, count)
+}
+
+type staticReminderRule struct {
+	name string
+	text string
+}
+
+func (r staticReminderRule) Name() string {
+	return r.name
+}
+
+func (r staticReminderRule) Eval(ctx context.Context, s agents.ReminderState) string {
+	return r.text
+}
+
+func uuidForTest(t *testing.T) uuid.UUID {
+	t.Helper()
+	return uuid.New()
+}
+
+func drainExecutor(t *testing.T, ctx context.Context, gen types.Generator[agents.ExecutorEvent]) {
+	t.Helper()
+	for {
+		ev, err := gen.Next(ctx)
+		if err != nil {
+			if errors.Is(err, types.ErrGeneratorDone) {
+				return
+			}
+			t.Fatalf("unexpected generator error: %v", err)
+		}
+		if ev.Type == agents.EventTypeError {
+			t.Fatalf("unexpected executor error: %v", ev.Error)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add opt-in `ReminderRule` support to the bichat ReAct executor via `WithReminderRules`.
- Capture per-tool outcomes after each tool batch and inject `<system-reminder>` system messages before the next model call.
- Ship generic reminder rules for batch preference, iteration pressure, SQL truncation, empty results, slow tools, and tool errors.
- Cover rule text, anti-spam de-duping, and injection order for both sync and speculative tool execution.

Closes #861

## Validation
- `go test -tags dev ./pkg/bichat/agents ./pkg/bichat/tools/sql`
- `go vet ./...`
- `go test ./...` was attempted; DB-backed integration packages fail locally because PostgreSQL is not listening on `127.0.0.1:5432`. Touched bichat packages passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable executor options for agent runs.
  * Introduced reminder rules that can surface helpful system reminders during multi-step tool use.
  * Added built-in reminder behaviors for batching, iteration limits, truncated results, empty results, slow tools, and tool errors.

* **Bug Fixes**
  * Improved tool execution tracking so reminder messages and tool outcomes are more accurate and consistent.
  * Added deduplication to avoid repeated reminders within the same turn.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->