### PR TITLE
Guard Lens stacked-bar total-badge JS against destroyed chart

### DIFF
--- a/pkg/lens/render/apex/apex.go
+++ b/pkg/lens/render/apex/apex.go
@@ -1021,6 +1021,20 @@ func stackedBarTotalBadgeJS(locale string, formatter templ.JSExpression, staticT
 			if (!el || !w) {
 				return;
 			}
+			// Bail if the chart was destroyed after this callback was queued.
+			// The total-badge JS is bound to mounted/updated/legendClick and
+			// defers via setTimeout(update, 0|80); a re-render (filter/drill
+			// HTMX swap, or the two-pass readiness render) can destroy the
+			// chart inside that window. Apex's Destroy.clear() nulls ctx.series
+			// but leaves ctx.el/ctx.w intact, so the guard above cannot catch a
+			// dead context — the pending timer would then call
+			// ctx.isSeriesHidden() -> this.series.isSeriesHidden -> null deref
+			// ("Cannot read properties of null (reading 'isSeriesHidden')").
+			// ctx.series is truthy on every live (mounted/updated) chart, so it
+			// is the reliable destroyed-marker.
+			if (!ctx.series) {
+				return;
+			}
 			if (window.getComputedStyle && window.getComputedStyle(el).position === 'static') {
 				el.style.position = 'relative';
 			}


### PR DESCRIPTION
## Problem

Report dashboards with a stacked-bar / total-badge panel (claims report, referral report, sales report) throw an uncaught page error on load and on every filter/drill:

```
Cannot read properties of null (reading 'isSeriesHidden')
```

## Root cause

`stackedBarTotalBadgeJS` (`pkg/lens/render/apex/apex.go`) binds the badge updater to the chart's `mounted`/`updated`/`legendClick` events and defers via `setTimeout(update, 0|80)`. If a re-render fires in that window — a filter/drill HTMX swap dispatching `sdk:rerenderCharts`, or the chart component's own two-pass readiness render — the chart is destroyed before the pending timer runs. Apex's `Destroy.clear()` nulls `ctx.series` but leaves `ctx.el` / `ctx.w` intact, so the existing `if (!el || !w) return;` guard misses a destroyed context. The orphaned timer then calls `ctx.isSeriesHidden()`, whose public method dereferences `this.series` (null) → the crash.

A prior fix serialized the chart component's own render/destroy (`scheduleRender`), but that has no control over this second, independent code path's orphaned timers.

## Fix

Add `if (!ctx || !ctx.series) return;` immediately after the `el`/`w` check. `ctx.series` is truthy on every live (mounted/updated) chart and null only after destroy, so it is the reliable destroyed-marker the `el`/`w` check cannot provide.

## Verification

Live (Chrome), server built against this branch: `/claim/claims-report`, `/insurance/sales-report`, `/analytics/referral-program` — reloaded and stress-tested by dispatching `sdk:rerenderCharts` 4× (the exact destroy-during-mount race) on pages with up to 10 charts. **Zero** `isSeriesHidden` / `resetSeries` errors (console positive-control confirmed tracking was live). `go vet ./...` and `go test ./pkg/lens/... ./components/charts/...` pass.

https://claude.ai/code/session_013XB5VGybpUczsLAamS1zUK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a chart crash when stacked-bar total badges update after chart state has been cleared.
  * Improved stability for delayed rendering updates by skipping invalid chart data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->