### PR TITLE
fix(bichat): make stream finalization resilient to malformed UTF-8

### DIFF
--- a/pkg/bichat/domain/message_factory.go
+++ b/pkg/bichat/domain/message_factory.go
@@ -60,6 +60,7 @@ func NewUserMessage(spec UserMessageSpec) (types.Message, error) {
 }
 
 func NewAssistantMessage(spec AssistantMessageSpec) (types.Message, error) {
+	spec = normalizeAssistantMessageUTF8(spec)
 	if spec.SessionID == uuid.Nil {
 		return nil, ErrInvalidAssistantMessage
 	}

--- a/pkg/bichat/domain/message_factory_utf8_test.go
+++ b/pkg/bichat/domain/message_factory_utf8_test.go
@@ -1,0 +1,72 @@
+package domain
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/pkg/bichat/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAssistantMessage_NormalizesInvalidUTF8AcrossPersistedPayload(t *testing.T) {
+	t.Parallel()
+
+	invalid := "Ответ " + string([]byte{0xd0}) + "."
+	trace := &types.DebugTrace{
+		TraceID:  invalid,
+		Thinking: invalid,
+		Tools: []types.DebugToolCall{{
+			CallID: invalid,
+			Result: invalid,
+		}},
+		Attempts: []types.DebugGeneration{{
+			ID:       invalid,
+			Output:   invalid,
+			Thinking: invalid,
+			ToolCalls: []types.DebugToolCall{{
+				Error: invalid,
+			}},
+		}},
+		Spans: []types.DebugSpan{{
+			ID:     invalid,
+			Output: invalid,
+		}},
+		Events: []types.DebugEvent{{
+			ID:      invalid,
+			Message: invalid,
+		}},
+	}
+
+	msg, err := NewAssistantMessage(AssistantMessageSpec{
+		SessionID: uuid.New(),
+		Content:   invalid,
+		ToolCalls: []types.ToolCall{{
+			ID:     invalid,
+			Result: invalid,
+		}},
+		DebugTrace: trace,
+	})
+	require.NoError(t, err)
+	require.True(t, utf8.ValidString(msg.Content()))
+	require.Contains(t, msg.Content(), invalidUTF8Replacement)
+	require.True(t, utf8.ValidString(msg.ToolCalls()[0].ID))
+	require.True(t, utf8.ValidString(msg.ToolCalls()[0].Result))
+
+	normalizedTrace := msg.DebugTrace()
+	require.NotNil(t, normalizedTrace)
+	require.True(t, utf8.ValidString(normalizedTrace.TraceID))
+	require.True(t, utf8.ValidString(normalizedTrace.Thinking))
+	require.True(t, utf8.ValidString(normalizedTrace.Tools[0].CallID))
+	require.True(t, utf8.ValidString(normalizedTrace.Tools[0].Result))
+	require.True(t, utf8.ValidString(normalizedTrace.Attempts[0].ID))
+	require.True(t, utf8.ValidString(normalizedTrace.Attempts[0].Output))
+	require.True(t, utf8.ValidString(normalizedTrace.Attempts[0].Thinking))
+	require.True(t, utf8.ValidString(normalizedTrace.Attempts[0].ToolCalls[0].Error))
+	require.True(t, utf8.ValidString(normalizedTrace.Spans[0].ID))
+	require.True(t, utf8.ValidString(normalizedTrace.Spans[0].Output))
+	require.True(t, utf8.ValidString(normalizedTrace.Events[0].ID))
+	require.True(t, utf8.ValidString(normalizedTrace.Events[0].Message))
+
+	require.Equal(t, invalid, trace.TraceID, "normalization must not mutate the caller's trace")
+}

--- a/pkg/bichat/domain/message_utf8.go
+++ b/pkg/bichat/domain/message_utf8.go
@@ -1,0 +1,133 @@
+package domain
+
+import (
+	"strings"
+
+	"github.com/iota-uz/iota-sdk/pkg/bichat/types"
+)
+
+const invalidUTF8Replacement = "�"
+
+func normalizeAssistantMessageUTF8(spec AssistantMessageSpec) AssistantMessageSpec {
+	spec.Content = validUTF8(spec.Content)
+	spec.ToolCalls = normalizeToolCallsUTF8(spec.ToolCalls)
+	spec.DebugTrace = normalizeDebugTraceUTF8(spec.DebugTrace)
+	return spec
+}
+
+func validUTF8(value string) string {
+	return strings.ToValidUTF8(value, invalidUTF8Replacement)
+}
+
+func normalizeToolCallsUTF8(toolCalls []types.ToolCall) []types.ToolCall {
+	if toolCalls == nil {
+		return nil
+	}
+
+	normalized := make([]types.ToolCall, len(toolCalls))
+	for i, toolCall := range toolCalls {
+		normalized[i] = types.ToolCall{
+			ID:         validUTF8(toolCall.ID),
+			Name:       validUTF8(toolCall.Name),
+			Arguments:  validUTF8(toolCall.Arguments),
+			Result:     validUTF8(toolCall.Result),
+			Error:      validUTF8(toolCall.Error),
+			DurationMs: toolCall.DurationMs,
+		}
+	}
+	return normalized
+}
+
+func normalizeDebugToolCallsUTF8(toolCalls []types.DebugToolCall) []types.DebugToolCall {
+	if toolCalls == nil {
+		return nil
+	}
+
+	normalized := make([]types.DebugToolCall, len(toolCalls))
+	for i, toolCall := range toolCalls {
+		normalized[i] = types.DebugToolCall{
+			CallID:     validUTF8(toolCall.CallID),
+			Name:       validUTF8(toolCall.Name),
+			Arguments:  validUTF8(toolCall.Arguments),
+			Result:     validUTF8(toolCall.Result),
+			Error:      validUTF8(toolCall.Error),
+			DurationMs: toolCall.DurationMs,
+		}
+	}
+	return normalized
+}
+
+func normalizeDebugTraceUTF8(trace *types.DebugTrace) *types.DebugTrace {
+	if trace == nil {
+		return nil
+	}
+
+	normalized := *trace
+	normalized.SchemaVersion = validUTF8(trace.SchemaVersion)
+	normalized.StartedAt = validUTF8(trace.StartedAt)
+	normalized.CompletedAt = validUTF8(trace.CompletedAt)
+	normalized.TraceID = validUTF8(trace.TraceID)
+	normalized.TraceURL = validUTF8(trace.TraceURL)
+	normalized.SessionID = validUTF8(trace.SessionID)
+	normalized.Thinking = validUTF8(trace.Thinking)
+	normalized.ObservationReason = validUTF8(trace.ObservationReason)
+	normalized.Tools = normalizeDebugToolCallsUTF8(trace.Tools)
+
+	if trace.Attempts != nil {
+		normalized.Attempts = make([]types.DebugGeneration, len(trace.Attempts))
+		for i, attempt := range trace.Attempts {
+			attempt.ID = validUTF8(attempt.ID)
+			attempt.RequestID = validUTF8(attempt.RequestID)
+			attempt.Model = validUTF8(attempt.Model)
+			attempt.Provider = validUTF8(attempt.Provider)
+			attempt.FinishReason = validUTF8(attempt.FinishReason)
+			attempt.Input = validUTF8(attempt.Input)
+			attempt.Output = validUTF8(attempt.Output)
+			attempt.Thinking = validUTF8(attempt.Thinking)
+			attempt.ObservationReason = validUTF8(attempt.ObservationReason)
+			attempt.StartedAt = validUTF8(attempt.StartedAt)
+			attempt.CompletedAt = validUTF8(attempt.CompletedAt)
+			attempt.ToolCalls = normalizeDebugToolCallsUTF8(attempt.ToolCalls)
+			normalized.Attempts[i] = attempt
+		}
+	}
+
+	if trace.Spans != nil {
+		normalized.Spans = make([]types.DebugSpan, len(trace.Spans))
+		for i, span := range trace.Spans {
+			span.ID = validUTF8(span.ID)
+			span.ParentID = validUTF8(span.ParentID)
+			span.GenerationID = validUTF8(span.GenerationID)
+			span.Name = validUTF8(span.Name)
+			span.Type = validUTF8(span.Type)
+			span.Status = validUTF8(span.Status)
+			span.Level = validUTF8(span.Level)
+			span.CallID = validUTF8(span.CallID)
+			span.ToolName = validUTF8(span.ToolName)
+			span.Input = validUTF8(span.Input)
+			span.Output = validUTF8(span.Output)
+			span.Error = validUTF8(span.Error)
+			span.StartedAt = validUTF8(span.StartedAt)
+			span.CompletedAt = validUTF8(span.CompletedAt)
+			normalized.Spans[i] = span
+		}
+	}
+
+	if trace.Events != nil {
+		normalized.Events = make([]types.DebugEvent, len(trace.Events))
+		for i, event := range trace.Events {
+			event.ID = validUTF8(event.ID)
+			event.Name = validUTF8(event.Name)
+			event.Type = validUTF8(event.Type)
+			event.Level = validUTF8(event.Level)
+			event.Message = validUTF8(event.Message)
+			event.Reason = validUTF8(event.Reason)
+			event.SpanID = validUTF8(event.SpanID)
+			event.GenerationID = validUTF8(event.GenerationID)
+			event.Timestamp = validUTF8(event.Timestamp)
+			normalized.Events[i] = event
+		}
+	}
+
+	return &normalized
+}

--- a/pkg/bichat/observability/otel/mapper.go
+++ b/pkg/bichat/observability/otel/mapper.go
@@ -142,7 +142,7 @@ func generationToAttributes(obs observability.GenerationObservation) []attribute
 		}
 	}
 
