### PR TITLE
fix(lens): panel matrix story actually exercises loading/error/stale states

### DIFF
--- a/web/lens/src/PanelMatrix.stories.tsx
+++ b/web/lens/src/PanelMatrix.stories.tsx
@@ -200,11 +200,15 @@ const storyChartAdapter: ChartAdapter = {
   },
 }
 
-function TriggerQuery({ enabled }: { enabled: boolean }) {
+function TriggerQuery({ enabled, panelId }: { enabled: boolean; panelId: string }) {
   const { drillInto } = useDrill()
   useEffect(() => {
-    if (enabled) drillInto('root')
-  }, [drillInto, enabled])
+    // Needs a real child key AND the panel id: invalid drill transitions
+    // no-op (A8), and without the panel id the in-flight query is never
+    // associated with the panel's frame state — either way loading/error/
+    // stale would silently collapse into the empty state.
+    if (enabled) drillInto('root/north', panelId)
+  }, [drillInto, enabled, panelId])
   return null
 }
 
@@ -231,7 +235,7 @@ function MatrixCell({ kind, state }: { kind: StoryKind; state: PanelState }) {
       <span className="lens-story-cell-label">{kind} · {state}</span>
       <DocumentProvider initialDocument={document} fetcher={fetcher}>
         <DashboardRuntimeProvider locale="en" fetcher={fetcher}>
-          <TriggerQuery enabled={state === 'loading' || state === 'stale' || state === 'error'} />
+          <TriggerQuery enabled={state === 'loading' || state === 'stale' || state === 'error'} panelId={document.panels[0]!.id} />
           <StoryPanel panel={document.panels[0]!} />
         </DashboardRuntimeProvider>
       </DocumentProvider>


### PR DESCRIPTION
Follow-up to #908, caught while reviewing the linux baseline candidates before promotion.

The kind×state matrix story rendered its **loading, error, and stale columns as the empty state** — visibly wrong in both darwin and linux VR baselines (loading showed "No data" instead of a skeleton, error showed "No data" instead of error+retry, stale showed plain data without the dimmed Updating treatment).

Root cause: the story's `TriggerQuery` drilled into `'root'`, which is not a child key of the root level — the A8 invalid-transition no-op silently swallowed it — and passed no panel id, so even a valid drill's in-flight query would never associate with the panel's frame state (`frameForPanel` guards on `active.id !== panel.id`). Unit tests drive frame states directly through the provider, so they stayed green; only the story path (and therefore the A10 visual baselines) was lying.

Fix: drill a real child key (`root/north`) with the panel id. The matrix now renders genuine D8 states: skeletons, error + Retry, dimmed stale with the Updating badge.

Verified: `pnpm check` 156 green; `just lens vr-update` + `just lens vr` 19/19 (darwin); matrix screenshot visually confirmed for all five columns.

Post-merge: re-run the `lens_vr_update` workflow and promote fresh linux candidates (the earlier candidate set pinned the wrong matrix renders and was not committed).

https://claude.ai/code/session_01YFEdp4UNyhRFgtYqoabV7v