### PR TITLE
feat(lens): serve layer — document endpoint, /lens/query, snapshot export (React Runtime A2)

### DIFF
--- a/pkg/lens/serve/doc.go
+++ b/pkg/lens/serve/doc.go
@@ -1,0 +1,26 @@
+// Package serve exposes the Lens document contract over HTTP.
+//
+// Serve intentionally has no authentication or authorization policy. A host
+// mounts handlers below its own middleware chain, for example:
+//
+//	handlers, err := serve.New(serve.Config{
+//		Spec:        dashboard,
+//		Engine:      executor,
+//		Snapshots:   document.NewMemoryStore(30*time.Minute, 128),
+//		BasePath:    "/analytics/premium",
+//		InlineDepth: 1,
+//		Request: func(r *http.Request) runtime.Request {
+//			return runtime.Request{
+//				Request: r.URL.Query(), DataScope: tenantScope(r.Context()),
+//				DataSources: dataSources(r.Context()), DataSourceIdentities: dataSourceIdentities,
+//			}
+//		},
+//	})
+//	if err != nil {
+//		return err
+//	}
+//	mux.HandleFunc("/analytics/premium/document", handlers.Document)
+//	mux.HandleFunc("/analytics/premium/lens/query", handlers.Query)
+//	mux.HandleFunc("/analytics/premium/export", handlers.Export)
+//	return authMiddleware(rbacMiddleware(mux))
+package serve

--- a/pkg/lens/serve/frames.go
+++ b/pkg/lens/serve/frames.go
@@ -1,0 +1,194 @@
+package serve
+
+import (
+	"fmt"
+
+	"github.com/iota-uz/iota-sdk/pkg/lens"
+	"github.com/iota-uz/iota-sdk/pkg/lens/document"
+	"github.com/iota-uz/iota-sdk/pkg/lens/explore"
+	"github.com/iota-uz/iota-sdk/pkg/lens/filter"
+	"github.com/iota-uz/iota-sdk/pkg/lens/frame"
+	"github.com/iota-uz/iota-sdk/pkg/lens/panel"
+	lensruntime "github.com/iota-uz/iota-sdk/pkg/lens/runtime"
+)
+
+func wireFrame(ref document.FrameRef, result *lensruntime.PanelResult) (document.Frame, error) {
+	if result == nil || result.Frames == nil || result.Frames.Primary() == nil {
+		return document.Frame{}, fmt.Errorf("frame %q has no primary frame", ref)
+	}
+	source := result.Frames.Primary()
+	wire := document.Frame{Columns: make([]document.Column, 0, len(source.Fields)), Rows: make([][]any, source.RowCount)}
+	for _, field := range source.Fields {
+		kind, err := wireColumnType(field.Type)
+		if err != nil {
+			return document.Frame{}, fmt.Errorf("frame %q field %s: %w", ref, field.Name, err)
+		}
+		wire.Columns = append(wire.Columns, document.Column{Name: field.Name, Type: kind})
+	}
+	for rowIndex := 0; rowIndex < source.RowCount; rowIndex++ {
+		wire.Rows[rowIndex] = make([]any, len(source.Fields))
+		for columnIndex := range source.Fields {
+			wire.Rows[rowIndex][columnIndex] = source.Fields[columnIndex].Values[rowIndex]
+		}
+	}
+	return wire, nil
+}
+
+func wireColumnType(kind frame.FieldType) (document.ColumnType, error) {
+	//nolint:exhaustive // Unknown field types are rejected by the meaningful default.
+	switch kind {
+	case frame.FieldTypeString, frame.FieldTypeLocalized:
+		return document.ColumnString, nil
+	case frame.FieldTypeNumber:
+		return document.ColumnNumber, nil
+	case frame.FieldTypeBoolean:
+		return document.ColumnBool, nil
+	case frame.FieldTypeTime:
+		return document.ColumnTime, nil
+	default:
+		return "", fmt.Errorf("unsupported field type %q", kind)
+	}
+}
+
+func runtimeResultFromSnapshot(spec lens.DashboardSpec, snapshot *document.Snapshot, request lensruntime.Request) (*lensruntime.DashboardResult, error) {
+	spec = snapshotExportSpec(spec)
+	result := &lensruntime.DashboardResult{
+		Spec: spec, Variables: variableParams(snapshot.Params), Filters: filter.Build(spec.Variables, snapshot.Params),
+		Datasets: make(map[string]*lensruntime.DatasetResult), Panels: make(map[string]*lensruntime.PanelResult),
+		Locale: request.Locale, Timezone: request.Timezone, RequestPath: request.Path, Request: cloneValues(request.Request),
+		StartedAt: snapshot.CreatedAt, SnapshotID: snapshot.ID,
+	}
+	for _, panelSpec := range lens.FlattenPanels(spec) {
+		if panelSpec.Kind.IsContainer() {
+			continue
+		}
+		ref := document.FrameRef("panel:" + panelSpec.ID)
+		wire, ok := snapshot.Frames[ref]
+		if !ok {
+			continue
+		}
+		frames, err := runtimeFrameSet(string(ref), wire)
+		if err != nil {
+			return nil, err
+		}
+		addRuntimePanel(result, panelSpec, frames)
+	}
+	for _, explorerSpec := range spec.Explorers {
+		for _, branch := range explorerSpec.Branches {
+			for _, perspective := range branch.Perspectives {
+				for _, node := range perspective.Nodes {
+					if node.Panel == nil {
+						continue
+					}
+					ref := document.FrameRef("explore:" + qualified(explorerSpec.ID, branch.Key, perspective.Key) + ":" + node.Key)
+					wire, ok := snapshot.Frames[ref]
+					if !ok {
+						continue
+					}
+					frames, err := runtimeFrameSet(string(ref), wire)
+					if err != nil {
+						return nil, err
+					}
+					addRuntimePanel(result, *node.Panel, frames)
+				}
+			}
+		}
+	}
+	return result, nil
+}
+
+func snapshotExportSpec(spec lens.DashboardSpec) lens.DashboardSpec {
+	// Evidence pages stay live and are never snapshot frames, so snapshot exports
+	// include only the aggregate frames that were visible to the runtime.
+	spec.Export.EvidenceDatasets = nil
+	spec.Export.IncludeUpstream = false
+	spec.Datasets = append([]lens.DatasetSpec(nil), spec.Datasets...)
+	for index := range spec.Datasets {
+		spec.Datasets[index].Export.EvidenceDatasets = nil
+		spec.Datasets[index].Export.IncludeUpstream = false
+	}
+	spec.Rows = append([]lens.RowSpec(nil), spec.Rows...)
+	for rowIndex := range spec.Rows {
+		spec.Rows[rowIndex].Panels = append([]panel.Spec(nil), spec.Rows[rowIndex].Panels...)
+		for panelIndex := range spec.Rows[rowIndex].Panels {
+			spec.Rows[rowIndex].Panels[panelIndex] = stripPanelEvidence(spec.Rows[rowIndex].Panels[panelIndex])
+		}
+	}
+	spec.Explorers = append([]explore.Spec(nil), spec.Explorers...)
+	for explorerIndex := range spec.Explorers {
+		spec.Explorers[explorerIndex].Branches = append([]explore.Branch(nil), spec.Explorers[explorerIndex].Branches...)
+		for branchIndex := range spec.Explorers[explorerIndex].Branches {
+			branch := &spec.Explorers[explorerIndex].Branches[branchIndex]
+			branch.Perspectives = append([]explore.Perspective(nil), branch.Perspectives...)
+			for perspectiveIndex := range branch.Perspectives {
+				perspective := &branch.Perspectives[perspectiveIndex]
+				perspective.Nodes = append([]explore.Node(nil), perspective.Nodes...)
+				for nodeIndex := range perspective.Nodes {
+					if perspective.Nodes[nodeIndex].Panel != nil {
+						cleaned := stripPanelEvidence(*perspective.Nodes[nodeIndex].Panel)
+						perspective.Nodes[nodeIndex].Panel = &cleaned
+					}
+				}
+			}
+		}
+	}
+	return spec
+}
+
+func stripPanelEvidence(spec panel.Spec) panel.Spec {
+	spec.Export.EvidenceDatasets = nil
+	spec.Export.IncludeUpstream = false
+	spec.Children = append([]panel.Spec(nil), spec.Children...)
+	for index := range spec.Children {
+		spec.Children[index] = stripPanelEvidence(spec.Children[index])
+	}
+	return spec
+}
+
+func addRuntimePanel(result *lensruntime.DashboardResult, spec panel.Spec, frames *frame.FrameSet) {
+	result.Panels[spec.ID] = &lensruntime.PanelResult{
+		Panel: spec, Frames: frames, Locale: result.Locale, Timezone: result.Timezone, Variables: cloneParams(result.Variables),
+		RequestPath: result.RequestPath, Request: cloneValues(result.Request),
+	}
+	if _, ok := result.Datasets[spec.Dataset]; !ok {
+		result.Datasets[spec.Dataset] = &lensruntime.DatasetResult{Frames: frames}
+	}
+}
+
+func runtimeFrameSet(name string, wire document.Frame) (*frame.FrameSet, error) {
+	fields := make([]frame.Field, len(wire.Columns))
+	for columnIndex, column := range wire.Columns {
+		kind, err := runtimeFieldType(column.Type)
+		if err != nil {
+			return nil, fmt.Errorf("frame %q column %s: %w", name, column.Name, err)
+		}
+		values := make([]any, len(wire.Rows))
+		for rowIndex, row := range wire.Rows {
+			if columnIndex >= len(row) {
+				return nil, fmt.Errorf("frame %q row %d has too few columns", name, rowIndex)
+			}
+			values[rowIndex] = row[columnIndex]
+		}
+		fields[columnIndex] = frame.Field{Name: column.Name, Type: kind, Values: values}
+	}
+	primary, err := frame.New(name, fields...)
+	if err != nil {
+		return nil, err
+	}
+	return frame.NewFrameSet(primary)
+}
+
+func runtimeFieldType(kind document.ColumnType) (frame.FieldType, error) {
+	switch kind {
+	case document.ColumnString:
+		return frame.FieldTypeString, nil
+	case document.ColumnNumber:
+		return frame.FieldTypeNumber, nil
+	case document.ColumnBool:
+		return frame.FieldTypeBoolean, nil
+	case document.ColumnTime:
+		return frame.FieldTypeTime, nil
+	default:
+		return frame.FieldTypeUnknown, fmt.Errorf("unsupported column type %q", kind)
+	}
+}