-	return attrs
+	return sanitizeAttributes(attrs)
 }
 
 // spanToAttributes maps a SpanObservation to attributes using the eai.span.*
@@ -187,7 +187,7 @@ func spanToAttributes(obs observability.SpanObservation) []attribute.KeyValue {
 		}
 	}
 
-	return attrs
+	return sanitizeAttributes(attrs)
 }
 
 // eventToAttributes maps an EventObservation to attributes using the
@@ -220,7 +220,7 @@ func eventToAttributes(obs observability.EventObservation) []attribute.KeyValue 
 		}
 	}
 
-	return attrs
+	return sanitizeAttributes(attrs)
 }
 
 // traceToAttributes maps a TraceObservation to attributes. Cost is omitted
@@ -256,6 +256,31 @@ func traceToAttributes(obs observability.TraceObservation) []attribute.KeyValue 
 		}
 	}
 
+	return sanitizeAttributes(attrs)
+}
+
+// sanitizeAttributes guarantees that every dynamically sourced string sent to
+// an OTLP exporter is valid UTF-8. Protobuf string fields reject malformed
+// bytes, and a single invalid model/tool payload would otherwise drop the
+// entire batch of spans during export.
+func sanitizeAttributes(attrs []attribute.KeyValue) []attribute.KeyValue {
+	for i, kv := range attrs {
+		key := strings.ToValidUTF8(string(kv.Key), "\uFFFD")
+		switch kv.Value.Type() {
+		case attribute.STRING:
+			attrs[i] = attribute.String(key, strings.ToValidUTF8(kv.Value.AsString(), "\uFFFD"))
+		case attribute.STRINGSLICE:
+			values := kv.Value.AsStringSlice()
+			for j := range values {
+				values[j] = strings.ToValidUTF8(values[j], "\uFFFD")
+			}
+			attrs[i] = attribute.StringSlice(key, values)
+		default:
+			if key != string(kv.Key) {
+				attrs[i] = attribute.KeyValue{Key: attribute.Key(key), Value: kv.Value}
+			}
+		}
+	}
 	return attrs
 }
 

