### PR TITLE
Users list: convert to scaffold table + filterbuilder chips

### DIFF
--- a/modules/core/presentation/templates/pages/users/users_test.go
+++ b/modules/core/presentation/templates/pages/users/users_test.go
@@ -158,7 +158,6 @@ func TestBuildTableConfig_ActionGating(t *testing.T) {
 
 	email, err := internet.NewEmail("action-gating@example.com")
 	require.NoError(t, err)
-
 	noPermUser := user.New("No", "Perm", email, user.UILanguageEN)
 	cfgNoPerm := BuildTableConfig(composables.WithUser(usersTestCtx(), noPermUser), props, req)
 	require.Len(t, cfgNoPerm.Rows, 1)


### PR DESCRIPTION
## Summary
- Converts the Users list page (`/users`) from the legacy `base.Table` + sidebar role/group checkbox filters to `components/scaffold/table` (sfui) with `components/scaffold/filterbuilder` chip filters (role, group, and createdAt folded into one bar).
- Adopts `table.ContentHTMX` as the single HTMX render entry point, replacing the old hand-rolled 3-way render branch.
- Breaking (intentional, no bookmarked links depend on it): URL filter params change from `?roleID=&groupID=&CreatedAt.From=` to the filterbuilder `f=`/`fb=` codec.

## Bug fixes surfaced during the conversion
- `user_query_repository.go`: `scanAndLoadUsers` issued nested relation queries (roles/permissions/groups) while the outer result set cursor was still open. Safe against a pooled connection, but caused `conn busy` errors against a single shared `pgx.Tx` (itf's per-test harness, or any real caller-supplied transaction). Fixed by fully draining the outer cursor into a slice before loading any relation.
- `htmx-alpine-init.js`: the `htmx:load` listener also fired for `document.body` during htmx's own initial page-load `htmx.process()` call, double-initializing Alpine on an already-initialized page and duplicating every `x-for`-rendered node (e.g. two entries per combobox option, site-wide). Fixed by skipping that redundant `document.body` case.

## Test plan
- [x] `go vet ./...`
- [x] `templ generate && just css`
- [x] `go test ./modules/core/...` (all green, including new tests for filter registry/decode/apply, table config action-gating, and a real-DB-row regression test for the conn-busy fix)
- [x] Manual browser verification: add/remove role, group, createdAt chips; infinite scroll; "New user" button permission gating; realtime create/update/delete OOB rows; duplicate-combobox-option bug confirmed fixed on both `/users` and `/users/new`

https://claude.ai/code/session_01J7vskTSCGXfQcLByExgWVr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Portuguese (Brazil) Help Center translation terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->