### PR TITLE
feat(lens): resolve action URL from row data

### DIFF
--- a/pkg/lens/action/action.go
+++ b/pkg/lens/action/action.go
@@ -1,7 +1,11 @@
 // Package action defines panel actions and action value sources for Lens dashboards.
 package action
 
-import "fmt"
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
 
 type Kind string
 
@@ -149,6 +153,19 @@ func LiteralValue(value any) ValueSource {
 
 func VariableValue(variable string) ValueSource {
 	return ValueSource{Kind: SourceVariable, Name: variable}
+}
+
+// SafeRelativeURL accepts URLs that cannot navigate outside the current origin.
+func SafeRelativeURL(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || strings.ContainsRune(raw, '\\') || strings.HasPrefix(raw, "//") {
+		return "", false
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed.IsAbs() || parsed.Host != "" || parsed.User != nil || parsed.Opaque != "" {
+		return "", false
+	}
+	return raw, true
 }
 
 // ResolveValue resolves a ValueSource against a data row and variable map,

--- a/pkg/lens/action/action.go
+++ b/pkg/lens/action/action.go
@@ -36,12 +36,22 @@ type Spec struct {
 	Kind          Kind
 	Method        string
 	URL           string
+	URLSource     *ValueSource
 	Target        string
 	Event         string
 	Payload       map[string]ValueSource
 	Params        []Param
 	Drill         *DrillSpec
 	PreserveQuery bool
+}
+
+func (s Spec) WithURLSource(source ValueSource) Spec {
+	s.URLSource = &source
+	return s
+}
+
+func (s Spec) WithFieldURL(field string) Spec {
+	return s.WithURLSource(FieldValue(field))
 }
 
 func Navigate(url string, params ...Param) Spec {

--- a/pkg/lens/action/action_test.go
+++ b/pkg/lens/action/action_test.go
@@ -1,0 +1,37 @@
+package action
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSafeRelativeURL(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{
+		"/analytics/drill?token=signed#result",
+		"analytics/drill",
+		"?token=signed",
+		"#result",
+	} {
+		t.Run("accepts "+raw, func(t *testing.T) {
+			actual, ok := SafeRelativeURL(raw)
+			require.True(t, ok)
+			require.Equal(t, raw, actual)
+		})
+	}
+
+	for _, raw := range []string{
+		"javascript:alert(1)",
+		"data:text/html,pwned",
+		"//evil.example/steal",
+		"https://evil.example/steal",
+		`\\evil.example\steal`,
+	} {
+		t.Run("rejects "+raw, func(t *testing.T) {
+			_, ok := SafeRelativeURL(raw)
+			require.False(t, ok)
+		})
+	}
+}

--- a/pkg/lens/render/apex/apex.go
+++ b/pkg/lens/render/apex/apex.go
@@ -1350,6 +1350,11 @@ func buildActionJS(spec *action.Spec, fr *frame.Frame, fields panel.FieldMapping
 			});
 		}
 	`, configJS)
+	if spec.URLSource != nil {
+		expr := actionValueJS(*spec.URLSource, fields)
+		js += fmt.Sprintf("const resolvedURL = %s;\nif (resolvedURL !== undefined && resolvedURL !== null && resolvedURL !== '') { nextURL = String(resolvedURL); }\n", expr)
+	}
+	js += "if (!nextURL) { return; }\n"
 	for idx, param := range spec.Params {
 		expr := actionValueJS(param.Source, fields)
 		js += fmt.Sprintf("const paramValue%d = %s;\nif (paramValue%d !== undefined) { replaceParam(%q, paramValue%d); payload[%q] = paramValue%d; }\n", idx, expr, idx, param.Name, idx, param.Name, idx)

--- a/pkg/lens/render/apex/apex.go
+++ b/pkg/lens/render/apex/apex.go
@@ -1312,6 +1312,24 @@ func buildActionJS(spec *action.Spec, fr *frame.Frame, fields panel.FieldMapping
 			}
 			return value;
 		};
+		const safeActionURL = function(value) {
+			if (value === undefined || value === null) {
+				return '';
+			}
+			const raw = String(value).trim();
+			if (!raw || raw.includes('\\\\') || raw.startsWith('//')) {
+				return '';
+			}
+			try {
+				const parsed = new URL(raw, window.location.href);
+				if ((parsed.protocol !== 'http:' && parsed.protocol !== 'https:') || parsed.origin !== window.location.origin) {
+					return '';
+				}
+				return parsed.pathname + parsed.search + parsed.hash;
+			} catch (_) {
+				return '';
+			}
+		};
 		const replaceParam = function(name, value) {
 			params.delete(name);
 			if (Array.isArray(value)) {
@@ -1352,7 +1370,7 @@ func buildActionJS(spec *action.Spec, fr *frame.Frame, fields panel.FieldMapping
 	`, configJS)
 	if spec.URLSource != nil {
 		expr := actionValueJS(*spec.URLSource, fields)
-		js += fmt.Sprintf("const resolvedURL = %s;\nif (resolvedURL !== undefined && resolvedURL !== null && resolvedURL !== '') { nextURL = String(resolvedURL); }\n", expr)
+		js += fmt.Sprintf("const resolvedURL = safeActionURL(%s);\nif (!resolvedURL) { return; }\nnextURL = resolvedURL;\n", expr)
 	}
 	js += "if (!nextURL) { return; }\n"
 	for idx, param := range spec.Params {

--- a/pkg/lens/render/apex/apex_test.go
+++ b/pkg/lens/render/apex/apex_test.go
@@ -120,7 +120,8 @@ func TestBuildActionJSResolvesFullURLFromClickedRow(t *testing.T) {
 	))
 
 	require.Contains(t, js, `resolveValue(row["action_url"], undefined)`)
