### PR TITLE
Add payout provider capability

### DIFF
--- a/migrations/changes-1785269000.sql
+++ b/migrations/changes-1785269000.sql
@@ -1,0 +1,14 @@
+-- Extend billing gateway constraint for transfer and Uzum transactions.
+-- +migrate Up
+ALTER TABLE billing_transactions
+    DROP CONSTRAINT IF EXISTS billing_transactions_gateway_check;
+
+ALTER TABLE billing_transactions
+    ADD CONSTRAINT billing_transactions_gateway_check CHECK (gateway IN ('click', 'payme', 'octo', 'stripe', 'cash', 'transfer', 'integrator', 'uzum'));
+
+-- +migrate Down
+ALTER TABLE billing_transactions
+    DROP CONSTRAINT IF EXISTS billing_transactions_gateway_check;
+
+ALTER TABLE billing_transactions
+    ADD CONSTRAINT billing_transactions_gateway_check CHECK (gateway IN ('click', 'payme', 'octo', 'stripe', 'cash', 'integrator'));

--- a/modules/billing/domain/aggregates/billing/billing_provider.go
+++ b/modules/billing/domain/aggregates/billing/billing_provider.go
@@ -2,6 +2,7 @@ package billing
 
 import (
 	"context"
+	"time"
 )
 
 type Gateway string
@@ -14,6 +15,7 @@ const (
 	Cash       Gateway = "cash"
 	Transfer   Gateway = "transfer"
 	Integrator Gateway = "integrator"
+	Uzum       Gateway = "uzum"
 )
 
 type Provider interface {
@@ -27,11 +29,49 @@ type Provider interface {
 type StatusCheckResult struct {
 	Status            string
 	ShopTransactionID string
-	OctoPaymentUUID   string
+	ProviderPaymentID string
 }
 
 // StatusChecker is an optional interface that providers can implement
 // to support checking the current status of a payment.
 type StatusChecker interface {
 	CheckStatus(ctx context.Context, shopTransactionID string) (*StatusCheckResult, error)
+}
+
+type PayoutDocument struct {
+	Type       string
+	Series     string
+	Number     string
+	IssuedDate *time.Time
+}
+
+type CreatePayoutRequest struct {
+	ExternalID      string
+	Amount          int64
+	Currency        string
+	Destination     string
+	DestinationName string
+	Document        *PayoutDocument
+	Metadata        map[string]string
+}
+
+type ConfirmPayoutRequest struct {
+	ExternalID        string
+	ProviderPaymentID string
+}
+
+type PayoutResult struct {
+	ExternalID        string
+	ProviderPaymentID string
+	Status            string
+	Amount            int64
+	Commission        int64
+}
+
+// PayoutProvider is an optional capability for gateways that support
+// irreversible outbound payments.
+type PayoutProvider interface {
+	CreatePayout(ctx context.Context, request CreatePayoutRequest) (*PayoutResult, error)
+	ConfirmPayout(ctx context.Context, request ConfirmPayoutRequest) (*PayoutResult, error)
+	CheckPayout(ctx context.Context, externalID string) (*PayoutResult, error)
 }

--- a/modules/billing/domain/aggregates/billing/billing_provider_test.go
+++ b/modules/billing/domain/aggregates/billing/billing_provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,14 +26,47 @@ func TestPayoutProviderCapability(t *testing.T) {
 	t.Parallel()
 
 	var provider PayoutProvider = payoutProviderStub{}
-	result, err := provider.CreatePayout(context.Background(), CreatePayoutRequest{
-		ExternalID:  "cashback-42",
-		Amount:      125_000,
-		Currency:    "UZS",
-		Destination: "8600123412341234",
-	})
-
-	require.NoError(t, err)
-	require.Equal(t, "created", result.Status)
-	require.Equal(t, Uzum, Gateway("uzum"))
+	tests := []struct {
+		name       string
+		call       func(context.Context, PayoutProvider) (*PayoutResult, error)
+		wantStatus string
+	}{
+		{
+			name: "create",
+			call: func(ctx context.Context, provider PayoutProvider) (*PayoutResult, error) {
+				return provider.CreatePayout(ctx, CreatePayoutRequest{
+					ExternalID:  "cashback-42",
+					Amount:      125_000,
+					Currency:    "UZS",
+					Destination: "8600123412341234",
+				})
+			},
+			wantStatus: "created",
+		},
+		{
+			name: "confirm",
+			call: func(ctx context.Context, provider PayoutProvider) (*PayoutResult, error) {
+				return provider.ConfirmPayout(ctx, ConfirmPayoutRequest{
+					ExternalID:        "cashback-42",
+					ProviderPaymentID: "receipt-42",
+				})
+			},
+			wantStatus: "completed",
+		},
+		{
+			name: "check",
+			call: func(ctx context.Context, provider PayoutProvider) (*PayoutResult, error) {
+				return provider.CheckPayout(ctx, "cashback-42")
+			},
+			wantStatus: "processing",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.call(context.Background(), provider)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantStatus, result.Status)
+		})
+	}
+	assert.Equal(t, Uzum, Gateway("uzum"))
 }

