### PR TITLE
fix(nav): preserve permission Logic when rebuilding NavigationItems

### DIFF
--- a/pkg/application/application.go
+++ b/pkg/application/application.go
@@ -49,7 +49,12 @@ func translate(localizer *i18n.Localizer, items []types.NavigationItem) []types.
 			Keywords:    append([]string(nil), item.Keywords...),
 			Icon:        item.Icon,
 			Permissions: item.Permissions,
-			IsBeta:      item.IsBeta,
+			// Logic must be carried through: dropping it reverts the item to the
+			// zero value (PermissionLogicAll), which turns a RequireAny nav gate
+			// into AND and hides the item from users holding only one of its
+			// permissions.
+			Logic:  item.Logic,
+			IsBeta: item.IsBeta,
 		})
 	}
 	return translated

--- a/pkg/application/nav_translate_logic_test.go
+++ b/pkg/application/nav_translate_logic_test.go
@@ -1,0 +1,58 @@
+package application
+
+import (
+	"context"
+	"testing"
+
+	"github.com/iota-uz/go-i18n/v2/i18n"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/permission"
+	"github.com/iota-uz/iota-sdk/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression for the Portfolio-sidebar bug: NavItemsForScope runs translate(),
+// which rebuilt each NavigationItem field-by-field and dropped Logic, reverting
+// a RequireAny (OR) gate to the zero value PermissionLogicAll (AND). Downstream
+// filterItems then hid the item from any user holding only one of its
+// permissions. NavItemsForScope must preserve Logic on items and children.
+func TestNavItemsForScope_PreservesAnyPermissionLogic(t *testing.T) {
+	app, err := New(&ApplicationOptions{
+		Bundle:             LoadBundle(),
+		SupportedLanguages: []string{"en"},
+	})
+	require.NoError(t, err)
+
+	permA := permission.New(permission.WithName("Portfolio.Read"))
+	permB := permission.New(permission.WithName("Reinsurance.Contract.Read"))
+
+	attachRuntimeSource(t, app, &testRuntimeSource{
+		navItems: []types.NavigationItem{{
+			Name:        "Spotlight.Badge.Action",
+			Href:        "/portfolio/policies",
+			Permissions: []permission.Permission{permA, permB},
+			Logic:       types.PermissionLogicAny,
+			Children: []types.NavigationItem{{
+				Name:        "Spotlight.Badge.Action",
+				Href:        "/portfolio/archive",
+				Permissions: []permission.Permission{permA, permB},
+				Logic:       types.PermissionLogicAny,
+			}},
+		}},
+	})
+
+	// NavItemsForScope is reached via interface assertion, exactly as the
+	// sidebar middleware does it.
+	type navScoper interface {
+		NavItemsForScope(context.Context, *i18n.Localizer, NavScope) []types.NavigationItem
+	}
+	scoper, ok := app.(navScoper)
+	require.True(t, ok, "application must expose NavItemsForScope")
+
+	localizer := i18n.NewLocalizer(LoadBundle(), "en")
+	items := scoper.NavItemsForScope(context.Background(), localizer, NavScope{})
+
+	require.Len(t, items, 1)
+	require.Equal(t, types.PermissionLogicAny, items[0].Logic, "translate() must preserve Logic on the parent")
+	require.Len(t, items[0].Children, 1)
+	require.Equal(t, types.PermissionLogicAny, items[0].Children[0].Logic, "translate() must preserve Logic on children")
+}

--- a/pkg/middleware/sidebar.go
+++ b/pkg/middleware/sidebar.go
@@ -81,7 +81,10 @@ func filterItems(items []types.NavigationItem, user user.User) []types.Navigatio
 				Keywords:    append([]string(nil), item.Keywords...),
 				Icon:        item.Icon,
 				Permissions: item.Permissions,
-				IsBeta:      item.IsBeta,
+				// Preserve Logic so a re-filter of the returned items keeps the
+				// RequireAny (OR) semantics instead of reverting to AND.
+				Logic:  item.Logic,
+				IsBeta: item.IsBeta,
 			})
 		}
 	}