-	require.Contains(t, js, "nextURL = String(resolvedURL)")
+	require.Contains(t, js, "const resolvedURL = safeActionURL")
+	require.Contains(t, js, "if (!resolvedURL) { return; }")
 	require.Contains(t, js, "window.location.href = nextURL")
 }
 
@@ -143,8 +144,30 @@ func TestBuildActionJSResolvesFullURLFromClickedRowForHtmxSwap(t *testing.T) {
 	))
 
 	require.Contains(t, js, `resolveValue(row["action_url"], undefined)`)
-	require.Contains(t, js, "nextURL = String(resolvedURL)")
+	require.Contains(t, js, "const resolvedURL = safeActionURL")
+	require.Contains(t, js, "if (!resolvedURL) { return; }")
 	require.Contains(t, js, "window.__lensDrillAjax(cfg.method || 'GET', nextURL, cfg.target, cfg.target)")
+}
+
+func TestBuildActionJSRejectsUnsafeURLSourceForNavigateAndHtmx(t *testing.T) {
+	t.Parallel()
+
+	fr, err := frame.New("costs",
+		frame.Field{Name: "action_url", Type: frame.FieldTypeString, Values: []any{"javascript:alert(1)"}},
+		frame.Field{Name: "value", Type: frame.FieldTypeNumber, Values: []any{42.0}},
+	)
+	require.NoError(t, err)
+
+	for _, spec := range []action.Spec{
+		action.Navigate("").WithFieldURL("action_url"),
+		action.HtmxSwap("", "#drawer").WithFieldURL("action_url"),
+	} {
+		js := string(buildActionJS(&spec, fr, panel.FieldMapping{Value: "value"}, &runtime.PanelResult{}))
+		require.Contains(t, js, "const resolvedURL = safeActionURL")
+		require.Contains(t, js, "raw.startsWith('//')")
+		require.Contains(t, js, "parsed.origin !== window.location.origin")
+		require.Contains(t, js, "if (!resolvedURL) { return; }")
+	}
 }
 
 func TestBuildActionJSUsesHtmxSwapForCubeDrill(t *testing.T) {

--- a/pkg/lens/render/apex/apex_test.go
+++ b/pkg/lens/render/apex/apex_test.go
@@ -101,6 +101,52 @@ func TestBuildActionJSHonorsFallbacks(t *testing.T) {
 	require.Contains(t, js, `resolveValue(variables["active_only"], true)`)
 }
 
+func TestBuildActionJSResolvesFullURLFromClickedRow(t *testing.T) {
+	t.Parallel()
+
+	fr, err := frame.New("costs",
+		frame.Field{Name: "segment", Type: frame.FieldTypeString, Values: []any{"Acquisition"}},
+		frame.Field{Name: "action_url", Type: frame.FieldTypeString, Values: []any{"/analytics/drill/acquisition_cost?token=signed-token"}},
+		frame.Field{Name: "value", Type: frame.FieldTypeNumber, Values: []any{42.0}},
+	)
+	require.NoError(t, err)
+
+	spec := action.Navigate("").WithFieldURL("action_url")
+	js := string(buildActionJS(
+		&spec,
+		fr,
+		panel.FieldMapping{Label: "segment", Value: "value"},
+		&runtime.PanelResult{},
+	))
+
+	require.Contains(t, js, `resolveValue(row["action_url"], undefined)`)
+	require.Contains(t, js, "nextURL = String(resolvedURL)")
+	require.Contains(t, js, "window.location.href = nextURL")
+}
+
+func TestBuildActionJSResolvesFullURLFromClickedRowForHtmxSwap(t *testing.T) {
+	t.Parallel()
+
+	fr, err := frame.New("costs",
+		frame.Field{Name: "segment", Type: frame.FieldTypeString, Values: []any{"Acquisition"}},
+		frame.Field{Name: "action_url", Type: frame.FieldTypeString, Values: []any{"/analytics/drill/acquisition_cost?token=signed-token"}},
+		frame.Field{Name: "value", Type: frame.FieldTypeNumber, Values: []any{42.0}},
+	)
+	require.NoError(t, err)
+
+	spec := action.HtmxSwap("", "#drawer").WithFieldURL("action_url")
+	js := string(buildActionJS(
+		&spec,
+		fr,
+		panel.FieldMapping{Label: "segment", Value: "value"},
+		&runtime.PanelResult{},
+	))
+
+	require.Contains(t, js, `resolveValue(row["action_url"], undefined)`)
+	require.Contains(t, js, "nextURL = String(resolvedURL)")
+	require.Contains(t, js, "window.__lensDrillAjax(cfg.method || 'GET', nextURL, cfg.target, cfg.target)")
+}
+
 func TestBuildActionJSUsesHtmxSwapForCubeDrill(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/lens/render/templ/helpers.go
+++ b/pkg/lens/render/templ/helpers.go
@@ -1210,7 +1210,11 @@ func actionURL(spec *action.Spec, row map[string]any, result *runtime.PanelResul
 	resolvedSpec := *spec
 	if spec.URLSource != nil {
 		if value, ok := action.ResolveValue(*spec.URLSource, row, resultVariables(result)); ok {
-			resolvedSpec.URL = fmt.Sprint(value)
+			resolvedURL, safe := action.SafeRelativeURL(fmt.Sprint(value))
+			if !safe {
+				return ""
+			}
+			resolvedSpec.URL = resolvedURL
 		}
 	}
 	if strings.TrimSpace(resolvedSpec.URL) == "" {

--- a/pkg/lens/render/templ/helpers.go
+++ b/pkg/lens/render/templ/helpers.go
@@ -1207,6 +1207,16 @@ func actionURL(spec *action.Spec, row map[string]any, result *runtime.PanelResul
 	default:
 		return ""
 	}
+	resolvedSpec := *spec
+	if spec.URLSource != nil {
+		if value, ok := action.ResolveValue(*spec.URLSource, row, resultVariables(result)); ok {
+			resolvedSpec.URL = fmt.Sprint(value)
+		}
+	}
+	if strings.TrimSpace(resolvedSpec.URL) == "" {
+		return ""
+	}
+	spec = &resolvedSpec
 	if spec.Kind == action.KindCubeDrill {
 		return cubeDrillActionURL(spec, row, result)
 	}

--- a/pkg/lens/render/templ/helpers_test.go
+++ b/pkg/lens/render/templ/helpers_test.go
@@ -89,6 +89,28 @@ func TestActionURLSupportsHtmxActions(t *testing.T) {
 	require.Equal(t, "/contracts?product=osago", url)
 }
 
+func TestActionURLResolvesFullURLFromRow(t *testing.T) {
+	t.Parallel()
+
+	spec := action.Navigate("").WithFieldURL("action_url")
+	url := actionURL(&spec, map[string]any{
+		"action_url": "/analytics/drill/rnp?token=signed-token",
+	}, &runtime.PanelResult{})
+
+	require.Equal(t, "/analytics/drill/rnp?token=signed-token", url)
+}
+
+func TestActionURLResolvesFullURLFromRowForHtmxSwap(t *testing.T) {
+	t.Parallel()
+
+	spec := action.HtmxSwap("", "#drawer").WithFieldURL("action_url")
+	url := actionURL(&spec, map[string]any{
+		"action_url": "/analytics/drill/acquisition_cost?token=signed-token",
+	}, &runtime.PanelResult{})
+
+	require.Equal(t, "/analytics/drill/acquisition_cost?token=signed-token", url)
+}
+
 func TestActionOnClickSupportsEmitEventFallbacks(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/lens/render/templ/helpers_test.go
+++ b/pkg/lens/render/templ/helpers_test.go
@@ -111,6 +111,26 @@ func TestActionURLResolvesFullURLFromRowForHtmxSwap(t *testing.T) {
 	require.Equal(t, "/analytics/drill/acquisition_cost?token=signed-token", url)
 }
 
+func TestActionURLRejectsUnsafeURLSource(t *testing.T) {
+	t.Parallel()
+
+	unsafeURLs := []string{
+		"javascript:alert(1)",
+		"data:text/html,pwned",
+		"//evil.example/steal",
+		"https://evil.example/steal",
+		`\\evil.example\steal`,
+	}
+	for _, kind := range []action.Kind{action.KindNavigate, action.KindHtmxSwap} {
+		for _, unsafeURL := range unsafeURLs {
+			t.Run(string(kind)+"/"+unsafeURL, func(t *testing.T) {
+				spec := action.Spec{Kind: kind}.WithURLSource(action.FieldValue("action_url"))
+				require.Empty(t, actionURL(&spec, map[string]any{"action_url": unsafeURL}, &runtime.PanelResult{}))
+			})
+		}
+	}
+}
+
 func TestActionOnClickSupportsEmitEventFallbacks(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/lens/runtime/runtime.go
+++ b/pkg/lens/runtime/runtime.go
@@ -877,7 +877,7 @@ func validatePanel(spec panel.Spec, datasets map[string]lens.DatasetSpec, panelI
 			return fmt.Errorf("panel %s requires series field", spec.ID)
 		}
 	}
-	if spec.Action != nil && strings.TrimSpace(spec.Action.URL) == "" && spec.Action.Kind != action.KindEmitEvent {
+	if spec.Action != nil && strings.TrimSpace(spec.Action.URL) == "" && spec.Action.URLSource == nil && spec.Action.Kind != action.KindEmitEvent {
 		return fmt.Errorf("panel %s action requires url", spec.ID)
 	}
 	if spec.Action != nil {
@@ -891,6 +891,11 @@ func validatePanel(spec panel.Spec, datasets map[string]lens.DatasetSpec, panelI
 		}
 		if spec.Action.Kind == action.KindHtmxSwap && strings.TrimSpace(spec.Action.Target) == "" {
 			return fmt.Errorf("panel %s htmx action requires target", spec.ID)
+		}
+		if spec.Action.URLSource != nil {
+			if err := validateValueSource(spec.ID, "url", *spec.Action.URLSource); err != nil {
+				return err
+			}
 		}
 		for _, param := range spec.Action.Params {
 			if err := validateValueSource(spec.ID, param.Name, param.Source); err != nil {
@@ -928,6 +933,11 @@ func validatePanelFrames(spec panel.Spec, frames *frame.FrameSet) error {
 		}
 	}
 	if spec.Action != nil {
+		if spec.Action.URLSource != nil {
+			if err := validateFrameValueSource(spec.ID, spec.Dataset, primary, *spec.Action.URLSource); err != nil {
+				return err
+			}
+		}
 		for _, param := range spec.Action.Params {
 			if err := validateFrameValueSource(spec.ID, spec.Dataset, primary, param.Source); err != nil {
 				return err

--- a/pkg/lens/runtime/runtime_test.go
+++ b/pkg/lens/runtime/runtime_test.go
@@ -348,6 +348,43 @@ func TestValidateRejectsMissingActionFieldSource(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestValidateAcceptsActionURLFieldSource(t *testing.T) {
+	t.Parallel()
+
+	spec := lensbuild.Dashboard("actions", "Actions",
+		lensbuild.Row(
+			panel.Bar("sales", "Sales", "dataset").
+				LabelField("label").
+				ValueField("value").
+				Action(action.Navigate("").WithFieldURL("label")).
+				Build(),
+		),
+	).Datasets(
+		lensbuild.StaticDataset("dataset", mustFrameSet(t, "dataset")),
+	).Build()
+
+	require.NoError(t, Validate(spec))
+}
+
+func TestValidateRejectsEmptyActionURLFieldSource(t *testing.T) {
+	t.Parallel()
+
+	spec := lensbuild.Dashboard("actions", "Actions",
+		lensbuild.Row(
+			panel.Bar("sales", "Sales", "dataset").
+				LabelField("label").
+				ValueField("value").
+				Action(action.Navigate("").WithFieldURL("")).
+				Build(),
+		),
+	).Datasets(
+		lensbuild.StaticDataset("dataset", mustFrameSet(t, "dataset")),
+	).Build()
+
+	err := Validate(spec)
+	require.ErrorContains(t, err, "action value url requires source name")
+}
+
 func TestExecuteMarksMissingPanelFieldsAsPanelError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- allow Lens actions to resolve a full URL from a row or variable value source
- keep the static URL as a fallback
- support dynamic URLs consistently in templ and Apex renderers
- validate URL sources against panel frames

## Tests

- `go test ./pkg/lens/...`
- `go vet ./pkg/lens/...`
- `git diff --check`

Required by iota-uz/eai#3536 for per-segment analytics drill-through.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Action URLs can now be dynamically derived from row fields or other value sources.
  * Added an easy option to specify a field as the action URL.
  * Dynamic URLs work for both standard navigation and HTMX actions, including query string handling.
* **Bug Fixes**
  * Added URL-safety validation for dynamic action URLs, preventing unsafe or non-relative targets.
  * Improved runtime validation to accept `URLSource` when `URL` is not set, and to reject empty/invalid sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->