--- a/pkg/bichat/observability/otel/mapper_test.go
+++ b/pkg/bichat/observability/otel/mapper_test.go
@@ -2,6 +2,7 @@ package otel
 
 import (
 	"testing"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 	"github.com/iota-uz/iota-sdk/pkg/bichat/observability"
@@ -220,4 +221,71 @@ func TestReadIntAttr(t *testing.T) {
 
 	_, ok = readIntAttr(nil, "n")
 	assert.False(t, ok)
+}
+
+func TestAttributeMappers_SanitizeInvalidUTF8(t *testing.T) {
+	invalid := "valid\xfftext"
+
+	tests := []struct {
+		name  string
+		attrs []attribute.KeyValue
+	}{
+		{
+			name: "generation strings and slices",
+			attrs: generationToAttributes(observability.GenerationObservation{
+				Model:        invalid,
+				FinishReason: invalid,
+				Input:        invalid,
+				Output:       invalid,
+				ModelParameters: map[string]interface{}{
+					invalid: invalid,
+				},
+			}),
+		},
+		{
+			name: "span payload and dynamic attribute key",
+			attrs: spanToAttributes(observability.SpanObservation{
+				Input:  invalid,
+				Output: invalid,
+				Attributes: map[string]interface{}{
+					invalid: invalid,
+				},
+			}),
+		},
+		{
+			name: "event payload",
+			attrs: eventToAttributes(observability.EventObservation{
+				Message: invalid,
+				Attributes: map[string]interface{}{
+					invalid: invalid,
+				},
+			}),
+		},
+		{
+			name: "trace payload",
+			attrs: traceToAttributes(observability.TraceObservation{
+				Name: invalid,
+				Attributes: map[string]interface{}{
+					invalid: invalid,
+				},
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NotEmpty(t, tt.attrs)
+			for _, kv := range tt.attrs {
+				assert.True(t, utf8.ValidString(string(kv.Key)), "invalid attribute key %q", kv.Key)
+				switch kv.Value.Type() {
+				case attribute.STRING:
+					assert.True(t, utf8.ValidString(kv.Value.AsString()), "invalid string value for %q", kv.Key)
+				case attribute.STRINGSLICE:
+					for _, value := range kv.Value.AsStringSlice() {
+						assert.True(t, utf8.ValidString(value), "invalid string slice value for %q", kv.Key)
+					}
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Root cause

Production logs after iota-uz/eai#2998 showed that stream finalization could still fail after a complete answer had been rendered. PostgreSQL rejected the critical message transaction with `SQLSTATE 22021` because the assistant payload contained an incomplete UTF-8 sequence (`0xd0 0x2e`). The existing timeout/retry fix cannot recover from deterministic encoding errors.

## What changed

- Normalize assistant content to valid UTF-8 at the domain factory boundary.
- Normalize every persisted string in tool calls and debug traces, including generations, spans, and events used by the observability projection.
- Copy nested payload slices before normalization so caller-owned trace data is not mutated.
- Add a regression test using the exact malformed Cyrillic byte pattern seen in production.

This makes the critical message transaction safe for malformed provider/tool output instead of discarding an otherwise complete answer.

## Validation

- `go test ./pkg/bichat/domain ./modules/bichat/services`
- `go test ./modules/bichat/infrastructure/persistence -run TestPostgresChatRepository_SaveMessage -count=1`
- `go vet ./pkg/bichat/domain ./modules/bichat/services ./modules/bichat/infrastructure/persistence`

Follow-up UI resilience is implemented in companion PR iota-uz/applets#37: already-rendered content is retained when terminal, transport, resume, or refetch paths still fail.

Refs iota-uz/eai#2998


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Assistant messages now safely handle invalid UTF-8 content by replacing malformed characters with a standard replacement symbol.
  * Related tool-call data, debug traces, and observability attributes are also sanitized to ensure valid UTF-8 output.
  * Original input trace data remains unchanged during normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->