--- a/modules/billing/domain/aggregates/billing/billing_provider_test.go
+++ b/modules/billing/domain/aggregates/billing/billing_provider_test.go
@@ -1,0 +1,38 @@
+package billing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type payoutProviderStub struct{}
+
+func (payoutProviderStub) CreatePayout(context.Context, CreatePayoutRequest) (*PayoutResult, error) {
+	return &PayoutResult{Status: "created"}, nil
+}
+
+func (payoutProviderStub) ConfirmPayout(context.Context, ConfirmPayoutRequest) (*PayoutResult, error) {
+	return &PayoutResult{Status: "completed"}, nil
+}
+
+func (payoutProviderStub) CheckPayout(context.Context, string) (*PayoutResult, error) {
+	return &PayoutResult{Status: "processing"}, nil
+}
+
+func TestPayoutProviderCapability(t *testing.T) {
+	t.Parallel()
+
+	var provider PayoutProvider = payoutProviderStub{}
+	result, err := provider.CreatePayout(context.Background(), CreatePayoutRequest{
+		ExternalID:  "cashback-42",
+		Amount:      125_000,
+		Currency:    "UZS",
+		Destination: "8600123412341234",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "created", result.Status)
+	require.Equal(t, Uzum, Gateway("uzum"))
+}

--- a/modules/billing/domain/aggregates/details/details.go
+++ b/modules/billing/domain/aggregates/details/details.go
@@ -239,6 +239,15 @@ type CashDetails interface {
 	Set(key string, value any) CashDetails
 }
 
+type PayoutDetails interface {
+	Details
+
+	Data() map[string]any
+	SetData(data map[string]any) PayoutDetails
+	Get(key string) any
+	Set(key string, value any) PayoutDetails
+}
+
 type TransferDetails interface {
 	Details
 

--- a/modules/billing/domain/aggregates/details/payout_details_impl.go
+++ b/modules/billing/domain/aggregates/details/payout_details_impl.go
@@ -1,0 +1,48 @@
+package details
+
+type PayoutOption func(d *payoutDetails)
+
+func PayoutWithData(data map[string]any) PayoutOption {
+	return func(d *payoutDetails) {
+		d.data = data
+	}
+}
+
+func NewPayoutDetails(opts ...PayoutOption) PayoutDetails {
+	d := &payoutDetails{data: make(map[string]any)}
+	for _, opt := range opts {
+		opt(d)
+	}
+	return d
+}
+
+type payoutDetails struct {
+	data map[string]any
+}
+
+func (d *payoutDetails) Data() map[string]any {
+	return d.data
+}
+
+func (d *payoutDetails) SetData(data map[string]any) PayoutDetails {
+	result := *d
+	result.data = data
+	return &result
+}
+
+func (d *payoutDetails) Get(key string) any {
+	if d.data == nil {
+		return nil
+	}
+	return d.data[key]
+}
+
+func (d *payoutDetails) Set(key string, value any) PayoutDetails {
+	result := *d
+	result.data = make(map[string]any, len(d.data)+1)
+	for k, v := range d.data {
+		result.data[k] = v
+	}
+	result.data[key] = value
+	return &result
+}

--- a/modules/billing/domain/aggregates/details/payout_details_impl.go
+++ b/modules/billing/domain/aggregates/details/payout_details_impl.go
@@ -1,10 +1,12 @@
 package details
 
+import "reflect"
+
 type PayoutOption func(d *payoutDetails)
 
 func PayoutWithData(data map[string]any) PayoutOption {
 	return func(d *payoutDetails) {
-		d.data = data
+		d.data = clonePayoutData(data)
 	}
 }
 
@@ -21,12 +23,12 @@ type payoutDetails struct {
 }
 
 func (d *payoutDetails) Data() map[string]any {
-	return d.data
+	return clonePayoutData(d.data)
 }
 
 func (d *payoutDetails) SetData(data map[string]any) PayoutDetails {
 	result := *d
-	result.data = data
+	result.data = clonePayoutData(data)
 	return &result
 }
 
@@ -34,15 +36,128 @@ func (d *payoutDetails) Get(key string) any {
 	if d.data == nil {
 		return nil
 	}
-	return d.data[key]
+	return clonePayoutValue(d.data[key])
 }
 
 func (d *payoutDetails) Set(key string, value any) PayoutDetails {
 	result := *d
-	result.data = make(map[string]any, len(d.data)+1)
-	for k, v := range d.data {
-		result.data[k] = v
+	result.data = clonePayoutData(d.data)
+	if result.data == nil {
+		result.data = make(map[string]any)
 	}
-	result.data[key] = value
+	result.data[key] = clonePayoutValue(value)
 	return &result
+}
+
+func clonePayoutData(data map[string]any) map[string]any {
+	if data == nil {
+		return nil
+	}
+	return clonePayoutReflect(
+		reflect.ValueOf(data),
+		make(map[payoutCloneVisit]reflect.Value),
+	).Interface().(map[string]any)
+}
+
+func clonePayoutValue(value any) any {
+	if value == nil {
+		return nil
+	}
+	return clonePayoutReflect(
+		reflect.ValueOf(value),
+		make(map[payoutCloneVisit]reflect.Value),
+	).Interface()
+}
+
+type payoutCloneVisit struct {
+	kind      reflect.Kind
+	valueType reflect.Type
+	pointer   uintptr
+	length    int
+	capacity  int
+}
+
+func clonePayoutReflect(value reflect.Value, visited map[payoutCloneVisit]reflect.Value) reflect.Value {
+	switch value.Kind() {
+	case reflect.Interface:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		cloned := clonePayoutReflect(value.Elem(), visited)
+		result := reflect.New(value.Type()).Elem()
+		result.Set(cloned)
+		return result
+	case reflect.Map:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		visit := payoutCloneVisit{
+			kind:      value.Kind(),
+			valueType: value.Type(),
+			pointer:   value.Pointer(),
+		}
+		if result, ok := visited[visit]; ok {
+			return result
+		}
+		result := reflect.MakeMapWithSize(value.Type(), value.Len())
+		visited[visit] = result
+		iter := value.MapRange()
+		for iter.Next() {
+			result.SetMapIndex(iter.Key(), clonePayoutReflect(iter.Value(), visited))
+		}
+		return result
+	case reflect.Slice:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		visit := payoutCloneVisit{
+			kind:      value.Kind(),
+			valueType: value.Type(),
+			pointer:   value.Pointer(),
+			length:    value.Len(),
+			capacity:  value.Cap(),
+		}
+		if result, ok := visited[visit]; ok {
+			return result
+		}
+		result := reflect.MakeSlice(value.Type(), value.Len(), value.Len())
+		visited[visit] = result
+		for i := range value.Len() {
+			result.Index(i).Set(clonePayoutReflect(value.Index(i), visited))
+		}
+		return result
+	case reflect.Array:
+		result := reflect.New(value.Type()).Elem()
+		for i := range value.Len() {
+			result.Index(i).Set(clonePayoutReflect(value.Index(i), visited))
+		}
+		return result
+	case reflect.Struct:
+		result := reflect.New(value.Type()).Elem()
+		result.Set(value)
+		for i := range value.NumField() {
+			if result.Field(i).CanSet() && value.Field(i).CanInterface() {
+				result.Field(i).Set(clonePayoutReflect(value.Field(i), visited))
+			}
+		}
+		return result
+	case reflect.Pointer:
+		if value.IsNil() {
+			return reflect.Zero(value.Type())
+		}
+		visit := payoutCloneVisit{
+			kind:      value.Kind(),
+			valueType: value.Type(),
+			pointer:   value.Pointer(),
+		}
+		if result, ok := visited[visit]; ok {
+			return result
+		}
+		result := reflect.New(value.Type().Elem())
+		visited[visit] = result
+		result.Elem().Set(clonePayoutReflect(value.Elem(), visited))
+		return result
+	default:
+		return value
+	}
 }

--- a/modules/billing/domain/aggregates/details/payout_details_impl.go
+++ b/modules/billing/domain/aggregates/details/payout_details_impl.go
@@ -95,6 +95,8 @@ func clonePayoutReflect(value reflect.Value, visited map[payoutCloneVisit]reflec
 			kind:      value.Kind(),
 			valueType: value.Type(),
 			pointer:   value.Pointer(),
+			length:    0,
+			capacity:  0,
 		}
 		if result, ok := visited[visit]; ok {
 			return result
@@ -149,6 +151,8 @@ func clonePayoutReflect(value reflect.Value, visited map[payoutCloneVisit]reflec
 			kind:      value.Kind(),
 			valueType: value.Type(),
 			pointer:   value.Pointer(),
+			length:    0,
+			capacity:  0,
 		}
 		if result, ok := visited[visit]; ok {
 			return result
@@ -157,7 +161,28 @@ func clonePayoutReflect(value reflect.Value, visited map[payoutCloneVisit]reflec
 		visited[visit] = result
 		result.Elem().Set(clonePayoutReflect(value.Elem(), visited))
 		return result
-	default:
+	case reflect.Invalid,
+		reflect.Bool,
+		reflect.Int,
+		reflect.Int8,
+		reflect.Int16,
+		reflect.Int32,
+		reflect.Int64,
+		reflect.Uint,
+		reflect.Uint8,
+		reflect.Uint16,
+		reflect.Uint32,
+		reflect.Uint64,
+		reflect.Uintptr,
+		reflect.Float32,
+		reflect.Float64,
+		reflect.Complex64,
+		reflect.Complex128,
+		reflect.Chan,
+		reflect.Func,
+		reflect.String,
+		reflect.UnsafePointer:
 		return value
 	}
+	return value
 }

--- a/modules/billing/domain/aggregates/details/payout_details_impl_test.go
+++ b/modules/billing/domain/aggregates/details/payout_details_impl_test.go
@@ -1,0 +1,120 @@
+package details
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPayoutDetailsPreservesValueOwnership(t *testing.T) {
+	t.Parallel()
+
+	input := map[string]any{
+		"nested": map[string]any{"value": "original"},
+		"items":  []any{map[string]any{"value": "original"}},
+	}
+	entity := NewPayoutDetails(PayoutWithData(input))
+
+	input["nested"].(map[string]any)["value"] = "mutated"
+	input["items"].([]any)[0].(map[string]any)["value"] = "mutated"
+	assertNestedPayoutValues(t, entity, "original")
+
+	exposed := entity.Data()
+	exposed["nested"].(map[string]any)["value"] = "mutated"
+	exposed["items"].([]any)[0].(map[string]any)["value"] = "mutated"
+	assertNestedPayoutValues(t, entity, "original")
+
+	nested := entity.Get("nested").(map[string]any)
+	nested["value"] = "mutated"
+	assertNestedPayoutValues(t, entity, "original")
+}
+
+func TestPayoutDetailsSettersPreserveValueOwnership(t *testing.T) {
+	t.Parallel()
+
+	original := NewPayoutDetails(PayoutWithData(map[string]any{
+		"nested": map[string]any{"value": "original"},
+		"items":  []any{map[string]any{"value": "original"}},
+	}))
+	replacement := map[string]any{
+		"nested": map[string]any{"value": "replacement"},
+		"items":  []any{map[string]any{"value": "replacement"}},
+	}
+
+	replaced := original.SetData(replacement)
+	replacement["nested"].(map[string]any)["value"] = "mutated"
+	replacement["items"].([]any)[0].(map[string]any)["value"] = "mutated"
+	assertNestedPayoutValues(t, replaced, "replacement")
+	assertNestedPayoutValues(t, original, "original")
+
+	value := map[string]any{"value": "added"}
+	updated := original.Set("added", value)
+	value["value"] = "mutated"
+	require.IsType(t, map[string]any{}, updated.Get("added"))
+	assert.Equal(t, "added", updated.Get("added").(map[string]any)["value"])
+	assert.Nil(t, original.Get("added"))
+}
+
+func TestPayoutDetailsSetAllocatesAfterNilData(t *testing.T) {
+	t.Parallel()
+
+	entity := NewPayoutDetails(PayoutWithData(nil)).Set("key", "value")
+	assert.Equal(t, "value", entity.Get("key"))
+}
+
+func TestPayoutDetailsClonesCyclicContainers(t *testing.T) {
+	t.Parallel()
+
+	cyclicMap := make(map[string]any)
+	cyclicMap["self"] = cyclicMap
+	cyclicSlice := make([]any, 1)
+	cyclicSlice[0] = cyclicSlice
+
+	entity := NewPayoutDetails(PayoutWithData(map[string]any{
+		"map":   cyclicMap,
+		"slice": cyclicSlice,
+	}))
+	data := entity.Data()
+
+	clonedMap := data["map"].(map[string]any)
+	assert.Equal(t, reflect.ValueOf(clonedMap).Pointer(), reflect.ValueOf(clonedMap["self"]).Pointer())
+	clonedSlice := data["slice"].([]any)
+	assert.Equal(t, reflect.ValueOf(clonedSlice).Pointer(), reflect.ValueOf(clonedSlice[0]).Pointer())
+}
+
+func TestPayoutDetailsClonesJSONStructFields(t *testing.T) {
+	t.Parallel()
+
+	type payload struct {
+		Values map[string]string `json:"values"`
+		Items  []string          `json:"items"`
+	}
+	input := payload{
+		Values: map[string]string{"key": "original"},
+		Items:  []string{"original"},
+	}
+	entity := NewPayoutDetails(PayoutWithData(map[string]any{"payload": input}))
+
+	input.Values["key"] = "mutated"
+	input.Items[0] = "mutated"
+	cloned := entity.Get("payload").(payload)
+	assert.Equal(t, "original", cloned.Values["key"])
+	assert.Equal(t, "original", cloned.Items[0])
+
+	cloned.Values["key"] = "mutated"
+	cloned.Items[0] = "mutated"
+	cloned = entity.Get("payload").(payload)
+	assert.Equal(t, "original", cloned.Values["key"])
+	assert.Equal(t, "original", cloned.Items[0])
+}
+
+func assertNestedPayoutValues(t *testing.T, entity PayoutDetails, expected string) {
+	t.Helper()
+	data := entity.Data()
+	require.IsType(t, map[string]any{}, data["nested"])
+	require.IsType(t, []any{}, data["items"])
+	assert.Equal(t, expected, data["nested"].(map[string]any)["value"])
+	assert.Equal(t, expected, data["items"].([]any)[0].(map[string]any)["value"])
+}

--- a/modules/billing/infrastructure/persistence/billing_mappers.go
+++ b/modules/billing/infrastructure/persistence/billing_mappers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/iota-uz/iota-sdk/modules/billing/domain/aggregates/billing"
 	"github.com/iota-uz/iota-sdk/modules/billing/domain/aggregates/details"
 	"github.com/iota-uz/iota-sdk/modules/billing/infrastructure/persistence/models"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
 )
 
 func ToDomainTransaction(dbRow *models.Transaction) (billing.Transaction, error) {
@@ -62,6 +63,8 @@ func ToDBTransaction(entity billing.Transaction) (*models.Transaction, error) {
 }
 
 func ToDomainDetails(gateway billing.Gateway, data json.RawMessage) (details.Details, error) {
+	const op serrors.Op = "billing.persistence.ToDomainDetails"
+
 	switch gateway {
 	case billing.Click:
 		var d models.ClickDetails
@@ -208,7 +211,7 @@ func ToDomainDetails(gateway billing.Gateway, data json.RawMessage) (details.Det
 	case billing.Uzum:
 		var d models.PayoutDetails
 		if err := json.Unmarshal(data, &d); err != nil {
-			return nil, err
+			return nil, serrors.E(op, err, "deserialize payout details")
 		}
 		return details.NewPayoutDetails(details.PayoutWithData(d.Data)), nil
 
@@ -240,6 +243,8 @@ func ToDomainDetails(gateway billing.Gateway, data json.RawMessage) (details.Det
 }
 
 func ToDBDetails(data details.Details) (json.RawMessage, error) {
+	const op serrors.Op = "billing.persistence.ToDBDetails"
+
 	switch d := data.(type) {
 	case details.ClickDetails:
 		return json.Marshal(&models.ClickDetails{
@@ -345,9 +350,13 @@ func ToDBDetails(data details.Details) (json.RawMessage, error) {
 		})
 
 	case details.PayoutDetails:
-		return json.Marshal(&models.PayoutDetails{
+		result, err := json.Marshal(&models.PayoutDetails{
 			Data: d.Data(),
 		})
+		if err != nil {
+			return nil, serrors.E(op, err, "serialize payout details")
+		}
+		return result, nil
 
 	case details.TransferDetails:
 		return json.Marshal(&models.TransferDetails{

--- a/modules/billing/infrastructure/persistence/billing_mappers.go
+++ b/modules/billing/infrastructure/persistence/billing_mappers.go
@@ -205,6 +205,13 @@ func ToDomainDetails(gateway billing.Gateway, data json.RawMessage) (details.Det
 		cashDetails := details.NewCashDetails(details.CashWithData(d.Data))
 		return cashDetails, nil
 
+	case billing.Uzum:
+		var d models.PayoutDetails
+		if err := json.Unmarshal(data, &d); err != nil {
+			return nil, err
+		}
+		return details.NewPayoutDetails(details.PayoutWithData(d.Data)), nil
+
 	case billing.Transfer:
 		var d models.TransferDetails
 		if err := json.Unmarshal(data, &d); err != nil {
@@ -334,6 +341,11 @@ func ToDBDetails(data details.Details) (json.RawMessage, error) {
 
 	case details.CashDetails:
 		return json.Marshal(&models.CashDetails{
+			Data: d.Data(),
+		})
+
+	case details.PayoutDetails:
+		return json.Marshal(&models.PayoutDetails{
 			Data: d.Data(),
 		})
 

--- a/modules/billing/infrastructure/persistence/billing_mappers_test.go
+++ b/modules/billing/infrastructure/persistence/billing_mappers_test.go
@@ -288,3 +288,19 @@ func TestToDomainTransaction_InvalidJSON(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse details")
 }
+
+func TestPayoutDetailsMapperErrorsIncludeOperation(t *testing.T) {
+	t.Parallel()
+
+	_, err := persistence.ToDomainDetails(billing.Uzum, json.RawMessage(`{`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "billing.persistence.ToDomainDetails")
+	assert.Contains(t, err.Error(), "deserialize payout details")
+
+	_, err = persistence.ToDBDetails(details.NewPayoutDetails(
+		details.PayoutWithData(map[string]any{"unsupported": func() {}}),
+	))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "billing.persistence.ToDBDetails")
+	assert.Contains(t, err.Error(), "serialize payout details")
+}

--- a/modules/billing/infrastructure/persistence/billing_mappers_test.go
+++ b/modules/billing/infrastructure/persistence/billing_mappers_test.go
@@ -180,6 +180,22 @@ func TestTransactionMapping(t *testing.T) {
 				assert.Len(t, cash.Data(), 3)
 			},
 		},
+		{
+			name:    "PayoutDetails",
+			gateway: billing.Uzum,
+			details: details.NewPayoutDetails(
+				details.PayoutWithData(map[string]any{
+					"external_id": "cashback-42",
+					"direction":   "outbound",
+				}),
+			),
+			validate: func(t *testing.T, d details.Details) {
+				t.Helper()
+				payout := d.(details.PayoutDetails)
+				assert.Equal(t, "cashback-42", payout.Get("external_id"))
+				assert.Equal(t, "outbound", payout.Get("direction"))
+			},
+		},
 		//{
 		//	name:    "StripeDetails",
 		//	gateway: billing.Stripe,

--- a/modules/billing/infrastructure/persistence/billing_repository_test.go
+++ b/modules/billing/infrastructure/persistence/billing_repository_test.go
@@ -53,6 +53,51 @@ func TestBillingRepository_Create(t *testing.T) {
 	assert.Equal(t, "https://example.com/pay", click.Link())
 }
 
+func TestBillingRepository_CreateNewGateways(t *testing.T) {
+	t.Parallel()
+	f := setupTest(t)
+	repository := persistence.NewBillingRepository()
+
+	tenant, err := composables.UseTenantID(f.Ctx)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		gateway billing.Gateway
+		details details.Details
+	}{
+		{
+			name:    "transfer",
+			gateway: billing.Transfer,
+			details: details.NewTransferDetails(details.TransferWithComment("bank transfer")),
+		},
+		{
+			name:    "uzum",
+			gateway: billing.Uzum,
+			details: details.NewPayoutDetails(details.PayoutWithData(map[string]any{
+				"external_id": "cashback-42",
+				"direction":   "outbound",
+			})),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transaction := billing.New(
+				100,
+				billing.UZS,
+				tt.gateway,
+				tt.details,
+				billing.WithTenantID(tenant),
+				billing.WithStatus(billing.Created),
+			)
+
+			created, err := repository.Save(f.Ctx, transaction)
+			require.NoError(t, err)
+			assert.Equal(t, tt.gateway, created.Gateway())
+		})
+	}
+}
+
 func TestBillingRepository_GetByID(t *testing.T) {
 	t.Parallel()
 	f := setupTest(t)

--- a/modules/billing/infrastructure/persistence/models/models.go
+++ b/modules/billing/infrastructure/persistence/models/models.go
@@ -122,6 +122,10 @@ type CashDetails struct {
 	Data map[string]any `json:"data"`
 }
 
+type PayoutDetails struct {
+	Data map[string]any `json:"data"`
+}
+
 type TransferDetails struct {
 	Data    map[string]any `json:"data"`
 	Comment string         `json:"comment"`

--- a/modules/billing/infrastructure/persistence/schema/billing-schema.sql
+++ b/modules/billing/infrastructure/persistence/schema/billing-schema.sql
@@ -4,7 +4,7 @@ CREATE TABLE billing_transactions (
     status varchar(50) NOT NULL CHECK (status IN ('created', 'pending', 'completed', 'failed', 'canceled', 'refunded', 'partially-refunded', 'expired')),
     quantity float8 NOT NULL,
     currency varchar(3) NOT NULL CHECK (currency IN ('UZS', 'USD', 'EUR', 'RUB')),
-    gateway varchar(50) NOT NULL CHECK (gateway IN ('click', 'payme', 'octo', 'stripe')),
+    gateway varchar(50) NOT NULL CHECK (gateway IN ('click', 'payme', 'octo', 'stripe', 'uzum')),
     details jsonb NOT NULL,
     created_at timestamptz NOT NULL DEFAULT NOW(),
     updated_at timestamptz NOT NULL DEFAULT NOW()
@@ -15,4 +15,3 @@ CREATE INDEX idx_billing_transactions_status ON billing_transactions (status);
 CREATE INDEX idx_billing_transactions_gateway ON billing_transactions (gateway);
 
 CREATE INDEX idx_billing_transactions_tenant_id ON billing_transactions (tenant_id);
-

--- a/modules/billing/infrastructure/persistence/schema/billing-schema.sql
+++ b/modules/billing/infrastructure/persistence/schema/billing-schema.sql
@@ -15,3 +15,4 @@ CREATE INDEX idx_billing_transactions_status ON billing_transactions (status);
 CREATE INDEX idx_billing_transactions_gateway ON billing_transactions (gateway);
 
 CREATE INDEX idx_billing_transactions_tenant_id ON billing_transactions (tenant_id);
+

--- a/modules/billing/infrastructure/persistence/schema/billing-schema.sql
+++ b/modules/billing/infrastructure/persistence/schema/billing-schema.sql
@@ -4,7 +4,7 @@ CREATE TABLE billing_transactions (
     status varchar(50) NOT NULL CHECK (status IN ('created', 'pending', 'completed', 'failed', 'canceled', 'refunded', 'partially-refunded', 'expired')),
     quantity float8 NOT NULL,
     currency varchar(3) NOT NULL CHECK (currency IN ('UZS', 'USD', 'EUR', 'RUB')),
-    gateway varchar(50) NOT NULL CHECK (gateway IN ('click', 'payme', 'octo', 'stripe', 'uzum')),
+    gateway varchar(50) NOT NULL CHECK (gateway IN ('click', 'payme', 'octo', 'stripe', 'cash', 'transfer', 'integrator', 'uzum')),
     details jsonb NOT NULL,
     created_at timestamptz NOT NULL DEFAULT NOW(),
     updated_at timestamptz NOT NULL DEFAULT NOW()

--- a/modules/billing/infrastructure/providers/octo_provider.go
+++ b/modules/billing/infrastructure/providers/octo_provider.go
@@ -143,7 +143,7 @@ func (o *octoProvider) CheckStatus(ctx context.Context, shopTransactionID string
 	result := &billing.StatusCheckResult{
 		Status:            resp.Data.GetStatus(),
 		ShopTransactionID: resp.Data.GetShopTransactionId(),
-		OctoPaymentUUID:   resp.Data.GetOctoPaymentUUID(),
+		ProviderPaymentID: resp.Data.GetOctoPaymentUUID(),
 	}
 
 	return result, nil


### PR DESCRIPTION
## Summary

- add a generic optional `PayoutProvider` capability for irreversible outbound payments
- add provider-neutral payout request/result value types and the Uzum gateway identifier
- generalize `StatusCheckResult` so it no longer exposes an Octo-specific field

## Why

EAI needs a reusable outbound payout rail without overloading the inbound payment `Provider` methods or pretending `Refund`/`Cancel` are payout clawbacks. The capability remains generic and optional for any billing gateway.

## Validation

- `go test ./modules/billing/...`
- `go vet ./modules/billing/...`

Consumer: iota-uz/eai#3427

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787855799&installation_model_id=2042&pr_number=938&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F938&signature=05618fe779b14bd3f62c862f482a28ecf484bbc3d2926044b0cfbb4b4432280d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the Uzum payment gateway.
  - Introduced payout workflows for creating, confirming, and checking payouts.
  - Added flexible payout details with custom key/value data and optional document fields.
  - Enabled saving and restoring payout information with its associated transaction.

- **Improvements**
  - Standardized provider payment identifiers in payout status results.
  - Updated Octo status mapping to use the unified provider payment identifier.

- **Tests**
  - Added coverage for payout provider capability and Uzum payout details mapping.

- **Chores**
  - Updated the billing database schema to allow Uzum and added supporting indexes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->