### PR TITLE
feat(lens): document contract + snapshot semantics (React Runtime A1)

### DIFF
--- a/pkg/lens/document/build.go
+++ b/pkg/lens/document/build.go
@@ -154,6 +154,7 @@ func appendPanelTree(doc *DashboardDocument, spec panel.Spec, result *runtime.Re
 }
 
 func panelKind(kind panel.Kind) (PanelKind, error) {
+	//nolint:exhaustive // Container/gauge kinds are not part of the wire contract; default rejects them.
 	switch kind {
 	case panel.KindStat:
 		return PanelKindStat, nil
@@ -177,6 +178,7 @@ func panelKind(kind panel.Kind) (PanelKind, error) {
 }
 
 func inferSemantics(kind PanelKind) Semantics {
+	//nolint:exhaustive // Remaining kinds are series-shaped by default.
 	switch kind {
 	case PanelKindPie, PanelKindDonut:
 		return SemanticsPartition
@@ -231,6 +233,7 @@ func buildFormats(spec panel.Spec) map[string]FieldFormat {
 
 func convertFormat(spec format.Spec) (FieldFormat, bool) {
 	result := FieldFormat{Precision: spec.Precision, Layout: spec.Layout}
+	//nolint:exhaustive // Formats without a wire representation are dropped via default.
 	switch spec.Kind {
 	case format.KindMoney:
 		result.Kind = FormatMoney
@@ -279,6 +282,7 @@ func buildFrame(source *frame.Frame) (Frame, error) {
 }
 
 func columnType(kind frame.FieldType) (ColumnType, error) {
+	//nolint:exhaustive // FieldTypeUnknown is rejected via default.
 	switch kind {
 	case frame.FieldTypeString, frame.FieldTypeLocalized:
 		return ColumnString, nil
@@ -316,6 +320,7 @@ func convertAction(spec action.Spec, leaf bool) (Action, bool) {
 		Method: spec.Method, URLTemplate: spec.URL, Event: spec.Event, PreserveQuery: spec.PreserveQuery,
 		Params: make([]ActionParam, 0, len(spec.Params)), Payload: make(map[string]Source),
 	}
+	//nolint:exhaustive // HTMX/cube-drill/explore actions are legacy renderer concerns, not wire actions.
 	switch spec.Kind {
 	case action.KindNavigate:
 		if leaf {
@@ -373,7 +378,7 @@ func defaultExplorerSemantics(spec explore.Spec, fallback Semantics) Semantics {
 func buildExplorer(doc *DashboardDocument, spec explore.Spec, result *runtime.Result) error {
 	rootKey := explorerRootKey(spec.ID)
 	rootPath := NodePath{rootKey}
-	root := Level{Path: rootPath, Label: spec.ID, Children: make([]Node, 0, len(spec.Branches)), Perspectives: make([]PerspectiveRef, 0)}
+	root := Level{Path: rootPath, Label: "", Children: make([]Node, 0, len(spec.Branches)), Perspectives: make([]PerspectiveRef, 0)}
 	if host := findDocumentPanel(doc.Panels, spec.HostPanelID); host != nil {
 		root.Frame = host.Frame
 	}
@@ -411,7 +416,7 @@ func buildExplorer(doc *DashboardDocument, spec explore.Spec, result *runtime.Re
 				for _, edge := range nodeSpec.Edges {
 					pointKey := qualifiedKey(spec.ID, branch.Key, view.Key, nodeSpec.Key, edge.PointKey)
 					childPath := appendPath(nodePath, pointKey)
-					child := Node{Key: pointKey, Path: childPath, Label: edge.PointKey}
+					child := Node{Key: pointKey, Path: childPath, Label: ""}
 					if edge.ToNode != "" {
 						child.Target = qualifiedKey(spec.ID, branch.Key, view.Key, edge.ToNode)
 					}

--- a/pkg/lens/document/build.go
+++ b/pkg/lens/document/build.go
@@ -1,0 +1,496 @@
+package document
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/iota-uz/iota-sdk/pkg/lens"
+	"github.com/iota-uz/iota-sdk/pkg/lens/action"
+	"github.com/iota-uz/iota-sdk/pkg/lens/explore"
+	"github.com/iota-uz/iota-sdk/pkg/lens/format"
+	"github.com/iota-uz/iota-sdk/pkg/lens/frame"
+	"github.com/iota-uz/iota-sdk/pkg/lens/panel"
+	"github.com/iota-uz/iota-sdk/pkg/lens/runtime"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
+)
+
+type BuildOptions struct {
+	SnapshotID  string
+	GeneratedAt time.Time
+	Locale      string
+	InlineDepth int
+	Endpoints   Endpoints
+	I18n        map[string]string
+	Theme       Theme
+}
+
+func Build(spec lens.DashboardSpec, result *runtime.Result, opts BuildOptions) (*DashboardDocument, error) {
+	const op serrors.Op = "lens/document.Build"
+	if result == nil {
+		return nil, serrors.E(op, fmt.Errorf("runtime result is required"))
+	}
+	if err := runtime.Validate(spec); err != nil {
+		return nil, serrors.E(op, err)
+	}
+	if opts.InlineDepth < 0 {
+		return nil, serrors.E(op, fmt.Errorf("inline depth cannot be negative"))
+	}
+
+	snapshotID := strings.TrimSpace(opts.SnapshotID)
+	if snapshotID == "" {
+		var err error
+		snapshotID, err = newSnapshotID()
+		if err != nil {
+			return nil, serrors.E(op, err)
+		}
+	}
+	generatedAt := opts.GeneratedAt
+	if generatedAt.IsZero() {
+		generatedAt = result.StartedAt
+	}
+	if generatedAt.IsZero() {
+		generatedAt = time.Now().UTC()
+	}
+	locale := strings.TrimSpace(opts.Locale)
+	if locale == "" {
+		locale = result.Locale
+	}
+
+	doc := &DashboardDocument{
+		Version:      ContractVersion,
+		SnapshotID:   snapshotID,
+		Meta:         Meta{DashboardID: spec.ID, Title: spec.Title, GeneratedAt: generatedAt, Locale: locale},
+		Layout:       Layout{Rows: make([]LayoutRow, 0, len(spec.Rows))},
+		Panels:       make([]Panel, 0),
+		Frames:       make(map[FrameRef]Frame),
+		Drill:        Drill{Edges: make(map[NodeKey]Level), InlineDepth: opts.InlineDepth},
+		Perspectives: make([]Perspective, 0),
+		Endpoints:    opts.Endpoints,
+		I18n:         cloneStrings(opts.I18n),
+		Theme:        cloneTheme(opts.Theme),
+	}
+	if doc.I18n == nil {
+		doc.I18n = make(map[string]string)
+	}
+
+	hosts := explorerHosts(spec.Explorers)
+	for _, rowSpec := range spec.Rows {
+		layoutRow := LayoutRow{Heading: rowSpec.Heading, Class: rowSpec.Class, Panels: make([]LayoutItem, 0)}
+		for _, panelSpec := range rowSpec.Panels {
+			if err := appendPanelTree(doc, panelSpec, result, hosts, &layoutRow); err != nil {
+				return nil, serrors.E(op, err)
+			}
+		}
+		doc.Layout.Rows = append(doc.Layout.Rows, layoutRow)
+	}
+	for _, explorerSpec := range spec.Explorers {
+		if err := buildExplorer(doc, explorerSpec, result); err != nil {
+			return nil, serrors.E(op, err)
+		}
+	}
+	if err := doc.Validate(); err != nil {
+		return nil, serrors.E(op, err)
+	}
+	return doc, nil
+}
+
+func appendPanelTree(doc *DashboardDocument, spec panel.Spec, result *runtime.Result, hosts map[string]explore.Spec, row *LayoutRow) error {
+	if spec.Kind.IsContainer() {
+		for _, child := range spec.Children {
+			if err := appendPanelTree(doc, child, result, hosts, row); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	kind, err := panelKind(spec.Kind)
+	if err != nil {
+		return fmt.Errorf("panel %s: %w", spec.ID, err)
+	}
+	panelResult := result.Panel(spec.ID)
+	if panelResult == nil {
+		return fmt.Errorf("panel %s is missing from runtime result", spec.ID)
+	}
+	if panelResult.Error != nil {
+		return fmt.Errorf("panel %s runtime result: %w", spec.ID, panelResult.Error)
+	}
+	primary := panelResult.Frames.Primary()
+	if primary == nil {
+		return fmt.Errorf("panel %s has no primary frame", spec.ID)
+	}
+	frameRef := FrameRef("panel:" + spec.ID)
+	wireFrame, err := buildFrame(primary)
+	if err != nil {
+		return fmt.Errorf("panel %s: %w", spec.ID, err)
+	}
+	doc.Frames[frameRef] = wireFrame
+	semantics := inferSemantics(kind)
+	var drillRoot *NodeKey
+	if explorerSpec, ok := hosts[spec.ID]; ok {
+		semantics = defaultExplorerSemantics(explorerSpec, semantics)
+		key := explorerRootKey(explorerSpec.ID)
+		drillRoot = &key
+	}
+	actions := panelActions(spec)
+	doc.Panels = append(doc.Panels, Panel{
+		ID: spec.ID, Kind: kind, Title: spec.Title, Semantics: semantics, Frame: frameRef,
+		Encoding: buildEncoding(spec.Fields, wireFrame), Format: buildFormats(spec), DrillRoot: drillRoot, Actions: actions,
+	})
+	span := spec.Span
+	if span == 0 {
+		span = 6
+	}
+	row.Panels = append(row.Panels, LayoutItem{PanelID: spec.ID, Span: span})
+	for index, color := range spec.Colors {
+		if strings.TrimSpace(color) != "" {
+			doc.Theme.Series[fmt.Sprintf("%s:%d", spec.ID, index)] = color
+		}
+	}
+	return nil
+}
+
+func panelKind(kind panel.Kind) (PanelKind, error) {
+	switch kind {
+	case panel.KindStat:
+		return PanelKindStat, nil
+	case panel.KindPie:
+		return PanelKindPie, nil
+	case panel.KindDonut:
+		return PanelKindDonut, nil
+	case panel.KindBar, panel.KindStackedBar:
+		return PanelKindBar, nil
+	case panel.KindHorizontalBar, panel.KindSegmentBar:
+		return PanelKindHBar, nil
+	case panel.KindTimeSeries:
+		return PanelKindLine, nil
+	case panel.KindCascade:
+		return PanelKindCascade, nil
+	case panel.KindTable:
+		return PanelKindTable, nil
+	default:
+		return "", fmt.Errorf("unsupported document panel kind %q", kind)
+	}
+}
+
+func inferSemantics(kind PanelKind) Semantics {
+	switch kind {
+	case PanelKindPie, PanelKindDonut:
+		return SemanticsPartition
+	case PanelKindCascade:
+		return SemanticsReconciliation
+	case PanelKindTable:
+		return SemanticsEvidence
+	default:
+		return SemanticsSeries
+	}
+}
+
+func buildEncoding(fields panel.FieldMapping, frame Frame) Encoding {
+	encoding := Encoding{}
+	available := make(map[string]struct{}, len(frame.Columns))
+	for _, column := range frame.Columns {
+		available[column.Name] = struct{}{}
+	}
+	assign := func(target *string, field panel.FieldRef) {
+		if _, ok := available[field.Name()]; ok {
+			*target = field.Name()
+		}
+	}
+	assign(&encoding.Label, fields.Label)
+	assign(&encoding.Value, fields.Value)
+	assign(&encoding.ID, fields.ID)
+	assign(&encoding.Series, fields.Series)
+	assign(&encoding.Category, fields.Category)
+	assign(&encoding.Cut, fields.Cut)
+	assign(&encoding.CutLabel, fields.CutLabel)
+	assign(&encoding.Final, fields.Final)
+	return encoding
+}
+
+func buildFormats(spec panel.Spec) map[string]FieldFormat {
+	formats := make(map[string]FieldFormat)
+	if !spec.Fields.Value.Empty() && spec.Formatter != nil {
+		if converted, ok := convertFormat(*spec.Formatter); ok {
+			formats[spec.Fields.Value.Name()] = converted
+		}
+	}
+	for _, column := range spec.Columns {
+		if column.Field.Empty() || column.Formatter == nil {
+			continue
+		}
+		if converted, ok := convertFormat(*column.Formatter); ok {
+			formats[column.Field.Name()] = converted
+		}
+	}
+	return formats
+}
+
+func convertFormat(spec format.Spec) (FieldFormat, bool) {
+	result := FieldFormat{Precision: spec.Precision, Layout: spec.Layout}
+	switch spec.Kind {
+	case format.KindMoney:
+		result.Kind = FormatMoney
+		result.Currency = spec.Currency
+		result.MinorUnits = false
+	case format.KindAbbreviatedMoney:
+		if strings.TrimSpace(spec.Currency) == "" {
+			result.Kind = FormatNumber
+		} else {
+			result.Kind = FormatMoney
+			result.Currency = spec.Currency
+			result.MinorUnits = false
+		}
+	case format.KindPercent:
+		result.Kind = FormatPercent
+	case format.KindDate, format.KindMonthLabel:
+		result.Kind = FormatDate
+		if spec.Kind == format.KindMonthLabel && result.Layout == "" {
+			result.Layout = "Jan 2006"
+		}
+	case format.KindInteger:
+		result.Kind = FormatNumber
+	default:
+		return FieldFormat{}, false
+	}
+	return result, true
+}
+
+func buildFrame(source *frame.Frame) (Frame, error) {
+	result := Frame{Columns: make([]Column, 0, len(source.Fields)), Rows: make([][]any, source.RowCount)}
+	for _, field := range source.Fields {
+		columnType, err := columnType(field.Type)
+		if err != nil {
+			return Frame{}, fmt.Errorf("field %s: %w", field.Name, err)
+		}
+		result.Columns = append(result.Columns, Column{Name: field.Name, Type: columnType})
+	}
+	for rowIndex := 0; rowIndex < source.RowCount; rowIndex++ {
+		row := make([]any, len(source.Fields))
+		for columnIndex := range source.Fields {
+			row[columnIndex] = cloneAny(source.Fields[columnIndex].Values[rowIndex])
+		}
+		result.Rows[rowIndex] = row
+	}
+	return result, nil
+}
+
+func columnType(kind frame.FieldType) (ColumnType, error) {
+	switch kind {
+	case frame.FieldTypeString, frame.FieldTypeLocalized:
+		return ColumnString, nil
+	case frame.FieldTypeNumber:
+		return ColumnNumber, nil
+	case frame.FieldTypeBoolean:
+		return ColumnBool, nil
+	case frame.FieldTypeTime:
+		return ColumnTime, nil
+	default:
+		return "", fmt.Errorf("unsupported frame field type %q", kind)
+	}
+}
+
+func panelActions(spec panel.Spec) []Action {
+	actions := make([]Action, 0)
+	if spec.Action != nil {
+		if converted, ok := convertAction(*spec.Action, spec.Kind == panel.KindTable); ok {
+			actions = append(actions, converted)
+		}
+	}
+	for _, column := range spec.Columns {
+		if column.Action == nil {
+			continue
+		}
+		if converted, ok := convertAction(*column.Action, true); ok {
+			actions = append(actions, converted)
+		}
+	}
+	return actions
+}
+
+func convertAction(spec action.Spec, leaf bool) (Action, bool) {
+	result := Action{
+		Method: spec.Method, URLTemplate: spec.URL, Event: spec.Event, PreserveQuery: spec.PreserveQuery,
+		Params: make([]ActionParam, 0, len(spec.Params)), Payload: make(map[string]Source),
+	}
+	switch spec.Kind {
+	case action.KindNavigate:
+		if leaf {
+			result.Kind = ActionNavigateToLeaf
+		} else {
+			result.Kind = ActionNavigate
+		}
+	case action.KindEmitEvent:
+		result.Kind = ActionEmitEvent
+	default:
+		return Action{}, false
+	}
+	for _, param := range spec.Params {
+		result.Params = append(result.Params, ActionParam{Name: param.Name, Source: convertSource(param.Source)})
+	}
+	for name, source := range spec.Payload {
+		result.Payload[name] = convertSource(source)
+	}
+	return result, true
+}
+
+func convertSource(source action.ValueSource) Source {
+	result := Source{Name: source.Name, Value: cloneAny(source.Value), Fallback: cloneAny(source.Fallback)}
+	switch source.Kind {
+	case action.SourceField:
+		result.Kind = ValueSourceField
+	case action.SourceVariable:
+		result.Kind = ValueSourceVariable
+	case action.SourceLiteral:
+		result.Kind = ValueSourceLiteral
+	}
+	return result
+}
+
+func explorerHosts(specs []explore.Spec) map[string]explore.Spec {
+	result := make(map[string]explore.Spec, len(specs))
+	for _, spec := range specs {
+		result[spec.HostPanelID] = spec
+	}
+	return result
+}
+
+func defaultExplorerSemantics(spec explore.Spec, fallback Semantics) Semantics {
+	if len(spec.Branches) == 0 {
+		return fallback
+	}
+	branch := spec.Branches[0]
+	perspective, ok := branch.Perspective(branch.DefaultPerspective)
+	if !ok {
+		return fallback
+	}
+	return Semantics(perspective.Semantics)
+}
+
+func buildExplorer(doc *DashboardDocument, spec explore.Spec, result *runtime.Result) error {
+	rootKey := explorerRootKey(spec.ID)
+	rootPath := NodePath{rootKey}
+	root := Level{Path: rootPath, Label: spec.ID, Children: make([]Node, 0, len(spec.Branches)), Perspectives: make([]PerspectiveRef, 0)}
+	if host := findDocumentPanel(doc.Panels, spec.HostPanelID); host != nil {
+		root.Frame = host.Frame
+	}
+	for _, branch := range spec.Branches {
+		branchKey := qualifiedKey(spec.ID, branch.Key)
+		branchPath := appendPath(rootPath, branchKey)
+		branchLevel := Level{Path: branchPath, Label: branch.Label, Children: make([]Node, 0), Perspectives: make([]PerspectiveRef, 0, len(branch.Perspectives))}
+		root.Children = append(root.Children, Node{Key: branchKey, Path: branchPath, Label: branch.Label, Target: branchKey})
+		for _, view := range branch.Perspectives {
+			perspectiveID := string(qualifiedKey(spec.ID, branch.Key, view.Key))
+			rootNode := qualifiedKey(spec.ID, branch.Key, view.Key, view.RootNode)
+			depths := explorationDepths(view)
+			doc.Perspectives = append(doc.Perspectives, Perspective{
+				ID: perspectiveID, ExplorerID: spec.ID, BranchKey: branchKey, Key: view.Key,
+				Label: view.Label, Semantics: Semantics(view.Semantics), Root: rootNode,
+			})
+			branchLevel.Perspectives = append(branchLevel.Perspectives, PerspectiveRef{ID: perspectiveID})
+			for _, nodeSpec := range view.Nodes {
+				nodeKey := qualifiedKey(spec.ID, branch.Key, view.Key, nodeSpec.Key)
+				nodePath := appendPath(branchPath, qualifiedKey(spec.ID, branch.Key, view.Key), nodeKey)
+				level := Level{Path: nodePath, Label: nodeSpec.Label, Children: make([]Node, 0, len(nodeSpec.Edges)), Perspectives: []PerspectiveRef{{ID: perspectiveID}}}
+				if nodeSpec.Panel != nil && depths[nodeSpec.Key] <= doc.Drill.InlineDepth {
+					if panelResult := result.Panel(nodeSpec.Panel.ID); panelResult != nil && panelResult.Error == nil && panelResult.Frames.Primary() != nil {
+						frameRef := FrameRef("explore:" + perspectiveID + ":" + nodeSpec.Key)
+						wireFrame, err := buildFrame(panelResult.Frames.Primary())
+						if err != nil {
+							return fmt.Errorf("explorer %s node %s: %w", spec.ID, nodeSpec.Key, err)
+						}
+						doc.Frames[frameRef] = wireFrame
+						level.Frame = frameRef
+						encoding := buildEncoding(nodeSpec.Panel.Fields, wireFrame)
+						level.Encoding = &encoding
+					}
+				}
+				for _, edge := range nodeSpec.Edges {
+					pointKey := qualifiedKey(spec.ID, branch.Key, view.Key, nodeSpec.Key, edge.PointKey)
+					childPath := appendPath(nodePath, pointKey)
+					child := Node{Key: pointKey, Path: childPath, Label: edge.PointKey}
+					if edge.ToNode != "" {
+						child.Target = qualifiedKey(spec.ID, branch.Key, view.Key, edge.ToNode)
+					}
+					if edge.Action != nil {
+						if converted, ok := convertAction(*edge.Action, true); ok {
+							child.Action = &converted
+						}
+					}
+					level.Children = append(level.Children, child)
+				}
+				doc.Drill.Edges[nodeKey] = level
+			}
+		}
+		doc.Drill.Edges[branchKey] = branchLevel
+	}
+	doc.Drill.Edges[rootKey] = root
+	return nil
+}
+
+func findDocumentPanel(panels []Panel, id string) *Panel {
+	for index := range panels {
+		if panels[index].ID == id {
+			return &panels[index]
+		}
+	}
+	return nil
+}
+
+func explorationDepths(view explore.Perspective) map[string]int {
+	const unseen = int(^uint(0) >> 1)
+	depths := make(map[string]int, len(view.Nodes))
+	for _, node := range view.Nodes {
+		depths[node.Key] = unseen
+	}
+	depths[view.RootNode] = 0
+	changed := true
+	for changed {
+		changed = false
+		for _, node := range view.Nodes {
+			depth := depths[node.Key]
+			if depth == unseen {
+				continue
+			}
+			for _, edge := range node.Edges {
+				if edge.ToNode != "" && depth+1 < depths[edge.ToNode] {
+					depths[edge.ToNode] = depth + 1
+					changed = true
+				}
+			}
+			for _, target := range node.DynamicTargets {
+				if depth+1 < depths[target] {
+					depths[target] = depth + 1
+					changed = true
+				}
+			}
+		}
+	}
+	return depths
+}
+
+func explorerRootKey(explorerID string) NodeKey { return qualifiedKey(explorerID) }
+
+func qualifiedKey(parts ...string) NodeKey {
+	escaped := make([]string, len(parts))
+	for index, part := range parts {
+		escaped[index] = url.PathEscape(part)
+	}
+	return NodeKey(strings.Join(escaped, "/"))
+}
+
+func appendPath(path NodePath, keys ...NodeKey) NodePath {
+	result := append(NodePath(nil), path...)
+	return append(result, keys...)
+}
+
+func newSnapshotID() (string, error) {
+	var raw [18]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", fmt.Errorf("generate snapshot id: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(raw[:]), nil
+}

--- a/pkg/lens/document/build_test.go
+++ b/pkg/lens/document/build_test.go
@@ -1,0 +1,118 @@
+package document
+
+import (
+	"context"
+	"encoding/json"
+	"maps"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/iota-uz/iota-sdk/pkg/lens"
+	"github.com/iota-uz/iota-sdk/pkg/lens/action"
+	lensbuild "github.com/iota-uz/iota-sdk/pkg/lens/build"
+	"github.com/iota-uz/iota-sdk/pkg/lens/explore"
+	"github.com/iota-uz/iota-sdk/pkg/lens/frame"
+	"github.com/iota-uz/iota-sdk/pkg/lens/panel"
+	"github.com/iota-uz/iota-sdk/pkg/lens/runtime"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuild_ExistingExploreSpec(t *testing.T) {
+	t.Parallel()
+	spec, result := executeExploreDashboard(t)
+	doc, err := Build(spec, result, BuildOptions{
+		SnapshotID: "snapshot-generated", GeneratedAt: time.Date(2026, time.July, 19, 10, 0, 0, 0, time.UTC),
+		Locale: "en", InlineDepth: 1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, ContractVersion, doc.Version)
+	require.Len(t, doc.Panels, 1)
+	require.Equal(t, SemanticsPartition, doc.Panels[0].Semantics)
+	require.NotNil(t, doc.Panels[0].DrillRoot)
+	require.Contains(t, doc.Drill.Edges, *doc.Panels[0].DrillRoot)
+	require.Len(t, doc.Perspectives, 1)
+	require.Equal(t, NodeKey("metric/focus/composition/root"), doc.Perspectives[0].Root)
+
+	payload, err := json.MarshalIndent(doc, "", "  ")
+	require.NoError(t, err)
+	require.Equal(t, golden(t, "generated_explore.json"), string(payload)+"\n")
+}
+
+func TestBuild_NodeKeysIgnoreLabelsAndDefinitionOrder(t *testing.T) {
+	t.Parallel()
+	spec, result := executeExploreDashboard(t)
+	first, err := Build(spec, result, BuildOptions{SnapshotID: "one", GeneratedAt: time.Unix(1, 0), InlineDepth: 1})
+	require.NoError(t, err)
+
+	view := &spec.Explorers[0].Branches[0].Perspectives[0]
+	view.Label = "Localized label"
+	for index := range view.Nodes {
+		view.Nodes[index].Label = "Localized " + view.Nodes[index].Key
+	}
+	slices.Reverse(view.Nodes)
+	second, err := Build(spec, result, BuildOptions{SnapshotID: "two", GeneratedAt: time.Unix(2, 0), InlineDepth: 1})
+	require.NoError(t, err)
+
+	firstKeys := maps.Keys(first.Drill.Edges)
+	secondKeys := maps.Keys(second.Drill.Edges)
+	require.ElementsMatch(t, slices.Collect(firstKeys), slices.Collect(secondKeys))
+	for index := range first.Perspectives {
+		require.Equal(t, first.Perspectives[index].Root, second.Perspectives[index].Root)
+	}
+}
+
+func TestBuild_ReusesRuntimeExploreValidation(t *testing.T) {
+	t.Parallel()
+	spec, result := executeExploreDashboard(t)
+	spec.Explorers[0].Branches[0].Perspectives[0].Semantics = "unsupported"
+	_, err := Build(spec, result, BuildOptions{SnapshotID: "invalid"})
+	require.ErrorContains(t, err, "unsupported semantics")
+}
+
+func TestBuild_InlineDepthIncludesOnlyMaterializedAggregateLevels(t *testing.T) {
+	t.Parallel()
+	spec, result := executeExploreDashboard(t)
+	view := &spec.Explorers[0].Branches[0].Perspectives[0]
+	rootPanel := panel.Pie("explore-root", "Root", "premium").IDField("id").Build()
+	detailPanel := panel.Pie("explore-detail", "Detail", "premium").IDField("id").Build()
+	view.Nodes[0].Load = nil
+	view.Nodes[0].Panel = &rootPanel
+	view.Nodes[1].Load = nil
+	view.Nodes[1].Panel = &detailPanel
+	result.Panels[rootPanel.ID] = &runtime.PanelResult{Panel: rootPanel, Frames: result.Panels["host"].Frames}
+	result.Panels[detailPanel.ID] = &runtime.PanelResult{Panel: detailPanel, Frames: result.Panels["host"].Frames}
+
+	doc, err := Build(spec, result, BuildOptions{SnapshotID: "inline", GeneratedAt: time.Unix(1, 0), InlineDepth: 0})
+	require.NoError(t, err)
+	require.Equal(t, FrameRef("explore:metric/focus/composition:root"), doc.Drill.Edges["metric/focus/composition/root"].Frame)
+	require.Empty(t, doc.Drill.Edges["metric/focus/composition/detail"].Frame)
+	require.NotContains(t, doc.Frames, FrameRef("explore:metric/focus/composition:detail"))
+}
+
+func executeExploreDashboard(t *testing.T) (lens.DashboardSpec, *runtime.Result) {
+	t.Helper()
+	primary, err := frame.New("premium",
+		frame.Field{Name: "id", Type: frame.FieldTypeString, Values: []any{"a", "b"}},
+		frame.Field{Name: "label", Type: frame.FieldTypeString, Values: []any{"Alpha", "Beta"}},
+		frame.Field{Name: "value", Type: frame.FieldTypeNumber, Values: []any{60.0, 40.0}},
+	)
+	require.NoError(t, err)
+	frames, err := frame.NewFrameSet(primary)
+	require.NoError(t, err)
+	explorerSpec, err := explore.New("metric", "host",
+		explore.NewBranch("focus", "Focus", "composition",
+			explore.NewPerspective("composition", "Composition", explore.SemanticsPartition, "root",
+				explore.LazyNode("root", "Root", "/explore", explore.ToNode("a", "detail")),
+				explore.LazyNode("detail", "Detail", "/explore", explore.ToAction("leaf", action.Navigate("/policies/{policyId}", action.LiteralParam("policyId", "selected")))),
+			),
+		),
+	).Build()
+	require.NoError(t, err)
+	spec := lensbuild.Dashboard("overview", "Overview",
+		lensbuild.Row(panel.Pie("host", "Premium", "premium").IDField("id").Build()),
+	).Datasets(lensbuild.StaticDataset("premium", frames)).Explorers(explorerSpec).Build()
+	executed, err := runtime.New(runtime.Options{}).Execute(context.Background(), spec, runtime.Request{Locale: "en", DataScope: "tenant:1"}, runtime.DashboardScope())
+	require.NoError(t, err)
+	return spec, executed
+}

--- a/pkg/lens/document/build_test.go
+++ b/pkg/lens/document/build_test.go
@@ -33,6 +33,10 @@ func TestBuild_ExistingExploreSpec(t *testing.T) {
 	require.Contains(t, doc.Drill.Edges, *doc.Panels[0].DrillRoot)
 	require.Len(t, doc.Perspectives, 1)
 	require.Equal(t, NodeKey("metric/focus/composition/root"), doc.Perspectives[0].Root)
+	require.Empty(t, doc.Drill.Edges["metric"].Label)
+	require.Equal(t, "Focus", doc.Drill.Edges["metric/focus"].Label)
+	require.Equal(t, "Root", doc.Drill.Edges["metric/focus/composition/root"].Label)
+	require.Empty(t, doc.Drill.Edges["metric/focus/composition/root"].Children[0].Label)
 
 	payload, err := json.MarshalIndent(doc, "", "  ")
 	require.NoError(t, err)

--- a/pkg/lens/document/doc.go
+++ b/pkg/lens/document/doc.go
@@ -1,0 +1,19 @@
+// Package document defines the versioned wire contract consumed by Lens React
+// runtimes.
+//
+// A snapshot freezes dashboard parameters and filter state together with the
+// aggregate frames materialized by one dashboard execution. Aggregate levels
+// deeper than the document's inline depth are resolved with those frozen
+// parameters and appended to the snapshot, so an already materialized level is
+// not executed again.
+//
+// Evidence pages are intentionally different: paginated policy, transaction,
+// and similar leaf rows are queried live using the snapshot's frozen
+// parameters. A snapshot therefore guarantees a consistent query context for
+// evidence, not an immutable copy of row-level data.
+//
+// Snapshot stores return ErrSnapshotGone for expired and unknown IDs. A client
+// receiving that error must fetch a fresh dashboard document.
+package document
+
+const ContractVersion = "1.0.0"

--- a/pkg/lens/document/doc.go
+++ b/pkg/lens/document/doc.go
@@ -7,13 +7,18 @@
 // parameters and appended to the snapshot, so an already materialized level is
 // not executed again.
 //
+// Lens frames must carry major-unit money values; a cube that SUMs a minor-unit
+// (e.g. tiyin) column must convert before it reaches a frame. MinorUnits remains
+// part of the wire contract for serve-layer and hand-built documents.
+//
 // Evidence pages are intentionally different: paginated policy, transaction,
 // and similar leaf rows are queried live using the snapshot's frozen
 // parameters. A snapshot therefore guarantees a consistent query context for
 // evidence, not an immutable copy of row-level data.
 //
-// Snapshot stores return ErrSnapshotGone for expired and unknown IDs. A client
-// receiving that error must fetch a fresh dashboard document.
+// Snapshot store TTLs slide on Get and Append. Stores return ErrSnapshotGone for
+// expired and unknown IDs; a client receiving that error must fetch a fresh
+// dashboard document.
 package document
 
 const ContractVersion = "1.0.0"

--- a/pkg/lens/document/document_test.go
+++ b/pkg/lens/document/document_test.go
@@ -2,6 +2,7 @@ package document
 
 import (
 	"encoding/json"
+	"fmt"
 	"math"
 	"os"
 	"path/filepath"
@@ -41,11 +42,32 @@ func TestDashboardDocumentValidate_DrillIdentity(t *testing.T) {
 		}
 		require.ErrorContains(t, doc.Validate(), "duplicate child key")
 	})
-	t.Run("duplicate full path", func(t *testing.T) {
+	t.Run("duplicate full paths cannot bypass parent consistency", func(t *testing.T) {
 		doc := testDocument()
 		doc.Drill.Edges["first"] = Level{Path: NodePath{"first"}, Children: []Node{{Key: "leaf", Path: NodePath{"root", "leaf"}, Label: "One"}}, Perspectives: []PerspectiveRef{}}
 		doc.Drill.Edges["second"] = Level{Path: NodePath{"second"}, Children: []Node{{Key: "leaf", Path: NodePath{"root", "leaf"}, Label: "Two"}}, Perspectives: []PerspectiveRef{}}
-		require.ErrorContains(t, doc.Validate(), "duplicates full path")
+		require.ErrorContains(t, doc.Validate(), "must extend parent level")
+	})
+	t.Run("level path must end with registered edge key", func(t *testing.T) {
+		doc := testDocument()
+		doc.Drill.Edges["root"] = Level{Path: NodePath{"other"}, Children: []Node{}, Perspectives: []PerspectiveRef{}}
+		require.ErrorContains(t, doc.Validate(), "invalid full path")
+	})
+	t.Run("child path must extend parent path", func(t *testing.T) {
+		doc := testDocument()
+		doc.Drill.Edges["root"] = Level{
+			Path: NodePath{"root"}, Perspectives: []PerspectiveRef{},
+			Children: []Node{{Key: "leaf", Path: NodePath{"unrelated", "leaf"}}},
+		}
+		require.ErrorContains(t, doc.Validate(), "must extend parent level")
+	})
+	t.Run("child path cannot skip a parent segment", func(t *testing.T) {
+		doc := testDocument()
+		doc.Drill.Edges["root"] = Level{
+			Path: NodePath{"root"}, Perspectives: []PerspectiveRef{},
+			Children: []Node{{Key: "leaf", Path: NodePath{"root", "extra", "leaf"}}},
+		}
+		require.ErrorContains(t, doc.Validate(), "must extend parent level")
 	})
 }
 
@@ -82,9 +104,16 @@ func TestDashboardDocumentValidate_Semantics(t *testing.T) {
 		doc.Panels[0].Actions = []Action{{Kind: ActionNavigateToLeaf, URLTemplate: "/evidence/{id}", Params: []ActionParam{}, Payload: map[string]Source{}}}
 		require.NoError(t, doc.Validate())
 	})
+	t.Run("emit event action", func(t *testing.T) {
+		doc := testDocument()
+		doc.Panels[0].Actions = []Action{{
+			Kind: ActionEmitEvent, Event: "lens.selected", Params: []ActionParam{},
+			Payload: map[string]Source{"id": {Kind: ValueSourceField, Name: "label"}},
+		}}
+		require.NoError(t, doc.Validate())
+	})
 	for _, value := range []float64{-1, math.Inf(1), math.NaN()} {
-		value := value
-		t.Run("invalid partition value", func(t *testing.T) {
+		t.Run(fmt.Sprintf("invalid partition value %v", value), func(t *testing.T) {
 			doc := testDocument()
 			doc.Panels[0].Semantics = SemanticsPartition
 			frame := doc.Frames[doc.Panels[0].Frame]

--- a/pkg/lens/document/document_test.go
+++ b/pkg/lens/document/document_test.go
@@ -1,0 +1,159 @@
+package document
+
+import (
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDashboardDocumentValidate_FrameReferences(t *testing.T) {
+	t.Parallel()
+
+	t.Run("panel", func(t *testing.T) {
+		doc := testDocument()
+		doc.Panels[0].Frame = "missing"
+		require.ErrorContains(t, doc.Validate(), "references missing frame")
+	})
+	t.Run("drill level", func(t *testing.T) {
+		doc := testDocument()
+		doc.Drill.Edges["root"] = Level{Path: NodePath{"root"}, Frame: "missing", Children: []Node{}, Perspectives: []PerspectiveRef{}}
+		require.ErrorContains(t, doc.Validate(), "references missing frame")
+	})
+}
+
+func TestDashboardDocumentValidate_DrillIdentity(t *testing.T) {
+	t.Parallel()
+
+	t.Run("duplicate siblings", func(t *testing.T) {
+		doc := testDocument()
+		doc.Drill.Edges["root"] = Level{
+			Path: NodePath{"root"}, Perspectives: []PerspectiveRef{},
+			Children: []Node{
+				{Key: "same", Path: NodePath{"root", "same"}, Label: "First"},
+				{Key: "same", Path: NodePath{"root", "same"}, Label: "Second"},
+			},
+		}
+		require.ErrorContains(t, doc.Validate(), "duplicate child key")
+	})
+	t.Run("duplicate full path", func(t *testing.T) {
+		doc := testDocument()
+		doc.Drill.Edges["first"] = Level{Path: NodePath{"first"}, Children: []Node{{Key: "leaf", Path: NodePath{"root", "leaf"}, Label: "One"}}, Perspectives: []PerspectiveRef{}}
+		doc.Drill.Edges["second"] = Level{Path: NodePath{"second"}, Children: []Node{{Key: "leaf", Path: NodePath{"root", "leaf"}, Label: "Two"}}, Perspectives: []PerspectiveRef{}}
+		require.ErrorContains(t, doc.Validate(), "duplicates full path")
+	})
+}
+
+func TestDashboardDocumentValidate_PartitionDrillFrame(t *testing.T) {
+	t.Parallel()
+	doc := testDocument()
+	doc.Frames["detail"] = Frame{Columns: []Column{{Name: "value", Type: ColumnNumber}}, Rows: [][]any{{-1.0}}}
+	doc.Perspectives = []Perspective{{
+		ID: "metric/branch/composition", ExplorerID: "metric", BranchKey: "metric/branch", Key: "composition",
+		Label: "Composition", Semantics: SemanticsPartition, Root: "detail",
+	}}
+	encoding := Encoding{Value: "value"}
+	doc.Drill.Edges["detail"] = Level{
+		Path: NodePath{"detail"}, Children: []Node{}, Frame: "detail", Encoding: &encoding,
+		Perspectives: []PerspectiveRef{{ID: "metric/branch/composition"}},
+	}
+	require.ErrorContains(t, doc.Validate(), "partition value row 0")
+}
+
+func TestDashboardDocumentValidate_Semantics(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reconciliation circular", func(t *testing.T) {
+		doc := testDocument()
+		doc.Panels[0].Kind = PanelKindPie
+		doc.Panels[0].Semantics = SemanticsReconciliation
+		require.ErrorContains(t, doc.Validate(), "reconciliation semantics")
+	})
+	t.Run("evidence leaf action", func(t *testing.T) {
+		doc := testDocument()
+		doc.Panels[0].Semantics = SemanticsEvidence
+		doc.Panels[0].Actions = nil
+		require.ErrorContains(t, doc.Validate(), "requires a leaf action")
+		doc.Panels[0].Actions = []Action{{Kind: ActionNavigateToLeaf, URLTemplate: "/evidence/{id}", Params: []ActionParam{}, Payload: map[string]Source{}}}
+		require.NoError(t, doc.Validate())
+	})
+	for _, value := range []float64{-1, math.Inf(1), math.NaN()} {
+		value := value
+		t.Run("invalid partition value", func(t *testing.T) {
+			doc := testDocument()
+			doc.Panels[0].Semantics = SemanticsPartition
+			frame := doc.Frames[doc.Panels[0].Frame]
+			frame.Rows[0][1] = value
+			doc.Frames[doc.Panels[0].Frame] = frame
+			require.ErrorContains(t, doc.Validate(), "finite")
+		})
+	}
+}
+
+func TestDashboardDocumentValidate_MoneyMetadata(t *testing.T) {
+	t.Parallel()
+	doc := testDocument()
+	doc.Panels[0].Format["value"] = FieldFormat{Kind: FormatMoney}
+	require.ErrorContains(t, doc.Validate(), "requires currency")
+
+	doc.Panels[0].Format["value"] = FieldFormat{Kind: FormatMoney, Currency: "UZS", MinorUnits: false}
+	require.NoError(t, doc.Validate())
+	payload, err := json.Marshal(doc)
+	require.NoError(t, err)
+	require.Contains(t, string(payload), `"minorUnits":false`)
+}
+
+func TestDashboardDocumentJSON_IsDeterministicAndPinsVersion(t *testing.T) {
+	t.Parallel()
+	doc := testDocument()
+	doc.Version = "9.0.0"
+	first, err := json.MarshalIndent(doc, "", "  ")
+	require.NoError(t, err)
+	for range 20 {
+		next, marshalErr := json.MarshalIndent(doc, "", "  ")
+		require.NoError(t, marshalErr)
+		require.Equal(t, first, next)
+	}
+	require.Contains(t, string(first), `"version": "1.0.0"`)
+	require.Equal(t, golden(t, "small.json"), string(first)+"\n")
+}
+
+func TestDashboardDocumentValidate_DetectsVersionMismatch(t *testing.T) {
+	t.Parallel()
+	doc := testDocument()
+	doc.Version = "2.0.0"
+	require.ErrorContains(t, doc.Validate(), "unsupported contract version")
+}
+
+func testDocument() *DashboardDocument {
+	return &DashboardDocument{
+		Version:    ContractVersion,
+		SnapshotID: "snapshot-test",
+		Meta:       Meta{DashboardID: "overview", Title: "Overview", GeneratedAt: time.Date(2026, time.July, 19, 9, 30, 0, 0, time.UTC), Locale: "en"},
+		Layout:     Layout{Rows: []LayoutRow{{Panels: []LayoutItem{{PanelID: "total", Span: 6}}}}},
+		Panels: []Panel{{
+			ID: "total", Kind: PanelKindStat, Title: "Total", Semantics: SemanticsSeries, Frame: "panel:total",
+			Encoding: Encoding{Label: "label", Value: "value"}, Format: map[string]FieldFormat{}, Actions: []Action{},
+		}},
+		Frames: map[FrameRef]Frame{
+			"panel:total": {Columns: []Column{{Name: "label", Type: ColumnString}, {Name: "value", Type: ColumnNumber}}, Rows: [][]any{{"Total", 42.0}}},
+		},
+		Drill:        Drill{Edges: map[NodeKey]Level{}, InlineDepth: 0},
+		Perspectives: []Perspective{},
+		Endpoints:    Endpoints{Query: "/lens/query", Export: "/lens/export"},
+		I18n:         map[string]string{"dashboard.total": "Total", "dashboard.title": "Overview"},
+		Theme:        Theme{Palette: map[string]string{"accent": "#2563eb", "danger": "#dc2626"}, Series: map[string]string{"total": "accent"}},
+	}
+}
+
+func golden(t *testing.T, name string) string {
+	t.Helper()
+	payload, err := os.ReadFile(filepath.Join("testdata", name))
+	require.NoError(t, err)
+	return strings.ReplaceAll(string(payload), "\r\n", "\n")
+}

--- a/pkg/lens/document/store.go
+++ b/pkg/lens/document/store.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -43,6 +42,7 @@ type memorySnapshot struct {
 	expiresAt time.Time
 }
 
+// NewMemoryStore returns a bounded store whose TTL slides on Get and Append.
 func NewMemoryStore(ttl time.Duration, maxEntries int) SnapshotStore {
 	if ttl <= 0 {
 		ttl = defaultSnapshotTTL
@@ -103,10 +103,12 @@ func (m *memoryStore) Get(ctx context.Context, id string) (*Snapshot, error) {
 		return nil, ErrSnapshotGone
 	}
 	entry := element.Value.(*memorySnapshot)
-	if !entry.expiresAt.After(m.clock()) {
+	now := m.clock()
+	if !entry.expiresAt.After(now) {
 		m.remove(element)
 		return nil, ErrSnapshotGone
 	}
+	entry.expiresAt = now.Add(m.ttl)
 	m.lru.MoveToFront(element)
 	return cloneSnapshot(entry.snapshot), nil
 }
@@ -123,7 +125,8 @@ func (m *memoryStore) Append(ctx context.Context, id string, frames map[FrameRef
 		return ErrSnapshotGone
 	}
 	entry := element.Value.(*memorySnapshot)
-	if !entry.expiresAt.After(m.clock()) {
+	now := m.clock()
+	if !entry.expiresAt.After(now) {
 		m.remove(element)
 		return ErrSnapshotGone
 	}
@@ -136,6 +139,7 @@ func (m *memoryStore) Append(ctx context.Context, id string, frames map[FrameRef
 		}
 		entry.snapshot.Frames[ref] = cloneFrame(frame)
 	}
+	entry.expiresAt = now.Add(m.ttl)
 	m.lru.MoveToFront(element)
 	return nil
 }
@@ -178,71 +182,32 @@ func cloneFrame(frame Frame) Frame {
 }
 
 func cloneAny(value any) any {
-	if value == nil {
-		return nil
-	}
-	return cloneReflect(reflect.ValueOf(value)).Interface()
-}
-
-func cloneReflect(value reflect.Value) reflect.Value {
-	if !value.IsValid() {
-		return reflect.ValueOf((*any)(nil)).Elem()
-	}
-	if value.Type() == reflect.TypeOf(time.Time{}) {
-		return value
-	}
-	switch value.Kind() {
-	case reflect.Interface:
-		if value.IsNil() {
-			return reflect.Zero(value.Type())
+	switch typed := value.(type) {
+	case nil, bool, string,
+		int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64, time.Time:
+		return typed
+	case []any:
+		if typed == nil {
+			return []any(nil)
 		}
-		cloned := cloneReflect(value.Elem())
-		result := reflect.New(value.Type()).Elem()
-		result.Set(cloned)
-		return result
-	case reflect.Pointer:
-		if value.IsNil() {
-			return reflect.Zero(value.Type())
-		}
-		result := reflect.New(value.Type().Elem())
-		result.Elem().Set(cloneReflect(value.Elem()))
-		return result
-	case reflect.Map:
-		if value.IsNil() {
-			return reflect.Zero(value.Type())
-		}
-		result := reflect.MakeMapWithSize(value.Type(), value.Len())
-		iterator := value.MapRange()
-		for iterator.Next() {
-			result.SetMapIndex(cloneReflect(iterator.Key()), cloneReflect(iterator.Value()))
+		result := make([]any, len(typed))
+		for index, item := range typed {
+			result[index] = cloneAny(item)
 		}
 		return result
-	case reflect.Slice:
-		if value.IsNil() {
-			return reflect.Zero(value.Type())
+	case map[string]any:
+		if typed == nil {
+			return map[string]any(nil)
 		}
-		result := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
-		for index := 0; index < value.Len(); index++ {
-			result.Index(index).Set(cloneReflect(value.Index(index)))
-		}
-		return result
-	case reflect.Array:
-		result := reflect.New(value.Type()).Elem()
-		for index := 0; index < value.Len(); index++ {
-			result.Index(index).Set(cloneReflect(value.Index(index)))
-		}
-		return result
-	case reflect.Struct:
-		result := reflect.New(value.Type()).Elem()
-		result.Set(value)
-		for index := 0; index < value.NumField(); index++ {
-			if result.Field(index).CanSet() && value.Type().Field(index).IsExported() {
-				result.Field(index).Set(cloneReflect(value.Field(index)))
-			}
+		result := make(map[string]any, len(typed))
+		for key, item := range typed {
+			result[key] = cloneAny(item)
 		}
 		return result
 	default:
-		return value
+		return typed
 	}
 }
 

--- a/pkg/lens/document/store.go
+++ b/pkg/lens/document/store.go
@@ -1,0 +1,269 @@
+package document
+
+import (
+	"container/list"
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+)
+
+const defaultSnapshotTTL = 30 * time.Minute
+const defaultMaxEntries = 128
+
+var ErrSnapshotGone = errors.New("lens document snapshot is gone")
+
+type Snapshot struct {
+	ID        string
+	Params    map[string]any
+	Frames    map[FrameRef]Frame
+	CreatedAt time.Time
+}
+
+type SnapshotStore interface {
+	Put(context.Context, *Snapshot) error
+	Get(context.Context, string) (*Snapshot, error)
+	Append(context.Context, string, map[FrameRef]Frame) error
+}
+
+type memoryStore struct {
+	mu         sync.Mutex
+	ttl        time.Duration
+	maxEntries int
+	clock      func() time.Time
+	items      map[string]*list.Element
+	lru        *list.List
+}
+
+type memorySnapshot struct {
+	snapshot  *Snapshot
+	expiresAt time.Time
+}
+
+func NewMemoryStore(ttl time.Duration, maxEntries int) SnapshotStore {
+	if ttl <= 0 {
+		ttl = defaultSnapshotTTL
+	}
+	if maxEntries <= 0 {
+		maxEntries = defaultMaxEntries
+	}
+	return &memoryStore{
+		ttl: ttl, maxEntries: maxEntries, clock: time.Now,
+		items: make(map[string]*list.Element), lru: list.New(),
+	}
+}
+
+func (m *memoryStore) Put(ctx context.Context, snapshot *Snapshot) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if snapshot == nil {
+		return fmt.Errorf("snapshot is required")
+	}
+	id := strings.TrimSpace(snapshot.ID)
+	if id == "" {
+		return fmt.Errorf("snapshot id is required")
+	}
+	cloned := cloneSnapshot(snapshot)
+	cloned.ID = id
+	now := m.clock()
+	if cloned.CreatedAt.IsZero() {
+		cloned.CreatedAt = now
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if existing, ok := m.items[id]; ok {
+		entry := existing.Value.(*memorySnapshot)
+		entry.snapshot = cloned
+		entry.expiresAt = now.Add(m.ttl)
+		m.lru.MoveToFront(existing)
+		return nil
+	}
+	element := m.lru.PushFront(&memorySnapshot{snapshot: cloned, expiresAt: now.Add(m.ttl)})
+	m.items[id] = element
+	for len(m.items) > m.maxEntries {
+		m.remove(m.lru.Back())
+	}
+	return nil
+}
+
+func (m *memoryStore) Get(ctx context.Context, id string) (*Snapshot, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	id = strings.TrimSpace(id)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	element, ok := m.items[id]
+	if !ok {
+		return nil, ErrSnapshotGone
+	}
+	entry := element.Value.(*memorySnapshot)
+	if !entry.expiresAt.After(m.clock()) {
+		m.remove(element)
+		return nil, ErrSnapshotGone
+	}
+	m.lru.MoveToFront(element)
+	return cloneSnapshot(entry.snapshot), nil
+}
+
+func (m *memoryStore) Append(ctx context.Context, id string, frames map[FrameRef]Frame) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	id = strings.TrimSpace(id)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	element, ok := m.items[id]
+	if !ok {
+		return ErrSnapshotGone
+	}
+	entry := element.Value.(*memorySnapshot)
+	if !entry.expiresAt.After(m.clock()) {
+		m.remove(element)
+		return ErrSnapshotGone
+	}
+	if entry.snapshot.Frames == nil {
+		entry.snapshot.Frames = make(map[FrameRef]Frame)
+	}
+	for ref, frame := range frames {
+		if _, materialized := entry.snapshot.Frames[ref]; materialized {
+			continue
+		}
+		entry.snapshot.Frames[ref] = cloneFrame(frame)
+	}
+	m.lru.MoveToFront(element)
+	return nil
+}
+
+func (m *memoryStore) remove(element *list.Element) {
+	if element == nil {
+		return
+	}
+	entry := element.Value.(*memorySnapshot)
+	delete(m.items, entry.snapshot.ID)
+	m.lru.Remove(element)
+}
+
+func cloneSnapshot(snapshot *Snapshot) *Snapshot {
+	if snapshot == nil {
+		return nil
+	}
+	result := &Snapshot{
+		ID: snapshot.ID, CreatedAt: snapshot.CreatedAt,
+		Params: make(map[string]any, len(snapshot.Params)), Frames: make(map[FrameRef]Frame, len(snapshot.Frames)),
+	}
+	for key, value := range snapshot.Params {
+		result.Params[key] = cloneAny(value)
+	}
+	for ref, frame := range snapshot.Frames {
+		result.Frames[ref] = cloneFrame(frame)
+	}
+	return result
+}
+
+func cloneFrame(frame Frame) Frame {
+	result := Frame{Columns: append([]Column(nil), frame.Columns...), Rows: make([][]any, len(frame.Rows))}
+	for rowIndex, row := range frame.Rows {
+		result.Rows[rowIndex] = make([]any, len(row))
+		for columnIndex, value := range row {
+			result.Rows[rowIndex][columnIndex] = cloneAny(value)
+		}
+	}
+	return result
+}
+
+func cloneAny(value any) any {
+	if value == nil {
+		return nil
+	}
+	return cloneReflect(reflect.ValueOf(value)).Interface()
+}
+
+func cloneReflect(value reflect.Value) reflect.Value {
+	if !value.IsValid() {
+		return reflect.ValueOf((*any)(nil)).Elem()
+	}
+	if value.Type() == reflect.TypeOf(time.Time{}) {
+		return value
+	}
+	switch value.Kind() {
+	case reflect.Interface:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := cloneReflect(value.Elem())
+		result := reflect.New(value.Type()).Elem()
+		result.Set(cloned)
+		return result
+	case reflect.Pointer:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		result := reflect.New(value.Type().Elem())
+		result.Elem().Set(cloneReflect(value.Elem()))
+		return result
+	case reflect.Map:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		result := reflect.MakeMapWithSize(value.Type(), value.Len())
+		iterator := value.MapRange()
+		for iterator.Next() {
+			result.SetMapIndex(cloneReflect(iterator.Key()), cloneReflect(iterator.Value()))
+		}
+		return result
+	case reflect.Slice:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		result := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		for index := 0; index < value.Len(); index++ {
+			result.Index(index).Set(cloneReflect(value.Index(index)))
+		}
+		return result
+	case reflect.Array:
+		result := reflect.New(value.Type()).Elem()
+		for index := 0; index < value.Len(); index++ {
+			result.Index(index).Set(cloneReflect(value.Index(index)))
+		}
+		return result
+	case reflect.Struct:
+		result := reflect.New(value.Type()).Elem()
+		result.Set(value)
+		for index := 0; index < value.NumField(); index++ {
+			if result.Field(index).CanSet() && value.Type().Field(index).IsExported() {
+				result.Field(index).Set(cloneReflect(value.Field(index)))
+			}
+		}
+		return result
+	default:
+		return value
+	}
+}
+
+func cloneStrings(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+	result := make(map[string]string, len(values))
+	for key, value := range values {
+		result[key] = value
+	}
+	return result
+}
+
+func cloneTheme(theme Theme) Theme {
+	result := Theme{Palette: cloneStrings(theme.Palette), Series: cloneStrings(theme.Series)}
+	if result.Palette == nil {
+		result.Palette = make(map[string]string)
+	}
+	if result.Series == nil {
+		result.Series = make(map[string]string)
+	}
+	return result
+}

--- a/pkg/lens/document/store_test.go
+++ b/pkg/lens/document/store_test.go
@@ -2,7 +2,6 @@ package document
 
 import (
 	"context"
-	"errors"
 	"testing"
 	"time"
 
@@ -52,6 +51,29 @@ func TestMemoryStore_ExpiryAndUnknownSnapshots(t *testing.T) {
 	require.ErrorIs(t, err, ErrSnapshotGone)
 }
 
+func TestMemoryStore_TTLSlidesOnAccess(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.July, 19, 12, 0, 0, 0, time.UTC)
+	store := NewMemoryStore(time.Minute, 3).(*memoryStore)
+	store.clock = func() time.Time { return now }
+	require.NoError(t, store.Put(context.Background(), &Snapshot{ID: "visited"}))
+	require.NoError(t, store.Put(context.Background(), &Snapshot{ID: "appended"}))
+	require.NoError(t, store.Put(context.Background(), &Snapshot{ID: "untouched"}))
+
+	now = now.Add(45 * time.Second)
+	_, err := store.Get(context.Background(), "visited")
+	require.NoError(t, err)
+	require.NoError(t, store.Append(context.Background(), "appended", map[FrameRef]Frame{"detail": testFrame(1)}))
+
+	now = now.Add(30 * time.Second)
+	_, err = store.Get(context.Background(), "visited")
+	require.NoError(t, err)
+	_, err = store.Get(context.Background(), "appended")
+	require.NoError(t, err)
+	_, err = store.Get(context.Background(), "untouched")
+	require.ErrorIs(t, err, ErrSnapshotGone)
+}
+
 func TestMemoryStore_DefaultsAndBound(t *testing.T) {
 	t.Parallel()
 	defaults := NewMemoryStore(0, 0).(*memoryStore)
@@ -62,7 +84,7 @@ func TestMemoryStore_DefaultsAndBound(t *testing.T) {
 	require.NoError(t, store.Put(context.Background(), &Snapshot{ID: "first"}))
 	require.NoError(t, store.Put(context.Background(), &Snapshot{ID: "second"}))
 	_, err := store.Get(context.Background(), "first")
-	require.True(t, errors.Is(err, ErrSnapshotGone))
+	require.ErrorIs(t, err, ErrSnapshotGone)
 	_, err = store.Get(context.Background(), "second")
 	require.NoError(t, err)
 }

--- a/pkg/lens/document/store_test.go
+++ b/pkg/lens/document/store_test.go
@@ -1,0 +1,85 @@
+package document
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemoryStore_PutGetAppendAreCloneSafe(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore(time.Hour, 2)
+	snapshot := &Snapshot{
+		ID:     "snapshot-1",
+		Params: map[string]any{"filters": map[string]any{"tenant": "one"}},
+		Frames: map[FrameRef]Frame{"root": testFrame(1)},
+	}
+	require.NoError(t, store.Put(context.Background(), snapshot))
+	snapshot.Params["filters"].(map[string]any)["tenant"] = "mutated"
+	snapshot.Frames["root"].Rows[0][0] = 99
+
+	loaded, err := store.Get(context.Background(), "snapshot-1")
+	require.NoError(t, err)
+	require.Equal(t, "one", loaded.Params["filters"].(map[string]any)["tenant"])
+	require.Equal(t, 1, loaded.Frames["root"].Rows[0][0])
+	loaded.Params["filters"].(map[string]any)["tenant"] = "changed again"
+
+	deeper := map[FrameRef]Frame{"detail": testFrame(2), "root": testFrame(3)}
+	require.NoError(t, store.Append(context.Background(), "snapshot-1", deeper))
+	deeper["detail"].Rows[0][0] = 100
+	loaded, err = store.Get(context.Background(), "snapshot-1")
+	require.NoError(t, err)
+	require.Equal(t, "one", loaded.Params["filters"].(map[string]any)["tenant"])
+	require.Equal(t, 1, loaded.Frames["root"].Rows[0][0], "append must not replace an already materialized frame")
+	require.Equal(t, 2, loaded.Frames["detail"].Rows[0][0])
+}
+
+func TestMemoryStore_ExpiryAndUnknownSnapshots(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.July, 19, 12, 0, 0, 0, time.UTC)
+	store := NewMemoryStore(time.Minute, 2).(*memoryStore)
+	store.clock = func() time.Time { return now }
+	require.NoError(t, store.Put(context.Background(), &Snapshot{ID: "expiring"}))
+	now = now.Add(time.Minute + time.Nanosecond)
+
+	_, err := store.Get(context.Background(), "expiring")
+	require.ErrorIs(t, err, ErrSnapshotGone)
+	require.ErrorIs(t, store.Append(context.Background(), "expiring", map[FrameRef]Frame{"late": testFrame(1)}), ErrSnapshotGone)
+	_, err = store.Get(context.Background(), "unknown")
+	require.ErrorIs(t, err, ErrSnapshotGone)
+}
+
+func TestMemoryStore_DefaultsAndBound(t *testing.T) {
+	t.Parallel()
+	defaults := NewMemoryStore(0, 0).(*memoryStore)
+	require.Equal(t, 30*time.Minute, defaults.ttl)
+	require.Equal(t, defaultMaxEntries, defaults.maxEntries)
+
+	store := NewMemoryStore(time.Hour, 1)
+	require.NoError(t, store.Put(context.Background(), &Snapshot{ID: "first"}))
+	require.NoError(t, store.Put(context.Background(), &Snapshot{ID: "second"}))
+	_, err := store.Get(context.Background(), "first")
+	require.True(t, errors.Is(err, ErrSnapshotGone))
+	_, err = store.Get(context.Background(), "second")
+	require.NoError(t, err)
+}
+
+func TestMemoryStore_ContextAndValidation(t *testing.T) {
+	t.Parallel()
+	store := NewMemoryStore(time.Hour, 1)
+	require.Error(t, store.Put(context.Background(), nil))
+	require.Error(t, store.Put(context.Background(), &Snapshot{}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, store.Put(ctx, &Snapshot{ID: "canceled"}), context.Canceled)
+	_, err := store.Get(ctx, "canceled")
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func testFrame(value int) Frame {
+	return Frame{Columns: []Column{{Name: "value", Type: ColumnNumber}}, Rows: [][]any{{value}}}
+}

--- a/pkg/lens/document/testdata/generated_explore.json
+++ b/pkg/lens/document/testdata/generated_explore.json
@@ -72,7 +72,7 @@
         "path": [
           "metric"
         ],
-        "label": "metric",
+        "label": "",
         "children": [
           {
             "key": "metric/focus",
@@ -118,7 +118,7 @@
               "metric/focus/composition/detail",
               "metric/focus/composition/detail/leaf"
             ],
-            "label": "leaf",
+            "label": "",
             "action": {
               "kind": "navigate_to_leaf",
               "method": "GET",
@@ -160,7 +160,7 @@
               "metric/focus/composition/root",
               "metric/focus/composition/root/a"
             ],
-            "label": "a",
+            "label": "",
             "target": "metric/focus/composition/detail"
           }
         ],

--- a/pkg/lens/document/testdata/generated_explore.json
+++ b/pkg/lens/document/testdata/generated_explore.json
@@ -1,0 +1,193 @@
+{
+  "version": "1.0.0",
+  "snapshotId": "snapshot-generated",
+  "meta": {
+    "dashboardId": "overview",
+    "title": "Overview",
+    "generatedAt": "2026-07-19T10:00:00Z",
+    "locale": "en"
+  },
+  "layout": {
+    "rows": [
+      {
+        "panels": [
+          {
+            "panelId": "host",
+            "span": 6
+          }
+        ]
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": "host",
+      "kind": "pie",
+      "title": "Premium",
+      "semantics": "partition",
+      "frame": "panel:host",
+      "encoding": {
+        "label": "label",
+        "value": "value",
+        "id": "id"
+      },
+      "format": {},
+      "drillRoot": "metric",
+      "actions": []
+    }
+  ],
+  "frames": {
+    "panel:host": {
+      "columns": [
+        {
+          "name": "id",
+          "type": "string"
+        },
+        {
+          "name": "label",
+          "type": "string"
+        },
+        {
+          "name": "value",
+          "type": "number"
+        }
+      ],
+      "rows": [
+        [
+          "a",
+          "Alpha",
+          60
+        ],
+        [
+          "b",
+          "Beta",
+          40
+        ]
+      ]
+    }
+  },
+  "drill": {
+    "edges": {
+      "metric": {
+        "path": [
+          "metric"
+        ],
+        "label": "metric",
+        "children": [
+          {
+            "key": "metric/focus",
+            "path": [
+              "metric",
+              "metric/focus"
+            ],
+            "label": "Focus",
+            "target": "metric/focus"
+          }
+        ],
+        "frame": "panel:host",
+        "perspectives": []
+      },
+      "metric/focus": {
+        "path": [
+          "metric",
+          "metric/focus"
+        ],
+        "label": "Focus",
+        "children": [],
+        "perspectives": [
+          {
+            "id": "metric/focus/composition"
+          }
+        ]
+      },
+      "metric/focus/composition/detail": {
+        "path": [
+          "metric",
+          "metric/focus",
+          "metric/focus/composition",
+          "metric/focus/composition/detail"
+        ],
+        "label": "Detail",
+        "children": [
+          {
+            "key": "metric/focus/composition/detail/leaf",
+            "path": [
+              "metric",
+              "metric/focus",
+              "metric/focus/composition",
+              "metric/focus/composition/detail",
+              "metric/focus/composition/detail/leaf"
+            ],
+            "label": "leaf",
+            "action": {
+              "kind": "navigate_to_leaf",
+              "method": "GET",
+              "urlTemplate": "/policies/{policyId}",
+              "params": [
+                {
+                  "name": "policyId",
+                  "source": {
+                    "kind": "literal",
+                    "value": "selected"
+                  }
+                }
+              ],
+              "payload": {}
+            }
+          }
+        ],
+        "perspectives": [
+          {
+            "id": "metric/focus/composition"
+          }
+        ]
+      },
+      "metric/focus/composition/root": {
+        "path": [
+          "metric",
+          "metric/focus",
+          "metric/focus/composition",
+          "metric/focus/composition/root"
+        ],
+        "label": "Root",
+        "children": [
+          {
+            "key": "metric/focus/composition/root/a",
+            "path": [
+              "metric",
+              "metric/focus",
+              "metric/focus/composition",
+              "metric/focus/composition/root",
+              "metric/focus/composition/root/a"
+            ],
+            "label": "a",
+            "target": "metric/focus/composition/detail"
+          }
+        ],
+        "perspectives": [
+          {
+            "id": "metric/focus/composition"
+          }
+        ]
+      }
+    },
+    "inlineDepth": 1
+  },
+  "perspectives": [
+    {
+      "id": "metric/focus/composition",
+      "explorerId": "metric",
+      "branchKey": "metric/focus",
+      "key": "composition",
+      "label": "Composition",
+      "semantics": "partition",
+      "root": "metric/focus/composition/root"
+    }
+  ],
+  "endpoints": {},
+  "i18n": {},
+  "theme": {
+    "palette": {},
+    "series": {}
+  }
+}

--- a/pkg/lens/document/testdata/small.json
+++ b/pkg/lens/document/testdata/small.json
@@ -1,0 +1,79 @@
+{
+  "version": "1.0.0",
+  "snapshotId": "snapshot-test",
+  "meta": {
+    "dashboardId": "overview",
+    "title": "Overview",
+    "generatedAt": "2026-07-19T09:30:00Z",
+    "locale": "en"
+  },
+  "layout": {
+    "rows": [
+      {
+        "panels": [
+          {
+            "panelId": "total",
+            "span": 6
+          }
+        ]
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": "total",
+      "kind": "stat",
+      "title": "Total",
+      "semantics": "series",
+      "frame": "panel:total",
+      "encoding": {
+        "label": "label",
+        "value": "value"
+      },
+      "format": {},
+      "actions": []
+    }
+  ],
+  "frames": {
+    "panel:total": {
+      "columns": [
+        {
+          "name": "label",
+          "type": "string"
+        },
+        {
+          "name": "value",
+          "type": "number"
+        }
+      ],
+      "rows": [
+        [
+          "Total",
+          42
+        ]
+      ]
+    }
+  },
+  "drill": {
+    "edges": {},
+    "inlineDepth": 0
+  },
+  "perspectives": [],
+  "endpoints": {
+    "query": "/lens/query",
+    "export": "/lens/export"
+  },
+  "i18n": {
+    "dashboard.title": "Overview",
+    "dashboard.total": "Total"
+  },
+  "theme": {
+    "palette": {
+      "accent": "#2563eb",
+      "danger": "#dc2626"
+    },
+    "series": {
+      "total": "accent"
+    }
+  }
+}

--- a/pkg/lens/document/types.go
+++ b/pkg/lens/document/types.go
@@ -1,0 +1,220 @@
+package document
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type FrameRef string
+
+type DashboardDocument struct {
+	Version      string             `json:"version"`
+	SnapshotID   string             `json:"snapshotId"`
+	Meta         Meta               `json:"meta"`
+	Layout       Layout             `json:"layout"`
+	Panels       []Panel            `json:"panels"`
+	Frames       map[FrameRef]Frame `json:"frames"`
+	Drill        Drill              `json:"drill"`
+	Perspectives []Perspective      `json:"perspectives"`
+	Endpoints    Endpoints          `json:"endpoints"`
+	I18n         map[string]string  `json:"i18n"`
+	Theme        Theme              `json:"theme"`
+}
+
+func (d DashboardDocument) MarshalJSON() ([]byte, error) {
+	type wireDocument DashboardDocument
+	d.Version = ContractVersion
+	return json.Marshal(wireDocument(d))
+}
+
+type Meta struct {
+	DashboardID string    `json:"dashboardId"`
+	Title       string    `json:"title"`
+	GeneratedAt time.Time `json:"generatedAt"`
+	Locale      string    `json:"locale"`
+}
+
+type Layout struct {
+	Rows []LayoutRow `json:"rows"`
+}
+
+type LayoutRow struct {
+	Heading string       `json:"heading,omitempty"`
+	Class   string       `json:"class,omitempty"`
+	Panels  []LayoutItem `json:"panels"`
+}
+
+type LayoutItem struct {
+	PanelID string `json:"panelId"`
+	Span    int    `json:"span"`
+}
+
+type PanelKind string
+
+const (
+	PanelKindStat    PanelKind = "stat"
+	PanelKindPie     PanelKind = "pie"
+	PanelKindDonut   PanelKind = "donut"
+	PanelKindBar     PanelKind = "bar"
+	PanelKindHBar    PanelKind = "hbar"
+	PanelKindLine    PanelKind = "line"
+	PanelKindArea    PanelKind = "area"
+	PanelKindCascade PanelKind = "cascade"
+	PanelKindTable   PanelKind = "table"
+)
+
+type Semantics string
+
+const (
+	SemanticsPartition      Semantics = "partition"
+	SemanticsReconciliation Semantics = "reconciliation"
+	SemanticsSeries         Semantics = "series"
+	SemanticsEvidence       Semantics = "evidence"
+)
+
+type Panel struct {
+	ID        string                 `json:"id"`
+	Kind      PanelKind              `json:"kind"`
+	Title     string                 `json:"title"`
+	Semantics Semantics              `json:"semantics"`
+	Frame     FrameRef               `json:"frame"`
+	Encoding  Encoding               `json:"encoding"`
+	Format    map[string]FieldFormat `json:"format"`
+	DrillRoot *NodeKey               `json:"drillRoot,omitempty"`
+	Actions   []Action               `json:"actions"`
+}
+
+type Encoding struct {
+	Label    string `json:"label,omitempty"`
+	Value    string `json:"value,omitempty"`
+	ID       string `json:"id,omitempty"`
+	Series   string `json:"series,omitempty"`
+	Category string `json:"category,omitempty"`
+	Cut      string `json:"cut,omitempty"`
+	CutLabel string `json:"cutLabel,omitempty"`
+	Final    string `json:"final,omitempty"`
+}
+
+type FormatKind string
+
+const (
+	FormatMoney   FormatKind = "money"
+	FormatPercent FormatKind = "percent"
+	FormatDate    FormatKind = "date"
+	FormatNumber  FormatKind = "number"
+	FormatString  FormatKind = "string"
+)
+
+type FieldFormat struct {
+	Kind       FormatKind `json:"kind"`
+	Currency   string     `json:"currency,omitempty"`
+	MinorUnits bool       `json:"minorUnits"`
+	Precision  int        `json:"precision,omitempty"`
+	Layout     string     `json:"layout,omitempty"`
+}
+
+type ActionKind string
+
+const (
+	ActionNavigate       ActionKind = "navigate"
+	ActionNavigateToLeaf ActionKind = "navigate_to_leaf"
+	ActionEmitEvent      ActionKind = "emit_event"
+)
+
+type ValueSourceKind string
+
+const (
+	ValueSourceField    ValueSourceKind = "field"
+	ValueSourceVariable ValueSourceKind = "variable"
+	ValueSourceLiteral  ValueSourceKind = "literal"
+)
+
+type Action struct {
+	Kind          ActionKind        `json:"kind"`
+	Method        string            `json:"method,omitempty"`
+	URLTemplate   string            `json:"urlTemplate,omitempty"`
+	Event         string            `json:"event,omitempty"`
+	Params        []ActionParam     `json:"params"`
+	Payload       map[string]Source `json:"payload"`
+	PreserveQuery bool              `json:"preserveQuery,omitempty"`
+}
+
+type ActionParam struct {
+	Name   string `json:"name"`
+	Source Source `json:"source"`
+}
+
+type Source struct {
+	Kind     ValueSourceKind `json:"kind"`
+	Name     string          `json:"name,omitempty"`
+	Value    any             `json:"value,omitempty"`
+	Fallback any             `json:"fallback,omitempty"`
+}
+
+type NodeKey string
+type NodePath []NodeKey
+
+type Drill struct {
+	Edges       map[NodeKey]Level `json:"edges"`
+	InlineDepth int               `json:"inlineDepth"`
+}
+
+type Level struct {
+	Path         NodePath         `json:"path"`
+	Label        string           `json:"label"`
+	Children     []Node           `json:"children"`
+	Frame        FrameRef         `json:"frame,omitempty"`
+	Encoding     *Encoding        `json:"encoding,omitempty"`
+	Perspectives []PerspectiveRef `json:"perspectives"`
+}
+
+type Node struct {
+	Key    NodeKey  `json:"key"`
+	Path   NodePath `json:"path"`
+	Label  string   `json:"label"`
+	Target NodeKey  `json:"target,omitempty"`
+	Action *Action  `json:"action,omitempty"`
+}
+
+type PerspectiveRef struct {
+	ID string `json:"id"`
+}
+
+type Perspective struct {
+	ID         string    `json:"id"`
+	ExplorerID string    `json:"explorerId"`
+	BranchKey  NodeKey   `json:"branchKey"`
+	Key        string    `json:"key"`
+	Label      string    `json:"label"`
+	Semantics  Semantics `json:"semantics"`
+	Root       NodeKey   `json:"root"`
+}
+
+type ColumnType string
+
+const (
+	ColumnString ColumnType = "string"
+	ColumnNumber ColumnType = "number"
+	ColumnBool   ColumnType = "bool"
+	ColumnTime   ColumnType = "time"
+)
+
+type Column struct {
+	Name string     `json:"name"`
+	Type ColumnType `json:"type"`
+}
+
+type Frame struct {
+	Columns []Column `json:"columns"`
+	Rows    [][]any  `json:"rows"`
+}
+
+type Endpoints struct {
+	Query  string `json:"query,omitempty"`
+	Export string `json:"export,omitempty"`
+}
+
+type Theme struct {
+	Palette map[string]string `json:"palette"`
+	Series  map[string]string `json:"series"`
+}

--- a/pkg/lens/document/validate.go
+++ b/pkg/lens/document/validate.go
@@ -1,0 +1,426 @@
+package document
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
+)
+
+func (d *DashboardDocument) Validate() error {
+	const op serrors.Op = "lens/document.DashboardDocument.Validate"
+	if d == nil {
+		return serrors.E(op, fmt.Errorf("document is required"))
+	}
+	if d.Version != ContractVersion {
+		return serrors.E(op, fmt.Errorf("unsupported contract version %q", d.Version))
+	}
+	if strings.TrimSpace(d.SnapshotID) == "" {
+		return serrors.E(op, fmt.Errorf("snapshot id is required"))
+	}
+	if strings.TrimSpace(d.Meta.DashboardID) == "" {
+		return serrors.E(op, fmt.Errorf("dashboard id is required"))
+	}
+	if d.Drill.InlineDepth < 0 {
+		return serrors.E(op, fmt.Errorf("inline depth cannot be negative"))
+	}
+	panelIDs := make(map[string]struct{}, len(d.Panels))
+	for ref, frame := range d.Frames {
+		if strings.TrimSpace(string(ref)) == "" {
+			return serrors.E(op, fmt.Errorf("frame reference is required"))
+		}
+		if err := validateFrame(ref, frame); err != nil {
+			return serrors.E(op, err)
+		}
+	}
+	for _, panel := range d.Panels {
+		if _, duplicate := panelIDs[panel.ID]; duplicate {
+			return serrors.E(op, fmt.Errorf("duplicate panel %q", panel.ID))
+		}
+		panelIDs[panel.ID] = struct{}{}
+		if err := d.validatePanel(panel); err != nil {
+			return serrors.E(op, err)
+		}
+	}
+	for rowIndex, row := range d.Layout.Rows {
+		for _, item := range row.Panels {
+			if _, ok := panelIDs[item.PanelID]; !ok {
+				return serrors.E(op, fmt.Errorf("layout row %d references missing panel %q", rowIndex, item.PanelID))
+			}
+			if item.Span < 1 || item.Span > 12 {
+				return serrors.E(op, fmt.Errorf("layout panel %s span must be between 1 and 12", item.PanelID))
+			}
+		}
+	}
+	if err := d.validateDrill(); err != nil {
+		return serrors.E(op, err)
+	}
+	perspectiveIDs := make(map[string]struct{}, len(d.Perspectives))
+	for _, perspective := range d.Perspectives {
+		if strings.TrimSpace(perspective.ID) == "" {
+			return serrors.E(op, fmt.Errorf("perspective id is required"))
+		}
+		if _, duplicate := perspectiveIDs[perspective.ID]; duplicate {
+			return serrors.E(op, fmt.Errorf("duplicate perspective %q", perspective.ID))
+		}
+		perspectiveIDs[perspective.ID] = struct{}{}
+		if !validSemantics(perspective.Semantics) {
+			return serrors.E(op, fmt.Errorf("perspective %s has unsupported semantics %q", perspective.ID, perspective.Semantics))
+		}
+		if _, ok := d.Drill.Edges[perspective.Root]; !ok {
+			return serrors.E(op, fmt.Errorf("perspective %s references missing root %q", perspective.ID, perspective.Root))
+		}
+	}
+	for key, level := range d.Drill.Edges {
+		for _, ref := range level.Perspectives {
+			if _, ok := perspectiveIDs[ref.ID]; !ok {
+				return serrors.E(op, fmt.Errorf("drill level %q references missing perspective %q", key, ref.ID))
+			}
+			perspective := findPerspective(d.Perspectives, ref.ID)
+			if perspective.Semantics == SemanticsPartition && level.Frame != "" {
+				if level.Encoding == nil {
+					return serrors.E(op, fmt.Errorf("partition drill level %q requires an encoding", key))
+				}
+				if err := validatePartitionFrame("drill level "+string(key), *level.Encoding, d.Frames[level.Frame]); err != nil {
+					return serrors.E(op, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (d *DashboardDocument) validatePanel(panel Panel) error {
+	if strings.TrimSpace(panel.ID) == "" {
+		return fmt.Errorf("panel id is required")
+	}
+	if _, ok := d.Frames[panel.Frame]; !ok {
+		return fmt.Errorf("panel %s references missing frame %q", panel.ID, panel.Frame)
+	}
+	if !validPanelKind(panel.Kind) {
+		return fmt.Errorf("panel %s has unsupported kind %q", panel.ID, panel.Kind)
+	}
+	if !validSemantics(panel.Semantics) {
+		return fmt.Errorf("panel %s has unsupported semantics %q", panel.ID, panel.Semantics)
+	}
+	if panel.Semantics == SemanticsReconciliation && (panel.Kind == PanelKindPie || panel.Kind == PanelKindDonut) {
+		return fmt.Errorf("panel %s reconciliation semantics cannot use %s encoding", panel.ID, panel.Kind)
+	}
+	if panel.Semantics == SemanticsEvidence && !hasLeafAction(panel.Actions) {
+		return fmt.Errorf("panel %s evidence semantics requires a leaf action", panel.ID)
+	}
+	if panel.DrillRoot != nil {
+		if _, ok := d.Drill.Edges[*panel.DrillRoot]; !ok {
+			return fmt.Errorf("panel %s references missing drill root %q", panel.ID, *panel.DrillRoot)
+		}
+	}
+	for field, format := range panel.Format {
+		if strings.TrimSpace(field) == "" {
+			return fmt.Errorf("panel %s has a format with an empty field", panel.ID)
+		}
+		if format.Kind == FormatMoney && strings.TrimSpace(format.Currency) == "" {
+			return fmt.Errorf("panel %s money field %s requires currency", panel.ID, field)
+		}
+		switch format.Kind {
+		case FormatMoney, FormatPercent, FormatDate, FormatNumber, FormatString:
+		default:
+			return fmt.Errorf("panel %s field %s has unsupported format %q", panel.ID, field, format.Kind)
+		}
+		if !frameHasColumn(d.Frames[panel.Frame], field) {
+			return fmt.Errorf("panel %s format references missing field %q", panel.ID, field)
+		}
+	}
+	for role, field := range map[string]string{
+		"label": panel.Encoding.Label, "value": panel.Encoding.Value, "id": panel.Encoding.ID,
+		"series": panel.Encoding.Series, "category": panel.Encoding.Category, "cut": panel.Encoding.Cut,
+		"cutLabel": panel.Encoding.CutLabel, "final": panel.Encoding.Final,
+	} {
+		if field != "" && !frameHasColumn(d.Frames[panel.Frame], field) {
+			return fmt.Errorf("panel %s %s encoding references missing field %q", panel.ID, role, field)
+		}
+	}
+	if panel.Semantics == SemanticsPartition {
+		if err := validatePartitionFrame("panel "+panel.ID, panel.Encoding, d.Frames[panel.Frame]); err != nil {
+			return err
+		}
+	}
+	for _, action := range panel.Actions {
+		if err := validateAction(panel.ID, action); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *DashboardDocument) validateDrill() error {
+	paths := make(map[string]NodeKey)
+	for key, level := range d.Drill.Edges {
+		if err := validNodeKey("drill level", key); err != nil {
+			return err
+		}
+		if err := validateNodePath("drill level", key, level.Path); err != nil {
+			return err
+		}
+		if level.Frame != "" {
+			if _, ok := d.Frames[level.Frame]; !ok {
+				return fmt.Errorf("drill level %q references missing frame %q", key, level.Frame)
+			}
+		}
+		seen := make(map[NodeKey]struct{}, len(level.Children))
+		for _, child := range level.Children {
+			if err := validNodeKey("drill child", child.Key); err != nil {
+				return err
+			}
+			if _, duplicate := seen[child.Key]; duplicate {
+				return fmt.Errorf("drill level %q has duplicate child key %q", key, child.Key)
+			}
+			seen[child.Key] = struct{}{}
+			if err := validateNodePath("drill child", child.Key, child.Path); err != nil {
+				return err
+			}
+			pathID := pathIdentity(child.Path)
+			if previous, duplicate := paths[pathID]; duplicate {
+				return fmt.Errorf("drill child %q duplicates full path used by %q", child.Key, previous)
+			}
+			paths[pathID] = child.Key
+			if child.Target != "" {
+				if _, ok := d.Drill.Edges[child.Target]; !ok {
+					return fmt.Errorf("drill child %q references missing target %q", child.Key, child.Target)
+				}
+			}
+			if child.Action != nil {
+				if err := validateAction(string(child.Key), *child.Action); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func validateFrame(ref FrameRef, frame Frame) error {
+	names := make(map[string]struct{}, len(frame.Columns))
+	for _, column := range frame.Columns {
+		if strings.TrimSpace(column.Name) == "" {
+			return fmt.Errorf("frame %q has a column without a name", ref)
+		}
+		if _, duplicate := names[column.Name]; duplicate {
+			return fmt.Errorf("frame %q has duplicate column %q", ref, column.Name)
+		}
+		names[column.Name] = struct{}{}
+		switch column.Type {
+		case ColumnString, ColumnNumber, ColumnBool, ColumnTime:
+		default:
+			return fmt.Errorf("frame %q column %s has unsupported type %q", ref, column.Name, column.Type)
+		}
+	}
+	for rowIndex, row := range frame.Rows {
+		if len(row) != len(frame.Columns) {
+			return fmt.Errorf("frame %q row %d has %d cells, expected %d", ref, rowIndex, len(row), len(frame.Columns))
+		}
+		for columnIndex, cell := range row {
+			if err := validateCell(frame.Columns[columnIndex], cell); err != nil {
+				return fmt.Errorf("frame %q row %d column %s: %w", ref, rowIndex, frame.Columns[columnIndex].Name, err)
+			}
+		}
+	}
+	return nil
+}
+
+func validateCell(column Column, value any) error {
+	if value == nil {
+		return nil
+	}
+	switch column.Type {
+	case ColumnString:
+		if _, ok := value.(string); !ok {
+			return fmt.Errorf("expected string, got %T", value)
+		}
+	case ColumnNumber:
+		number, ok := numericValue(value)
+		if !ok {
+			return fmt.Errorf("expected number, got %T", value)
+		}
+		if math.IsNaN(number) || math.IsInf(number, 0) {
+			return fmt.Errorf("number must be finite")
+		}
+	case ColumnBool:
+		if _, ok := value.(bool); !ok {
+			return fmt.Errorf("expected bool, got %T", value)
+		}
+	case ColumnTime:
+		switch value.(type) {
+		case time.Time, string:
+		default:
+			return fmt.Errorf("expected time, got %T", value)
+		}
+	}
+	return nil
+}
+
+func validatePartitionFrame(owner string, encoding Encoding, frame Frame) error {
+	valueIndex := -1
+	for index, column := range frame.Columns {
+		if column.Name == encoding.Value {
+			valueIndex = index
+			break
+		}
+	}
+	if valueIndex < 0 {
+		return fmt.Errorf("%s partition value field %q is missing", owner, encoding.Value)
+	}
+	for rowIndex, row := range frame.Rows {
+		value, ok := numericValue(row[valueIndex])
+		if !ok || math.IsNaN(value) || math.IsInf(value, 0) || value < 0 {
+			return fmt.Errorf("%s partition value row %d must be finite and non-negative", owner, rowIndex)
+		}
+	}
+	return nil
+}
+
+func frameHasColumn(frame Frame, name string) bool {
+	for _, column := range frame.Columns {
+		if column.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func validateAction(owner string, action Action) error {
+	switch action.Kind {
+	case ActionNavigate, ActionNavigateToLeaf:
+		if strings.TrimSpace(action.URLTemplate) == "" {
+			return fmt.Errorf("%s navigate action requires url", owner)
+		}
+	case ActionEmitEvent:
+		if strings.TrimSpace(action.Event) == "" {
+			return fmt.Errorf("%s emit action requires event", owner)
+		}
+	default:
+		return fmt.Errorf("%s has unsupported action kind %q", owner, action.Kind)
+	}
+	params := make(map[string]struct{}, len(action.Params))
+	for _, param := range action.Params {
+		if strings.TrimSpace(param.Name) == "" {
+			return fmt.Errorf("%s action parameter name is required", owner)
+		}
+		if _, duplicate := params[param.Name]; duplicate {
+			return fmt.Errorf("%s action has duplicate parameter %q", owner, param.Name)
+		}
+		params[param.Name] = struct{}{}
+		if err := validateSource(owner, param.Source); err != nil {
+			return err
+		}
+	}
+	for _, source := range action.Payload {
+		if err := validateSource(owner, source); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateSource(owner string, source Source) error {
+	switch source.Kind {
+	case ValueSourceField, ValueSourceVariable:
+		if strings.TrimSpace(source.Name) == "" {
+			return fmt.Errorf("%s action source name is required", owner)
+		}
+	case ValueSourceLiteral:
+		if source.Value == nil {
+			return fmt.Errorf("%s action literal value is required", owner)
+		}
+	default:
+		return fmt.Errorf("%s action has unsupported value source %q", owner, source.Kind)
+	}
+	return nil
+}
+
+func hasLeafAction(actions []Action) bool {
+	for _, action := range actions {
+		if action.Kind == ActionNavigateToLeaf {
+			return true
+		}
+	}
+	return false
+}
+
+func validPanelKind(kind PanelKind) bool {
+	switch kind {
+	case PanelKindStat, PanelKindPie, PanelKindDonut, PanelKindBar, PanelKindHBar,
+		PanelKindLine, PanelKindArea, PanelKindCascade, PanelKindTable:
+		return true
+	default:
+		return false
+	}
+}
+
+func validSemantics(semantics Semantics) bool {
+	switch semantics {
+	case SemanticsPartition, SemanticsReconciliation, SemanticsSeries, SemanticsEvidence:
+		return true
+	default:
+		return false
+	}
+}
+
+func validNodeKey(owner string, key NodeKey) error {
+	trimmed := strings.TrimSpace(string(key))
+	if trimmed == "" {
+		return fmt.Errorf("%s key is required", owner)
+	}
+	if trimmed != string(key) {
+		return fmt.Errorf("%s key %q has surrounding whitespace", owner, key)
+	}
+	return nil
+}
+
+func validateNodePath(owner string, key NodeKey, path NodePath) error {
+	if len(path) == 0 || path[len(path)-1] != key {
+		return fmt.Errorf("%s %q has an invalid full path", owner, key)
+	}
+	for _, segment := range path {
+		if err := validNodeKey(owner+" path", segment); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func findPerspective(perspectives []Perspective, id string) Perspective {
+	for _, perspective := range perspectives {
+		if perspective.ID == id {
+			return perspective
+		}
+	}
+	return Perspective{}
+}
+
+func pathIdentity(path NodePath) string {
+	var builder strings.Builder
+	for _, key := range path {
+		fmt.Fprintf(&builder, "%d:%s;", len(key), key)
+	}
+	return builder.String()
+}
+
+func numericValue(value any) (float64, bool) {
+	reflected := reflect.ValueOf(value)
+	if !reflected.IsValid() {
+		return 0, false
+	}
+	switch reflected.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return float64(reflected.Int()), true
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return float64(reflected.Uint()), true
+	case reflect.Float32, reflect.Float64:
+		return reflected.Float(), true
+	default:
+		return 0, false
+	}
+}

--- a/pkg/lens/document/validate.go
+++ b/pkg/lens/document/validate.go
@@ -3,7 +3,6 @@ package document
 import (
 	"fmt"
 	"math"
-	"reflect"
 	"strings"
 	"time"
 
@@ -178,7 +177,7 @@ func (d *DashboardDocument) validateDrill() error {
 				return fmt.Errorf("drill level %q has duplicate child key %q", key, child.Key)
 			}
 			seen[child.Key] = struct{}{}
-			if err := validateNodePath("drill child", child.Key, child.Path); err != nil {
+			if err := validateChildPath(key, level.Path, child); err != nil {
 				return err
 			}
 			pathID := pathIdentity(child.Path)
@@ -391,6 +390,21 @@ func validateNodePath(owner string, key NodeKey, path NodePath) error {
 	return nil
 }
 
+func validateChildPath(parentKey NodeKey, parentPath NodePath, child Node) error {
+	if err := validateNodePath("drill child", child.Key, child.Path); err != nil {
+		return err
+	}
+	if len(child.Path) != len(parentPath)+1 {
+		return fmt.Errorf("drill child %q path must extend parent level %q path", child.Key, parentKey)
+	}
+	for index, segment := range parentPath {
+		if child.Path[index] != segment {
+			return fmt.Errorf("drill child %q path must extend parent level %q path", child.Key, parentKey)
+		}
+	}
+	return nil
+}
+
 func findPerspective(perspectives []Perspective, id string) Perspective {
 	for _, perspective := range perspectives {
 		if perspective.ID == id {
@@ -409,17 +423,31 @@ func pathIdentity(path NodePath) string {
 }
 
 func numericValue(value any) (float64, bool) {
-	reflected := reflect.ValueOf(value)
-	if !reflected.IsValid() {
-		return 0, false
-	}
-	switch reflected.Kind() {
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return float64(reflected.Int()), true
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return float64(reflected.Uint()), true
-	case reflect.Float32, reflect.Float64:
-		return reflected.Float(), true
+	switch number := value.(type) {
+	case int:
+		return float64(number), true
+	case int8:
+		return float64(number), true
+	case int16:
+		return float64(number), true
+	case int32:
+		return float64(number), true
+	case int64:
+		return float64(number), true
+	case uint:
+		return float64(number), true
+	case uint8:
+		return float64(number), true
+	case uint16:
+		return float64(number), true
+	case uint32:
+		return float64(number), true
+	case uint64:
+		return float64(number), true
+	case float32:
+		return float64(number), true
+	case float64:
+		return number, true
 	default:
 		return 0, false
 	}


### PR DESCRIPTION
Closes #888. Part of the Lens React Runtime epic #887 (implements the D1/D3/D4 foundations).

## What

New additive package `pkg/lens/document` — the versioned `DashboardDocument` wire contract and snapshot semantics that the upcoming React runtime consumes:

- Versioned document types (`ContractVersion` stamped at marshal time), deterministic JSON marshaling for golden-file testing.
- `Build(...)` bridge assembling a document from a prepared lens spec + executed `runtime.Result` + explore tree; container layouts flatten to leaf grid items.
- `Validate()` enforcing the spec invariants (frame-ref resolution, node-key uniqueness/stability, semantics constraints incl. "Reconciliation never renders as pie/donut", money fields must declare currency + minor-units); reuses existing explore semantics validation instead of duplicating it.
- In-memory `SnapshotStore` (TTL + LRU cap) with clone-safe reads, non-overwriting `Append` for later-materialized drill levels, and typed `ErrSnapshotGone`.
- Golden fixtures in `testdata/` (hand-built + generated from an existing explore spec) — these become the A3 Go↔zod contract-test inputs.

No changes to any existing lens public API.

## Design choices beyond the spec (flagging for review)

- Container layouts flatten to leaf panel grid items (containers are absent from the wire `PanelKind` set).
- Ordinary panel semantics inferred by kind; explorer hosts use the first branch's default perspective.
- Existing time-series panels map to `line`; `area` stays available in the contract.
- Snapshot `Append` never replaces already-materialized frames.
- Drill edge keys are path-qualified (length-prefixed encoding) so sibling key reuse under different parents stays unambiguous.

## Verification

- `go vet ./...` — clean
- `go test ./pkg/lens/... -count=1` — pass
- `go test -race ./pkg/lens/document -count=1` — pass

## Provenance

Implementation drafted by Codex (GPT) against the issue spec; reviewed, verified, and committed via Claude Code orchestration.

https://claude.ai/code/session_01YFEdp4UNyhRFgtYqoabV7v


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a standardized dashboard document wire format (metadata, layout, panels/frames, themes, translations, drill-downs, perspectives, actions).
  - Added document generation from dashboard specifications and runtime results, including configurable inline exploration depth and defaulting behavior.
  - Added comprehensive document validation for integrity, semantics, drill graphs, formats, partition rules, and action constraints.
  - Added an in-memory snapshot store with TTL, LRU eviction, cloning, and incremental frame appends.
  - Added deterministic JSON serialization with contract-version pinning.
- **Tests**
  - Added unit tests covering build output (goldens and drill stability), validation rules, determinism, snapshot store clone-safety/TTL, and context handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->