### PR TITLE
fix(lens): complete runtime review follow-ups

### DIFF
--- a/modules/core/presentation/controllers/dashboard_controller.go
+++ b/modules/core/presentation/controllers/dashboard_controller.go
@@ -212,7 +212,8 @@ func (c *DashboardController) Get(w http.ResponseWriter, r *http.Request) {
 				DataSources: map[string]datasource.DataSource{
 					"primary": c.ds,
 				},
-				DataScope: tenantID.String(), Namespace: "core.dashboard",
+				DataSourceIdentities: map[string]string{"primary": "core-postgres:v1"},
+				DataScope:            tenantID.String(), Namespace: "core.dashboard",
 			}, runtime.DashboardScope())
 			results = executed
 			return execErr

--- a/modules/core/presentation/controllers/showcase_controller.go
+++ b/modules/core/presentation/controllers/showcase_controller.go
@@ -279,7 +279,8 @@ func (c *ShowcaseController) Lens(
 			DataSources: map[string]datasource.DataSource{
 				"primary": c.ds,
 			},
-			DataScope: tenantID.String(), Namespace: "core.showcase",
+			DataSourceIdentities: map[string]string{"primary": "core-postgres:v1"},
+			DataScope:            tenantID.String(), Namespace: "core.showcase",
 		}, runtime.DashboardScope())
 		if err != nil {
 			logger.WithError(err).Error("failed to execute lens showcase dashboard")

--- a/pkg/lens/runtime/cache.go
+++ b/pkg/lens/runtime/cache.go
@@ -263,10 +263,21 @@ func cloneReflect(value reflect.Value) reflect.Value {
 			out.SetMapIndex(iter.Key(), cloneReflect(iter.Value()))
 		}
 		return out
+	case reflect.Struct:
+		for i := range value.NumField() {
+			if value.Type().Field(i).PkgPath != "" {
+				return value
+			}
+		}
+		out := reflect.New(value.Type()).Elem()
+		for i := range value.NumField() {
+			out.Field(i).Set(cloneReflect(value.Field(i)))
+		}
+		return out
 	case reflect.Invalid, reflect.Bool, reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr,
 		reflect.Float32, reflect.Float64, reflect.Complex64, reflect.Complex128, reflect.Chan,
-		reflect.Func, reflect.String, reflect.Struct, reflect.UnsafePointer:
+		reflect.Func, reflect.String, reflect.UnsafePointer:
 		return value
 	}
 	return value

--- a/pkg/lens/runtime/cache.go
+++ b/pkg/lens/runtime/cache.go
@@ -57,6 +57,8 @@ func (s *ExecutionSnapshot) Clone() *ExecutionSnapshot {
 type SnapshotStore interface {
 	Load(context.Context, string) (*ExecutionSnapshot, bool)
 	Save(context.Context, string, *ExecutionSnapshot, time.Duration)
+	// Update atomically supplies a clone-safe snapshot to update and transfers
+	// ownership of the callback result to the store.
 	Update(context.Context, string, time.Duration, func(*ExecutionSnapshot) *ExecutionSnapshot)
 	Invalidate(context.Context, string)
 	Stats() CacheStats
@@ -167,7 +169,6 @@ func (m *MemorySnapshotStore) Update(_ context.Context, key string, ttl time.Dur
 		ttl = m.ttl
 	}
 	expiresAt := m.clock().Add(ttl)
-	next = next.Clone()
 	next.ExpiresAt = expiresAt
 	if existing, ok := m.items[key]; ok {
 		entry := existing.Value.(*memoryEntry)

--- a/pkg/lens/runtime/cache_test.go
+++ b/pkg/lens/runtime/cache_test.go
@@ -72,14 +72,18 @@ func TestRuntimeSnapshot_UsesShortestDatasetTTL(t *testing.T) {
 func TestMemorySnapshotStore_DeepClonesTypedNestedVariables(t *testing.T) {
 	t.Parallel()
 	store := NewMemorySnapshotStore(MemoryStoreOptions{})
-	variables := map[string]any{"rows": []map[string][]int{{"values": {1, 2}}}}
+	type nested struct{ Values []int }
+	variables := map[string]any{"rows": []map[string][]int{{"values": {1, 2}}}, "struct": nested{Values: []int{3, 4}}}
 	store.Save(context.Background(), "core:key", &ExecutionSnapshot{Variables: variables}, time.Minute)
 	loaded, ok := store.Load(context.Background(), "core:key")
 	require.True(t, ok)
 	loaded.Variables["rows"].([]map[string][]int)[0]["values"][0] = 99
+	structValue := loaded.Variables["struct"].(nested)
+	structValue.Values[0] = 88
 	again, ok := store.Load(context.Background(), "core:key")
 	require.True(t, ok)
 	require.Equal(t, 1, again.Variables["rows"].([]map[string][]int)[0]["values"][0])
+	require.Equal(t, 3, again.Variables["struct"].(nested).Values[0])
 }
 
 func TestMemorySnapshotStore_InvalidateMatchesNamespaceBoundary(t *testing.T) {

--- a/pkg/lens/runtime/runtime.go
+++ b/pkg/lens/runtime/runtime.go
@@ -610,13 +610,13 @@ func (r *Runtime) saveSnapshot(ctx context.Context, state plannedExecutor, resul
 		createdAt := now
 		if existing != nil {
 			createdAt = existing.CreatedAt
-			for name, frames := range existing.Datasets {
-				if frames != nil {
-					datasets[name] = frames.Clone()
-				}
+			datasets = existing.Datasets
+			provenance = existing.Provenance
+			if datasets == nil {
+				datasets = map[string]*frame.FrameSet{}
 			}
-			for name, item := range existing.Provenance {
-				provenance[name] = item
+			if provenance == nil {
+				provenance = map[string]DatasetProvenance{}
 			}
 		}
 		for name, item := range result.Datasets {

--- a/pkg/lens/runtime/runtime.go
+++ b/pkg/lens/runtime/runtime.go
@@ -368,7 +368,8 @@ func (s *plannedExecutor) executeDatasets(ctx context.Context, stages [][]lens.D
 		stageResults := make(map[string]*DatasetResult, len(stage))
 		var mu sync.Mutex
 		group, groupCtx := errgroup.WithContext(ctx)
-		for _, datasetSpec := range stage {
+		for index := range stage {
+			datasetSpec := stage[index]
 			if _, cached := results[datasetSpec.Name]; cached {
 				continue
 			}


### PR DESCRIPTION
## Summary

- supplies required data-source identities in SDK core Lens controllers
- deep-clones exported runtime structs and safely captures staged datasets
- removes redundant FrameSet clones while holding the snapshot-store lock

## Why

These fixes address the final review pass that arrived immediately after #884 auto-merged. They preserve the fail-closed runtime identity contract and reduce lock-held clone work.

## Validation

- targeted Lens and core controller tests
- `go vet` on affected packages
- golangci-lint: 0 issues
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dashboard and showcase data loading by providing explicit datasource metadata.
  - Fixed concurrent dataset processing to ensure each dataset uses the correct configuration.
  - Improved snapshot caching to preserve data accurately across loads, including nested structured values.
  - Reduced unnecessary snapshot processing while retaining previously stored dataset and provenance information.

- **Refactor**
  - Clarified snapshot ownership and update behavior for more predictable caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->