--- a/pkg/lens/serve/handlers.go
+++ b/pkg/lens/serve/handlers.go
@@ -1,0 +1,303 @@
+package serve
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/iota-uz/iota-sdk/pkg/lens/document"
+	lensexport "github.com/iota-uz/iota-sdk/pkg/lens/export"
+	lensruntime "github.com/iota-uz/iota-sdk/pkg/lens/runtime"
+)
+
+const maxQueryBodyBytes = 1 << 20
+
+type errorResponse struct {
+	Error   string `json:"error"`
+	Message string `json:"message"`
+}
+
+// QueryRequest is the snapshot-scoped level request accepted by Query.
+type QueryRequest struct {
+	SnapshotID  string            `json:"snapshotId"`
+	Path        document.NodePath `json:"path"`
+	Perspective string            `json:"perspective,omitempty"`
+	Page        int               `json:"page,omitempty"`
+}
+
+// Page describes an Evidence response page.
+type Page struct {
+	Number int `json:"number"`
+	Size   int `json:"size"`
+}
+
+// QueryResponse contains the frames materialized for one requested level.
+type QueryResponse struct {
+	Frames map[document.FrameRef]document.Frame `json:"frames"`
+	Page   *Page                                `json:"page,omitempty"`
+}
+
+// Document executes and returns a new snapshot-backed dashboard document.
+func (h *Handlers) Document(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "bad_request", "method must be GET")
+		return
+	}
+	req := h.runtimeRequest(r)
+	result, err := h.engine.Execute(r.Context(), h.spec, req, lensruntime.DashboardScope())
+	if err != nil {
+		h.writeExecutionError(w, r.Context(), err)
+		return
+	}
+	if result == nil {
+		writeError(w, http.StatusInternalServerError, "internal", "dashboard execution failed")
+		return
+	}
+	if result.Panels == nil {
+		result.Panels = make(map[string]*lensruntime.PanelResult)
+	}
+	frozen := freezeParams(result, req)
+	for _, target := range inlineTargets(h.spec, h.inlineDepth) {
+		existing := result.Panel(target.panel.ID)
+		if existing != nil && existing.Error == nil && existing.Frames != nil && existing.Frames.Primary() != nil {
+			continue
+		}
+		levelResult, execErr := h.executeLevel(r.Context(), req, frozen, target, 0)
+		if execErr != nil {
+			h.writeExecutionError(w, r.Context(), execErr)
+			return
+		}
+		result.Panels[target.panel.ID] = levelResult
+	}
+	doc, err := document.Build(h.spec, result, document.BuildOptions{
+		Locale: result.Locale, InlineDepth: h.inlineDepth,
+		Endpoints: document.Endpoints{Query: h.endpoint("/lens/query"), Export: h.endpoint("/export")},
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", "document build failed")
+		return
+	}
+	if err := h.snapshots.Put(r.Context(), &document.Snapshot{
+		ID: doc.SnapshotID, Params: frozen, Frames: doc.Frames, CreatedAt: doc.Meta.GeneratedAt,
+	}); err != nil {
+		if r.Context().Err() != nil {
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal", "snapshot storage failed")
+		return
+	}
+	writeJSON(w, http.StatusOK, doc)
+}
+
+// Query returns a cached aggregate level or executes one level using frozen
+// snapshot parameters. Evidence levels are always executed live.
+func (h *Handlers) Query(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, "bad_request", "method must be POST")
+		return
+	}
+	var req QueryRequest
+	if err := decodeJSON(w, r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	req.SnapshotID = strings.TrimSpace(req.SnapshotID)
+	if req.SnapshotID == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "snapshotId is required")
+		return
+	}
+	if len(req.Path) == 0 {
+		writeError(w, http.StatusBadRequest, "bad_request", "path is required")
+		return
+	}
+	if req.Page < 0 {
+		writeError(w, http.StatusBadRequest, "bad_request", "page cannot be negative")
+		return
+	}
+	snapshot, err := h.snapshots.Get(r.Context(), req.SnapshotID)
+	if err != nil {
+		h.writeSnapshotError(w, r.Context(), err)
+		return
+	}
+	target, err := resolveTarget(h.spec, req.Path, req.Perspective)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if !target.evidence {
+		if cached, ok := snapshot.Frames[target.ref]; ok {
+			writeJSON(w, http.StatusOK, QueryResponse{Frames: map[document.FrameRef]document.Frame{target.ref: cached}})
+			return
+		}
+		h.queryAggregate(w, r, req, snapshot, target)
+		return
+	}
+	page := req.Page
+	if page == 0 {
+		page = lensruntime.DefaultTablePage
+	}
+	panelResult, err := h.executeLevel(r.Context(), thawRuntimeRequest(h.runtimeRequest(r), snapshot.Params), snapshot.Params, target, page)
+	if err != nil {
+		h.writeExecutionError(w, r.Context(), err)
+		return
+	}
+	wire, err := wireFrame(target.ref, panelResult)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", "level result conversion failed")
+		return
+	}
+	writeJSON(w, http.StatusOK, QueryResponse{
+		Frames: map[document.FrameRef]document.Frame{target.ref: wire},
+		Page:   &Page{Number: page, Size: h.pageSize},
+	})
+}
+
+func (h *Handlers) queryAggregate(w http.ResponseWriter, r *http.Request, req QueryRequest, snapshot *document.Snapshot, target levelTarget) {
+	key := snapshot.ID + ":" + string(target.ref)
+	result := h.loads.DoChan(key, func() (any, error) {
+		latest, err := h.snapshots.Get(r.Context(), snapshot.ID)
+		if err != nil {
+			return nil, err
+		}
+		if cached, ok := latest.Frames[target.ref]; ok {
+			return cached, nil
+		}
+		panelResult, err := h.executeLevel(r.Context(), thawRuntimeRequest(h.runtimeRequest(r), latest.Params), latest.Params, target, 0)
+		if err != nil {
+			return nil, err
+		}
+		wire, err := wireFrame(target.ref, panelResult)
+		if err != nil {
+			return nil, err
+		}
+		if err := h.snapshots.Append(r.Context(), snapshot.ID, map[document.FrameRef]document.Frame{target.ref: wire}); err != nil {
+			return nil, err
+		}
+		return wire, nil
+	})
+	select {
+	case <-r.Context().Done():
+		return
+	case loaded := <-result:
+		if loaded.Err != nil {
+			if errors.Is(loaded.Err, document.ErrSnapshotGone) {
+				h.writeSnapshotError(w, r.Context(), loaded.Err)
+				return
+			}
+			h.writeExecutionError(w, r.Context(), loaded.Err)
+			return
+		}
+		frame, ok := loaded.Val.(document.Frame)
+		if !ok {
+			writeError(w, http.StatusInternalServerError, "internal", "level execution failed")
+			return
+		}
+		writeJSON(w, http.StatusOK, QueryResponse{Frames: map[document.FrameRef]document.Frame{target.ref: frame}})
+	}
+}
+
+// Export writes a snapshot-keyed workbook for one panel or the full document.
+func (h *Handlers) Export(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "bad_request", "method must be GET")
+		return
+	}
+	snapshotID := strings.TrimSpace(r.URL.Query().Get("snapshot"))
+	if snapshotID == "" {
+		writeError(w, http.StatusBadRequest, "bad_request", "snapshot is required")
+		return
+	}
+	snapshot, err := h.snapshots.Get(r.Context(), snapshotID)
+	if err != nil {
+		h.writeSnapshotError(w, r.Context(), err)
+		return
+	}
+	request := thawRuntimeRequest(h.runtimeRequest(r), snapshot.Params)
+	result, err := runtimeResultFromSnapshot(h.spec, snapshot, request)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal", "snapshot conversion failed")
+		return
+	}
+	panelID := strings.TrimSpace(r.URL.Query().Get("panel"))
+	if panelID != "" && result.Panel(panelID) == nil {
+		writeError(w, http.StatusBadRequest, "bad_request", "panel is not available in the snapshot")
+		return
+	}
+	var workbook bytes.Buffer
+	if err := lensexport.New().Write(r.Context(), &workbook, lensexport.Request{Result: result, PanelID: panelID}); err != nil {
+		if r.Context().Err() != nil {
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal", "export failed")
+		return
+	}
+	filename := lensexport.WorkbookFilename(result, panelID, snapshot.CreatedAt)
+	w.Header().Set("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+	w.Header().Set("Content-Disposition", lensexport.ContentDisposition(filename))
+	w.Header().Set("Content-Length", strconv.Itoa(workbook.Len()))
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(workbook.Bytes())
+}
+
+func (h *Handlers) writeSnapshotError(w http.ResponseWriter, ctx context.Context, err error) {
+	if ctx.Err() != nil {
+		return
+	}
+	if errors.Is(err, document.ErrSnapshotGone) {
+		writeError(w, http.StatusGone, "snapshot_gone", "snapshot is unknown or expired")
+		return
+	}
+	writeError(w, http.StatusInternalServerError, "internal", "snapshot lookup failed")
+}
+
+func (h *Handlers) writeExecutionError(w http.ResponseWriter, ctx context.Context, err error) {
+	if ctx.Err() != nil || errors.Is(err, context.Canceled) {
+		return
+	}
+	writeError(w, http.StatusInternalServerError, "internal", "lens execution failed")
+}
+
+func decodeJSON(w http.ResponseWriter, r *http.Request, target any) error {
+	r.Body = http.MaxBytesReader(w, r.Body, maxQueryBodyBytes)
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return fmt.Errorf("invalid JSON body: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return fmt.Errorf("request body must contain one JSON object")
+		}
+		return fmt.Errorf("invalid JSON body: %w", err)
+	}
+	return nil
+}
+
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	writeJSON(w, status, errorResponse{Error: code, Message: message})
+}
+
+func writeJSON(w http.ResponseWriter, status int, value any) {
+	payload, err := json.Marshal(value)
+	if err != nil {
+		payload = []byte(`{"error":"internal","message":"JSON encoding failed"}`)
+		status = http.StatusInternalServerError
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(append(payload, '\n'))
+}
+
+func cloneParams(values map[string]any) map[string]any {
+	result := make(map[string]any, len(values))
+	for key, value := range values {
+		result[key] = value
+	}
+	return result
+}

--- a/pkg/lens/serve/handlers.go
+++ b/pkg/lens/serve/handlers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/lens/document"
 	lensexport "github.com/iota-uz/iota-sdk/pkg/lens/export"
 	lensruntime "github.com/iota-uz/iota-sdk/pkg/lens/runtime"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
 )
 
 const maxQueryBodyBytes = 1 << 20
