### PR TITLE
feat(bichat): durable trusted continuation runs

### DIFF
--- a/modules/bichat/component.go
+++ b/modules/bichat/component.go
@@ -194,6 +194,9 @@ func (c *component) Build(builder *composition.Builder) error {
 	provideBundleField(builder, func(b *bichatBundle) bichatservices.SessionCommands { return b.services.SessionCommands() })
 	provideBundleField(builder, func(b *bichatBundle) bichatservices.SessionQueries { return b.services.SessionQueries() })
 	provideBundleField(builder, func(b *bichatBundle) bichatservices.TurnCommands { return b.services.TurnCommands() })
+	provideBundleField(builder, func(b *bichatBundle) bichatservices.ContinuationCommands {
+		return b.services.ContinuationCommands()
+	})
 	provideBundleField(builder, func(b *bichatBundle) bichatservices.TurnQueries { return b.services.TurnQueries() })
 	provideBundleField(builder, func(b *bichatBundle) bichatservices.StreamCommands { return b.services.StreamCommands() })
 	provideBundleField(builder, func(b *bichatBundle) bichatservices.HITLCommands { return b.services.HITLCommands() })

--- a/modules/bichat/config.go
+++ b/modules/bichat/config.go
@@ -293,20 +293,21 @@ type ModuleConfig struct {
 // ServiceContainer holds built services created by ModuleConfig.BuildServices().
 // Use accessor methods to retrieve individual services.
 type ServiceContainer struct {
-	sessionCommands   bichatservices.SessionCommands
-	sessionQueries    bichatservices.SessionQueries
-	turnCommands      bichatservices.TurnCommands
-	turnQueries       bichatservices.TurnQueries
-	streamCommands    bichatservices.StreamCommands
-	hitlCommands      bichatservices.HITLCommands
-	agentService      bichatservices.AgentService
-	attachmentService bichatservices.AttachmentService
-	artifactService   bichatservices.ArtifactService
-	observability     *services.StreamObservability
-	titleService      services.TitleService
-	titleJobQueue     *services.RedisTitleJobQueue
-	titleQueueConfig  *TitleQueueConfig
-	logger            *logrus.Logger
+	sessionCommands      bichatservices.SessionCommands
+	sessionQueries       bichatservices.SessionQueries
+	turnCommands         bichatservices.TurnCommands
+	continuationCommands bichatservices.ContinuationCommands
+	turnQueries          bichatservices.TurnQueries
+	streamCommands       bichatservices.StreamCommands
+	hitlCommands         bichatservices.HITLCommands
+	agentService         bichatservices.AgentService
+	attachmentService    bichatservices.AttachmentService
+	artifactService      bichatservices.ArtifactService
+	observability        *services.StreamObservability
+	titleService         services.TitleService
+	titleJobQueue        *services.RedisTitleJobQueue
+	titleQueueConfig     *TitleQueueConfig
+	logger               *logrus.Logger
 	// sharedRedisClose is the single owner of the *redis.Client shared across
 	// all Redis-backed components (event log, active-run index, job queue).
 	// Component Close() calls are no-ops when the client was supplied externally.
@@ -328,6 +329,11 @@ func (sc *ServiceContainer) SessionQueries() bichatservices.SessionQueries { ret
 
 // TurnCommands returns non-streaming turn command actions.
 func (sc *ServiceContainer) TurnCommands() bichatservices.TurnCommands { return sc.turnCommands }
+
+// ContinuationCommands returns trusted internal continuation actions.
+func (sc *ServiceContainer) ContinuationCommands() bichatservices.ContinuationCommands {
+	return sc.continuationCommands
+}
 
 // TurnQueries returns turn query actions.
 func (sc *ServiceContainer) TurnQueries() bichatservices.TurnQueries { return sc.turnQueries }

--- a/modules/bichat/config_build.go
+++ b/modules/bichat/config_build.go
@@ -201,6 +201,7 @@ func (c *ModuleConfig) BuildServices() (*ServiceContainer, error) {
 		sessionCommands:      chatServices.SessionCommands,
 		sessionQueries:       chatServices.SessionQueries,
 		turnCommands:         chatServices.TurnCommands,
+		continuationCommands: chatServices.ContinuationCommands,
 		turnQueries:          chatServices.TurnQueries,
 		streamCommands:       chatServices.StreamCommands,
 		hitlCommands:         chatServices.HITLCommands,

--- a/modules/bichat/infrastructure/llmproviders/openai_input_mapper.go
+++ b/modules/bichat/infrastructure/llmproviders/openai_input_mapper.go
@@ -192,6 +192,14 @@ func (m *OpenAIModel) buildInputItems(messages []types.Message) responses.Respon
 }
 
 func (m *OpenAIModel) buildInputItemsWithContext(ctx context.Context, messages []types.Message) responses.ResponseInputParam {
+	return m.buildInputItemsWithContextOptions(ctx, messages, false)
+}
+
+func (m *OpenAIModel) buildInputItemsWithContextOptions(
+	ctx context.Context,
+	messages []types.Message,
+	allowPreviousResponseToolOutputs bool,
+) responses.ResponseInputParam {
 	resolved := m.resolveImageUploadsForMessages(ctx, messages)
 	validToolCalls := m.validToolCallIDsFromMessages(messages)
 
@@ -253,10 +261,10 @@ func (m *OpenAIModel) buildInputItemsWithContext(ctx context.Context, messages [
 				continue
 			}
 			toolName, ok := validToolCalls[callID]
-			if !ok {
+			if !ok && !allowPreviousResponseToolOutputs {
 				continue
 			}
-			if toolName == webFetchToolName {
+			if ok && toolName == webFetchToolName {
 				if richOutput, ok := buildWebFetchFunctionCallOutput(ctx, msg.Content(), m.logger); ok {
 					items = append(items, responses.ResponseInputItemParamOfFunctionCallOutput(
 						callID,

--- a/modules/bichat/infrastructure/llmproviders/openai_model_test.go
+++ b/modules/bichat/infrastructure/llmproviders/openai_model_test.go
@@ -227,6 +227,27 @@ func TestOpenAIModel_BuildResponseParams(t *testing.T) {
 	assert.NotNil(t, params.Text.Format.OfJSONObject)
 }
 
+func TestOpenAIModel_BuildResponseParams_AllowsToolOutputFromPreviousResponse(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewOpenAIModelFromConfig(testCfg())
+	require.NoError(t, err)
+	oaiModel := model.(*OpenAIModel)
+	previousResponseID := "resp_with_tool_call"
+	params := oaiModel.buildResponseParams(context.Background(), agents.Request{
+		Messages: []types.Message{
+			types.SystemMessage("Keep the developer instruction."),
+			types.ToolResponse("call_from_previous_response", `{"value":"found"}`),
+		},
+		PreviousResponseID: &previousResponseID,
+	}, agents.GenerateConfig{})
+
+	require.True(t, params.PreviousResponseID.Valid())
+	assert.Equal(t, previousResponseID, params.PreviousResponseID.Value)
+	require.NotNil(t, params.Input.OfInputItemList)
+	assert.Len(t, params.Input.OfInputItemList, 2)
+}
+
 func TestOpenAIModel_BuildResponseParams_NativeWebSearch(t *testing.T) {
 	model, err := NewOpenAIModelFromConfig(testCfg())
 	require.NoError(t, err)

--- a/modules/bichat/infrastructure/llmproviders/openai_params_builder.go
+++ b/modules/bichat/infrastructure/llmproviders/openai_params_builder.go
@@ -21,15 +21,19 @@ func (m *OpenAIModel) buildResponseParams(ctx context.Context, req agents.Reques
 		Store: openai.Bool(true),
 	}
 
-	inputItems := m.buildInputItemsWithContext(ctx, req.Messages)
+	hasPreviousResponse := req.PreviousResponseID != nil &&
+		strings.TrimSpace(*req.PreviousResponseID) != ""
+	inputItems := m.buildInputItemsWithContextOptions(
+		ctx,
+		req.Messages,
+		hasPreviousResponse,
+	)
 	params.Input = responses.ResponseNewParamsInputUnion{
 		OfInputItemList: inputItems,
 	}
-	if req.PreviousResponseID != nil {
+	if hasPreviousResponse {
 		previousResponseID := strings.TrimSpace(*req.PreviousResponseID)
-		if previousResponseID != "" {
-			params.PreviousResponseID = openai.String(previousResponseID)
-		}
+		params.PreviousResponseID = openai.String(previousResponseID)
 	}
 
 	if config.MaxTokens != nil {

--- a/modules/bichat/infrastructure/persistence/postgres_chat_repository.go
+++ b/modules/bichat/infrastructure/persistence/postgres_chat_repository.go
@@ -296,6 +296,14 @@ const (
 			id, session_id, tenant_id, user_id, status, partial_content, partial_metadata, started_at, last_updated_at
 		) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 	`
+	cancelStaleGenerationRunQuery = `
+		UPDATE bichat.generation_runs
+		SET status = 'cancelled', last_updated_at = $1::timestamptz
+		WHERE tenant_id = $3
+		  AND session_id = $4
+		  AND status = 'streaming'
+		  AND last_updated_at < $2::timestamptz
+	`
 	selectActiveGenerationRunBySessionQuery = `
 		SELECT id, session_id, tenant_id, user_id, status, partial_content, partial_metadata, started_at, last_updated_at
 		FROM bichat.generation_runs
@@ -308,6 +316,21 @@ const (
 		WHERE tenant_id = $1 AND id = $2
 		LIMIT 1
 	`
+	restartGenerationRunQuery = `
+		UPDATE bichat.generation_runs
+		SET status = 'streaming',
+		    partial_content = '',
+		    partial_metadata = '{}'::jsonb,
+		    started_at = $1,
+		    last_updated_at = $1
+		WHERE tenant_id = $3
+		  AND id = $4
+		  AND (
+		      status IN ('cancelled', 'failed')
+		      OR (status = 'streaming' AND last_updated_at < $2)
+		  )
+		RETURNING id, session_id, tenant_id, user_id, status, partial_content, partial_metadata, started_at, last_updated_at
+	`
 	updateGenerationRunSnapshotQuery = `
 		UPDATE bichat.generation_runs
 		SET partial_content = $1, partial_metadata = $2, last_updated_at = $3
@@ -316,6 +339,11 @@ const (
 	completeGenerationRunQuery = `
 		UPDATE bichat.generation_runs
 		SET status = 'completed', last_updated_at = $1
+		WHERE tenant_id = $2 AND id = $3
+	`
+	failGenerationRunQuery = `
+		UPDATE bichat.generation_runs
+		SET status = 'failed', last_updated_at = $1
 		WHERE tenant_id = $2 AND id = $3
 	`
 	cancelGenerationRunQuery = `
@@ -1477,6 +1505,21 @@ func (r *PostgresChatRepository) CreateRun(ctx context.Context, run domain.Gener
 	}
 	model.TenantID = tenantID
 
+	// Redis is optional, but the PostgreSQL refresh-state table is not. If a
+	// process dies while streaming, its row cannot heartbeat and must not
+	// block the next durable continuation forever.
+	now := time.Now()
+	if _, err := tx.Exec(
+		ctx,
+		cancelStaleGenerationRunQuery,
+		now,
+		now.Add(-domain.GenerationRunStaleAfter),
+		tenantID,
+		model.SessionID,
+	); err != nil {
+		return serrors.E(op, err)
+	}
+
 	_, err = tx.Exec(ctx, insertGenerationRunQuery,
 		model.ID,
 		model.SessionID,
@@ -1578,6 +1621,54 @@ func (r *PostgresChatRepository) GetRunByID(ctx context.Context, runID uuid.UUID
 	return runEntity, nil
 }
 
+// RestartRun atomically reopens a terminal run for an idempotent retry.
+func (r *PostgresChatRepository) RestartRun(
+	ctx context.Context,
+	runID uuid.UUID,
+	staleBefore time.Time,
+) (domain.GenerationRun, error) {
+	const op serrors.Op = "PostgresChatRepository.RestartRun"
+
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return nil, serrors.E(op, err)
+	}
+	tx, err := composables.UseTx(ctx)
+	if err != nil {
+		return nil, serrors.E(op, err)
+	}
+
+	row := tx.QueryRow(ctx, restartGenerationRunQuery, time.Now(), staleBefore, tenantID, runID)
+	var model models.GenerationRunModel
+	err = row.Scan(
+		&model.ID,
+		&model.SessionID,
+		&model.TenantID,
+		&model.UserID,
+		&model.Status,
+		&model.PartialContent,
+		&model.PartialMeta,
+		&model.StartedAt,
+		&model.LastUpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, domain.ErrRunNotFound
+		}
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return nil, domain.ErrActiveRunExists
+		}
+		return nil, serrors.E(op, err)
+	}
+
+	runEntity, err := model.ToDomain()
+	if err != nil {
+		return nil, serrors.E(op, err)
+	}
+	return runEntity, nil
+}
+
 // UpdateRunSnapshot updates partial content and metadata for the run.
 func (r *PostgresChatRepository) UpdateRunSnapshot(ctx context.Context, runID uuid.UUID, partialContent string, partialMetadata map[string]any) error {
 	const op serrors.Op = "PostgresChatRepository.UpdateRunSnapshot"
@@ -1617,6 +1708,26 @@ func (r *PostgresChatRepository) CompleteRun(ctx context.Context, runID uuid.UUI
 	}
 
 	_, err = tx.Exec(ctx, completeGenerationRunQuery, time.Now(), tenantID, runID)
+	if err != nil {
+		return serrors.E(op, err)
+	}
+	return nil
+}
+
+// FailRun marks the run as failed.
+func (r *PostgresChatRepository) FailRun(ctx context.Context, runID uuid.UUID) error {
+	const op serrors.Op = "PostgresChatRepository.FailRun"
+
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return serrors.E(op, err)
+	}
+	tx, err := composables.UseTx(ctx)
+	if err != nil {
+		return serrors.E(op, err)
+	}
+
+	_, err = tx.Exec(ctx, failGenerationRunQuery, time.Now(), tenantID, runID)
 	if err != nil {
 		return serrors.E(op, err)
 	}

--- a/modules/bichat/services/agent_service_impl.go
+++ b/modules/bichat/services/agent_service_impl.go
@@ -138,7 +138,33 @@ func (s *agentServiceImpl) ProcessMessage(
 	content string,
 	attachments []domain.Attachment,
 ) (types.Generator[agents.ExecutorEvent], error) {
-	const op serrors.Op = "agentServiceImpl.ProcessMessage"
+	return s.process(ctx, sessionID, content, attachments, "")
+}
+
+// ProcessContinuation executes a trusted internal continuation in the same
+// session without synthesizing a user turn.
+func (s *agentServiceImpl) ProcessContinuation(
+	ctx context.Context,
+	sessionID uuid.UUID,
+	event services.ContinuationEvent,
+) (types.Generator[agents.ExecutorEvent], error) {
+	const op serrors.Op = "agentServiceImpl.ProcessContinuation"
+	prompt, err := event.Prompt()
+	if err != nil {
+		return nil, serrors.E(op, serrors.KindValidation, err)
+	}
+	ctx = services.WithContinuationEvent(ctx, event)
+	return s.process(ctx, sessionID, "", nil, prompt)
+}
+
+func (s *agentServiceImpl) process(
+	ctx context.Context,
+	sessionID uuid.UUID,
+	content string,
+	attachments []domain.Attachment,
+	continuation string,
+) (types.Generator[agents.ExecutorEvent], error) {
+	const op serrors.Op = "agentServiceImpl.process"
 	ctx = agents.WithRuntimeSessionID(ctx, sessionID)
 
 	// Get tenant ID for multi-tenant isolation
@@ -208,16 +234,26 @@ You are assisting a developer in diagnostic mode. Provide complete and explicit 
 		builder.History(historyCodec, historyPayload)
 	}
 
-	// 3. Current user turn (KindTurn)
-	turnCodec := codecs.NewTurnCodec()
-	turnPayload := codecs.TurnPayload{
-		Content: content,
+	if continuation != "" {
+		builder.Continuation(
+			codecs.NewSystemRulesCodec(),
+			continuation,
+			bichatctx.BlockOptions{
+				Sensitivity: bichatctx.SensitivityInternal,
+				Source:      "internal-continuation",
+				Tags:        []string{"internal", "continuation"},
+			},
+		)
+	} else {
+		turnCodec := codecs.NewTurnCodec()
+		turnPayload := codecs.TurnPayload{
+			Content: content,
+		}
+		if len(attachments) > 0 {
+			turnPayload.Attachments = codecs.ConvertAttachmentsToTurnAttachments(convertToTypeAttachments(attachments))
+		}
+		builder.Turn(turnCodec, turnPayload)
 	}
-	// Add attachments if present
-	if len(attachments) > 0 {
-		turnPayload.Attachments = codecs.ConvertAttachmentsToTurnAttachments(convertToTypeAttachments(attachments))
-	}
-	builder.Turn(turnCodec, turnPayload)
 
 	// Compile with renderer and policy
 	compiled, err := builder.Compile(s.renderer, s.policy)

--- a/modules/bichat/services/agent_service_impl_test.go
+++ b/modules/bichat/services/agent_service_impl_test.go
@@ -208,6 +208,12 @@ func (s *spyRenderer) Render(block bichatctx.ContextBlock) (bichatctx.RenderedBl
 		}
 		return bichatctx.RenderedBlock{Messages: []types.Message{types.SystemMessage("history")}}, nil
 
+	case bichatctx.KindContinuation:
+		if v, ok := block.Payload.(string); ok && v != "" {
+			return bichatctx.RenderedBlock{Messages: []types.Message{types.SystemMessage(v)}}, nil
+		}
+		return bichatctx.RenderedBlock{Messages: []types.Message{types.SystemMessage("continuation")}}, nil
+
 	case bichatctx.KindTurn:
 		if t, ok := block.Payload.(codecs.TurnPayload); ok {
 			return bichatctx.RenderedBlock{Messages: []types.Message{types.UserMessage(t.Content)}}, nil
@@ -300,6 +306,7 @@ type mockChatRepository struct {
 	messages    map[uuid.UUID][]types.Message
 	attachments map[uuid.UUID]domain.Attachment
 	artifacts   map[uuid.UUID]domain.Artifact
+	runs        map[uuid.UUID]domain.GenerationRun
 }
 
 func newMockChatRepository() *mockChatRepository {
@@ -308,6 +315,7 @@ func newMockChatRepository() *mockChatRepository {
 		messages:    make(map[uuid.UUID][]types.Message),
 		attachments: make(map[uuid.UUID]domain.Attachment),
 		artifacts:   make(map[uuid.UUID]domain.Artifact),
+		runs:        make(map[uuid.UUID]domain.GenerationRun),
 	}
 }
 
@@ -682,27 +690,245 @@ func (m *mockChatRepository) GetPendingQuestionMessage(ctx context.Context, sess
 }
 
 func (m *mockChatRepository) CreateRun(ctx context.Context, run domain.GenerationRun) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.runs[run.ID()]; exists {
+		return domain.ErrActiveRunExists
+	}
+	staleBefore := time.Now().Add(-domain.GenerationRunStaleAfter)
+	for id, existing := range m.runs {
+		lastSeen := existing.LastUpdatedAt()
+		if lastSeen.IsZero() {
+			lastSeen = existing.StartedAt()
+		}
+		if existing.Status() == domain.GenerationRunStatusStreaming &&
+			lastSeen.Before(staleBefore) {
+			cancelled, err := existing.Cancel(time.Now())
+			if err != nil {
+				return err
+			}
+			m.runs[id] = cancelled
+		}
+	}
+	for _, existing := range m.runs {
+		if existing.SessionID() == run.SessionID() &&
+			existing.Status() == domain.GenerationRunStatusStreaming {
+			return domain.ErrActiveRunExists
+		}
+	}
+	m.runs[run.ID()] = run
 	return nil
 }
 
 func (m *mockChatRepository) GetActiveRunBySession(ctx context.Context, sessionID uuid.UUID) (domain.GenerationRun, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, run := range m.runs {
+		if run.SessionID() == sessionID && run.Status() == domain.GenerationRunStatusStreaming {
+			return run, nil
+		}
+	}
 	return nil, domain.ErrNoActiveRun
 }
 
 func (m *mockChatRepository) GetRunByID(ctx context.Context, runID uuid.UUID) (domain.GenerationRun, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	run, ok := m.runs[runID]
+	if ok {
+		return run, nil
+	}
 	return nil, domain.ErrRunNotFound
 }
 
+func (m *mockChatRepository) RestartRun(
+	ctx context.Context,
+	runID uuid.UUID,
+	staleBefore time.Time,
+) (domain.GenerationRun, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	run, ok := m.runs[runID]
+	if !ok {
+		return nil, domain.ErrRunNotFound
+	}
+	if run.Status() == domain.GenerationRunStatusStreaming &&
+		!run.LastUpdatedAt().Before(staleBefore) {
+		return nil, domain.ErrRunNotFound
+	}
+	if run.Status() != domain.GenerationRunStatusStreaming &&
+		run.Status() != domain.GenerationRunStatusCancelled &&
+		run.Status() != domain.GenerationRunStatusFailed {
+		return nil, domain.ErrRunNotFound
+	}
+	for id, existing := range m.runs {
+		if id != runID &&
+			existing.SessionID() == run.SessionID() &&
+			existing.Status() == domain.GenerationRunStatusStreaming {
+			return nil, domain.ErrActiveRunExists
+		}
+	}
+	restarted, err := domain.NewGenerationRun(domain.GenerationRunSpec{
+		ID:        run.ID(),
+		SessionID: run.SessionID(),
+		TenantID:  run.TenantID(),
+		UserID:    run.UserID(),
+		StartedAt: time.Now(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	m.runs[runID] = restarted
+	return restarted, nil
+}
+
 func (m *mockChatRepository) UpdateRunSnapshot(ctx context.Context, runID uuid.UUID, partialContent string, partialMetadata map[string]any) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	run, ok := m.runs[runID]
+	if !ok {
+		return domain.ErrRunNotFound
+	}
+	updated, err := run.UpdateSnapshot(partialContent, partialMetadata, time.Now())
+	if err != nil {
+		return err
+	}
+	m.runs[runID] = updated
 	return nil
 }
 
 func (m *mockChatRepository) CompleteRun(ctx context.Context, runID uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	run, ok := m.runs[runID]
+	if !ok {
+		return nil
+	}
+	completed, err := run.Complete(time.Now())
+	if err != nil {
+		if run.Status() == domain.GenerationRunStatusCompleted {
+			return nil
+		}
+		return err
+	}
+	m.runs[runID] = completed
+	return nil
+}
+
+func (m *mockChatRepository) FailRun(ctx context.Context, runID uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	run, ok := m.runs[runID]
+	if !ok {
+		return nil
+	}
+	failed, err := run.Fail(time.Now())
+	if err != nil {
+		if run.Status() == domain.GenerationRunStatusFailed {
+			return nil
+		}
+		return err
+	}
+	m.runs[runID] = failed
 	return nil
 }
 
 func (m *mockChatRepository) CancelRun(ctx context.Context, runID uuid.UUID) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	run, ok := m.runs[runID]
+	if !ok {
+		return nil
+	}
+	cancelled, err := run.Cancel(time.Now())
+	if err != nil {
+		if run.Status() == domain.GenerationRunStatusCancelled {
+			return nil
+		}
+		return err
+	}
+	m.runs[runID] = cancelled
 	return nil
+}
+
+func TestProcessContinuation_UsesInternalBlockWithoutUserTurn(t *testing.T) {
+	t.Parallel()
+
+	agent := newMockAgent()
+	model := newMockModel()
+	renderer := &spyRenderer{}
+	chatRepo := newMockChatRepository()
+	service := NewAgentService(AgentServiceConfig{
+		Agent: agent,
+		Model: model,
+		Policy: bichatctx.ContextPolicy{
+			ContextWindow:     4096,
+			CompletionReserve: 1024,
+			MaxSensitivity:    bichatctx.SensitivityInternal,
+			OverflowStrategy:  bichatctx.OverflowTruncate,
+		},
+		Renderer:     renderer,
+		Checkpointer: newMockCheckpointer(),
+		EventBus:     hooks.NewEventBus(),
+		ChatRepo:     chatRepo,
+	})
+
+	tenantID := uuid.New()
+	sessionID := uuid.New()
+	ctx := composables.WithTenantID(context.Background(), tenantID)
+	require.NoError(t, chatRepo.CreateSession(ctx, mustSession(t,
+		withSessionID(sessionID),
+		withSessionTenantID(tenantID),
+		withSessionUserID(1),
+		withSessionTitle("continuation"),
+	)))
+	require.NoError(t, chatRepo.SaveMessage(ctx, types.UserMessage(
+		"prepare the report",
+		types.WithSessionID(sessionID),
+	)))
+	require.NoError(t, chatRepo.SaveMessage(ctx, types.AssistantMessage(
+		"snapshot started",
+		types.WithSessionID(sessionID),
+	)))
+
+	continuationService := service.(services.ContinuationAgentService)
+	gen, err := continuationService.ProcessContinuation(ctx, sessionID, services.ContinuationEvent{
+		Trigger:       "background_task_completed",
+		CorrelationID: "snapshot-42",
+		Payload:       []byte(`{"artifact_id":"artifact-7"}`),
+	})
+	require.NoError(t, err)
+	defer gen.Close()
+
+	renderer.mu.Lock()
+	rendered := append([]bichatctx.ContextBlock(nil), renderer.renderedBlocks...)
+	renderer.mu.Unlock()
+
+	require.Len(t, rendered, 3)
+	assert.Equal(t, bichatctx.KindPinned, rendered[0].Meta.Kind)
+	assert.Equal(t, bichatctx.KindHistory, rendered[1].Meta.Kind)
+	assert.Equal(t, bichatctx.KindContinuation, rendered[2].Meta.Kind)
+	assert.Equal(t, "internal-continuation", rendered[2].Meta.Source)
+	assert.Contains(t, rendered[2].Payload, `"artifact_id":"artifact-7"`)
+	for _, block := range rendered {
+		assert.NotEqual(t, bichatctx.KindTurn, block.Meta.Kind)
+	}
+}
+
+func TestContinuationEventContextRoundTrip(t *testing.T) {
+	t.Parallel()
+	event := services.ContinuationEvent{
+		Trigger:       "snapshot_ready",
+		CorrelationID: "workflow-42",
+		Payload:       []byte(`{"workflow_id":"workflow-42"}`),
+	}
+	ctx := services.WithContinuationEvent(context.Background(), event)
+	actual, ok := services.UseContinuationEvent(ctx)
+	require.True(t, ok)
+	assert.Equal(t, event.Trigger, actual.Trigger)
+	assert.Equal(t, event.CorrelationID, actual.CorrelationID)
+	assert.JSONEq(t, string(event.Payload), string(actual.Payload))
 }
 
 func TestProcessMessage_Success(t *testing.T) {

--- a/modules/bichat/services/chat_service_continuation.go
+++ b/modules/bichat/services/chat_service_continuation.go
@@ -1,0 +1,229 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	streamingsvc "github.com/iota-uz/iota-sdk/modules/bichat/services/streaming"
+	"github.com/iota-uz/iota-sdk/pkg/bichat/domain"
+	bichatservices "github.com/iota-uz/iota-sdk/pkg/bichat/services"
+	"github.com/iota-uz/iota-sdk/pkg/constants"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
+)
+
+// ContinueSession starts a trusted internal turn in an existing session.
+func (s *chatServiceImpl) ContinueSession(
+	ctx context.Context,
+	req bichatservices.ContinueSessionRequest,
+) (bichatservices.AsyncRunAccepted, error) {
+	const op serrors.Op = "chatServiceImpl.ContinueSession"
+
+	if req.SessionID == uuid.Nil || strings.TrimSpace(req.IdempotencyKey) == "" {
+		return bichatservices.AsyncRunAccepted{}, serrors.E(op, serrors.KindValidation, bichatservices.ErrInvalidContinuation)
+	}
+	if err := req.Event.Validate(); err != nil {
+		return bichatservices.AsyncRunAccepted{}, serrors.E(op, serrors.KindValidation, err)
+	}
+
+	continuationAgent, ok := s.agentService.(bichatservices.ContinuationAgentService)
+	if !ok {
+		return bichatservices.AsyncRunAccepted{}, serrors.E(op, bichatservices.ErrContinuationUnsupported)
+	}
+
+	return s.startAsyncRun(
+		ctx,
+		req.SessionID,
+		bichatservices.AsyncRunOperationContinuation,
+		req.IdempotencyKey,
+		func(txCtx context.Context, _ domain.Session) error {
+			return s.ensureNoOpenQuestionForSend(txCtx, req.SessionID)
+		},
+		func(
+			processCtx context.Context,
+			persistCtx context.Context,
+			runID uuid.UUID,
+			session domain.Session,
+			active *streamingsvc.ActiveRun,
+		) {
+			defer func() {
+				if active.Cancel != nil {
+					active.Cancel()
+				}
+				active.CloseAllSubscribers()
+				s.runRegistry.Remove(active.RunID)
+				s.unregisterStreamCancel(req.SessionID)
+				if s.eventLog != nil {
+					_ = s.eventLog.DropAfterTerminal(persistCtx, session.TenantID(), runID, 5*time.Minute)
+				}
+			}()
+
+			if req.ReasoningEffort != nil {
+				processCtx = bichatservices.WithReasoningEffort(processCtx, *req.ReasoningEffort)
+			}
+			if req.Model != nil {
+				processCtx = bichatservices.WithModelOverride(processCtx, *req.Model)
+			}
+			if s.eventLog != nil {
+				active.SetMirror(func(chunk bichatservices.StreamChunk) {
+					eventType, body, err := encodeRunEventFromChunk(chunk)
+					if err != nil {
+						return
+					}
+					_, _ = s.eventLog.Append(persistCtx, session.TenantID(), runID, RunEvent{
+						Type:    eventType,
+						Payload: body,
+					})
+				})
+			}
+
+			startedAt := time.Now()
+			gen, err := continuationAgent.ProcessContinuation(processCtx, req.SessionID, req.Event)
+			if err != nil {
+				s.failContinuationRun(persistCtx, active, op, err, session, runID)
+				return
+			}
+			defer gen.Close()
+
+			result, err := consumeAgentEvents(processCtx, gen)
+			if err != nil {
+				s.failContinuationRun(persistCtx, active, op, err, session, runID)
+				return
+			}
+			if strings.TrimSpace(result.content) != "" {
+				active.Mu.Lock()
+				active.Content = result.content
+				active.Mu.Unlock()
+				active.Broadcast(bichatservices.StreamChunk{
+					Type:      bichatservices.ChunkTypeContent,
+					Content:   result.content,
+					Timestamp: time.Now(),
+				})
+			}
+			_ = s.updateRunSnapshot(
+				persistCtx,
+				session.TenantID(),
+				req.SessionID,
+				runID,
+				result.content,
+				map[string]any{
+					"tool_calls":      result.toolCalls,
+					"continuation":    true,
+					"correlation_id":  req.Event.CorrelationID,
+					"idempotency_key": req.IdempotencyKey,
+				},
+			)
+
+			if err := processCtx.Err(); err != nil {
+				s.failContinuationRun(persistCtx, active, op, err, session, runID)
+				return
+			}
+
+			saveCtx, cancel := context.WithTimeout(persistCtx, streamPersistenceTimeout)
+			defer cancel()
+			eventPrompt, _ := req.Event.Prompt()
+			err = s.withinTx(saveCtx, func(txCtx context.Context) error {
+				_, _, saveErr := s.saveAgentResult(
+					txCtx,
+					op,
+					session,
+					req.SessionID,
+					result,
+					startedAt,
+					eventPrompt,
+				)
+				return saveErr
+			})
+			if err != nil {
+				s.failContinuationRun(persistCtx, active, op, err, session, runID)
+				return
+			}
+			if err := s.completeRunState(persistCtx, session.TenantID(), req.SessionID, runID); err != nil {
+				s.failContinuationRun(persistCtx, active, op, err, session, runID)
+				return
+			}
+			active.Broadcast(streamingsvc.TerminalChunk(nil, time.Since(startedAt).Milliseconds()))
+		},
+	)
+}
+
+// GetContinuationRun returns the database-backed terminal status of a trusted
+// continuation. It intentionally bypasses the optional Redis run store so host
+// workflow reconcilers work in local development and after process restarts.
+func (s *chatServiceImpl) GetContinuationRun(
+	ctx context.Context,
+	runID uuid.UUID,
+) (bichatservices.ContinuationRun, error) {
+	const op serrors.Op = "chatServiceImpl.GetContinuationRun"
+	if runID == uuid.Nil {
+		return bichatservices.ContinuationRun{}, serrors.E(
+			op,
+			serrors.KindValidation,
+			bichatservices.ErrInvalidContinuation,
+		)
+	}
+	var run domain.GenerationRun
+	err := s.withinTx(ctx, func(txCtx context.Context) error {
+		var getErr error
+		run, getErr = s.chatRepo.GetRunByID(txCtx, runID)
+		return getErr
+	})
+	if err != nil {
+		return bichatservices.ContinuationRun{}, serrors.E(op, err)
+	}
+	metadata := run.PartialMetadata()
+	errorSummary, _ := metadata["error"].(string)
+	status := string(run.Status())
+	if terminalStatus, ok := metadata["terminal_status"].(string); ok &&
+		terminalStatus == string(domain.GenerationRunStatusFailed) {
+		// Some hosts still constrain the durable database column to the
+		// legacy three statuses. Preserve compatibility while exposing the
+		// semantically correct terminal state to reconcilers.
+		status = terminalStatus
+	}
+	return bichatservices.ContinuationRun{
+		ID:        run.ID(),
+		SessionID: run.SessionID(),
+		Status:    status,
+		Error:     errorSummary,
+		StartedAt: run.StartedAt(),
+		UpdatedAt: run.LastUpdatedAt(),
+	}, nil
+}
+
+func (s *chatServiceImpl) failContinuationRun(
+	ctx context.Context,
+	active *streamingsvc.ActiveRun,
+	op serrors.Op,
+	err error,
+	session domain.Session,
+	runID uuid.UUID,
+) {
+	active.Broadcast(streamingsvc.TerminalChunk(serrors.E(op, err), 0))
+	_ = s.withinTx(context.WithoutCancel(ctx), func(txCtx context.Context) error {
+		if snapshotErr := s.chatRepo.UpdateRunSnapshot(
+			txCtx,
+			runID,
+			"",
+			map[string]any{
+				"terminal_status": "failed",
+				"error":           err.Error(),
+			},
+		); snapshotErr != nil {
+			return snapshotErr
+		}
+		return s.chatRepo.FailRun(txCtx, runID)
+	})
+	if failErr := s.runState.FailRunState(
+		context.WithValue(ctx, constants.TxKey, nil),
+		session.TenantID(),
+		session.ID(),
+		runID,
+	); failErr != nil && !errors.Is(failErr, domain.ErrRunNotFound) {
+		_ = s.cancelRunState(ctx, session.TenantID(), session.ID(), runID)
+		return
+	}
+	s.publishTerminalStatus(ctx, session.TenantID(), session.ID(), runID, string(domain.GenerationRunStatusFailed))
+}

--- a/modules/bichat/services/chat_service_history.go
+++ b/modules/bichat/services/chat_service_history.go
@@ -119,6 +119,7 @@ func (s *chatServiceImpl) CompactSessionHistoryAsync(ctx context.Context, sessio
 		ctx,
 		sessionID,
 		bichatservices.AsyncRunOperationSessionCompact,
+		"",
 		nil,
 		func(processCtx context.Context, persistCtx context.Context, runID uuid.UUID, session domain.Session, active *streamingsvc.ActiveRun) {
 			defer func() {

--- a/modules/bichat/services/chat_service_hitl.go
+++ b/modules/bichat/services/chat_service_hitl.go
@@ -354,6 +354,7 @@ func (s *chatServiceImpl) ResumeWithAnswerAsync(ctx context.Context, req bichats
 		ctx,
 		req.SessionID,
 		bichatservices.AsyncRunOperationQuestionSubmit,
+		"",
 		func(txCtx context.Context, _ domain.Session) error {
 			pendingMsg, err := s.findLatestOpenQuestionMessage(txCtx, req.SessionID)
 			if err != nil {
@@ -638,6 +639,7 @@ func (s *chatServiceImpl) RejectPendingQuestionAsync(ctx context.Context, sessio
 		ctx,
 		sessionID,
 		bichatservices.AsyncRunOperationQuestionReject,
+		"",
 		func(txCtx context.Context, _ domain.Session) error {
 			pendingMsg, err := s.findLatestOpenQuestionMessage(txCtx, sessionID)
 			if err != nil {

--- a/modules/bichat/services/chat_service_impl.go
+++ b/modules/bichat/services/chat_service_impl.go
@@ -333,6 +333,11 @@ func (s *chatServiceImpl) updateRunSnapshot(ctx context.Context, tenantID, sessi
 }
 
 func (s *chatServiceImpl) completeRunState(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error {
+	if err := s.withinTx(context.WithoutCancel(ctx), func(txCtx context.Context) error {
+		return s.chatRepo.CompleteRun(txCtx, runID)
+	}); err != nil {
+		return err
+	}
 	err := s.runState.CompleteRunState(ctx, tenantID, sessionID, runID)
 	if err == nil {
 		s.publishTerminalStatus(ctx, tenantID, sessionID, runID, string(domain.GenerationRunStatusCompleted))
@@ -341,6 +346,11 @@ func (s *chatServiceImpl) completeRunState(ctx context.Context, tenantID, sessio
 }
 
 func (s *chatServiceImpl) cancelRunState(ctx context.Context, tenantID, sessionID, runID uuid.UUID) error {
+	if err := s.withinTx(context.WithoutCancel(ctx), func(txCtx context.Context) error {
+		return s.chatRepo.CancelRun(txCtx, runID)
+	}); err != nil {
+		return err
+	}
 	err := s.runState.CancelRunState(ctx, tenantID, sessionID, runID)
 	if err == nil {
 		s.publishTerminalStatus(ctx, tenantID, sessionID, runID, string(domain.GenerationRunStatusCancelled))
@@ -370,31 +380,113 @@ func (s *chatServiceImpl) startAsyncRun(
 	ctx context.Context,
 	sessionID uuid.UUID,
 	operation bichatservices.AsyncRunOperation,
+	idempotencyKey string,
 	prepare func(txCtx context.Context, session domain.Session) error,
 	worker asyncRunWorker,
 ) (bichatservices.AsyncRunAccepted, error) {
 	const op serrors.Op = "chatServiceImpl.startAsyncRun"
 
 	var (
-		session         domain.Session
-		run             domain.GenerationRun
-		err             error
-		runStateCreated bool
+		session     domain.Session
+		run         domain.GenerationRun
+		err         error
+		existingRun bool
 	)
 	err = s.withinTx(ctx, func(txCtx context.Context) error {
 		session, err = s.chatRepo.GetSession(txCtx, sessionID)
 		if err != nil {
 			return serrors.E(op, err)
 		}
-		run, err = domain.NewGenerationRun(domain.GenerationRunSpec{
-			SessionID: sessionID,
-			TenantID:  session.TenantID(),
-			UserID:    session.UserID(),
-		})
-		if err != nil {
-			return serrors.E(op, serrors.KindValidation, err)
+		var runID uuid.UUID
+		databaseRunReady := false
+		if strings.TrimSpace(idempotencyKey) != "" {
+			runID = continuationRunID(session.TenantID(), sessionID, idempotencyKey)
+			run, err = s.chatRepo.GetRunByID(txCtx, runID)
+			if err == nil {
+				if run.SessionID() != sessionID || run.TenantID() != session.TenantID() {
+					return serrors.E(op, serrors.KindValidation, "idempotent run belongs to another session")
+				}
+				switch run.Status() {
+				case domain.GenerationRunStatusCompleted:
+					existingRun = true
+					return nil
+				case domain.GenerationRunStatusStreaming:
+					lastSeen := run.LastUpdatedAt()
+					if lastSeen.IsZero() {
+						lastSeen = run.StartedAt()
+					}
+					if !lastSeen.Before(time.Now().Add(-domain.GenerationRunStaleAfter)) {
+						existingRun = true
+						return nil
+					}
+				case domain.GenerationRunStatusCancelled, domain.GenerationRunStatusFailed:
+					// Terminal failures are retryable under the same
+					// idempotency key and deterministic run id.
+				default:
+					return serrors.E(op, serrors.KindValidation, "unsupported generation run status")
+				}
+
+				run, err = s.chatRepo.RestartRun(
+					txCtx,
+					runID,
+					time.Now().Add(-domain.GenerationRunStaleAfter),
+				)
+				if err == nil {
+					databaseRunReady = true
+				} else {
+					if !errors.Is(err, domain.ErrRunNotFound) {
+						return serrors.E(op, err)
+					}
+
+					// Another process may have won the restart race. Re-read the
+					// deterministic row and accept its live/completed result.
+					run, err = s.chatRepo.GetRunByID(txCtx, runID)
+					if err != nil {
+						return serrors.E(op, err)
+					}
+					if run.SessionID() != sessionID || run.TenantID() != session.TenantID() {
+						return serrors.E(op, serrors.KindValidation, "idempotent run belongs to another session")
+					}
+					if run.Status() == domain.GenerationRunStatusStreaming ||
+						run.Status() == domain.GenerationRunStatusCompleted {
+						existingRun = true
+						return nil
+					}
+					return serrors.E(op, domain.ErrActiveRunExists)
+				}
+			}
+			if err != nil && !errors.Is(err, domain.ErrRunNotFound) {
+				return serrors.E(op, err)
+			}
 		}
-		runStateCreated, err = s.createRunState(txCtx, run)
+		if !databaseRunReady {
+			run, err = domain.NewGenerationRun(domain.GenerationRunSpec{
+				ID:        runID,
+				SessionID: sessionID,
+				TenantID:  session.TenantID(),
+				UserID:    session.UserID(),
+			})
+			if err != nil {
+				return serrors.E(op, serrors.KindValidation, err)
+			}
+			if err := s.chatRepo.CreateRun(txCtx, run); err != nil {
+				if strings.TrimSpace(idempotencyKey) != "" &&
+					errors.Is(err, domain.ErrActiveRunExists) {
+					concurrent, getErr := s.chatRepo.GetRunByID(txCtx, run.ID())
+					if getErr == nil &&
+						concurrent.SessionID() == sessionID &&
+						concurrent.TenantID() == session.TenantID() &&
+						(concurrent.Status() == domain.GenerationRunStatusStreaming ||
+							concurrent.Status() == domain.GenerationRunStatusCompleted) {
+						run = concurrent
+						existingRun = true
+						return nil
+					}
+				}
+				return serrors.E(op, err)
+			}
+		}
+		_, err = s.createRunState(txCtx, run)
 		if err != nil {
 			return serrors.E(op, err)
 		}
@@ -406,10 +498,19 @@ func (s *chatServiceImpl) startAsyncRun(
 		return nil
 	})
 	if err != nil {
-		if runStateCreated && run != nil && session != nil {
+		if run != nil && session != nil {
 			_ = s.cancelRunState(context.WithoutCancel(ctx), session.TenantID(), sessionID, run.ID())
 		}
 		return bichatservices.AsyncRunAccepted{}, serrors.E(op, err)
+	}
+	if existingRun {
+		return bichatservices.AsyncRunAccepted{
+			Accepted:  true,
+			Operation: operation,
+			SessionID: sessionID,
+			RunID:     run.ID(),
+			StartedAt: run.StartedAt(),
+		}, nil
 	}
 
 	processCtx, cancelProcess := context.WithCancel(context.WithoutCancel(ctx))
@@ -429,6 +530,11 @@ func (s *chatServiceImpl) startAsyncRun(
 		RunID:     run.ID(),
 		StartedAt: active.StartedAt,
 	}, nil
+}
+
+func continuationRunID(tenantID, sessionID uuid.UUID, idempotencyKey string) uuid.UUID {
+	name := tenantID.String() + "/" + sessionID.String() + "/" + strings.TrimSpace(idempotencyKey)
+	return uuid.NewSHA1(uuid.NameSpaceURL, []byte("iota-sdk/bichat/continuation/"+name))
 }
 
 // ResumeStream attaches to an active run and streams snapshot then new chunks.

--- a/modules/bichat/services/chat_service_impl_test.go
+++ b/modules/bichat/services/chat_service_impl_test.go
@@ -1611,17 +1611,21 @@ type stubTitleJobQueue struct {
 }
 
 type stubAgentService struct {
-	processEvents    []agents.ExecutorEvent
-	processErr       error
-	processStreamErr error
-	resumeEvents     []agents.ExecutorEvent
-	resumeErr        error
-	resumeStreamErr  error
-	resumeCalls      int
-	resumeCheckpoint string
-	resumeAnswers    map[string]types.Answer
-	resumeStarted    chan struct{}
-	resumeRelease    <-chan struct{}
+	processEvents       []agents.ExecutorEvent
+	processErr          error
+	processStreamErr    error
+	resumeEvents        []agents.ExecutorEvent
+	resumeErr           error
+	resumeStreamErr     error
+	resumeCalls         int
+	resumeCheckpoint    string
+	resumeAnswers       map[string]types.Answer
+	resumeStarted       chan struct{}
+	resumeRelease       <-chan struct{}
+	continuationEvents  []agents.ExecutorEvent
+	continuationErr     error
+	continuationStarted chan bichatservices.ContinuationEvent
+	continuationRelease <-chan struct{}
 }
 
 func (s *stubAgentService) ProcessMessage(ctx context.Context, sessionID uuid.UUID, content string, attachments []domain.Attachment) (types.Generator[agents.ExecutorEvent], error) {
@@ -1681,6 +1685,312 @@ func (s *stubAgentService) ResumeWithAnswer(ctx context.Context, sessionID uuid.
 		}
 		return streamErr
 	}), nil
+}
+
+func (s *stubAgentService) ProcessContinuation(
+	ctx context.Context,
+	_ uuid.UUID,
+	event bichatservices.ContinuationEvent,
+) (types.Generator[agents.ExecutorEvent], error) {
+	if s.continuationStarted != nil {
+		select {
+		case s.continuationStarted <- event:
+		default:
+		}
+	}
+	if s.continuationErr != nil {
+		return nil, s.continuationErr
+	}
+	evs := append([]agents.ExecutorEvent(nil), s.continuationEvents...)
+	return types.NewGenerator(ctx, func(ctx context.Context, yield func(agents.ExecutorEvent) bool) error {
+		if s.continuationRelease != nil {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-s.continuationRelease:
+			}
+		}
+		for _, ev := range evs {
+			if !yield(ev) {
+				return nil
+			}
+		}
+		return nil
+	}), nil
+}
+
+func TestChatService_ContinueSession_DeduplicatesConcurrentDelivery(t *testing.T) {
+	t.Parallel()
+
+	chatRepo := newMockChatRepository()
+	session := mustSession(t,
+		withSessionTenantID(uuid.New()),
+		withSessionUserID(1),
+		withSessionTitle("concurrent continuation"),
+	)
+	require.NoError(t, chatRepo.CreateSession(t.Context(), session))
+
+	started := make(chan bichatservices.ContinuationEvent, 2)
+	release := make(chan struct{})
+	agentSvc := &stubAgentService{
+		continuationStarted: started,
+		continuationRelease: release,
+		continuationEvents:  []agents.ExecutorEvent{{Type: agents.EventTypeDone}},
+	}
+	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	require.NoError(t, err)
+	request := bichatservices.ContinueSessionRequest{
+		SessionID: session.ID(),
+		Event: bichatservices.ContinuationEvent{
+			Trigger:       "background_task_completed",
+			CorrelationID: "snapshot-concurrent",
+		},
+		IdempotencyKey: "workflow-1/concurrent",
+	}
+
+	first, err := svc.ContinueSession(t.Context(), request)
+	require.NoError(t, err)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		require.Fail(t, "first continuation did not start")
+	}
+
+	second, err := svc.ContinueSession(t.Context(), request)
+	require.NoError(t, err)
+	assert.Equal(t, first.RunID, second.RunID)
+	select {
+	case <-started:
+		require.Fail(t, "duplicate continuation started a second agent turn")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+}
+
+func TestChatService_ContinueSession_PersistsAssistantWithoutUserMessage(t *testing.T) {
+	t.Parallel()
+
+	chatRepo := newMockChatRepository()
+	session := mustSession(t,
+		withSessionTenantID(uuid.New()),
+		withSessionUserID(1),
+		withSessionTitle("durable workflow"),
+	)
+	require.NoError(t, chatRepo.CreateSession(t.Context(), session))
+
+	started := make(chan bichatservices.ContinuationEvent, 1)
+	agentSvc := &stubAgentService{
+		continuationStarted: started,
+		continuationEvents: []agents.ExecutorEvent{
+			{Type: agents.EventTypeContent, Content: "analysis resumed"},
+			{Type: agents.EventTypeDone},
+		},
+	}
+	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	require.NoError(t, err)
+
+	accepted, err := svc.ContinueSession(t.Context(), bichatservices.ContinueSessionRequest{
+		SessionID: session.ID(),
+		Event: bichatservices.ContinuationEvent{
+			Trigger:       "background_task_completed",
+			CorrelationID: "snapshot-42",
+			Payload:       []byte(`{"artifact_id":"artifact-7"}`),
+		},
+		IdempotencyKey: "workflow-1/snapshot-42",
+	})
+	require.NoError(t, err)
+	assert.True(t, accepted.Accepted)
+	assert.Equal(t, bichatservices.AsyncRunOperationContinuation, accepted.Operation)
+	assert.NotEqual(t, uuid.Nil, accepted.RunID)
+
+	select {
+	case event := <-started:
+		assert.Equal(t, "background_task_completed", event.Trigger)
+	case <-time.After(time.Second):
+		require.Fail(t, "continuation did not start")
+	}
+
+	require.Eventually(t, func() bool {
+		messages, msgErr := chatRepo.GetSessionMessages(t.Context(), session.ID(), domain.ListOptions{})
+		if msgErr != nil || len(messages) != 1 {
+			return false
+		}
+		return messages[0].Role() == types.RoleAssistant && messages[0].Content() == "analysis resumed"
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestChatService_ContinueSession_DeduplicatesCompletedDelivery(t *testing.T) {
+	t.Parallel()
+
+	chatRepo := newMockChatRepository()
+	session := mustSession(t,
+		withSessionTenantID(uuid.New()),
+		withSessionUserID(1),
+		withSessionTitle("idempotent continuation"),
+	)
+	require.NoError(t, chatRepo.CreateSession(t.Context(), session))
+
+	started := make(chan bichatservices.ContinuationEvent, 2)
+	agentSvc := &stubAgentService{
+		continuationStarted: started,
+		continuationEvents: []agents.ExecutorEvent{
+			{Type: agents.EventTypeContent, Content: "one durable result"},
+			{Type: agents.EventTypeDone},
+		},
+	}
+	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	require.NoError(t, err)
+	request := bichatservices.ContinueSessionRequest{
+		SessionID: session.ID(),
+		Event: bichatservices.ContinuationEvent{
+			Trigger:       "background_task_completed",
+			CorrelationID: "snapshot-42",
+			Payload:       []byte(`{"artifact_id":"artifact-7"}`),
+		},
+		IdempotencyKey: "workflow-1/snapshot-42",
+	}
+
+	first, err := svc.ContinueSession(t.Context(), request)
+	require.NoError(t, err)
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		require.Fail(t, "first continuation did not start")
+	}
+	require.Eventually(t, func() bool {
+		run, runErr := chatRepo.GetRunByID(t.Context(), first.RunID)
+		return runErr == nil && run.Status() == domain.GenerationRunStatusCompleted
+	}, time.Second, 10*time.Millisecond)
+	runStatus, err := svc.GetContinuationRun(t.Context(), first.RunID)
+	require.NoError(t, err)
+	assert.Equal(t, first.RunID, runStatus.ID)
+	assert.Equal(t, session.ID(), runStatus.SessionID)
+	assert.Equal(t, string(domain.GenerationRunStatusCompleted), runStatus.Status)
+	assert.False(t, runStatus.UpdatedAt.IsZero())
+
+	second, err := svc.ContinueSession(t.Context(), request)
+	require.NoError(t, err)
+	assert.True(t, second.Accepted)
+	assert.Equal(t, first.RunID, second.RunID)
+	select {
+	case <-started:
+		require.Fail(t, "duplicate continuation started a second agent turn")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	messages, err := chatRepo.GetSessionMessages(t.Context(), session.ID(), domain.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "one durable result", messages[0].Content())
+}
+
+func TestChatService_ContinueSession_PersistsTerminalFailureReason(t *testing.T) {
+	t.Parallel()
+
+	chatRepo := newMockChatRepository()
+	session := mustSession(t,
+		withSessionTenantID(uuid.New()),
+		withSessionUserID(1),
+		withSessionTitle("failed continuation"),
+	)
+	require.NoError(t, chatRepo.CreateSession(t.Context(), session))
+
+	agentSvc := &stubAgentService{
+		continuationErr: errors.New("provider request rejected"),
+	}
+	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	require.NoError(t, err)
+	request := bichatservices.ContinueSessionRequest{
+		SessionID: session.ID(),
+		Event: bichatservices.ContinuationEvent{
+			Trigger:       "background_task_completed",
+			CorrelationID: "snapshot-42",
+		},
+		IdempotencyKey: "workflow-1/failed",
+	}
+	accepted, err := svc.ContinueSession(t.Context(), request)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		run, runErr := svc.GetContinuationRun(t.Context(), accepted.RunID)
+		return runErr == nil &&
+			run.Status == string(domain.GenerationRunStatusFailed) &&
+			run.Error == "provider request rejected"
+	}, time.Second, 10*time.Millisecond)
+
+	// A failed delivery can be retried with the same key and deterministic id.
+	retryService, err := NewChatService(
+		chatRepo,
+		&stubAgentService{continuationEvents: []agents.ExecutorEvent{{Type: agents.EventTypeDone}}},
+		nil,
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	retried, err := retryService.ContinueSession(t.Context(), request)
+	require.NoError(t, err)
+	assert.Equal(t, accepted.RunID, retried.RunID)
+	require.Eventually(t, func() bool {
+		run, runErr := retryService.GetContinuationRun(t.Context(), retried.RunID)
+		return runErr == nil && run.Status == string(domain.GenerationRunStatusCompleted)
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestChatService_ContinueSession_ReplacesStaleDatabaseRun(t *testing.T) {
+	t.Parallel()
+
+	chatRepo := newMockChatRepository()
+	session := mustSession(t,
+		withSessionTenantID(uuid.New()),
+		withSessionUserID(1),
+		withSessionTitle("restart-safe continuation"),
+	)
+	require.NoError(t, chatRepo.CreateSession(t.Context(), session))
+
+	staleAt := time.Now().Add(-domain.GenerationRunStaleAfter - time.Minute)
+	staleRun, err := domain.NewGenerationRun(domain.GenerationRunSpec{
+		ID:            uuid.New(),
+		SessionID:     session.ID(),
+		TenantID:      session.TenantID(),
+		UserID:        session.UserID(),
+		Status:        domain.GenerationRunStatusStreaming,
+		StartedAt:     staleAt,
+		LastUpdatedAt: staleAt,
+	})
+	require.NoError(t, err)
+	require.NoError(t, chatRepo.CreateRun(t.Context(), staleRun))
+
+	started := make(chan bichatservices.ContinuationEvent, 1)
+	agentSvc := &stubAgentService{
+		continuationStarted: started,
+		continuationEvents: []agents.ExecutorEvent{
+			{Type: agents.EventTypeDone},
+		},
+	}
+	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	require.NoError(t, err)
+
+	accepted, err := svc.ContinueSession(t.Context(), bichatservices.ContinueSessionRequest{
+		SessionID: session.ID(),
+		Event: bichatservices.ContinuationEvent{
+			Trigger:       "background_task_completed",
+			CorrelationID: "snapshot-after-restart",
+		},
+		IdempotencyKey: "workflow-1/generation-2",
+	})
+	require.NoError(t, err)
+	assert.True(t, accepted.Accepted)
+	assert.NotEqual(t, staleRun.ID(), accepted.RunID)
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		require.Fail(t, "replacement continuation did not start")
+	}
+
+	reaped, err := chatRepo.GetRunByID(t.Context(), staleRun.ID())
+	require.NoError(t, err)
+	assert.Equal(t, domain.GenerationRunStatusCancelled, reaped.Status())
 }
 
 func (s *captureTitleContextService) GenerateSessionTitle(ctx context.Context, _ uuid.UUID) error {

--- a/modules/bichat/services/chat_services_api.go
+++ b/modules/bichat/services/chat_services_api.go
@@ -10,13 +10,14 @@ import (
 
 // ChatApplicationServices exposes explicit command/query facades over shared use cases.
 type ChatApplicationServices struct {
-	SessionCommands bichatservices.SessionCommands
-	SessionQueries  bichatservices.SessionQueries
-	TurnCommands    bichatservices.TurnCommands
-	TurnQueries     bichatservices.TurnQueries
-	StreamCommands  bichatservices.StreamCommands
-	HITLCommands    bichatservices.HITLCommands
-	Observability   *StreamObservability
+	SessionCommands      bichatservices.SessionCommands
+	SessionQueries       bichatservices.SessionQueries
+	TurnCommands         bichatservices.TurnCommands
+	ContinuationCommands bichatservices.ContinuationCommands
+	TurnQueries          bichatservices.TurnQueries
+	StreamCommands       bichatservices.StreamCommands
+	HITLCommands         bichatservices.HITLCommands
+	Observability        *StreamObservability
 	// core holds the single chatServiceImpl so shutdown helpers can reach it.
 	core *chatServiceImpl
 }
@@ -24,6 +25,7 @@ type ChatApplicationServices struct {
 type sessionCommandsService struct{ *chatServiceImpl }
 type sessionQueriesService struct{ *chatServiceImpl }
 type turnCommandsService struct{ *chatServiceImpl }
+type continuationCommandsService struct{ *chatServiceImpl }
 type turnQueriesService struct{ *chatServiceImpl }
 type streamCommandsService struct{ *chatServiceImpl }
 type hitlCommandsService struct{ *chatServiceImpl }
@@ -47,14 +49,15 @@ func NewChatApplicationServices(
 		core.WithLogger(logger[0])
 	}
 	return ChatApplicationServices{
-		SessionCommands: &sessionCommandsService{chatServiceImpl: core},
-		SessionQueries:  &sessionQueriesService{chatServiceImpl: core},
-		TurnCommands:    &turnCommandsService{chatServiceImpl: core},
-		TurnQueries:     &turnQueriesService{chatServiceImpl: core},
-		StreamCommands:  &streamCommandsService{chatServiceImpl: core},
-		HITLCommands:    &hitlCommandsService{chatServiceImpl: core},
-		Observability:   NewStreamObservability(core.runRegistry),
-		core:            core,
+		SessionCommands:      &sessionCommandsService{chatServiceImpl: core},
+		SessionQueries:       &sessionQueriesService{chatServiceImpl: core},
+		TurnCommands:         &turnCommandsService{chatServiceImpl: core},
+		ContinuationCommands: &continuationCommandsService{chatServiceImpl: core},
+		TurnQueries:          &turnQueriesService{chatServiceImpl: core},
+		StreamCommands:       &streamCommandsService{chatServiceImpl: core},
+		HITLCommands:         &hitlCommandsService{chatServiceImpl: core},
+		Observability:        NewStreamObservability(core.runRegistry),
+		core:                 core,
 	}, nil
 }
 

--- a/pkg/bichat/agents/executor.go
+++ b/pkg/bichat/agents/executor.go
@@ -491,9 +491,21 @@ func (e *Executor) Execute(ctx context.Context, input Input) types.Generator[Exe
 
 		// Use input messages as-is (system prompt already included from context compilation)
 		messages := input.Messages
+		stickySystemMessages := make([]types.Message, 0, 1)
+		for _, message := range input.Messages {
+			if message.Role() == types.RoleSystem {
+				stickySystemMessages = append(stickySystemMessages, message)
+			}
+		}
 
 		// Track provider continuity across iterations in a single execution.
 		previousResponseID := input.PreviousResponseID
+		// Once a provider returns a continuity token, the provider already owns
+		// the response and everything that preceded it. Re-sending the full
+		// local transcript alongside previous_response_id duplicates context on
+		// every tool iteration and eventually grows it quadratically. Keep only
+		// developer instructions plus messages created after that response.
+		incrementalMessageStart := -1
 		reminderTracker := newReminderTracker()
 		turnToolCounts := make(map[string]int)
 
@@ -542,8 +554,15 @@ func (e *Executor) Execute(ctx context.Context, input Input) types.Generator[Exe
 			batchToolNames := buildBatchToolNames(tools)
 
 			// Build model request
+			requestMessages := messages
+			if previousResponseID != nil && incrementalMessageStart >= 0 {
+				requestMessages = make([]types.Message, 0,
+					len(stickySystemMessages)+len(messages)-incrementalMessageStart)
+				requestMessages = append(requestMessages, stickySystemMessages...)
+				requestMessages = append(requestMessages, messages[incrementalMessageStart:]...)
+			}
 			req := Request{
-				Messages:           messages,
+				Messages:           requestMessages,
 				Tools:              tools,
 				PreviousResponseID: previousResponseID,
 			}
@@ -949,6 +968,7 @@ func (e *Executor) Execute(ctx context.Context, input Input) types.Generator[Exe
 			if providerResponseID != "" {
 				id := providerResponseID
 				previousResponseID = &id
+				incrementalMessageStart = len(messages)
 			}
 
 			// Accumulate tokens for agent lifecycle tracking

--- a/pkg/bichat/agents/executor_test.go
+++ b/pkg/bichat/agents/executor_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/iota-uz/iota-sdk/pkg/bichat/agents"
 	"github.com/iota-uz/iota-sdk/pkg/bichat/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,10 +28,11 @@ type mockModel struct {
 }
 
 type mockResponse struct {
-	content      string
-	toolCalls    []types.ToolCall
-	finishReason string
-	err          error
+	content            string
+	toolCalls          []types.ToolCall
+	finishReason       string
+	providerResponseID string
+	err                error
 }
 
 func newMockModel(responses ...mockResponse) *mockModel {
@@ -108,11 +110,12 @@ func (m *mockModel) Stream(ctx context.Context, req agents.Request, opts ...agen
 
 		// Final chunk with tool calls and metadata
 		finalChunk := agents.Chunk{
-			Delta:        "",
-			ToolCalls:    resp.toolCalls,
-			Usage:        &types.TokenUsage{PromptTokens: 10, CompletionTokens: 20, TotalTokens: 30},
-			FinishReason: resp.finishReason,
-			Done:         true,
+			Delta:              "",
+			ToolCalls:          resp.toolCalls,
+			Usage:              &types.TokenUsage{PromptTokens: 10, CompletionTokens: 20, TotalTokens: 30},
+			FinishReason:       resp.finishReason,
+			ProviderResponseID: resp.providerResponseID,
+			Done:               true,
 		}
 
 		if !yield(finalChunk) {
@@ -470,6 +473,63 @@ func TestExecutor_ToolCalls(t *testing.T) {
 		if toolEndEvent.DurationMs < 0 {
 			t.Error("Expected non-negative duration")
 		}
+	}
+}
+
+func TestExecutor_UsesIncrementalMessagesWithProviderContinuity(t *testing.T) {
+	t.Parallel()
+
+	tool := agents.NewTool(
+		"lookup",
+		"Looks up a value",
+		map[string]any{"type": "object"},
+		func(context.Context, string) (string, error) {
+			return `{"value":"found"}`, nil
+		},
+	)
+	agent := newMockAgent("continuity-agent", tool)
+	model := newMockModel(
+		mockResponse{
+			toolCalls: []types.ToolCall{{
+				ID: "call_continuity", Name: "lookup", Arguments: `{}`,
+			}},
+			finishReason:       "tool_calls",
+			providerResponseID: "resp_continuity",
+		},
+		mockResponse{content: "Done", finishReason: "stop"},
+	)
+	executor := agents.NewExecutor(agent, model)
+	ctx := context.Background()
+	gen := executor.Execute(ctx, agents.Input{
+		Messages: []types.Message{
+			types.SystemMessage("Keep this instruction."),
+			types.UserMessage("Find the value."),
+		},
+		SessionID: uuid.New(),
+		TenantID:  uuid.New(),
+	})
+	defer gen.Close()
+	for {
+		_, err := gen.Next(ctx)
+		if errors.Is(err, types.ErrGeneratorDone) {
+			break
+		}
+		require.NoError(t, err)
+	}
+
+	requests := model.capturedRequests()
+	require.Len(t, requests, 2)
+	require.Nil(t, requests[0].PreviousResponseID)
+	require.NotNil(t, requests[1].PreviousResponseID)
+	assert.Equal(t, "resp_continuity", *requests[1].PreviousResponseID)
+	require.Len(t, requests[1].Messages, 2)
+	assert.Equal(t, types.RoleSystem, requests[1].Messages[0].Role())
+	assert.Equal(t, "Keep this instruction.", requests[1].Messages[0].Content())
+	assert.Equal(t, types.RoleTool, requests[1].Messages[1].Role())
+	assert.Equal(t, "call_continuity", *requests[1].Messages[1].ToolCallID())
+	for _, message := range requests[1].Messages {
+		assert.NotEqual(t, types.RoleUser, message.Role())
+		assert.NotEqual(t, types.RoleAssistant, message.Role())
 	}
 }
 

--- a/pkg/bichat/context/block.go
+++ b/pkg/bichat/context/block.go
@@ -32,6 +32,10 @@ const (
 	// KindHistory represents conversation history.
 	KindHistory BlockKind = "history"
 
+	// KindContinuation represents a trusted internal event that resumes an
+	// existing session without attributing the event to the user.
+	KindContinuation BlockKind = "continuation"
+
 	// KindTurn represents the current user message (always last).
 	KindTurn BlockKind = "turn"
 )
@@ -44,6 +48,7 @@ var KindOrder = []BlockKind{
 	KindState,
 	KindToolOutput,
 	KindHistory,
+	KindContinuation,
 	KindTurn,
 }
 

--- a/pkg/bichat/context/builder.go
+++ b/pkg/bichat/context/builder.go
@@ -67,6 +67,11 @@ func (b *ContextBuilder) History(codec Codec, payload any, opts ...BlockOptions)
 	return b.add(KindHistory, codec, payload, opts...)
 }
 
+// Continuation adds a trusted internal event that resumes the session.
+func (b *ContextBuilder) Continuation(codec Codec, payload any, opts ...BlockOptions) *ContextBuilder {
+	return b.add(KindContinuation, codec, payload, opts...)
+}
+
 // Turn adds a user turn block (current user message).
 func (b *ContextBuilder) Turn(codec Codec, payload any, opts ...BlockOptions) *ContextBuilder {
 	return b.add(KindTurn, codec, payload, opts...)
@@ -126,6 +131,14 @@ func (b *ContextBuilder) MustToolOutput(codec Codec, payload any, opts ...BlockO
 func (b *ContextBuilder) MustHistory(codec Codec, payload any, opts ...BlockOptions) *ContextBuilder {
 	if err := b.Add(KindHistory, codec, payload, opts...); err != nil {
 		panic(fmt.Sprintf("MustHistory failed: %v", err))
+	}
+	return b
+}
+
+// MustContinuation adds an internal continuation block and panics on validation error.
+func (b *ContextBuilder) MustContinuation(codec Codec, payload any, opts ...BlockOptions) *ContextBuilder {
+	if err := b.Add(KindContinuation, codec, payload, opts...); err != nil {
+		panic(fmt.Sprintf("MustContinuation failed: %v", err))
 	}
 	return b
 }

--- a/pkg/bichat/context/compiler_test.go
+++ b/pkg/bichat/context/compiler_test.go
@@ -24,7 +24,7 @@ func newMockRenderer() *mockRenderer {
 
 func (r *mockRenderer) Render(block context.ContextBlock) (context.RenderedBlock, error) {
 	switch block.Meta.Kind {
-	case context.KindPinned:
+	case context.KindPinned, context.KindContinuation:
 		// System blocks produce system messages
 		content, ok := block.Payload.(string)
 		if !ok {

--- a/pkg/bichat/context/policy.go
+++ b/pkg/bichat/context/policy.go
@@ -85,6 +85,7 @@ func DefaultKindPriorities() []KindPriority {
 		{Kind: KindState, MinTokens: 200, MaxTokens: 2000, Truncatable: false},
 		{Kind: KindToolOutput, MinTokens: 1000, MaxTokens: 20000, Truncatable: true},
 		{Kind: KindHistory, MinTokens: 2000, MaxTokens: 50000, Truncatable: true},
+		{Kind: KindContinuation, MinTokens: 200, MaxTokens: 4000, Truncatable: false},
 		{Kind: KindTurn, MinTokens: 500, MaxTokens: 10000, Truncatable: false},
 	}
 }

--- a/pkg/bichat/context/renderers/anthropic.go
+++ b/pkg/bichat/context/renderers/anthropic.go
@@ -60,6 +60,8 @@ func (r *AnthropicRenderer) Render(block context.ContextBlock) (context.Rendered
 		return r.renderToolOutput(block)
 	case context.KindHistory:
 		return r.renderHistory(block)
+	case context.KindContinuation:
+		return r.renderState(block)
 	case context.KindTurn:
 		return r.renderTurn(block)
 	default:

--- a/pkg/bichat/context/renderers/gemini.go
+++ b/pkg/bichat/context/renderers/gemini.go
@@ -59,6 +59,8 @@ func (r *GeminiRenderer) Render(block context.ContextBlock) (context.RenderedBlo
 		return r.renderToolOutput(block)
 	case context.KindHistory:
 		return r.renderHistory(block)
+	case context.KindContinuation:
+		return r.renderSystem(block)
 	case context.KindTurn:
 		return r.renderTurn(block)
 	default:

--- a/pkg/bichat/context/renderers/openai.go
+++ b/pkg/bichat/context/renderers/openai.go
@@ -59,6 +59,8 @@ func (r *OpenAIRenderer) Render(block context.ContextBlock) (context.RenderedBlo
 		return r.renderToolOutput(block)
 	case context.KindHistory:
 		return r.renderHistory(block)
+	case context.KindContinuation:
+		return r.renderSystem(block)
 	case context.KindTurn:
 		return r.renderTurn(block)
 	default:

--- a/pkg/bichat/domain/generation_run.go
+++ b/pkg/bichat/domain/generation_run.go
@@ -12,6 +12,10 @@ import (
 type GenerationRunStatus string
 
 const (
+	// GenerationRunStaleAfter is the shared liveness threshold used by both
+	// service orchestration and persistence when reclaiming abandoned runs.
+	GenerationRunStaleAfter = 5 * time.Minute
+
 	GenerationRunStatusStreaming GenerationRunStatus = "streaming"
 	GenerationRunStatusCompleted GenerationRunStatus = "completed"
 	GenerationRunStatusCancelled GenerationRunStatus = "cancelled"

--- a/pkg/bichat/domain/repository.go
+++ b/pkg/bichat/domain/repository.go
@@ -93,10 +93,15 @@ type GenerationRunRepository interface {
 	GetActiveRunBySession(ctx context.Context, sessionID uuid.UUID) (GenerationRun, error)
 	// GetRunByID returns a run by id regardless of status.
 	GetRunByID(ctx context.Context, runID uuid.UUID) (GenerationRun, error)
+	// RestartRun reopens a failed or cancelled run with the same deterministic id.
+	// It returns ErrRunNotFound when the row is absent or no longer restartable.
+	RestartRun(ctx context.Context, runID uuid.UUID, staleBefore time.Time) (GenerationRun, error)
 	// UpdateRunSnapshot updates partial_content and partial_metadata for the run.
 	UpdateRunSnapshot(ctx context.Context, runID uuid.UUID, partialContent string, partialMetadata map[string]any) error
 	// CompleteRun marks the run as completed.
 	CompleteRun(ctx context.Context, runID uuid.UUID) error
+	// FailRun marks the run as failed.
+	FailRun(ctx context.Context, runID uuid.UUID) error
 	// CancelRun marks the run as cancelled.
 	CancelRun(ctx context.Context, runID uuid.UUID) error
 }

--- a/pkg/bichat/services/agent_service.go
+++ b/pkg/bichat/services/agent_service.go
@@ -3,12 +3,73 @@ package services
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/iota-uz/iota-sdk/pkg/bichat/agents"
 	"github.com/iota-uz/iota-sdk/pkg/bichat/domain"
 	"github.com/iota-uz/iota-sdk/pkg/bichat/types"
 )
+
+var ErrInvalidContinuation = errors.New("invalid internal continuation")
+
+// ContinuationEvent is a trusted application event that resumes an existing
+// chat session. It is never attributed to a user.
+type ContinuationEvent struct {
+	Trigger       string          `json:"trigger"`
+	CorrelationID string          `json:"correlation_id"`
+	Payload       json.RawMessage `json:"payload,omitempty"`
+}
+
+type continuationEventContextKey struct{}
+
+// WithContinuationEvent attaches a trusted continuation to the execution
+// context. Application tools can correlate durable workflow state without
+// relying on the model to copy opaque identifiers from the rendered prompt.
+func WithContinuationEvent(ctx context.Context, event ContinuationEvent) context.Context {
+	return context.WithValue(ctx, continuationEventContextKey{}, event)
+}
+
+// UseContinuationEvent returns the trusted continuation that started the
+// current turn. Ordinary user turns do not carry one.
+func UseContinuationEvent(ctx context.Context) (ContinuationEvent, bool) {
+	event, ok := ctx.Value(continuationEventContextKey{}).(ContinuationEvent)
+	if !ok || event.Validate() != nil {
+		return ContinuationEvent{}, false
+	}
+	return event, true
+}
+
+func (e ContinuationEvent) Validate() error {
+	if strings.TrimSpace(e.Trigger) == "" || strings.TrimSpace(e.CorrelationID) == "" {
+		return ErrInvalidContinuation
+	}
+	if len(e.Payload) > 0 && !json.Valid(e.Payload) {
+		return ErrInvalidContinuation
+	}
+	return nil
+}
+
+func (e ContinuationEvent) Prompt() (string, error) {
+	if err := e.Validate(); err != nil {
+		return "", err
+	}
+	if len(e.Payload) == 0 {
+		e.Payload = json.RawMessage(`{}`)
+	}
+	data, err := json.Marshal(e)
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrInvalidContinuation, err)
+	}
+	return "INTERNAL CONTINUATION EVENT\n" +
+		"This event was emitted by a trusted application workflow, not by the user. " +
+		"Resume the existing goal using the conversation history and event payload. " +
+		"Do not ask the user to repeat identifiers already present here.\n" +
+		string(data), nil
+}
 
 // AgentService provides the framework bridge for executing agent interactions.
 // It connects the chat domain to the underlying agent framework (pkg/bichat/agents).
@@ -21,4 +82,10 @@ type AgentService interface {
 	// ResumeWithAnswer resumes agent execution after user answers questions (HITL).
 	// Returns a Generator for streaming the resumed execution.
 	ResumeWithAnswer(ctx context.Context, sessionID uuid.UUID, checkpointID string, answers map[string]types.Answer) (types.Generator[agents.ExecutorEvent], error)
+}
+
+// ContinuationAgentService is implemented by agents that support trusted
+// internal continuation turns.
+type ContinuationAgentService interface {
+	ProcessContinuation(ctx context.Context, sessionID uuid.UUID, event ContinuationEvent) (types.Generator[agents.ExecutorEvent], error)
 }

--- a/pkg/bichat/services/chat_service.go
+++ b/pkg/bichat/services/chat_service.go
@@ -27,6 +27,10 @@ var ErrRunEventLogUnavailable = errors.New("run event log unavailable")
 // same transport.
 var ErrActiveRunIndexUnavailable = errors.New("active run index unavailable")
 
+// ErrContinuationUnsupported is returned when the configured AgentService
+// does not implement ContinuationAgentService.
+var ErrContinuationUnsupported = errors.New("internal continuations are not supported by the configured agent service")
+
 // SessionCommands manages mutating session actions.
 type SessionCommands interface {
 	CreateSession(ctx context.Context, tenantID uuid.UUID, userID int64, title string) (domain.Session, error)
@@ -62,6 +66,12 @@ type SessionQueries interface {
 // TurnCommands handles non-streaming turn execution.
 type TurnCommands interface {
 	SendMessage(ctx context.Context, req SendMessageRequest) (*SendMessageResponse, error)
+}
+
+// ContinuationCommands resumes a session from trusted application workflows.
+type ContinuationCommands interface {
+	ContinueSession(ctx context.Context, req ContinueSessionRequest) (AsyncRunAccepted, error)
+	GetContinuationRun(ctx context.Context, runID uuid.UUID) (ContinuationRun, error)
 }
 
 // TurnQueries reads conversation messages for a session.
@@ -160,6 +170,7 @@ const (
 	AsyncRunOperationQuestionSubmit AsyncRunOperation = "question_submit"
 	AsyncRunOperationQuestionReject AsyncRunOperation = "question_reject"
 	AsyncRunOperationSessionCompact AsyncRunOperation = "session_compact"
+	AsyncRunOperationContinuation   AsyncRunOperation = "continuation"
 )
 
 type AsyncRunAccepted struct {
@@ -168,6 +179,29 @@ type AsyncRunAccepted struct {
 	SessionID uuid.UUID
 	RunID     uuid.UUID
 	StartedAt time.Time
+}
+
+// ContinuationRun is the durable status projection applications use to
+// reconcile an asynchronously dispatched continuation after a process restart.
+type ContinuationRun struct {
+	ID        uuid.UUID
+	SessionID uuid.UUID
+	Status    string
+	Error     string
+	StartedAt time.Time
+	UpdatedAt time.Time
+}
+
+// ContinueSessionRequest starts an internal continuation turn. The
+// IdempotencyKey is required so durable application workers can safely retry
+// delivery. The SDK derives a stable run id from the tenant, session, and key;
+// repeated delivery returns that run without executing a second turn.
+type ContinueSessionRequest struct {
+	SessionID       uuid.UUID
+	Event           ContinuationEvent
+	IdempotencyKey  string
+	ReasoningEffort *string
+	Model           *string
 }
 
 // SendMessageRequest contains the input for sending a message

--- a/pkg/bichat/testutil/chat_repository.go
+++ b/pkg/bichat/testutil/chat_repository.go
@@ -126,11 +126,19 @@ func (m *NoOpChatRepository) GetRunByID(ctx context.Context, runID uuid.UUID) (d
 	return nil, domain.ErrRunNotFound
 }
 
+func (m *NoOpChatRepository) RestartRun(ctx context.Context, runID uuid.UUID, staleBefore time.Time) (domain.GenerationRun, error) {
+	return nil, domain.ErrRunNotFound
+}
+
 func (m *NoOpChatRepository) UpdateRunSnapshot(ctx context.Context, runID uuid.UUID, partialContent string, partialMetadata map[string]any) error {
 	return nil
 }
 
 func (m *NoOpChatRepository) CompleteRun(ctx context.Context, runID uuid.UUID) error {
+	return nil
+}
+
+func (m *NoOpChatRepository) FailRun(ctx context.Context, runID uuid.UUID) error {
 	return nil
 }
 


### PR DESCRIPTION
Closes #942
Parent epic: #941

## Outcome

Adds generic trusted continuation runs that let an application workflow resume the same BiChat session without synthesizing a user message.

- typed continuation events are carried in trusted context and rendered for OpenAI, Anthropic, and Gemini
- deterministic run IDs make repeated delivery idempotent across process restarts and concurrent delivery races
- terminal failed/cancelled deterministic runs can be retried with the same run identity
- all asynchronous generations are persisted in PostgreSQL before Redis publication
- duplicate continuations reuse the same run and assistant turn
- active generations can be cancelled and stale DB-backed streaming runs are recovered safely
- host reconcilers can read durable continuation status directly from PostgreSQL, including actual failure state and error details when Redis is disabled or after a process restart
- generation completion, cancellation, and failure are mirrored consistently across PostgreSQL, Redis, broadcasts, and the public status API
- OpenAI continuation tokens send only sticky instructions and messages created after the previous response, preventing quadratic context growth
- tool outputs may refer correctly to tool calls from the previous provider response

## Scope and safety

The SDK remains domain-neutral. It supplies continuation, persistence, idempotency, status reconciliation, cancellation, and context-continuity primitives; host applications retain workflow semantics, permissions, retry policy, and human approval gates.

## Verification

- `golangci-lint run --build-tags=dev ./...`
- `go test ./modules/bichat/... ./pkg/bichat/... -count=1 -timeout=240s`
- GitHub CI covers four E2E shards, security, formatting, unit/integration tests, and CodeRabbit

## Consumer

EAI PR iota-uz/eai#3774 pins SDK commit `0397322bce59` and implements the durable NSBU → IFRS workflow.