--- a/pkg/middleware/sidebar_anyperm_test.go
+++ b/pkg/middleware/sidebar_anyperm_test.go
@@ -1,0 +1,57 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/user"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/permission"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/value_objects/internet"
+	"github.com/iota-uz/iota-sdk/pkg/types"
+	"github.com/stretchr/testify/require"
+)
+
+// permA / permB model the eai "Portfolio.Read" and "Reinsurance.Contract.Read"
+// permissions that gate the Portfolio nav item with Logic: Any.
+var (
+	permA = permission.MustCreate(uuid.MustParse("019db8a0-2001-7000-8000-000000000001"), "Portfolio.Read", "portfolio", "read", permission.ModifierAll)
+	permB = permission.MustCreate(uuid.MustParse("019db8a0-3001-7000-8000-000000000002"), "Reinsurance.Contract.Read", "reinsurance_contract", "read", permission.ModifierAll)
+)
+
+func userWith(perms ...permission.Permission) user.User {
+	return user.New("Test", "User", internet.MustParseEmail("test@example.com"), user.UILanguageEN, user.WithPermissions(perms))
+}
+
+// A user holding only permA must still see a nav item gated Any[A, B].
+func TestFilterItems_AnyLogic_LeafVisibleWithOnePermission(t *testing.T) {
+	t.Parallel()
+	items := []types.NavigationItem{
+		{Key: "portfolio", Href: "/portfolio/policies", Permissions: []permission.Permission{permA, permB}, Logic: types.PermissionLogicAny},
+	}
+	out := filterItems(items, userWith(permA))
+	require.Equal(t, []string{"portfolio"}, keysOf(out), "Any[A,B] leaf must be visible to a user holding A")
+	require.Equal(t, types.PermissionLogicAny, out[0].Logic, "filterItems must preserve Logic on surviving items")
+}
+
+// The real eai shape: a parent gated Any[A, B] whose children each require one
+// permission. A user with only A should see the parent with its A-children.
+func TestFilterItems_AnyLogic_ParentVisibleWithSurvivingChildren(t *testing.T) {
+	t.Parallel()
+	items := []types.NavigationItem{
+		{
+			Key:         "portfolio",
+			Href:        "/portfolio/policies",
+			Permissions: []permission.Permission{permA, permB},
+			Logic:       types.PermissionLogicAny,
+			Children: []types.NavigationItem{
+				{Key: "portfolio.direct", Href: "/portfolio/policies", Permissions: []permission.Permission{permA}},
+				{Key: "reinsurance", Href: "/reinsurance/contracts/outgoing", Permissions: []permission.Permission{permB}},
+				{Key: "portfolio.archive", Href: "/portfolio/archive", Permissions: []permission.Permission{permA}},
+			},
+		},
+	}
+	out := filterItems(items, userWith(permA))
+	require.Equal(t, []string{"portfolio"}, keysOf(out), "parent must survive when it has surviving children")
+	require.Equal(t, []string{"portfolio.direct", "portfolio.archive"}, keysOf(out[0].Children))
+	require.Equal(t, types.PermissionLogicAny, out[0].Logic, "filterItems must preserve parent Logic")
+}


### PR DESCRIPTION
## Problem

Sidebar nav items gated with `RequireAny` (`Logic: PermissionLogicAny`) were hidden from users holding **only one** of the listed permissions — the gate behaved as **AND** instead of **OR**. The affected user could still open the pages directly (route auth was correct); only the sidebar entry vanished.

## Root cause

Two functions rebuild `types.NavigationItem` field-by-field and **omitted the `Logic` field**, so surviving items silently reverted to the zero value `PermissionLogicAll`:

- **`application.translate()`** runs inside `NavItemsForScope` — the live sidebar path — **before** permission filtering. Dropping `Logic` there turned every `Any`-gated item into an `All`-gated one, so `filterItems` then required *all* permissions. **This is the user-visible bug.**
- **`middleware.filterItems()`** drops `Logic` the same way when reconstructing survivors. Latent today (no second filter pass) but the same defect; fixed defensively.

The nav model builder (`nav_model.go:navNodeToItem`) already carried `Logic` correctly, so the model was fine — the loss happened downstream at request time.

### Concrete failure

A Portfolio menu gated `Any[Portfolio.Read, Reinsurance.Contract.Read]` disappeared for a user holding only `Portfolio.Read`. Granting `Reinsurance.Contract.Read` made it reappear (satisfying the accidental AND) — confirming the diagnosis.

## Fix

Carry `Logic` through both reconstructions.

## Tests

- `TestNavItemsForScope_PreservesAnyPermissionLogic` (pkg/application) — fails without the fix (`Any`→`All`), passes with it; covers parent + children.
- `TestFilterItems_AnyLogic_*` (pkg/middleware) — an `Any`-gated leaf and a parent-with-surviving-children stay visible to a user holding one permission, and `Logic` is preserved on output.

`go vet` clean; `application`, `middleware`, `composition`, `sidebar` suites pass.

https://claude.ai/code/session_01BwXw7gSsFLQbu2SQLe7AwP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved navigation permission logic when items are translated and filtered, preventing items from falling back to default permission behavior.
  * Ensured parent and child navigation entries keep their intended visibility rules after processing.
* **Tests**
  * Added regression tests covering “any permission” navigation behavior for both single items and nested menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->