### PR TITLE
feat: add GPT-5.6 Sol and Luna model specs

### DIFF
--- a/pkg/bichat/agents/model.go
+++ b/pkg/bichat/agents/model.go
@@ -200,6 +200,9 @@ type GenerateConfig struct {
 type ReasoningEffort string
 
 const (
+	// ReasoningNone disables reasoning for the lowest-latency responses.
+	ReasoningNone ReasoningEffort = "none"
+
 	// ReasoningLow uses minimal thinking for faster responses.
 	ReasoningLow ReasoningEffort = "low"
 
@@ -212,6 +215,9 @@ const (
 	// ReasoningXHigh uses extra-high thinking for the most demanding tasks.
 	// Supported by select models (e.g., gpt-5.2).
 	ReasoningXHigh ReasoningEffort = "xhigh"
+
+	// ReasoningMax uses the highest available reasoning effort.
+	ReasoningMax ReasoningEffort = "max"
 )
 
 // GenerateOption configures a Generate/Stream request.

--- a/pkg/bichat/agents/model_catalog_openai.go
+++ b/pkg/bichat/agents/model_catalog_openai.go
@@ -12,6 +12,60 @@ const ProviderOpenAI = "openai"
 const DefaultOpenAIModelSnapshot = "gpt-5.5"
 
 var (
+	// SpecGPT56Sol is the canonical spec for GPT-5.6 Sol.
+	//
+	// Pricing per platform.openai.com/docs/models/gpt-5.6-sol (Input $5.00 /
+	// Cached input $0.50 / Output $30.00 per 1M tokens). Cache writes are
+	// billed at 1.25x the uncached input token rate.
+	SpecGPT56Sol = ModelSpec{
+		Name:          "gpt-5.6-sol",
+		Provider:      ProviderOpenAI,
+		ContextWindow: 1_050_000,
+		Capabilities: []Capability{
+			CapabilityStreaming,
+			CapabilityTools,
+			CapabilityJSONMode,
+			CapabilityThinking,
+		},
+		ReasoningEffortOptions: []ReasoningEffort{
+			ReasoningNone, ReasoningLow, ReasoningMedium, ReasoningHigh, ReasoningXHigh, ReasoningMax,
+		},
+		Pricing: ModelPricing{
+			Currency:        "USD",
+			InputPer1M:      5.00,
+			OutputPer1M:     30.00,
+			CacheWritePer1M: 6.25,
+			CacheReadPer1M:  0.50,
+		},
+	}
+
+	// SpecGPT56Luna is the canonical spec for GPT-5.6 Luna.
+	//
+	// Pricing per platform.openai.com/docs/models/gpt-5.6-luna (Input $1.00 /
+	// Cached input $0.10 / Output $6.00 per 1M tokens). Cache writes are
+	// billed at 1.25x the uncached input token rate.
+	SpecGPT56Luna = ModelSpec{
+		Name:          "gpt-5.6-luna",
+		Provider:      ProviderOpenAI,
+		ContextWindow: 1_050_000,
+		Capabilities: []Capability{
+			CapabilityStreaming,
+			CapabilityTools,
+			CapabilityJSONMode,
+			CapabilityThinking,
+		},
+		ReasoningEffortOptions: []ReasoningEffort{
+			ReasoningNone, ReasoningLow, ReasoningMedium, ReasoningHigh, ReasoningXHigh, ReasoningMax,
+		},
+		Pricing: ModelPricing{
+			Currency:        "USD",
+			InputPer1M:      1.00,
+			OutputPer1M:     6.00,
+			CacheWritePer1M: 1.25,
+			CacheReadPer1M:  0.10,
+		},
+	}
+
 	// SpecGPT55 is the canonical spec for GPT-5.5.
 	//
 	// Pricing per platform.openai.com/docs/models (Input $5.00 / Cached input
@@ -114,6 +168,12 @@ var (
 )
 
 func init() {
+	// GPT-5.6 Sol is the flagship model; "gpt-5.6" is its floating alias.
+	RegisterModelSpec(ProviderOpenAI, []string{"gpt-5.6-sol", "gpt-5.6"}, SpecGPT56Sol, false)
+
+	// GPT-5.6 Luna is the cost-sensitive model in the GPT-5.6 family.
+	RegisterModelSpec(ProviderOpenAI, []string{"gpt-5.6-luna"}, SpecGPT56Luna, false)
+
 	// GPT-5.5 is the provider default. DefaultOpenAIModelSnapshot is the
 	// canonical name; add dated snapshots ("gpt-5.5-YYYY-MM-DD") to the alias
 	// list once OpenAI publishes them.

--- a/pkg/bichat/agents/model_catalog_test.go
+++ b/pkg/bichat/agents/model_catalog_test.go
@@ -24,6 +24,62 @@ func TestLookupModelSpec_OpenAI(t *testing.T) {
 	assert.False(t, ok3)
 }
 
+func TestLookupModelSpec_GPT56(t *testing.T) {
+	tests := []struct {
+		name            string
+		model           string
+		wantName        string
+		inputPer1M      float64
+		outputPer1M     float64
+		cacheWritePer1M float64
+		cacheReadPer1M  float64
+	}{
+		{
+			name:            "Sol canonical model",
+			model:           "gpt-5.6-sol",
+			wantName:        "gpt-5.6-sol",
+			inputPer1M:      5,
+			outputPer1M:     30,
+			cacheWritePer1M: 6.25,
+			cacheReadPer1M:  0.5,
+		},
+		{
+			name:            "Sol alias",
+			model:           "gpt-5.6",
+			wantName:        "gpt-5.6-sol",
+			inputPer1M:      5,
+			outputPer1M:     30,
+			cacheWritePer1M: 6.25,
+			cacheReadPer1M:  0.5,
+		},
+		{
+			name:            "Luna canonical model",
+			model:           "gpt-5.6-luna",
+			wantName:        "gpt-5.6-luna",
+			inputPer1M:      1,
+			outputPer1M:     6,
+			cacheWritePer1M: 1.25,
+			cacheReadPer1M:  0.1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec, ok := LookupModelSpec(ProviderOpenAI, tt.model)
+			require.True(t, ok)
+			assert.Equal(t, tt.wantName, spec.Name)
+			assert.Equal(t, 1_050_000, spec.ContextWindow)
+			assert.Equal(t, []ReasoningEffort{
+				ReasoningNone, ReasoningLow, ReasoningMedium, ReasoningHigh, ReasoningXHigh, ReasoningMax,
+			}, spec.ReasoningEffortOptions)
+			assert.Equal(t, tt.inputPer1M, spec.Pricing.InputPer1M)
+			assert.Equal(t, tt.outputPer1M, spec.Pricing.OutputPer1M)
+			assert.Equal(t, tt.cacheWritePer1M, spec.Pricing.CacheWritePer1M)
+			assert.Equal(t, tt.cacheReadPer1M, spec.Pricing.CacheReadPer1M)
+		})
+	}
+}
+
 func TestDefaultModelForProvider_OpenAI(t *testing.T) {
 	name, ok := DefaultModelForProvider(ProviderOpenAI)
 	require.True(t, ok)

--- a/pkg/bichat/agents/model_catalog_test.go
+++ b/pkg/bichat/agents/model_catalog_test.go
@@ -72,10 +72,10 @@ func TestLookupModelSpec_GPT56(t *testing.T) {
 			assert.Equal(t, []ReasoningEffort{
 				ReasoningNone, ReasoningLow, ReasoningMedium, ReasoningHigh, ReasoningXHigh, ReasoningMax,
 			}, spec.ReasoningEffortOptions)
-			assert.Equal(t, tt.inputPer1M, spec.Pricing.InputPer1M)
-			assert.Equal(t, tt.outputPer1M, spec.Pricing.OutputPer1M)
-			assert.Equal(t, tt.cacheWritePer1M, spec.Pricing.CacheWritePer1M)
-			assert.Equal(t, tt.cacheReadPer1M, spec.Pricing.CacheReadPer1M)
+			assert.InDelta(t, tt.inputPer1M, spec.Pricing.InputPer1M, 1e-9)
+			assert.InDelta(t, tt.outputPer1M, spec.Pricing.OutputPer1M, 1e-9)
+			assert.InDelta(t, tt.cacheWritePer1M, spec.Pricing.CacheWritePer1M, 1e-9)
+			assert.InDelta(t, tt.cacheReadPer1M, spec.Pricing.CacheReadPer1M, 1e-9)
 		})
 	}
 }


### PR DESCRIPTION
## What changed

- Added GPT-5.6 Sol (`gpt-5.6-sol`, plus the `gpt-5.6` alias) to the OpenAI model catalog.
- Added GPT-5.6 Luna (`gpt-5.6-luna`) to the OpenAI model catalog.
- Recorded context limits, reasoning levels, and token pricing, including cached-input and cache-write rates.
- Added catalog coverage tests for identifiers, pricing, context window, and supported reasoning levels.

## Why

EAI needs Sol for deep mode and Luna for fast mode. Without explicit catalog entries, the SDK uses its fallback model metadata and reports incorrect costs.

## Validation

- `go test ./pkg/bichat/agents ./modules/bichat/infrastructure/llmproviders`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenAI GPT-5.6 Sol and Luna model support.
  * Added the `gpt-5.6` alias for GPT-5.6 Sol.
  * Added reasoning-effort controls, including the ability to disable reasoning (`none`) or request the maximum effort (`max`).
* **Bug Fixes**
  * Improved model lookup to correctly resolve GPT-5.6 variants to their expected configuration.
* **Tests**
  * Added coverage for GPT-5.6 model specification resolution and pricing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->