@@ -52,11 +53,11 @@ func (h *Handlers) Document(w http.ResponseWriter, r *http.Request) {
 	req := h.runtimeRequest(r)
 	result, err := h.engine.Execute(r.Context(), h.spec, req, lensruntime.DashboardScope())
 	if err != nil {
-		h.writeExecutionError(w, r.Context(), err)
+		h.writeExecutionError(r.Context(), w, err)
 		return
 	}
 	if result == nil {
-		writeError(w, http.StatusInternalServerError, "internal", "dashboard execution failed")
+		h.writeInternalError(r.Context(), w, "lens/serve.Document", "dashboard execution failed", fmt.Errorf("executor returned a nil dashboard result"))
 		return
 	}
 	if result.Panels == nil {
@@ -70,7 +71,10 @@ func (h *Handlers) Document(w http.ResponseWriter, r *http.Request) {
 		}
 		levelResult, execErr := h.executeLevel(r.Context(), req, frozen, target, 0)
 		if execErr != nil {
-			h.writeExecutionError(w, r.Context(), execErr)
+			if levelResult != nil && levelResult.Error != nil {
+				continue
+			}
+			h.writeExecutionError(r.Context(), w, execErr)
 			return
 		}
 		result.Panels[target.panel.ID] = levelResult
@@ -80,7 +84,7 @@ func (h *Handlers) Document(w http.ResponseWriter, r *http.Request) {
 		Endpoints: document.Endpoints{Query: h.endpoint("/lens/query"), Export: h.endpoint("/export")},
 	})
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "internal", "document build failed")
+		h.writeInternalError(r.Context(), w, "lens/serve.Document", "document build failed", err)
 		return
 	}
 	if err := h.snapshots.Put(r.Context(), &document.Snapshot{
@@ -89,7 +93,7 @@ func (h *Handlers) Document(w http.ResponseWriter, r *http.Request) {
 		if r.Context().Err() != nil {
 			return
 		}
-		writeError(w, http.StatusInternalServerError, "internal", "snapshot storage failed")
+		h.writeInternalError(r.Context(), w, "lens/serve.Document", "snapshot storage failed", err)
 		return
 	}
 	writeJSON(w, http.StatusOK, doc)
@@ -122,7 +126,7 @@ func (h *Handlers) Query(w http.ResponseWriter, r *http.Request) {
 	}
 	snapshot, err := h.snapshots.Get(r.Context(), req.SnapshotID)
 	if err != nil {
-		h.writeSnapshotError(w, r.Context(), err)
+		h.writeSnapshotError(r.Context(), w, err)
 		return
 	}
 	target, err := resolveTarget(h.spec, req.Path, req.Perspective)
@@ -144,12 +148,12 @@ func (h *Handlers) Query(w http.ResponseWriter, r *http.Request) {
 	}
 	panelResult, err := h.executeLevel(r.Context(), thawRuntimeRequest(h.runtimeRequest(r), snapshot.Params), snapshot.Params, target, page)
 	if err != nil {
-		h.writeExecutionError(w, r.Context(), err)
+		h.writeExecutionError(r.Context(), w, err)
 		return
 	}
 	wire, err := wireFrame(target.ref, panelResult)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "internal", "level result conversion failed")
+		h.writeInternalError(r.Context(), w, "lens/serve.Query", "level result conversion failed", err)
 		return
 	}
 	writeJSON(w, http.StatusOK, QueryResponse{
@@ -159,16 +163,20 @@ func (h *Handlers) Query(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handlers) queryAggregate(w http.ResponseWriter, r *http.Request, req QueryRequest, snapshot *document.Snapshot, target levelTarget) {
+	ctx := r.Context()
+	base := h.runtimeRequest(r)
 	key := snapshot.ID + ":" + string(target.ref)
 	result := h.loads.DoChan(key, func() (any, error) {
-		latest, err := h.snapshots.Get(r.Context(), snapshot.ID)
+		workCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), h.workTimeout)
+		defer cancel()
+		latest, err := h.snapshots.Get(workCtx, snapshot.ID)
 		if err != nil {
 			return nil, err
 		}
 		if cached, ok := latest.Frames[target.ref]; ok {
 			return cached, nil
 		}
-		panelResult, err := h.executeLevel(r.Context(), thawRuntimeRequest(h.runtimeRequest(r), latest.Params), latest.Params, target, 0)
+		panelResult, err := h.executeLevel(workCtx, thawRuntimeRequest(base, latest.Params), latest.Params, target, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -176,26 +184,26 @@ func (h *Handlers) queryAggregate(w http.ResponseWriter, r *http.Request, req Qu
 		if err != nil {
 			return nil, err
 		}
-		if err := h.snapshots.Append(r.Context(), snapshot.ID, map[document.FrameRef]document.Frame{target.ref: wire}); err != nil {
+		if err := h.snapshots.Append(workCtx, snapshot.ID, map[document.FrameRef]document.Frame{target.ref: wire}); err != nil {
 			return nil, err
 		}
 		return wire, nil
 	})
 	select {
-	case <-r.Context().Done():
+	case <-ctx.Done():
 		return
 	case loaded := <-result:
 		if loaded.Err != nil {
 			if errors.Is(loaded.Err, document.ErrSnapshotGone) {
-				h.writeSnapshotError(w, r.Context(), loaded.Err)
+				h.writeSnapshotError(ctx, w, loaded.Err)
 				return
 			}
-			h.writeExecutionError(w, r.Context(), loaded.Err)
+			h.writeExecutionError(ctx, w, loaded.Err)
 			return
 		}
 		frame, ok := loaded.Val.(document.Frame)
 		if !ok {
-			writeError(w, http.StatusInternalServerError, "internal", "level execution failed")
+			h.writeInternalError(ctx, w, "lens/serve.Query", "level execution failed", fmt.Errorf("level execution returned %T", loaded.Val))
 			return
 		}
 		writeJSON(w, http.StatusOK, QueryResponse{Frames: map[document.FrameRef]document.Frame{target.ref: frame}})
@@ -215,13 +223,13 @@ func (h *Handlers) Export(w http.ResponseWriter, r *http.Request) {
 	}
 	snapshot, err := h.snapshots.Get(r.Context(), snapshotID)
 	if err != nil {
-		h.writeSnapshotError(w, r.Context(), err)
+		h.writeSnapshotError(r.Context(), w, err)
 		return
 	}
 	request := thawRuntimeRequest(h.runtimeRequest(r), snapshot.Params)
 	result, err := runtimeResultFromSnapshot(h.spec, snapshot, request)
 	if err != nil {
-		writeError(w, http.StatusInternalServerError, "internal", "snapshot conversion failed")
+		h.writeInternalError(r.Context(), w, "lens/serve.Export", "snapshot conversion failed", err)
 		return
 	}
 	panelID := strings.TrimSpace(r.URL.Query().Get("panel"))
@@ -234,7 +242,7 @@ func (h *Handlers) Export(w http.ResponseWriter, r *http.Request) {
 		if r.Context().Err() != nil {
 			return
 		}
-		writeError(w, http.StatusInternalServerError, "internal", "export failed")
+		h.writeInternalError(r.Context(), w, "lens/serve.Export", "export failed", err)
 		return
 	}
 	filename := lensexport.WorkbookFilename(result, panelID, snapshot.CreatedAt)
@@ -245,7 +253,7 @@ func (h *Handlers) Export(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(workbook.Bytes())
 }
 
-func (h *Handlers) writeSnapshotError(w http.ResponseWriter, ctx context.Context, err error) {
+func (h *Handlers) writeSnapshotError(ctx context.Context, w http.ResponseWriter, err error) {
 	if ctx.Err() != nil {
 		return
 	}
@@ -253,14 +261,23 @@ func (h *Handlers) writeSnapshotError(w http.ResponseWriter, ctx context.Context
 		writeError(w, http.StatusGone, "snapshot_gone", "snapshot is unknown or expired")
 		return
 	}
-	writeError(w, http.StatusInternalServerError, "internal", "snapshot lookup failed")
+	h.writeInternalError(ctx, w, "lens/serve.writeSnapshotError", "snapshot lookup failed", err)
 }
 
-func (h *Handlers) writeExecutionError(w http.ResponseWriter, ctx context.Context, err error) {
-	if ctx.Err() != nil || errors.Is(err, context.Canceled) {
+func (h *Handlers) writeExecutionError(ctx context.Context, w http.ResponseWriter, err error) {
+	if ctx.Err() != nil {
 		return
 	}
-	writeError(w, http.StatusInternalServerError, "internal", "lens execution failed")
+	h.writeInternalError(ctx, w, "lens/serve.writeExecutionError", "lens execution failed", err)
+}
+
+func (h *Handlers) writeInternalError(ctx context.Context, w http.ResponseWriter, op, message string, err error) {
+	if ctx.Err() != nil {
+		return
+	}
+	wrapped := serrors.E(serrors.Op(op), err)
+	h.observer.OnError(ctx, op, wrapped)
+	writeError(w, http.StatusInternalServerError, "internal", message)
 }
 
 func decodeJSON(w http.ResponseWriter, r *http.Request, target any) error {

--- a/pkg/lens/serve/levels.go
+++ b/pkg/lens/serve/levels.go
@@ -161,7 +161,7 @@ func (h *Handlers) executeLevel(ctx context.Context, base lensruntime.Request, p
 	}
 	panelResult := result.Panel(target.panel.ID)
 	if panelResult.Error != nil {
-		return nil, serrors.E(op, panelResult.Error)
+		return panelResult, serrors.E(op, panelResult.Error)
 	}
 	return panelResult, nil
 }

--- a/pkg/lens/serve/levels.go
+++ b/pkg/lens/serve/levels.go
@@ -1,0 +1,230 @@
+package serve
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/iota-uz/iota-sdk/pkg/lens"
+	"github.com/iota-uz/iota-sdk/pkg/lens/document"
+	"github.com/iota-uz/iota-sdk/pkg/lens/explore"
+	"github.com/iota-uz/iota-sdk/pkg/lens/panel"
+	lensruntime "github.com/iota-uz/iota-sdk/pkg/lens/runtime"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
+)
+
+type levelTarget struct {
+	explorerID     string
+	branchKey      string
+	perspectiveKey string
+	nodeKey        string
+	path           []string
+	panel          panel.Spec
+	ref            document.FrameRef
+	evidence       bool
+}
+
+func inlineTargets(spec lens.DashboardSpec, inlineDepth int) []levelTarget {
+	targets := make([]levelTarget, 0)
+	for _, explorerSpec := range spec.Explorers {
+		for _, branch := range explorerSpec.Branches {
+			for _, perspective := range branch.Perspectives {
+				depths := perspectiveDepths(perspective)
+				for _, node := range perspective.Nodes {
+					if node.Panel == nil || depths[node.Key] > inlineDepth || isEvidence(perspective, node) {
+						continue
+					}
+					targets = append(targets, makeTarget(explorerSpec.ID, branch.Key, perspective, node))
+				}
+			}
+		}
+	}
+	return targets
+}
+
+func resolveTarget(spec lens.DashboardSpec, path document.NodePath, requestedPerspective string) (levelTarget, error) {
+	last := strings.TrimSpace(string(path[len(path)-1]))
+	requestedPerspective = strings.TrimSpace(requestedPerspective)
+	candidates := make([]levelTarget, 0, 1)
+	for _, explorerSpec := range spec.Explorers {
+		for _, branch := range explorerSpec.Branches {
+			for _, perspective := range branch.Perspectives {
+				perspectiveID := qualified(explorerSpec.ID, branch.Key, perspective.Key)
+				if requestedPerspective != "" && requestedPerspective != perspective.Key && requestedPerspective != perspectiveID {
+					continue
+				}
+				for _, node := range perspective.Nodes {
+					if node.Panel == nil {
+						continue
+					}
+					nodeID := qualified(perspectiveID, node.Key)
+					if last == node.Key || last == nodeID {
+						candidates = append(candidates, makeTarget(explorerSpec.ID, branch.Key, perspective, node))
+					}
+				}
+				for _, source := range perspective.Nodes {
+					for _, edge := range source.Edges {
+						pointID := qualified(perspectiveID, source.Key, edge.PointKey)
+						if edge.ToNode == "" || last != edge.PointKey && last != pointID {
+							continue
+						}
+						if node, ok := perspective.Node(edge.ToNode); ok && node.Panel != nil {
+							candidates = append(candidates, makeTarget(explorerSpec.ID, branch.Key, perspective, node))
+						}
+					}
+				}
+			}
+		}
+	}
+	if len(candidates) == 0 {
+		return levelTarget{}, fmt.Errorf("requested path does not identify an executable level")
+	}
+	unique := candidates[:0]
+	seen := make(map[document.FrameRef]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		if _, ok := seen[candidate.ref]; ok {
+			continue
+		}
+		seen[candidate.ref] = struct{}{}
+		candidate.path = nodePath(path)
+		unique = append(unique, candidate)
+	}
+	if len(unique) != 1 {
+		return levelTarget{}, fmt.Errorf("requested path is ambiguous; perspective is required")
+	}
+	return unique[0], nil
+}
+
+func makeTarget(explorerID, branchKey string, perspective explore.Perspective, node explore.Node) levelTarget {
+	perspectiveID := qualified(explorerID, branchKey, perspective.Key)
+	return levelTarget{
+		explorerID: explorerID, branchKey: branchKey, perspectiveKey: perspective.Key, nodeKey: node.Key,
+		path: []string{node.Key}, panel: *node.Panel,
+		ref: document.FrameRef("explore:" + perspectiveID + ":" + node.Key), evidence: isEvidence(perspective, node),
+	}
+}
+
+func isEvidence(perspective explore.Perspective, node explore.Node) bool {
+	leaf := !node.DynamicEdges
+	for _, edge := range node.Edges {
+		if edge.ToNode != "" {
+			leaf = false
+			break
+		}
+	}
+	return leaf && (perspective.Semantics == explore.SemanticsEvidence || node.Panel != nil && node.Panel.Kind == panel.KindTable)
+}
+
+func perspectiveDepths(perspective explore.Perspective) map[string]int {
+	const unseen = int(^uint(0) >> 1)
+	depths := make(map[string]int, len(perspective.Nodes))
+	for _, node := range perspective.Nodes {
+		depths[node.Key] = unseen
+	}
+	depths[perspective.RootNode] = 0
+	changed := true
+	for changed {
+		changed = false
+		for _, node := range perspective.Nodes {
+			depth := depths[node.Key]
+			if depth == unseen {
+				continue
+			}
+			for _, edge := range node.Edges {
+				if edge.ToNode != "" && depth+1 < depths[edge.ToNode] {
+					depths[edge.ToNode] = depth + 1
+					changed = true
+				}
+			}
+			for _, target := range node.DynamicTargets {
+				if depth+1 < depths[target] {
+					depths[target] = depth + 1
+					changed = true
+				}
+			}
+		}
+	}
+	return depths
+}
+
+func (h *Handlers) executeLevel(ctx context.Context, base lensruntime.Request, params map[string]any, target levelTarget, page int) (*lensruntime.PanelResult, error) {
+	const op serrors.Op = "lens/serve.executeLevel"
+	req := scopedRuntimeRequest(base, params, target, page, h.pageSize)
+	result, err := h.engine.Execute(ctx, levelSpec(h.spec, target.panel), req, lensruntime.PanelScope(target.panel.ID))
+	if err != nil {
+		return nil, serrors.E(op, err)
+	}
+	if result == nil || result.Panel(target.panel.ID) == nil {
+		return nil, serrors.E(op, fmt.Errorf("panel %q was not executed", target.panel.ID))
+	}
+	panelResult := result.Panel(target.panel.ID)
+	if panelResult.Error != nil {
+		return nil, serrors.E(op, panelResult.Error)
+	}
+	return panelResult, nil
+}
+
+func levelSpec(spec lens.DashboardSpec, target panel.Spec) lens.DashboardSpec {
+	spec.Rows = []lens.RowSpec{{Panels: []panel.Spec{target}}}
+	spec.Explorers = nil
+	return spec
+}
+
+func scopedRuntimeRequest(base lensruntime.Request, params map[string]any, target levelTarget, page, pageSize int) lensruntime.Request {
+	base.Overrides = variableParams(params)
+	base.Request = cloneValues(base.Request)
+	base.Request.Set(lensexplorerParam, target.explorerID)
+	base.Request.Set(lensbranchParam, target.branchKey)
+	base.Request.Set(lensperspectiveParam, target.perspectiveKey)
+	base.Request.Set(lensnodeParam, target.nodeKey)
+	base.Request.Del(lenspathParam)
+	for _, item := range target.path {
+		base.Request.Add(lenspathParam, item)
+	}
+	if page > 0 {
+		base.Request.Set(lensruntime.TablePaginationPanelQuery, target.panel.ID)
+		base.Request.Set(lensruntime.TablePaginationPageQuery, strconv.Itoa(page))
+		base.Request.Set(lensruntime.TablePaginationLimitQuery, strconv.Itoa(pageSize))
+	}
+	return base
+}
+
+const (
+	lensexplorerParam    = "lens_explorer"
+	lensbranchParam      = "lens_explore_branch"
+	lensperspectiveParam = "lens_explore_perspective"
+	lenspathParam        = "lens_explore_path"
+	lensnodeParam        = "lens_explore_node"
+)
+
+func qualified(parts ...string) string {
+	cleaned := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.Trim(strings.TrimSpace(part), "/")
+		if part != "" {
+			cleaned = append(cleaned, part)
+		}
+	}
+	return strings.Join(cleaned, "/")
+}
+
+func nodePath(path document.NodePath) []string {
+	result := make([]string, 0, len(path))
+	for _, item := range path {
+		value := strings.TrimSpace(string(item))
+		if value != "" {
+			result = append(result, value)
+		}
+	}
+	return result
+}
+
+func cloneValues(values url.Values) url.Values {
+	result := make(url.Values, len(values))
+	for key, items := range values {
+		result[key] = append([]string(nil), items...)
+	}
+	return result
+}

--- a/pkg/lens/serve/params.go
+++ b/pkg/lens/serve/params.go
@@ -1,0 +1,106 @@
+package serve
+
+import (
+	"net/url"
+
+	lensruntime "github.com/iota-uz/iota-sdk/pkg/lens/runtime"
+)
+
+const (
+	paramLocale    = "__lens_serve_locale"
+	paramTimezone  = "__lens_serve_timezone"
+	paramPath      = "__lens_serve_path"
+	paramRequest   = "__lens_serve_request"
+	paramDataScope = "__lens_serve_data_scope"
+	paramNamespace = "__lens_serve_namespace"
+)
+
+func freezeParams(result *lensruntime.DashboardResult, request lensruntime.Request) map[string]any {
+	params := cloneParams(result.Variables)
+	locale := result.Locale
+	if locale == "" {
+		locale = request.Locale
+	}
+	timezone := result.Timezone
+	if timezone == "" {
+		timezone = request.Timezone
+	}
+	requestPath := result.RequestPath
+	if requestPath == "" {
+		requestPath = request.Path
+	}
+	values := result.Request
+	if values == nil {
+		values = request.Request
+	}
+	params[paramLocale] = locale
+	params[paramTimezone] = timezone
+	params[paramPath] = requestPath
+	params[paramRequest] = freezeValues(values)
+	params[paramDataScope] = request.DataScope
+	params[paramNamespace] = request.Namespace
+	return params
+}
+
+func thawRuntimeRequest(request lensruntime.Request, params map[string]any) lensruntime.Request {
+	request.Locale = stringParam(params, paramLocale, request.Locale)
+	request.Timezone = stringParam(params, paramTimezone, request.Timezone)
+	request.Path = stringParam(params, paramPath, request.Path)
+	request.DataScope = stringParam(params, paramDataScope, request.DataScope)
+	request.Namespace = stringParam(params, paramNamespace, request.Namespace)
+	if frozen, ok := params[paramRequest].(map[string]any); ok {
+		request.Request = thawValues(frozen)
+	}
+	return request
+}
+
+func variableParams(params map[string]any) map[string]any {
+	result := make(map[string]any, len(params))
+	for key, value := range params {
+		switch key {
+		case paramLocale, paramTimezone, paramPath, paramRequest, paramDataScope, paramNamespace:
+			continue
+		default:
+			result[key] = value
+		}
+	}
+	return result
+}
+
+func freezeValues(values url.Values) map[string]any {
+	result := make(map[string]any, len(values))
+	for key, items := range values {
+		frozen := make([]any, len(items))
+		for index, item := range items {
+			frozen[index] = item
+		}
+		result[key] = frozen
+	}
+	return result
+}
+
+func thawValues(values map[string]any) url.Values {
+	result := make(url.Values, len(values))
+	for key, value := range values {
+		switch typed := value.(type) {
+		case string:
+			result[key] = []string{typed}
+		case []any:
+			items := make([]string, 0, len(typed))
+			for _, item := range typed {
+				if text, ok := item.(string); ok {
+					items = append(items, text)
+				}
+			}
+			result[key] = items
+		}
+	}
+	return result
+}
+
+func stringParam(params map[string]any, key, fallback string) string {
+	if value, ok := params[key].(string); ok {
+		return value
+	}
+	return fallback
+}

--- a/pkg/lens/serve/serve.go
+++ b/pkg/lens/serve/serve.go
@@ -1,0 +1,114 @@
+package serve
+
+import (
+	"fmt"
+	"net/http"
+	"path"
+	"strings"
+
+	"github.com/iota-uz/iota-sdk/pkg/intl"
+	"github.com/iota-uz/iota-sdk/pkg/lens"
+	"github.com/iota-uz/iota-sdk/pkg/lens/document"
+	"github.com/iota-uz/iota-sdk/pkg/lens/engine"
+	lensruntime "github.com/iota-uz/iota-sdk/pkg/lens/runtime"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
+	"golang.org/x/sync/singleflight"
+)
+
+const defaultPageSize = 50
+
+// RequestResolver supplies host-owned runtime inputs such as data sources and
+// tenant scope. Serve fills empty transport fields from the HTTP request.
+type RequestResolver func(*http.Request) lensruntime.Request
+
+// Config describes one host-registered dashboard HTTP surface.
+type Config struct {
+	Spec        lens.DashboardSpec
+	Engine      engine.Executor
+	Snapshots   document.SnapshotStore
+	BasePath    string
+	InlineDepth int
+	PageSize    int
+	Request     RequestResolver
+}
+
+// Handlers serves one dashboard registration.
+type Handlers struct {
+	spec        lens.DashboardSpec
+	engine      engine.Executor
+	snapshots   document.SnapshotStore
+	basePath    string
+	inlineDepth int
+	pageSize    int
+	request     RequestResolver
+	loads       singleflight.Group
+}
+
+// New validates cfg and constructs the dashboard handlers.
+func New(cfg Config) (*Handlers, error) {
+	const op serrors.Op = "lens/serve.New"
+	if cfg.Engine == nil {
+		return nil, serrors.E(op, fmt.Errorf("lens executor is required"))
+	}
+	if cfg.Snapshots == nil {
+		return nil, serrors.E(op, fmt.Errorf("snapshot store is required"))
+	}
+	if cfg.InlineDepth < 0 {
+		return nil, serrors.E(op, fmt.Errorf("inline depth cannot be negative"))
+	}
+	if cfg.PageSize < 0 {
+		return nil, serrors.E(op, fmt.Errorf("page size cannot be negative"))
+	}
+	if err := lensruntime.Validate(cfg.Spec); err != nil {
+		return nil, serrors.E(op, err)
+	}
+	basePath, err := normalizeBasePath(cfg.BasePath)
+	if err != nil {
+		return nil, serrors.E(op, err)
+	}
+	pageSize := cfg.PageSize
+	if pageSize == 0 {
+		pageSize = defaultPageSize
+	}
+	return &Handlers{
+		spec: cfg.Spec, engine: cfg.Engine, snapshots: cfg.Snapshots,
+		basePath: basePath, inlineDepth: cfg.InlineDepth, pageSize: pageSize, request: cfg.Request,
+	}, nil
+}
+
+func normalizeBasePath(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" || value == "/" {
+		return "", nil
+	}
+	if !strings.HasPrefix(value, "/") {
+		return "", fmt.Errorf("base path must start with a slash")
+	}
+	if strings.ContainsAny(value, "?#") {
+		return "", fmt.Errorf("base path cannot contain a query or fragment")
+	}
+	return strings.TrimSuffix(path.Clean(value), "/"), nil
+}
+
+func (h *Handlers) endpoint(suffix string) string {
+	return h.basePath + suffix
+}
+
+func (h *Handlers) runtimeRequest(r *http.Request) lensruntime.Request {
+	var req lensruntime.Request
+	if h.request != nil {
+		req = h.request(r)
+	}
+	if req.Locale == "" {
+		if locale, ok := intl.UseLocale(r.Context()); ok {
+			req.Locale = locale.String()
+		}
+	}
+	if req.Path == "" {
+		req.Path = r.URL.Path
+	}
+	if req.Request == nil {
+		req.Request = r.URL.Query()
+	}
+	return req
+}

--- a/pkg/lens/serve/serve.go
+++ b/pkg/lens/serve/serve.go
@@ -1,10 +1,12 @@
 package serve
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/iota-uz/iota-sdk/pkg/intl"
 	"github.com/iota-uz/iota-sdk/pkg/lens"
@@ -15,11 +17,26 @@ import (
 	"golang.org/x/sync/singleflight"
 )
 
-const defaultPageSize = 50
+const (
+	defaultPageSize    = 50
+	defaultWorkTimeout = 2 * time.Minute
+)
 
 // RequestResolver supplies host-owned runtime inputs such as data sources and
 // tenant scope. Serve fills empty transport fields from the HTTP request.
 type RequestResolver func(*http.Request) lensruntime.Request
+
+// Observer receives internal serve errors before a generic response is written.
+type Observer interface {
+	OnError(context.Context, string, error)
+}
+
+// ObserverFunc adapts a function to Observer.
+type ObserverFunc func(context.Context, string, error)
+
+func (f ObserverFunc) OnError(ctx context.Context, op string, err error) {
+	f(ctx, op, err)
+}
 
 // Config describes one host-registered dashboard HTTP surface.
 type Config struct {
@@ -29,7 +46,9 @@ type Config struct {
 	BasePath    string
 	InlineDepth int
 	PageSize    int
+	WorkTimeout time.Duration
 	Request     RequestResolver
+	Observer    Observer
 }
 
 // Handlers serves one dashboard registration.
@@ -40,9 +59,15 @@ type Handlers struct {
 	basePath    string
 	inlineDepth int
 	pageSize    int
+	workTimeout time.Duration
 	request     RequestResolver
+	observer    Observer
 	loads       singleflight.Group
 }
+
+type noopObserver struct{}
+
+func (noopObserver) OnError(context.Context, string, error) {}
 
 // New validates cfg and constructs the dashboard handlers.
 func New(cfg Config) (*Handlers, error) {
@@ -70,9 +95,18 @@ func New(cfg Config) (*Handlers, error) {
 	if pageSize == 0 {
 		pageSize = defaultPageSize
 	}
+	workTimeout := cfg.WorkTimeout
+	if workTimeout <= 0 {
+		workTimeout = defaultWorkTimeout
+	}
+	observer := cfg.Observer
+	if observer == nil {
+		observer = noopObserver{}
+	}
 	return &Handlers{
 		spec: cfg.Spec, engine: cfg.Engine, snapshots: cfg.Snapshots,
-		basePath: basePath, inlineDepth: cfg.InlineDepth, pageSize: pageSize, request: cfg.Request,
+		basePath: basePath, inlineDepth: cfg.InlineDepth, pageSize: pageSize, workTimeout: workTimeout,
+		request: cfg.Request, observer: observer,
 	}, nil
 }
 

--- a/pkg/lens/serve/serve_test.go
+++ b/pkg/lens/serve/serve_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -34,6 +35,8 @@ type fakeExecutor struct {
 	cancelPanel string
 	delay       time.Duration
 	frames      map[string]*frame.FrameSet
+	executeErrs map[string]error
+	panelErrs   map[string]error
 	startOnce   sync.Once
 }
 
@@ -45,8 +48,13 @@ func (f *fakeExecutor) Execute(ctx context.Context, spec lens.DashboardSpec, req
 	f.mu.Lock()
 	f.calls = append(f.calls, executorCall{panelID: panelID, request: cloneRuntimeRequest(req)})
 	f.mu.Unlock()
-	if f.cancelPanel != "" && panelID == f.cancelPanel {
+	if f.started != nil && panelID != "" {
 		f.startOnce.Do(func() { close(f.started) })
+	}
+	if err := f.executeErrs[panelID]; err != nil {
+		return nil, err
+	}
+	if f.cancelPanel != "" && panelID == f.cancelPanel {
 		<-ctx.Done()
 		return nil, ctx.Err()
 	}
@@ -77,7 +85,30 @@ func (f *fakeExecutor) Execute(ctx context.Context, spec lens.DashboardSpec, req
 		return nil, errors.New("scoped panel is missing")
 	}
 	result.Panels[panelID] = panelResult(target, f.frames[panelID], req)
+	result.Panels[panelID].Error = f.panelErrs[panelID]
 	return result, nil
+}
+
+type observedError struct {
+	op  string
+	err error
+}
+
+type recordingObserver struct {
+	mu     sync.Mutex
+	errors []observedError
+}
+
+func (o *recordingObserver) OnError(_ context.Context, op string, err error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.errors = append(o.errors, observedError{op: op, err: err})
+}
+
+func (o *recordingObserver) recorded() []observedError {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return append([]observedError(nil), o.errors...)
 }
 
 func (f *fakeExecutor) callCount(panelID string) int {
@@ -132,6 +163,24 @@ func TestHandlers_DocumentQueryCacheAndAppend(t *testing.T) {
 	require.Contains(t, snapshot.Frames, document.FrameRef("explore:metric/focus/composition:detail"))
 }
 
+func TestHandlers_QueryUsesFrozenScopeOverConflictingQueryParams(t *testing.T) {
+	t.Parallel()
+	handlers, executor, _ := newTestHandlers(t, 0)
+	doc := requestDocument(t, handlers, "/dash/document?region=west")
+	body := marshal(t, QueryRequest{
+		SnapshotID:  doc.SnapshotID,
+		Path:        document.NodePath{"detail"},
+		Perspective: "composition",
+	})
+	recorder := httptest.NewRecorder()
+	handlers.Query(recorder, httptest.NewRequest(http.MethodPost, "/dash/lens/query?region=EVIL", body))
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+
+	call := executor.lastCall("detail-panel")
+	require.Equal(t, "west", call.request.Request.Get("region"))
+	require.Equal(t, "west", call.request.Overrides["region"])
+}
+
 func TestHandlers_SnapshotGone(t *testing.T) {
 	t.Parallel()
 	handlers, _, _ := newTestHandlers(t, 0)
@@ -146,6 +195,22 @@ func TestHandlers_SnapshotGone(t *testing.T) {
 	recorder = httptest.NewRecorder()
 	handlers.Export(recorder, httptest.NewRequest(http.MethodGet, "/dash/export?snapshot=gone", nil))
 	require.Equal(t, http.StatusGone, recorder.Code)
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	require.Equal(t, "snapshot_gone", response.Error)
+}
+
+func TestHandlers_ExpiredSnapshotReturnsGone(t *testing.T) {
+	t.Parallel()
+	store := document.NewMemoryStore(time.Millisecond, 32)
+	handlers, _, _ := newTestHandlersWithStore(t, 0, store, nil)
+	doc := requestDocument(t, handlers, "/dash/document")
+	time.Sleep(2 * time.Millisecond)
+
+	body := marshal(t, QueryRequest{SnapshotID: doc.SnapshotID, Path: document.NodePath{"root"}, Perspective: "composition"})
+	recorder := httptest.NewRecorder()
+	handlers.Query(recorder, httptest.NewRequest(http.MethodPost, "/dash/lens/query", body))
+	require.Equal(t, http.StatusGone, recorder.Code, recorder.Body.String())
+	var response errorResponse
 	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
 	require.Equal(t, "snapshot_gone", response.Error)
 }
@@ -169,6 +234,58 @@ func TestHandlers_EvidenceIsLiveAndPaginated(t *testing.T) {
 	snapshot, err := store.Get(t.Context(), doc.SnapshotID)
 	require.NoError(t, err)
 	require.NotContains(t, snapshot.Frames, document.FrameRef("explore:metric/focus/evidence:evidence"))
+}
+
+func TestHandlers_DocumentSkipsErroredExplorePanelAndQueryReportsIt(t *testing.T) {
+	t.Parallel()
+	observer := &recordingObserver{}
+	handlers, executor, _ := newTestHandlersWithStore(t, 0, document.NewMemoryStore(time.Minute, 32), observer)
+	rootErr := errors.New("root panel failed")
+	detailErr := errors.New("detail panel failed")
+	executor.panelErrs = map[string]error{"root-panel": rootErr, "detail-panel": detailErr}
+
+	recorder := httptest.NewRecorder()
+	handlers.Document(recorder, httptest.NewRequest(http.MethodGet, "/dash/document", nil))
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	var doc document.DashboardDocument
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &doc))
+	require.NotContains(t, doc.Frames, document.FrameRef("explore:metric/focus/composition:root"))
+	require.Empty(t, observer.recorded())
+
+	body := marshal(t, QueryRequest{
+		SnapshotID:  doc.SnapshotID,
+		Path:        document.NodePath{"detail"},
+		Perspective: "composition",
+	})
+	recorder = httptest.NewRecorder()
+	handlers.Query(recorder, httptest.NewRequest(http.MethodPost, "/dash/lens/query", body))
+	require.Equal(t, http.StatusInternalServerError, recorder.Code, recorder.Body.String())
+	recorded := observer.recorded()
+	require.Len(t, recorded, 1)
+	require.ErrorIs(t, recorded[0].err, detailErr)
+}
+
+func TestHandlers_ObserverReceivesWrappedExecutionError(t *testing.T) {
+	t.Parallel()
+	observer := &recordingObserver{}
+	handlers, executor, _ := newTestHandlersWithStore(t, 0, document.NewMemoryStore(time.Minute, 32), observer)
+	doc := requestDocument(t, handlers, "/dash/document")
+	executionErr := errors.New("datasource unavailable")
+	executor.executeErrs = map[string]error{"detail-panel": executionErr}
+
+	body := marshal(t, QueryRequest{
+		SnapshotID:  doc.SnapshotID,
+		Path:        document.NodePath{"detail"},
+		Perspective: "composition",
+	})
+	recorder := httptest.NewRecorder()
+	handlers.Query(recorder, httptest.NewRequest(http.MethodPost, "/dash/lens/query", body))
+	require.Equal(t, http.StatusInternalServerError, recorder.Code, recorder.Body.String())
+	recorded := observer.recorded()
+	require.Len(t, recorded, 1)
+	require.Equal(t, "lens/serve.writeExecutionError", recorded[0].op)
+	require.ErrorIs(t, recorded[0].err, executionErr)
+	require.ErrorContains(t, recorded[0].err, "lens/serve.executeLevel")
 }
 
 func TestHandlers_ConcurrentAppendExecutesAggregateOnce(t *testing.T) {
@@ -205,10 +322,55 @@ func TestHandlers_ConcurrentAppendExecutesAggregateOnce(t *testing.T) {
 	require.Contains(t, snapshot.Frames, document.FrameRef("explore:metric/focus/composition:end"))
 }
 
-func TestHandlers_QueryCancellationAbortsExecution(t *testing.T) {
+func TestHandlers_FirstCanceledCallerDoesNotAbortSharedExecution(t *testing.T) {
 	t.Parallel()
 	handlers, executor, _ := newTestHandlers(t, 0)
 	doc := requestDocument(t, handlers, "/dash/document")
+	executor.delay = 75 * time.Millisecond
+	executor.started = make(chan struct{})
+	payload, err := json.Marshal(QueryRequest{
+		SnapshotID:  doc.SnapshotID,
+		Path:        document.NodePath{"detail"},
+		Perspective: "composition",
+	})
+	require.NoError(t, err)
+
+	firstCtx, cancelFirst := context.WithCancel(t.Context())
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		request := httptest.NewRequest(http.MethodPost, "/dash/lens/query", bytes.NewReader(payload)).WithContext(firstCtx)
+		handlers.Query(httptest.NewRecorder(), request)
+	}()
+	select {
+	case <-executor.started:
+	case <-time.After(time.Second):
+		t.Fatal("executor did not start")
+	}
+
+	canceled := make(chan struct{})
+	timer := time.AfterFunc(10*time.Millisecond, func() {
+		cancelFirst()
+		close(canceled)
+	})
+	defer timer.Stop()
+	second := httptest.NewRecorder()
+	handlers.Query(second, httptest.NewRequest(http.MethodPost, "/dash/lens/query", bytes.NewReader(payload)))
+	<-canceled
+	require.Equal(t, http.StatusOK, second.Code, second.Body.String())
+	select {
+	case <-firstDone:
+	case <-time.After(time.Second):
+		t.Fatal("canceled waiter did not stop")
+	}
+	require.Equal(t, 1, executor.callCount("detail-panel"))
+}
+
+func TestHandlers_QueryCancellationStopsWaiter(t *testing.T) {
+	t.Parallel()
+	handlers, executor, _ := newTestHandlers(t, 0)
+	doc := requestDocument(t, handlers, "/dash/document")
+	handlers.workTimeout = 25 * time.Millisecond
 	executor.cancelPanel = "detail-panel"
 	executor.started = make(chan struct{})
 	ctx, cancel := context.WithCancel(t.Context())
@@ -272,11 +434,21 @@ func TestNew_ValidatesConfig(t *testing.T) {
 
 func newTestHandlers(t *testing.T, inlineDepth int) (*Handlers, *fakeExecutor, document.SnapshotStore) {
 	t.Helper()
+	return newTestHandlersWithStore(t, inlineDepth, document.NewMemoryStore(time.Minute, 32), nil)
+}
+
+func newTestHandlersWithStore(
+	t *testing.T,
+	inlineDepth int,
+	store document.SnapshotStore,
+	observer Observer,
+) (*Handlers, *fakeExecutor, document.SnapshotStore) {
+	t.Helper()
 	spec, frames := testDashboard(t)
 	executor := &fakeExecutor{frames: frames}
-	store := document.NewMemoryStore(time.Minute, 32)
 	handlers, err := New(Config{
 		Spec: spec, Engine: executor, Snapshots: store, BasePath: "/dash", InlineDepth: inlineDepth, PageSize: 17,
+		Observer: observer,
 		Request: func(r *http.Request) lensruntime.Request {
 			locale := requestValue(r.URL.Query(), "locale", "en")
 			return lensruntime.Request{Locale: locale, DataScope: "tenant:test", Request: r.URL.Query()}
@@ -414,4 +586,47 @@ func TestHandlers_BadRequestsAreJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
 	assert.Equal(t, "bad_request", response.Error)
 	assert.NotEmpty(t, response.Message)
+}
+
+func TestHandlers_EnforceMethods(t *testing.T) {
+	t.Parallel()
+	handlers, _, _ := newTestHandlers(t, 0)
+	tests := []struct {
+		name    string
+		method  string
+		target  string
+		handler http.HandlerFunc
+	}{
+		{name: "document", method: http.MethodPost, target: "/dash/document", handler: handlers.Document},
+		{name: "query", method: http.MethodGet, target: "/dash/lens/query", handler: handlers.Query},
+		{name: "export", method: http.MethodPost, target: "/dash/export", handler: handlers.Export},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			recorder := httptest.NewRecorder()
+			test.handler(recorder, httptest.NewRequest(test.method, test.target, nil))
+			require.Equal(t, http.StatusMethodNotAllowed, recorder.Code, recorder.Body.String())
+		})
+	}
+}
+
+func TestHandlers_QueryRejectsOversizedBody(t *testing.T) {
+	t.Parallel()
+	handlers, _, _ := newTestHandlers(t, 0)
+	body := strings.NewReader(`{"snapshotId":"` + strings.Repeat("x", maxQueryBodyBytes) + `"}`)
+	recorder := httptest.NewRecorder()
+	handlers.Query(recorder, httptest.NewRequest(http.MethodPost, "/dash/lens/query", body))
+	require.Equal(t, http.StatusBadRequest, recorder.Code, recorder.Body.String())
+	require.Contains(t, recorder.Body.String(), "request body too large")
+}
+
+func TestHandlers_QueryRejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+	handlers, _, _ := newTestHandlers(t, 0)
+	body := strings.NewReader(`{"snapshotId":"snapshot","path":["root"],"unexpected":true}`)
+	recorder := httptest.NewRecorder()
+	handlers.Query(recorder, httptest.NewRequest(http.MethodPost, "/dash/lens/query", body))
+	require.Equal(t, http.StatusBadRequest, recorder.Code, recorder.Body.String())
+	require.Contains(t, recorder.Body.String(), "unknown field")
 }

--- a/pkg/lens/serve/serve_test.go
+++ b/pkg/lens/serve/serve_test.go
@@ -1,0 +1,417 @@
+package serve
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/iota-uz/iota-sdk/pkg/lens"
+	"github.com/iota-uz/iota-sdk/pkg/lens/document"
+	"github.com/iota-uz/iota-sdk/pkg/lens/explore"
+	"github.com/iota-uz/iota-sdk/pkg/lens/frame"
+	"github.com/iota-uz/iota-sdk/pkg/lens/panel"
+	lensruntime "github.com/iota-uz/iota-sdk/pkg/lens/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type executorCall struct {
+	panelID string
+	request lensruntime.Request
+}
+
+type fakeExecutor struct {
+	mu          sync.Mutex
+	calls       []executorCall
+	started     chan struct{}
+	cancelPanel string
+	delay       time.Duration
+	frames      map[string]*frame.FrameSet
+	startOnce   sync.Once
+}
+
+func (f *fakeExecutor) Execute(ctx context.Context, spec lens.DashboardSpec, req lensruntime.Request, scope lensruntime.Scope) (*lensruntime.DashboardResult, error) {
+	panelID := ""
+	if len(scope.PanelIDs) > 0 {
+		panelID = scope.PanelIDs[0]
+	}
+	f.mu.Lock()
+	f.calls = append(f.calls, executorCall{panelID: panelID, request: cloneRuntimeRequest(req)})
+	f.mu.Unlock()
+	if f.cancelPanel != "" && panelID == f.cancelPanel {
+		f.startOnce.Do(func() { close(f.started) })
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+	if f.delay > 0 && panelID != "" {
+		timer := time.NewTimer(f.delay)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	result := &lensruntime.DashboardResult{
+		Spec: spec, Variables: map[string]any{"region": requestValue(req.Request, "region", "all")},
+		Panels: make(map[string]*lensruntime.PanelResult), Datasets: make(map[string]*lensruntime.DatasetResult),
+		Locale: req.Locale, Timezone: req.Timezone, RequestPath: req.Path, Request: req.Request, StartedAt: time.Unix(100, 0).UTC(),
+	}
+	if panelID == "" {
+		host, ok := lens.FindPanel(spec, "host")
+		if !ok {
+			return nil, errors.New("host panel is missing")
+		}
+		result.Panels[host.ID] = panelResult(host, f.frames[host.ID], req)
+		return result, nil
+	}
+	target, ok := lens.FindPanel(spec, panelID)
+	if !ok {
+		return nil, errors.New("scoped panel is missing")
+	}
+	result.Panels[panelID] = panelResult(target, f.frames[panelID], req)
+	return result, nil
+}
+
+func (f *fakeExecutor) callCount(panelID string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	count := 0
+	for _, call := range f.calls {
+		if call.panelID == panelID {
+			count++
+		}
+	}
+	return count
+}
+
+func (f *fakeExecutor) lastCall(panelID string) executorCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for index := len(f.calls) - 1; index >= 0; index-- {
+		if f.calls[index].panelID == panelID {
+			return f.calls[index]
+		}
+	}
+	return executorCall{}
+}
+
+func TestHandlers_DocumentQueryCacheAndAppend(t *testing.T) {
+	t.Parallel()
+	handlers, executor, store := newTestHandlers(t, 0)
+	doc := requestDocument(t, handlers, "/dash/document?region=west&locale=ru")
+
+	require.Equal(t, "/dash/lens/query", doc.Endpoints.Query)
+	require.Equal(t, "/dash/export", doc.Endpoints.Export)
+	require.Contains(t, doc.Frames, document.FrameRef("explore:metric/focus/composition:root"))
+	require.NotContains(t, doc.Frames, document.FrameRef("explore:metric/focus/composition:detail"))
+	require.Equal(t, 1, executor.callCount("root-panel"))
+
+	root := queryLevel(t, handlers, QueryRequest{SnapshotID: doc.SnapshotID, Path: document.NodePath{"root"}, Perspective: "composition"})
+	require.Contains(t, root.Frames, document.FrameRef("explore:metric/focus/composition:root"))
+	require.Equal(t, 1, executor.callCount("root-panel"))
+
+	detail := queryLevel(t, handlers, QueryRequest{SnapshotID: doc.SnapshotID, Path: document.NodePath{"root", "detail"}, Perspective: "composition"})
+	require.Contains(t, detail.Frames, document.FrameRef("explore:metric/focus/composition:detail"))
+	require.Equal(t, 1, executor.callCount("detail-panel"))
+	require.Equal(t, "west", executor.lastCall("detail-panel").request.Overrides["region"])
+	require.Equal(t, "west", executor.lastCall("detail-panel").request.Request.Get("region"))
+	require.Equal(t, "ru", executor.lastCall("detail-panel").request.Locale)
+
+	queryLevel(t, handlers, QueryRequest{SnapshotID: doc.SnapshotID, Path: document.NodePath{"detail"}, Perspective: "composition"})
+	require.Equal(t, 1, executor.callCount("detail-panel"))
+	snapshot, err := store.Get(t.Context(), doc.SnapshotID)
+	require.NoError(t, err)
+	require.Contains(t, snapshot.Frames, document.FrameRef("explore:metric/focus/composition:detail"))
+}
+
+func TestHandlers_SnapshotGone(t *testing.T) {
+	t.Parallel()
+	handlers, _, _ := newTestHandlers(t, 0)
+	body := marshal(t, QueryRequest{SnapshotID: "gone", Path: document.NodePath{"root"}, Perspective: "composition"})
+	recorder := httptest.NewRecorder()
+	handlers.Query(recorder, httptest.NewRequest(http.MethodPost, "/dash/lens/query", body))
+	require.Equal(t, http.StatusGone, recorder.Code)
+	var response errorResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	require.Equal(t, "snapshot_gone", response.Error)
+
+	recorder = httptest.NewRecorder()
+	handlers.Export(recorder, httptest.NewRequest(http.MethodGet, "/dash/export?snapshot=gone", nil))
+	require.Equal(t, http.StatusGone, recorder.Code)
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	require.Equal(t, "snapshot_gone", response.Error)
+}
+
+func TestHandlers_EvidenceIsLiveAndPaginated(t *testing.T) {
+	t.Parallel()
+	handlers, executor, store := newTestHandlers(t, 0)
+	doc := requestDocument(t, handlers, "/dash/document?region=east")
+	request := QueryRequest{SnapshotID: doc.SnapshotID, Path: document.NodePath{"evidence"}, Perspective: "evidence", Page: 3}
+
+	first := queryLevel(t, handlers, request)
+	second := queryLevel(t, handlers, request)
+	require.Equal(t, &Page{Number: 3, Size: 17}, first.Page)
+	require.Equal(t, first.Page, second.Page)
+	require.Equal(t, 2, executor.callCount("evidence-panel"))
+	call := executor.lastCall("evidence-panel")
+	require.Equal(t, "3", call.request.Request.Get(lensruntime.TablePaginationPageQuery))
+	require.Equal(t, "17", call.request.Request.Get(lensruntime.TablePaginationLimitQuery))
+	require.Equal(t, "evidence-panel", call.request.Request.Get(lensruntime.TablePaginationPanelQuery))
+	require.Equal(t, "east", call.request.Overrides["region"])
+	snapshot, err := store.Get(t.Context(), doc.SnapshotID)
+	require.NoError(t, err)
+	require.NotContains(t, snapshot.Frames, document.FrameRef("explore:metric/focus/evidence:evidence"))
+}
+
+func TestHandlers_ConcurrentAppendExecutesAggregateOnce(t *testing.T) {
+	t.Parallel()
+	handlers, executor, store := newTestHandlers(t, 0)
+	executor.delay = 25 * time.Millisecond
+	doc := requestDocument(t, handlers, "/dash/document?region=north")
+	request := QueryRequest{SnapshotID: doc.SnapshotID, Path: document.NodePath{"end"}, Perspective: "composition"}
+
+	const workers = 12
+	var wg sync.WaitGroup
+	errorsFound := make(chan error, workers)
+	payload, err := json.Marshal(request)
+	require.NoError(t, err)
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			recorder := httptest.NewRecorder()
+			handlers.Query(recorder, httptest.NewRequest(http.MethodPost, "/dash/lens/query", bytes.NewReader(payload)))
+			if recorder.Code != http.StatusOK {
+				errorsFound <- errors.New(recorder.Body.String())
+			}
+		}()
+	}
+	wg.Wait()
+	close(errorsFound)
+	for err := range errorsFound {
+		require.NoError(t, err)
+	}
+	require.Equal(t, 1, executor.callCount("end-panel"))
+	snapshot, err := store.Get(t.Context(), doc.SnapshotID)
+	require.NoError(t, err)
+	require.Contains(t, snapshot.Frames, document.FrameRef("explore:metric/focus/composition:end"))
+}
+
+func TestHandlers_QueryCancellationAbortsExecution(t *testing.T) {
+	t.Parallel()
+	handlers, executor, _ := newTestHandlers(t, 0)
+	doc := requestDocument(t, handlers, "/dash/document")
+	executor.cancelPanel = "detail-panel"
+	executor.started = make(chan struct{})
+	ctx, cancel := context.WithCancel(t.Context())
+	request := httptest.NewRequest(http.MethodPost, "/dash/lens/query", marshal(t, QueryRequest{
+		SnapshotID: doc.SnapshotID, Path: document.NodePath{"detail"}, Perspective: "composition",
+	})).WithContext(ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handlers.Query(httptest.NewRecorder(), request)
+	}()
+	select {
+	case <-executor.started:
+	case <-time.After(time.Second):
+		t.Fatal("executor did not start")
+	}
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("query did not stop after cancellation")
+	}
+}
+
+func TestHandlers_ExportUsesSnapshotFrames(t *testing.T) {
+	t.Parallel()
+	handlers, executor, _ := newTestHandlers(t, 0)
+	doc := requestDocument(t, handlers, "/dash/document")
+	recorder := httptest.NewRecorder()
+	handlers.Export(recorder, httptest.NewRequest(http.MethodGet, "/dash/export?snapshot="+url.QueryEscape(doc.SnapshotID)+"&panel=host", nil))
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	require.Equal(t, "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", recorder.Header().Get("Content-Type"))
+	require.True(t, bytes.HasPrefix(recorder.Body.Bytes(), []byte("PK")))
+	require.Equal(t, 1, executor.callCount(""))
+}
+
+func TestNew_ValidatesConfig(t *testing.T) {
+	t.Parallel()
+	spec, frames := testDashboard(t)
+	executor := &fakeExecutor{frames: frames}
+	store := document.NewMemoryStore(time.Minute, 10)
+	tests := []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		{name: "executor", cfg: Config{Spec: spec, Snapshots: store}, want: "executor"},
+		{name: "store", cfg: Config{Spec: spec, Engine: executor}, want: "snapshot store"},
+		{name: "depth", cfg: Config{Spec: spec, Engine: executor, Snapshots: store, InlineDepth: -1}, want: "inline depth"},
+		{name: "page size", cfg: Config{Spec: spec, Engine: executor, Snapshots: store, PageSize: -1}, want: "page size"},
+		{name: "base path", cfg: Config{Spec: spec, Engine: executor, Snapshots: store, BasePath: "relative"}, want: "base path"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := New(test.cfg)
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+}
+
+func newTestHandlers(t *testing.T, inlineDepth int) (*Handlers, *fakeExecutor, document.SnapshotStore) {
+	t.Helper()
+	spec, frames := testDashboard(t)
+	executor := &fakeExecutor{frames: frames}
+	store := document.NewMemoryStore(time.Minute, 32)
+	handlers, err := New(Config{
+		Spec: spec, Engine: executor, Snapshots: store, BasePath: "/dash", InlineDepth: inlineDepth, PageSize: 17,
+		Request: func(r *http.Request) lensruntime.Request {
+			locale := requestValue(r.URL.Query(), "locale", "en")
+			return lensruntime.Request{Locale: locale, DataScope: "tenant:test", Request: r.URL.Query()}
+		},
+	})
+	require.NoError(t, err)
+	return handlers, executor, store
+}
+
+func testDashboard(t *testing.T) (lens.DashboardSpec, map[string]*frame.FrameSet) {
+	t.Helper()
+	frames := map[string]*frame.FrameSet{
+		"host":           testFrames(t, "host", 100),
+		"root-panel":     testFrames(t, "root", 80),
+		"detail-panel":   testFrames(t, "detail", 60),
+		"end-panel":      testFrames(t, "end", 40),
+		"evidence-panel": evidenceFrames(t),
+	}
+	host := panel.Pie("host", "Premium", "host-data").IDField("id").Build()
+	host.Export.EvidenceDatasets = []string{"evidence-data"}
+	root := panel.Pie("root-panel", "Root", "root-data").IDField("id").Build()
+	detail := panel.Pie("detail-panel", "Detail", "detail-data").IDField("id").Build()
+	end := panel.Pie("end-panel", "End", "end-data").IDField("id").Build()
+	evidence := panel.Table("evidence-panel", "Evidence", "evidence-data").Build()
+	explorer := explore.Spec{
+		ID: "metric", HostPanelID: "host", Branches: []explore.Branch{{
+			Key: "focus", Label: "Focus", DefaultPerspective: "composition", Perspectives: []explore.Perspective{
+				{Key: "composition", Label: "Composition", Semantics: explore.SemanticsPartition, RootNode: "root", Nodes: []explore.Node{
+					{Key: "root", Label: "Root", Panel: &root, Edges: []explore.Edge{{PointKey: "a", ToNode: "detail"}}},
+					{Key: "detail", Label: "Detail", Panel: &detail, Edges: []explore.Edge{{PointKey: "b", ToNode: "end"}}},
+					{Key: "end", Label: "End", Panel: &end},
+				}},
+				{Key: "evidence", Label: "Evidence", Semantics: explore.SemanticsEvidence, RootNode: "evidence", Nodes: []explore.Node{
+					{Key: "evidence", Label: "Evidence", Panel: &evidence},
+				}},
+			},
+		}},
+	}
+	spec := lens.DashboardSpec{
+		ID: "dashboard", Title: "Dashboard", Rows: []lens.RowSpec{{Panels: []panel.Spec{host}}},
+		Variables: []lens.VariableSpec{{Name: "region", Label: "Region", Kind: lens.VariableText, Default: "all"}},
+		Datasets: []lens.DatasetSpec{
+			staticDataset("host-data", frames["host"]), staticDataset("root-data", frames["root-panel"]),
+			staticDataset("detail-data", frames["detail-panel"]), staticDataset("end-data", frames["end-panel"]),
+			staticDataset("evidence-data", frames["evidence-panel"]),
+		},
+		Explorers: []explore.Spec{explorer},
+	}
+	require.NoError(t, lensruntime.Validate(spec))
+	return spec, frames
+}
+
+func staticDataset(name string, frames *frame.FrameSet) lens.DatasetSpec {
+	return lens.DatasetSpec{Name: name, Kind: lens.DatasetKindStatic, Static: frames}
+}
+
+func testFrames(t *testing.T, name string, value float64) *frame.FrameSet {
+	t.Helper()
+	primary, err := frame.New(name,
+		frame.Field{Name: "id", Type: frame.FieldTypeString, Values: []any{name}},
+		frame.Field{Name: "label", Type: frame.FieldTypeString, Values: []any{name}},
+		frame.Field{Name: "value", Type: frame.FieldTypeNumber, Values: []any{value}},
+	)
+	require.NoError(t, err)
+	result, err := frame.NewFrameSet(primary)
+	require.NoError(t, err)
+	return result
+}
+
+func evidenceFrames(t *testing.T) *frame.FrameSet {
+	t.Helper()
+	primary, err := frame.New("evidence",
+		frame.Field{Name: "policy", Type: frame.FieldTypeString, Values: []any{"P-1"}},
+		frame.Field{Name: "amount", Type: frame.FieldTypeNumber, Values: []any{25.0}},
+	)
+	require.NoError(t, err)
+	result, err := frame.NewFrameSet(primary)
+	require.NoError(t, err)
+	return result
+}
+
+func panelResult(spec panel.Spec, frames *frame.FrameSet, req lensruntime.Request) *lensruntime.PanelResult {
+	return &lensruntime.PanelResult{Panel: spec, Frames: frames, Locale: req.Locale, Timezone: req.Timezone, Variables: req.Overrides, Request: req.Request}
+}
+
+func requestDocument(t *testing.T, handlers *Handlers, target string) document.DashboardDocument {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	handlers.Document(recorder, httptest.NewRequest(http.MethodGet, target, nil))
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	var response document.DashboardDocument
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	return response
+}
+
+func queryLevel(t *testing.T, handlers *Handlers, request QueryRequest) QueryResponse {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	handlers.Query(recorder, httptest.NewRequest(http.MethodPost, "/dash/lens/query", marshal(t, request)))
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	var response QueryResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	return response
+}
+
+func marshal(t *testing.T, value any) *bytes.Reader {
+	t.Helper()
+	payload, err := json.Marshal(value)
+	require.NoError(t, err)
+	return bytes.NewReader(payload)
+}
+
+func requestValue(values url.Values, key, fallback string) string {
+	value := values.Get(key)
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func cloneRuntimeRequest(req lensruntime.Request) lensruntime.Request {
+	req.Request = cloneValues(req.Request)
+	req.Overrides = cloneParams(req.Overrides)
+	return req
+}
+
+func TestHandlers_BadRequestsAreJSON(t *testing.T) {
+	t.Parallel()
+	handlers, _, _ := newTestHandlers(t, 0)
+	recorder := httptest.NewRecorder()
+	handlers.Query(recorder, httptest.NewRequest(http.MethodPost, "/dash/lens/query", bytes.NewBufferString("{}")))
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+	require.Equal(t, "application/json", recorder.Header().Get("Content-Type"))
+	var response errorResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, "bad_request", response.Error)
+	assert.NotEmpty(t, response.Message)
+}


### PR DESCRIPTION
Closes #889. Part of epic #887 (D4 HTTP surface).

New additive `pkg/lens/serve`: GET document (snapshot materialization, frozen request scope), POST /lens/query (cache-hit appends, single-flight scoped execution, 410 `snapshot_gone`), snapshot-keyed export from materialized frames, live paginated Evidence leaves, stable JSON error codes, context-cancel abort. Host mounts handlers under its own auth/RBAC.

Verification: `go vet ./...`, `go test ./pkg/lens/serve/... -race -count=1`, `go test ./pkg/lens/... -count=1`, `golangci-lint run` — 0 issues.

Implementation drafted by Codex against the issue spec; reviewed, verified, committed via Claude Code orchestration.

https://claude.ai/code/session_01YFEdp4UNyhRFgtYqoabV7v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP endpoints for retrieving dashboard documents, querying dashboard data, and exporting results to Excel.
  * Added snapshot-aware results with pagination, caching, cancellation, and live evidence queries.
  * Added configurable dashboard serving, request resolution, URL mounting, and execution settings.
  * Added clear handling for invalid requests and unavailable snapshots.

* **Documentation**
  * Added package documentation with setup guidance and an integration example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->