### PR TITLE
fix(lens): declare encodings on lazy explore levels

### DIFF
--- a/pkg/lens/document/build.go
+++ b/pkg/lens/document/build.go
@@ -366,6 +366,27 @@ func inferSemantics(kind PanelKind) Semantics {
 	}
 }
 
+// declaredEncoding maps a panel's declared fields into a wire encoding without
+// consulting a frame. It backs lazy explore levels, whose frame does not exist
+// at build time: the declaration is the contract the later query must satisfy.
+func declaredEncoding(fields panel.FieldMapping) Encoding {
+	encoding := Encoding{}
+	assign := func(target *string, field panel.FieldRef) {
+		if !field.Empty() {
+			*target = field.Name()
+		}
+	}
+	assign(&encoding.Label, fields.Label)
+	assign(&encoding.Value, fields.Value)
+	assign(&encoding.ID, fields.ID)
+	assign(&encoding.Series, fields.Series)
+	assign(&encoding.Category, fields.Category)
+	assign(&encoding.Cut, fields.Cut)
+	assign(&encoding.CutLabel, fields.CutLabel)
+	assign(&encoding.Final, fields.Final)
+	return encoding
+}
+
 func buildEncoding(fields panel.FieldMapping, frame Frame) Encoding {
 	encoding := Encoding{}
 	available := make(map[string]struct{}, len(frame.Columns))
@@ -731,6 +752,15 @@ func buildExplorer(doc *DashboardDocument, spec explore.Spec, result *runtime.Re
 				nodeKey := qualifiedKey(spec.ID, branch.Key, view.Key, nodeSpec.Key)
 				nodePath := appendPath(branchPath, qualifiedKey(spec.ID, branch.Key, view.Key), nodeKey)
 				level := Level{Path: nodePath, Label: nodeSpec.Label, Children: make([]Node, 0, len(nodeSpec.Edges)), Perspectives: []PerspectiveRef{{ID: perspectiveID}}}
+				if nodeSpec.Panel != nil {
+					// Every level with a panel declares its encoding, inlined or
+					// not. A lazy level's frame arrives later via a query, and
+					// the client renders it with `level.encoding ?? panel.encoding`
+					// — without this, the host panel's field names leak in and
+					// match nothing in the fetched frame, drawing an empty level.
+					encoding := declaredEncoding(nodeSpec.Panel.Fields)
+					level.Encoding = &encoding
+				}
 				if nodeSpec.Panel != nil && depths[nodeSpec.Key] <= doc.Drill.InlineDepth {
 					if panelResult := result.Panel(nodeSpec.Panel.ID); panelResult != nil && panelResult.Error == nil && panelResult.Frames.Primary() != nil {
 						frameRef := FrameRef("explore:" + perspectiveID + ":" + nodeSpec.Key)

--- a/pkg/lens/document/build_test.go
+++ b/pkg/lens/document/build_test.go
@@ -513,3 +513,34 @@ func TestBuild_PercentFormatPinsSeparator(t *testing.T) {
 	// separator so the runtime does not drift to "47,1 %".
 	require.Equal(t, FieldFormat{Kind: FormatPercent, Precision: PrecisionOf(1), DecimalSeparator: "."}, doc.Panels[0].Format["value"])
 }
+
+// TestBuild_LazyExploreLevelsCarryDeclaredEncoding pins the contract that made
+// document-mode expansion of lazy levels renderable: a level beyond the inline
+// depth has no frame yet, but its declared field mapping must still ship, or
+// the client falls back to the host panel's encoding and draws the fetched
+// frame as empty.
+func TestBuild_LazyExploreLevelsCarryDeclaredEncoding(t *testing.T) {
+	t.Parallel()
+	spec, result := executeExploreDashboard(t)
+	view := &spec.Explorers[0].Branches[0].Perspectives[0]
+	rootPanel := panel.Pie("explore-root", "Root", "premium").IDField("id").Build()
+	detailPanel := panel.Pie("explore-detail", "Detail", "premium").
+		IDField("id").LabelField("label").ValueField("value").Build()
+	view.Nodes[0].Load = nil
+	view.Nodes[0].Panel = &rootPanel
+	view.Nodes[1].Load = nil
+	view.Nodes[1].Panel = &detailPanel
+	result.Panels[rootPanel.ID] = &runtime.PanelResult{Panel: rootPanel, Frames: result.Panels["host"].Frames}
+	result.Panels[detailPanel.ID] = &runtime.PanelResult{Panel: detailPanel, Frames: result.Panels["host"].Frames}
+
+	doc, err := Build(spec, result, BuildOptions{SnapshotID: "lazy", GeneratedAt: time.Unix(1, 0), InlineDepth: 0})
+	require.NoError(t, err)
+
+	detail := doc.Drill.Edges["metric/focus/composition/detail"]
+	require.Empty(t, detail.Frame, "the lazy level still has no inline frame")
+	require.NotNil(t, detail.Encoding, "a lazy level with a panel must declare its encoding")
+	require.Equal(t, "id", detail.Encoding.ID)
+	require.Equal(t, "label", detail.Encoding.Label)
+	require.Equal(t, "value", detail.Encoding.Value)
+	require.NoError(t, doc.Validate(), "encoding without a frame must stay valid")
+}


### PR DESCRIPTION
## Defect

Document-mode expansion of any lazy explore level (depth > `InlineDepth`) rendered an empty panel even when the level's query returned rows. Found in EAI while verifying Pareto «Остальные» expansion in the browser: the query POST returned the collapsed tail, the panel drew nothing.

## Root cause

`buildExplorer` set `level.Encoding` only inside the inline branch, so a lazy level shipped as `{path, label, children, perspectives}` with no encoding. The React runtime renders a fetched frame with `level.encoding ?? panel.encoding` (`web/lens/src/explore/ExplorePanel.tsx`), so the HOST panel's encoding leaked in — its field names (`metric`/`segment`/`amount` in the EAI case) match nothing in the explore frame's `id`/`label`/`value` columns → zero marks, only the host's static total badge. No lazy explore level has ever rendered in document mode; an earlier scope bug masked it by returning zero rows.

## Fix

Every node with a panel now declares its encoding, derived from the panel's declared field mapping alone (`declaredEncoding` — the frame-independent sibling of `buildEncoding`). The inline branch still overwrites with the frame-checked version. Encoding without a frame is already legal in validation (the cross-check only fires when `level.Frame != ""`). No client change needed.

## Tests

`TestBuild_LazyExploreLevelsCarryDeclaredEncoding`: lazy detail level has no frame, carries the declared `id`/`label`/`value` encoding, and the document still validates. Full `./pkg/lens/...` suite green.

Consumer follow-up: iota-uz/eai#3652 will pin this and extend its wire test to assert document-contract parity for the expansion level.

https://claude.ai/code/session_01SpFsbgRTjyBtqBRM17RC9b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Explore levels that load data lazily now retain their declared field mappings.
  * Documents remain valid even when a lazy level does not yet have an available data frame.
* **Tests**
  * Added coverage to verify field mappings and document validation for lazy explore levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->