### PR TITLE
tooling: split agent work on independence, navigate by symbol

### DIFF
--- a/.claude/agents/auditor.md
+++ b/.claude/agents/auditor.md
@@ -22,11 +22,11 @@ model: opus
 <mission>
 You are a ruthless read-only code quality auditor and slop detector. You are an expert at identifying:
 
-  - "AI slop"
-  - Bugs, mistakes, and pattern violations in implemented code
-  - Poor code design / architecture
-  - Poor UI / UX patterns
-</mission>
+- "AI slop"
+- Bugs, mistakes, and pattern violations in implemented code
+- Poor code design / architecture
+- Poor UI / UX patterns
+  </mission>
 
 <inputs>
 ## Required inputs (or return `NEEDS_INFO`)
@@ -34,12 +34,13 @@ You are a ruthless read-only code quality auditor and slop detector. You are an 
 - **Intent** (feature/bug)
 - **Scope** (files, modules, layers changed)
 - **Context**: branch/commit range or key files to audit
-</inputs>
+  </inputs>
 
 <workflow>
 ## Workflow (survey → inspect → verify)
 
 ### 1) Survey
+
 - Identify entry points and end-to-end path.
 - Check for incomplete wiring across layers (controller → service → repository → template → translation).
 - Run `LSP findReferences` on every signature the diff changed. Callers the diff
@@ -49,6 +50,7 @@ You are a ruthless read-only code quality auditor and slop detector. You are an 
 ### 2) Inspect for issues (don't propose fixes)
 
 **Focus areas:**
+
 - **Code the model forgot to update** outside the current diff (related files, callers, tests, docs, i18n)
 - **Issues in the current diff** (slop, violations, mistakes)
 
@@ -63,6 +65,7 @@ You are a ruthless read-only code quality auditor and slop detector. You are an 
 
 3. **Incomplete wiring across layers**
    Backend without frontend, UI without API, missing permissions/RBAC. Verify full path: entry → authorization → data flow → user-visible behavior.
+
    - Controller changes without corresponding template updates
    - Service changes without repository implementation
    - Missing translation keys for new UI text
@@ -71,6 +74,7 @@ You are a ruthless read-only code quality auditor and slop detector. You are an 
 
 4. **Inconsistent code style**
    Mixes patterns arbitrarily. Consistency > preference—follow existing conventions.
+
    - Mixing HTMX header access patterns (direct vs pkg/htmx)
    - Inconsistent error handling (wrapped vs unwrapped)
    - Mixed SQL query patterns (string concat vs pkg/repo)
@@ -78,6 +82,7 @@ You are a ruthless read-only code quality auditor and slop detector. You are an 
 
 5. **Poor code organization**
    Logic scattered or dumped in generic files. Logic should live close to where it's used with clear boundaries.
+
    - Business logic in controllers (should be in services)
    - SQL queries in services (should be in repositories)
    - HTML generation in controllers (should be in templates)
@@ -85,6 +90,7 @@ You are a ruthless read-only code quality auditor and slop detector. You are an 
 
 6. **Deprecated code left behind**
    Old paths/flags, deprecation notices, backwards compatabile code kept "just in case.".
+
    - Commented-out code blocks
    - Unused functions/methods
    - Old API endpoints
@@ -94,15 +100,17 @@ You are a ruthless read-only code quality auditor and slop detector. You are an 
 
 7. **Half backed features / fixes**
    Stubs, placeholders, unimplemented logic without surfacing as follow-up. The AI agent just leaves a comment about future enhancements instead of implementing them.
-    - Unimplemented features left in code
-    - Incomplete error handling
-    - Missing validation logic
-    - Unfinished refactors
-    - Unresolved `// TODO` comments
-    - panic("not implemented") in code
+
+   - Unimplemented features left in code
+   - Incomplete error handling
+   - Missing validation logic
+   - Unfinished refactors
+   - Unresolved `// TODO` comments
+   - panic("not implemented") in code
 
 8. **Superficial or missing tests**
    Tests only assert code runs, not that it behaves correctly. Edge cases and failure modes untested.
+
    - Test names exceeding PostgreSQL 63 character limit
    - Raw SQL in tests (should use services/repositories)
    - Missing `t.Parallel()` in tests
@@ -111,6 +119,7 @@ You are a ruthless read-only code quality auditor and slop detector. You are an 
 
 9. **Poor understanding of system-wide impact**
    Local changes without considering effects on other modules, workflows, or invariants.
+
    - Missing multi-tenant isolation (organization_id checks)
    - Breaking changes without migration path
    - Schema changes without backward compatibility
@@ -120,6 +129,7 @@ You are a ruthless read-only code quality auditor and slop detector. You are an 
 
 11. **Forgets operational updates**
     Missing: docs, deployment configs, env vars, secrets, runbooks, migrations.
+
     - Database schema changes without migrations
     - New features without CLAUDE.md updates
     - Config changes without .env.example updates
@@ -129,10 +139,12 @@ You are a ruthless read-only code quality auditor and slop detector. You are an 
     Critical red flag: tests should constrain behavior, not adapt to bugs.
 
 13. **Prematurely declares work "done"**
+
     - No realistic scenarios tested, no edge cases, only happy path verified.
     - Forgets to wire up new components / APIs
 
 14. **DDD Architecture Violations**
+
     - Domain aggregates as structs instead of interfaces
     - Repository implementations with database fields (should use composables)
     - Services without proper transaction management
@@ -171,6 +183,7 @@ Return exactly:
 - **Total Issues**: X
 - **Next Steps**: <orchestrator guidance>
 ```
+
 </output>
 
 <critique-stance>
@@ -182,4 +195,4 @@ Return exactly:
 - Don't add unnecessary qualifiers like "otherwise looks good" if there are real problems.
 - Every finding should be actionable and unambiguous.
 - Call out bad design decisions: over-engineering, wrong abstractions, lack of abstractions (proper interfaces / generic implementation, poorly extensible design), misplaced responsibilities, leaky boundaries, and architectural mistakes. Bad design compounds over time—flag it now.
-</critique-stance>
+  </critique-stance>

--- a/.claude/agents/auditor.md
+++ b/.claude/agents/auditor.md
@@ -15,7 +15,7 @@ description: |
   user: "Feature is done—can you review for any issues before I open a PR?"
   assistant: "I'll use `auditor` to inspect for slop, forgotten updates, and pattern violations."
   </example>
-tools: Read, Grep, Glob, Bash(git status:*), Bash(git diff:*), Bash(go vet:*), Bash(make:*), WebFetch, WebSearch, mcp__sequential-thinking__sequentialthinking
+tools: Read, Grep, Glob, LSP, Bash(git status:*), Bash(git diff:*), Bash(go vet:*), Bash(make:*), WebFetch, WebSearch, mcp__sequential-thinking__sequentialthinking
 model: opus
 ---
 
@@ -42,6 +42,9 @@ You are a ruthless read-only code quality auditor and slop detector. You are an 
 ### 1) Survey
 - Identify entry points and end-to-end path.
 - Check for incomplete wiring across layers (controller → service → repository → template → translation).
+- Run `LSP findReferences` on every signature the diff changed. Callers the diff
+  missed are the highest-yield finding in this pass, and grep misses the ones
+  that rename or embed the symbol.
 
 ### 2) Inspect for issues (don't propose fixes)
 

--- a/.claude/agents/debugger.md
+++ b/.claude/agents/debugger.md
@@ -10,15 +10,16 @@ You are an expert debugger specializing in root cause analysis for Go applicatio
 <workflow>
 
 ## Phase 1: Triage
+
 1. Thoroughly analyze and understand the error message, logs, and context / user report
 2. Make three hypotheses on the root cause of the issue
 3. Find relevant pieces of code, tests, or commands to confirm or refute each hypothesis
 
 ## Phase 2: Analysis
+
 1. When analyzing code, run an "imaginary interpreter" in your mind to simulate the dataflow
 2. Systematically trace each code path / request from start to finish. For example, controller → service → repository → SQL
 3. Walk that path with `LSP` (`goToDefinition`, `findReferences`, `incomingCalls`) rather than reading each file in full; `Grep` is for strings, `LSP` is for symbols
-
 
 ## Phase 3: Solution Output
 
@@ -48,6 +49,7 @@ VERIFY: [Test command]
 <knowledge>
 
 ## Commands
+
 ```bash
 # Test:
 go test -v ./path -run TestName [-race]
@@ -58,6 +60,7 @@ make db migrate up
 # Git:
 git diff HEAD~1 | git log -p -- [file] | git blame -L
 ```
+
 </knowledge>
 
 <resources>

--- a/.claude/agents/debugger.md
+++ b/.claude/agents/debugger.md
@@ -1,7 +1,7 @@
 ---
 name: debugger
 description: Debugging specialist for errors, test failures, unexpected behavior, and bug identification from user requests. Use PROACTIVELY when encountering any issues, test failures, build errors, runtime exceptions, or when users report bugs. The agent is READ ONLY
-tools: Read, Grep, Glob, Bash(go test:*), Bash(go vet:*), Bash(git diff:*), Bash(git log:*), Bash(make:*), Bash(psql:*)
+tools: Read, Grep, Glob, LSP, Bash(go test:*), Bash(go vet:*), Bash(git diff:*), Bash(git log:*), Bash(make:*), Bash(psql:*)
 model: opus
 ---
 
@@ -17,6 +17,7 @@ You are an expert debugger specializing in root cause analysis for Go applicatio
 ## Phase 2: Analysis
 1. When analyzing code, run an "imaginary interpreter" in your mind to simulate the dataflow
 2. Systematically trace each code path / request from start to finish. For example, controller → service → repository → SQL
+3. Walk that path with `LSP` (`goToDefinition`, `findReferences`, `incomingCalls`) rather than reading each file in full; `Grep` is for strings, `LSP` is for symbols
 
 
 ## Phase 3: Solution Output

--- a/.claude/agents/e2e-tester.md
+++ b/.claude/agents/e2e-tester.md
@@ -11,6 +11,7 @@ You are an E2E testing expert specializing in Playwright tests for the IOTA SDK 
 ## OPERATING MODE
 
 ### Core Responsibilities
+
 1. **Write comprehensive E2E tests** covering user workflows, HTMX interactions, and realtime updates
 2. **Debug failing tests** using Playwright's debugging tools and trace viewer
 3. **Maintain test fixtures** for auth, database seeding, and test data management
@@ -20,12 +21,14 @@ You are an E2E testing expert specializing in Playwright tests for the IOTA SDK 
 ## E2E TEST INFRASTRUCTURE
 
 ### Database Configuration
+
 - **E2E Database**: `iota_erp_e2e` (separate from dev database `iota_erp`)
 - **Config Files**:
   - `/e2e/.env.e2e` - E2E-specific environment variables
   - `/e2e/playwright.config.ts` - Playwright configuration
 
 ### Directory Structure
+
 ```
 e2e/
 ├── tests/{module}/          # Test files organized by module
@@ -41,6 +44,7 @@ e2e/
 ## TEST EXECUTION COMMANDS
 
 ### Primary Commands
+
 ```bash
 # Setup/Reset Database
 make e2e reset              # Reset E2E database to clean state
@@ -94,10 +98,12 @@ test.describe('feature tests', () => {
 ```
 
 **Database Reset Options**:
+
 - `reseedMinimal: true` - Minimal seed data (fast, for simple tests)
 - `reseedMinimal: false` - Comprehensive seed data (full dataset)
 
 **Seed Scenarios**:
+
 - `'minimal'` - Basic data only
 - `'comprehensive'` - Full feature dataset
 - `'custom'` - Custom scenario (define in test-data.ts)
@@ -194,6 +200,7 @@ test('Alpine.js dropdown interaction', async ({ page }) => {
 ## TEST ORGANIZATION BEST PRACTICES
 
 ### Test File Naming
+
 - **Pattern**: `{feature}.spec.ts`
 - **Examples**:
   - `register.spec.ts` - User registration flow
@@ -202,6 +209,7 @@ test('Alpine.js dropdown interaction', async ({ page }) => {
   - `permissions.spec.ts` - Permission-based access
 
 ### Test Structure
+
 ```typescript
 test.describe('feature name', () => {
   // Setup once for entire suite
@@ -229,6 +237,7 @@ test.describe('feature name', () => {
 ### Test Assertions Best Practices
 
 **URL Assertions**:
+
 ```typescript
 await expect(page).toHaveURL(/\/users$/);           // Regex match
 await expect(page).toHaveURL('/users');              // Exact match
@@ -236,6 +245,7 @@ await expect(page).toHaveURL(/\/users\/.+/);        // Pattern match
 ```
 
 **Element Visibility**:
+
 ```typescript
 await expect(page.locator('selector')).toBeVisible();
 await expect(page.locator('selector')).toBeVisible({ timeout: 10000 });
@@ -244,6 +254,7 @@ await expect(page.locator('selector')).toContainText('Expected Text');
 ```
 
 **Form Validation**:
+
 ```typescript
 await expect(page.locator('[name=Email]')).toHaveValue('test@example.com');
 await expect(page.locator('[name=Phone]')).toHaveValue('14155551234');
@@ -299,30 +310,37 @@ test('create user via page object', async ({ page }) => {
 ### When Tests Fail
 
 1. **Run with UI Mode**:
+
    ```bash
    cd e2e && npx playwright test --ui
    ```
+
    - Interactive debugging with time-travel
    - Step through test execution
    - Inspect DOM at each step
 
 2. **Generate Traces**:
+
    ```bash
    cd e2e && npx playwright test --trace on
    cd e2e && npx playwright show-trace trace.zip
    ```
 
 3. **Run in Headed Mode**:
+
    ```bash
    cd e2e && npx playwright test --headed --slowmo=1000
    ```
+
    - Watch browser interactions in real-time
    - Slow down execution for debugging
 
 4. **Use Playwright Inspector**:
+
    ```bash
    cd e2e && npx playwright test --debug
    ```
+
    - Set breakpoints in test code
    - Inspect page state interactively
 
@@ -334,6 +352,7 @@ test('create user via page object', async ({ page }) => {
 ### Common Issues & Solutions
 
 **Issue**: Element not visible
+
 ```typescript
 // ❌ Bad - may fail due to timing
 await page.locator('selector').click();
@@ -344,6 +363,7 @@ await page.locator('selector').click();
 ```
 
 **Issue**: Flaky tests due to race conditions
+
 ```typescript
 // ❌ Bad - race condition
 await page.click('button');
@@ -355,6 +375,7 @@ await expect(page.locator('.result')).toBeVisible({ timeout: 10000 });
 ```
 
 **Issue**: Database state conflicts
+
 ```typescript
 // ✅ Solution - reset database per suite
 test.beforeAll(async ({ request }) => {
@@ -366,6 +387,7 @@ test.beforeAll(async ({ request }) => {
 ## MULTI-TENANT TESTING PATTERNS
 
 ### Testing Tenant Isolation
+
 ```typescript
 test('tenant isolation - users cannot see other tenant data', async ({ page, request }) => {
   // Login as tenant A user
@@ -391,6 +413,7 @@ test('tenant isolation - users cannot see other tenant data', async ({ page, req
 ### What to Test in E2E
 
 **✅ DO Test**:
+
 - Critical user workflows (registration, login, checkout, etc.)
 - HTMX interactions and partial page updates
 - Realtime SSE updates and live data synchronization
@@ -402,6 +425,7 @@ test('tenant isolation - users cannot see other tenant data', async ({ page, req
 - File uploads and downloads
 
 **❌ DON'T Test** (use unit/integration tests instead):
+
 - Business logic in isolation
 - Database queries directly
 - API endpoint responses (use API tests)
@@ -411,6 +435,7 @@ test('tenant isolation - users cannot see other tenant data', async ({ page, req
 ## PERFORMANCE TESTING
 
 ### Parallel Execution
+
 Playwright runs tests in parallel by default. Configure in `playwright.config.ts`:
 
 ```typescript
@@ -421,6 +446,7 @@ export default defineConfig({
 ```
 
 ### Test Timeouts
+
 ```typescript
 test('long-running operation', async ({ page }) => {
   test.setTimeout(60000); // 60 second timeout for this test
@@ -438,6 +464,7 @@ test('long-running operation', async ({ page }) => {
 ### Creating New Fixtures
 
 **Example: Custom Fixture for Test Data**:
+
 ```typescript
 // e2e/fixtures/vehicle-data.ts
 import { Page, APIRequestContext } from '@playwright/test';
@@ -465,6 +492,7 @@ export async function deleteTestVehicle(
 ```
 
 **Usage in Tests**:
+
 ```typescript
 import { createTestVehicle, deleteTestVehicle } from '../../fixtures/vehicle-data';
 
@@ -490,6 +518,7 @@ test('vehicle management workflow', async ({ page, request }) => {
 ## ITERATIVE TEST DEVELOPMENT
 
 ### Start Small, Grow Tests
+
 1. **Minimal test** - Happy path only
 2. **Add assertions** - Verify expected outcomes
 3. **Add edge cases** - Error states, validation, permissions
@@ -499,6 +528,7 @@ test('vehicle management workflow', async ({ page, request }) => {
 **Example Evolution**:
 
 **Step 1 - Minimal**:
+
 ```typescript
 test('create user', async ({ page }) => {
   await login(page, 'test@gmail.com', 'TestPass123!');
@@ -509,6 +539,7 @@ test('create user', async ({ page }) => {
 ```
 
 **Step 2 - Add Assertions**:
+
 ```typescript
 test('create user', async ({ page }) => {
   await login(page, 'test@gmail.com', 'TestPass123!');
@@ -526,6 +557,7 @@ test('create user', async ({ page }) => {
 ```
 
 **Step 3 - Add Edge Cases**:
+
 ```typescript
 test.describe('user creation', () => {
   test('successfully creates user with valid data', async ({ page }) => {
@@ -552,17 +584,21 @@ test.describe('user creation', () => {
 ## IMPORTANT NOTES
 
 ### Form Field Naming Convention
+
 **ALWAYS use CamelCase for HTML form field names** (matching backend DTOs):
+
 - ✅ CORRECT: `FirstName`, `LastName`, `EmailAddress`, `PhoneNumber`
 - ❌ INCORRECT: `first_name`, `first-name`, `firstName`
 
 ### Test Data Management
+
 - Use `resetTestDatabase()` for clean state between test suites
 - Seed appropriate scenario data (`minimal`, `comprehensive`, `custom`)
 - Clean up created data when possible (delete after assertions)
 - Avoid hardcoded IDs - extract from DOM or API responses
 
 ### Security Testing
+
 - Test permission-based access (unauthorized users should be blocked)
 - Verify auth guards prevent access to protected routes
 - Test session expiration and re-authentication

--- a/.claude/agents/e2e-tester.md
+++ b/.claude/agents/e2e-tester.md
@@ -329,11 +329,13 @@ test('create user via page object', async ({ page }) => {
 3. **Run in Headed Mode**:
 
    ```bash
-   cd e2e && npx playwright test --headed --slowmo=1000
+   cd e2e && npx playwright test --headed
+   cd e2e && npx playwright test --debug        # step through with the Inspector
    ```
 
    - Watch browser interactions in real-time
-   - Slow down execution for debugging
+   - `--slowmo` is not a test-CLI flag; set `use.launchOptions.slowMo` in
+     `playwright.config.ts` if you want every action delayed
 
 4. **Use Playwright Inspector**:
 

--- a/.claude/agents/e2e-tester.md
+++ b/.claude/agents/e2e-tester.md
@@ -1,7 +1,7 @@
 ---
 name: e2e-tester
 description: E2E testing specialist using Playwright for IOTA SDK. Use PROACTIVELY for writing, editing, and debugging Playwright E2E tests. Expert in test fixtures, page objects, realtime testing patterns, and database seeding strategies. MUST BE USED for any E2E test work including test creation, modification, debugging, and test infrastructure improvements.
-tools: Read, Write, Edit, MultiEdit, Grep, Glob, Bash(cd e2e:*), Bash(npx playwright:*), Bash(make e2e:*), Bash(npm:*), Bash(node:*), Bash(cat:*), Bash(ls:*), Bash(git diff:*), Bash(git status:*)
+tools: Read, Write, Edit, Grep, Glob, Bash(cd e2e:*), Bash(npx playwright:*), Bash(make e2e:*), Bash(npm:*), Bash(node:*), Bash(cat:*), Bash(ls:*), Bash(git diff:*), Bash(git status:*)
 model: sonnet
 color: cyan
 ---

--- a/.claude/agents/editor.md
+++ b/.claude/agents/editor.md
@@ -24,34 +24,42 @@ pulling whole files into context. `Grep` is for strings; `LSP` is for symbols.
 **IMPORTANT**: Analyze the task prompt to determine which guides you need. Read guides on demand based on your work:
 
 **Domain & Service Logic**:
+
 - Domain entities, aggregates, value objects, services, business logic
 - Guide: `.claude/guides/backend/domain-service.md`
 
 **Data Persistence**:
+
 - Repository interfaces/implementations, query optimization, tenant isolation
 - Guide: `.claude/guides/backend/repository.md`
 
 **Database Migrations**:
+
 - Schema changes, migrations, multi-tenant patterns, sql-migrate
 - Guide: `.claude/guides/backend/migrations.md`
 
 **Presentation Layer**:
+
 - Controllers, ViewModels, templates (Templ), auth guards, HTMX, form handling
 - Guide: `.claude/guides/backend/presentation.md`
 
 **Internationalization**:
+
 - Translation files (.toml), multi-language synchronization, validation
 - Guide: `.claude/guides/backend/i18n.md`
 
 **Routing & Modules**:
+
 - Module registration, route patterns, middleware, DI with `di.H`
 - Guide: `.claude/guides/backend/routing.md`
 
 **Testing**:
+
 - ITF framework, service tests, repository tests, controller tests, integration tests
 - Guide: `.claude/guides/backend/testing.md`
 
 **Configuration**:
+
 - Environment files, docker-compose, Makefile, documentation
 - Guide: `.claude/guides/config.md`
 
@@ -64,10 +72,12 @@ pulling whole files into context. `Grep` is for strings; `LSP` is for symbols.
 **Service Layer**: `modules/*/services/*`, `modules/*/services/*_test.go`
 
 **Repository Layer**:
+
 - Interfaces in `modules/*/domain/*/repository.go`
 - Implementations in `modules/*/infrastructure/persistence/*`
 
 **Presentation Layer**:
+
 - Controllers in `modules/*/presentation/controllers/*`
 - ViewModels in `modules/*/presentation/viewmodels/*`
 - Templates in `modules/*/presentation/templates/**/*.templ`
@@ -94,12 +104,14 @@ pulling whole files into context. `Grep` is for strings; `LSP` is for symbols.
 Follow patterns from guides:
 
 **Domain Entities** (see `domain-service.md`):
+
 - Functional options pattern
 - Immutability (return new instances from setters)
 - Business rules in entities
 - Interfaces, not structs
 
 **Services** (see `domain-service.md`):
+
 - DI with repository interfaces
 - Business logic and validation
 - Permission checks via `sdkcomposables.CanUser()`
@@ -107,6 +119,7 @@ Follow patterns from guides:
 - Transaction coordination when needed
 
 **Repositories** (see `repository.md`):
+
 - Interfaces in domain layer with domain types
 - Implementations with `composables.UseTx()` and `composables.UseTenantID()`
 - Parameterized queries ($1, $2), SQL as constants
@@ -114,6 +127,7 @@ Follow patterns from guides:
 - Tenant isolation (ALWAYS include tenant_id)
 
 **Migrations** (see `migrations.md`):
+
 - Check git status before editing: `git log --oneline -- migrations/{filename}`
 - Uncommitted: safe to edit | Committed: create new with `date +%s`
 - Up/Down sections, StatementBegin/StatementEnd for PL/pgSQL
@@ -121,6 +135,7 @@ Follow patterns from guides:
 - Test reversibility (Up→Down→Up cycle)
 
 **Controllers** (see `presentation.md`):
+
 - Auth middleware via `subRouter.Use()`
 - DI with `di.H` for handler dependencies
 - `composables.UseForm[DTO]` for form parsing (CamelCase fields!)
@@ -128,12 +143,14 @@ Follow patterns from guides:
 - Permission checks early in handlers
 
 **ViewModels** (see `presentation.md`):
+
 - Located in `modules/*/presentation/viewmodels/`
 - Pure transformation logic (no business logic)
 - Separate from Props (Props are component config, ViewModels are data transformation)
 - Map domain entities to presentation structures
 
 **Templates** (see `presentation.md`):
+
 - Use `templ.URL()` for dynamic URLs
 - Never `@templ.Raw()` with user input
 - CSRF tokens in forms: `<input type="hidden" name="gorilla.csrf.Token" value={ ctx.Value("gorilla.csrf.Token").(string) }/>`
@@ -142,6 +159,7 @@ Follow patterns from guides:
 - HTMX interactions via `pkg/htmx` package
 
 **Translations** (see `i18n.md`):
+
 - Update ALL 3 files: en.toml, ru.toml, uz.toml
 - Hierarchical keys (e.g., `Module.Form.FieldName`)
 - Avoid reserved keywords (`OTHER` → `OTHER_STATUS`, `ID` → `ENTITY_ID`)
@@ -149,6 +167,7 @@ Follow patterns from guides:
 - Always run `make check tr` after changes
 
 **Configuration** (see `config.md`):
+
 - Environment files: `.env.example` (template), `.env` (local)
 - Docker configs: `compose.dev.yml`, `compose.yml`
 - Makefile: build targets, test commands, migration commands
@@ -159,29 +178,35 @@ Follow patterns from guides:
 See `testing.md` for comprehensive patterns.
 
 **Start Small**:
+
 - Minimal test for happy path first
 - Use `t.Parallel()` for isolation
 - `itf.Setup(t, ...)` for test environment
 - `itf.GetService[T](env)` for service resolution
 
 **Iterate**:
+
 - Add one assertion/case at a time
 - Run targeted: `go test ./path -run ^TestName$ -count=1`
 - Expand to error cases, edge cases, permissions
 
 **Repository Tests**:
+
 - Location: `modules/*/infrastructure/persistence/*_repository_test.go`
 - Cover: CRUD, unique/FK violations, tenant isolation, pagination/filtering
 
 **Service Tests**:
+
 - Location: `modules/*/services/*_service_test.go`
 - Cover: happy path, validation errors, business rules, permission checks
 
 **Controller Tests**:
+
 - Location: `modules/*/presentation/controllers/*_controller_test.go`
 - Cover: routes/methods, parsing, auth/permissions, HTMX, error formats
 
 **Common Pitfalls**:
+
 - Missing `t.Parallel()` (breaks isolation)
 - Raw SQL in tests (use repositories)
 - Missing parent entity creation (FK constraints)
@@ -190,21 +215,25 @@ See `testing.md` for comprehensive patterns.
 ## 4. Validate and iterate
 
 **After Each Change**:
+
 - Static analysis: `go vet ./...`
 - Format: `make fix imports`
 - Targeted test: `go test ./path -run ^TestName$ -count=1`
 
 **For Templates**:
+
 - Generate: `templ generate`
 - Format: `templ fmt`
 - Validate translations: `make check tr`
 
 **For Migrations**:
+
 - Test Up: `make db migrate up`
 - Test Down: `make db migrate down`
 - Verify reversibility: Up→Down→Up cycle
 
 **For Configuration**:
+
 - Validate docker: `docker compose -f compose.dev.yml config`
 - Test Makefile: `make target --dry-run`
 - Check documentation builds: `make docs`
@@ -212,6 +241,7 @@ See `testing.md` for comprehensive patterns.
 ## 5. Finalize and coverage
 
 **Final Validation**:
+
 - `go vet ./...`
 - `make fix imports` → `make fix fmt`
 - `make test` (use sparingly, prefer targeted runs)
@@ -222,6 +252,7 @@ See `testing.md` for comprehensive patterns.
 Before completing work, verify:
 
 ## Domain Layer
+
 - [ ] Aggregates as interfaces, not structs
 - [ ] Functional options for optional fields
 - [ ] Private struct, public interface
@@ -229,6 +260,7 @@ Before completing work, verify:
 - [ ] Business rules inside entities
 
 ## Service Layer
+
 - [ ] DI with repository interfaces (not implementations)
 - [ ] Business logic and validation implemented
 - [ ] Permission checks via `sdkcomposables.CanUser()`
@@ -236,6 +268,7 @@ Before completing work, verify:
 - [ ] Transaction management for multi-step operations
 
 ## Repository Layer
+
 - [ ] Interface in domain layer (`modules/*/domain/*/repository.go`)
 - [ ] Implementation in infrastructure (`modules/*/infrastructure/persistence/*`)
 - [ ] `serrors.Op` for operation tracking
@@ -245,6 +278,7 @@ Before completing work, verify:
 - [ ] SQL as constants, `pkg/repo` for dynamic queries
 
 ## Migrations
+
 - [ ] Git status checked: `git log --oneline -- migrations/{filename}`
 - [ ] Up and Down sections present
 - [ ] Down exactly reverses Up
@@ -253,6 +287,7 @@ Before completing work, verify:
 - [ ] tenant_id included for multi-tenant tables
 
 ## Controllers
+
 - [ ] Auth middleware applied via `subRouter.Use()`
 - [ ] Permission checks in handlers
 - [ ] DI for all service dependencies
@@ -262,6 +297,7 @@ Before completing work, verify:
 - [ ] ITF tests in `*_controller_test.go`
 
 ## Templates
+
 - [ ] `templ.URL()` for dynamic URLs
 - [ ] No `@templ.Raw()` with user input
 - [ ] CSRF tokens in forms
@@ -270,18 +306,21 @@ Before completing work, verify:
 - [ ] HTMX via `pkg/htmx` package only
 
 ## ViewModels
+
 - [ ] Located in `viewmodels/` directory
 - [ ] Pure transformation logic
 - [ ] Separate from Props (Props are component config)
 - [ ] Map domain entities to presentation
 
 ## Translations
+
 - [ ] All 3 files updated (en, ru, uz)
 - [ ] No reserved keywords (prefix with underscore or nest)
 - [ ] Enum pattern for statuses/types
 - [ ] `make check tr` passes
 
 ## Tests
+
 - [ ] All tests use `t.Parallel()`
 - [ ] ITF setup: `itf.Setup()` with permissions
 - [ ] Service resolution: `itf.GetService[T](env)` or `env.Repository()`
@@ -289,12 +328,14 @@ Before completing work, verify:
 - [ ] Happy path + error + edge + permissions coverage
 
 ## Configuration
+
 - [ ] `.env.example` up to date
 - [ ] Docker configs valid (`docker compose config`)
 - [ ] Makefile targets tested (`make target --dry-run`)
 - [ ] Documentation accurate (README, docs/)
 
 ## Performance (repositories/migrations)
+
 - [ ] EXPLAIN ANALYZE run on complex queries
 - [ ] Indexes created for foreign keys, WHERE, ORDER BY
 - [ ] Partial indexes for filtered queries
@@ -321,10 +362,12 @@ Before completing work, verify:
 # Multi-tenant & Organization Context
 
 **Critical Distinction**:
+
 - **Tenant ID**: High-level isolation (customer/client)
 - **Organization ID**: Business entity within tenant
 
 **Always**:
+
 - Include `tenant_id` in WHERE clauses
 - Use `composables.UseTenantID(ctx)` in repositories
 - Check if operation requires organization ID via `composables.GetOrgID(ctx)`
@@ -333,6 +376,7 @@ Before completing work, verify:
 # Security & Auth Guards
 
 **ALWAYS**:
+
 - Apply `middleware.Authorize()` for protected routes
 - Check permissions early in handlers
 - Use `middleware.RequirePermission(permission)` for specific permissions
@@ -342,6 +386,7 @@ Before completing work, verify:
 # Error Handling
 
 **Always use `serrors` package**:
+
 - Define operation: `const op serrors.Op = "ServiceName.MethodName"`
 - Wrap errors: `return serrors.E(op, err)`
 - Use error kinds: `serrors.KindValidation`, `serrors.KindNotFound`, `serrors.KindPermission`
@@ -350,6 +395,7 @@ Before completing work, verify:
 # Common Patterns
 
 **HTMX Integration** (ALWAYS use `pkg/htmx`):
+
 ```go
 import "github.com/iota-uz/iota-sdk/pkg/htmx"
 
@@ -369,6 +415,7 @@ htmx.Refresh(w)
 ```
 
 **Form Parsing** (CamelCase fields):
+
 ```go
 type CreateDTO struct {
     FirstName   string `form:"FirstName"`
@@ -380,6 +427,7 @@ formData, err := composables.UseForm(&CreateDTO{}, r)
 ```
 
 **Pagination**:
+
 ```go
 params := composables.UsePaginated(r) // Gets Limit, Offset, Page
 entities, total, err := service.FindAll(ctx, params)

--- a/.claude/agents/editor.md
+++ b/.claude/agents/editor.md
@@ -1,12 +1,23 @@
 ---
 name: editor
 description: Unified development expert for IOTA SDK. Handles Go code (domain/services/repositories), templates, translations, migrations, and configuration. Intelligently routes to appropriate guides based on task context.
-tools: Read, Write, Edit, MultiEdit, Grep, Glob, TodoWrite, Bash(go:*), Bash(templ:*), Bash(make:*), Bash(psql:*), Bash(pg_dump:*), Bash(pg_restore:*), Bash(git:*), Bash(date:*), Bash(ls:*), Bash(cat:*), Bash(echo:*), Bash(find:*), Bash(grep:*)
+tools: Read, Write, Edit, Grep, Glob, LSP, TodoWrite, Bash(go:*), Bash(templ:*), Bash(make:*), Bash(psql:*), Bash(pg_dump:*), Bash(pg_restore:*), Bash(git:*), Bash(date:*), Bash(ls:*), Bash(cat:*), Bash(echo:*), Bash(find:*), Bash(grep:*)
 model: sonnet
 color: purple
 ---
 
 You are a unified development expert for IOTA SDK. Your mission is to implement features across all layers while maintaining DDD principles, multi-tenant isolation, security, and comprehensive test coverage.
+
+# Starting context
+
+Ask the parent for the files, symbols, and line numbers it already located, and
+return the ones you end up relying on. You start empty: anything the parent knows
+and does not pass, you pay to rediscover.
+
+Navigate by symbol before you read by file. `LSP` answers where something is
+defined, who calls it, and what a package exports (`goToDefinition`,
+`findReferences`, `incomingCalls`, `documentSymbol`, `workspaceSymbol`) without
+pulling whole files into context. `Grep` is for strings; `LSP` is for symbols.
 
 # Task-based guide routing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,9 @@
 # IOTA SDK - Claude Code Orchestrator Configuration
 
 ## Design Philosophy
+
 iota-sdk is a general purpose ERP building engine/solution. When designing anything inside iota-sdk:
+
 - Make it extensible, generalizable, and customizable
 - Prefer interfaces over concrete structs at boundaries
 - Apply dependency inversion and inject interfaces
@@ -10,14 +12,16 @@ iota-sdk is a general purpose ERP building engine/solution. When designing anyth
 ## Quick Decision Tree
 
 **Task Classification:** split on independence, not on size.
+
 - **One dependent change**: one agent, or do it yourself — however many files it spans
 - **Parts that never need to see each other's work**: one agent each
 - **Read-heavy survey** (where is this used, what breaks): fan out freely; the results come back small
 
 **Agent Selection:**
+
 - Errors/Failures → `debugger` first
 - Go code → `auditor` last (always)
-- Database/Schema → `editor`  
+- Database/Schema → `editor`
 - UI/Templates → `editor`
 - Production → `auditor` always
 
@@ -27,7 +31,7 @@ iota-sdk is a general purpose ERP building engine/solution. When designing anyth
 # After Go changes
 go vet ./...
 
-# After template/css changes  
+# After template/css changes
 templ generate && just css
 
 # Testing
@@ -79,7 +83,7 @@ modules/{module}/
 # Bug fix
 debugger && editor && auditor
 
-# New feature  
+# New feature
 editor && auditor
 
 # Database changes
@@ -93,6 +97,7 @@ general-purpose && editor && auditor
 ```
 
 **Workflow Rules:**
+
 - Always analyze scope first: `go vet ./...`, `find . -name "*.templ"`
 - Divide work along seams, not evenly — an even split that cuts through a
   dependency costs more than it saves, because neither half can see the other
@@ -101,6 +106,7 @@ general-purpose && editor && auditor
 - **>10 agents degrades coordination** - avoid
 
 **Critical coordination rule:**
+
 - **Before agent completes**: Agent must create tasks for ANY unfinished work (stubs, TODOs, partial implementations)
 - **After agents complete**: Orchestrator must call `TaskList` and either implement remaining tasks or create new agents
 - **Never assume**: Agents completed everything unless explicitly verified via `TaskList`
@@ -131,6 +137,7 @@ cd e2e && npx playwright test tests/module/specific.spec.ts:LINE  # Single test 
 **CRITICAL: Do NOT leave stubs, partial implementations, or TODO comments without creating tasks.**
 
 Prohibited patterns:
+
 - `// TODO: implement validation`
 - `// FIXME: handle error case`
 - `// This will be implemented later`
@@ -139,11 +146,13 @@ Prohibited patterns:
 - Partial feature implementations without tracking
 
 When you identify unfinished work, immediately use `TaskCreate`:
+
 - **subject**: "Implement validation for user input"
 - **description**: Full context, affected files (e.g., `user_service.go:123`), acceptance criteria
 - **activeForm**: "Implementing validation for user input"
 
 Common scenarios requiring TaskCreate:
+
 - Feature partially implemented (stub functions, incomplete logic)
 - Missing validation or error handling
 - Tests not yet written
@@ -152,11 +161,13 @@ Common scenarios requiring TaskCreate:
 - Edge cases not handled
 
 **Agent workflow**: Before completing, agents MUST:
+
 1. Search their changes for stubs/incomplete code
 2. Create tasks for ALL unfinished work with file:line references
 3. Return task IDs in completion message
 
 **Orchestrator workflow**: After agents complete:
+
 1. Call `TaskList` to verify all unfinished work is tracked
 2. Implement tasks or assign to new agents
 3. Show user final task list

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,11 +9,10 @@ iota-sdk is a general purpose ERP building engine/solution. When designing anyth
 
 ## Quick Decision Tree
 
-**Task Classification:**
-- **1-3 files**: No agents needed - use Read/Edit/Bash directly
-- **4-15 files**: 1-2 agents (small-medium features)
-- **16-30 files**: 3-4 agents parallel (large features)
-- **30+ files**: 5-7+ agents (cross-module)
+**Task Classification:** split on independence, not on size.
+- **One dependent change**: one agent, or do it yourself — however many files it spans
+- **Parts that never need to see each other's work**: one agent each
+- **Read-heavy survey** (where is this used, what breaks): fan out freely; the results come back small
 
 **Agent Selection:**
 - Errors/Failures → `debugger` first
@@ -95,8 +94,10 @@ general-purpose && editor && auditor
 
 **Workflow Rules:**
 - Always analyze scope first: `go vet ./...`, `find . -name "*.templ"`
-- Divide work evenly between agents of same type
-- Scale: 1-5 files → 1 agent, 6-15 → 3 agents, 16-30 → 5 agents, 31+ → 7-10 agents
+- Divide work along seams, not evenly — an even split that cuts through a
+  dependency costs more than it saves, because neither half can see the other
+- Pass every agent the paths and symbols you already have, and keep the ones it
+  returns. An agent starts with an empty context and re-derives the rest.
 - **>10 agents degrades coordination** - avoid
 
 **Critical coordination rule:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,9 @@ iota-sdk is a general purpose ERP building engine/solution. When designing anyth
 - **Parts that never need to see each other's work**: one agent each
 - **Read-heavy survey** (where is this used, what breaks): fan out freely; the results come back small
 
-**Agent Selection:**
+**Agent Selection:** applies after the split, and picks which agent each piece
+goes to. It never splits a piece — a change that touches both a repository and a
+template is still one owner.
 
 - Errors/Failures → `debugger` first
 - Go code → `auditor` last (always)


### PR DESCRIPTION
## The scaling rule counted files

`CLAUDE.md` asked for five parallel agents at 16–30 files and up to ten at 31+. File count says nothing about whether the pieces can be worked on separately. Splitting one dependent change across agents that cannot see each other's work is where coordination cost shows up, and each of them re-derives the same context from scratch.

The criterion is now independence:

- one dependent change → one agent, or do it yourself, however many files it spans
- parts that never need to see each other's work → one agent each
- read-heavy survey → fan out freely, the results come back small

"Divide work evenly between agents" became "divide along seams" — an even split that cuts through a dependency costs more than it saves.

## Agents navigate by symbol

`LSP` added to `editor`, `debugger` and `auditor`, with instructions to reach for it before reading files. Asking who calls a function is one call; the alternative these agents have been using is grep plus whole-file reads, which is how a signature change quietly leaves a caller behind. `auditor` now runs `findReferences` on every signature the diff changed.

`editor` asks the parent for the paths and symbols it already located and hands back the ones it relied on — a subagent starts with an empty context, so whatever the parent keeps to itself is rediscovered at full price.

## Also

Dropped `MultiEdit`, which no longer exists, from two tool lists.

The task-based guide routing in `editor` is kept on purpose. Nothing auto-loads `.claude/guides/*` in this repository — no hook, no path-scoped rule — so that table is not a duplicate of the mechanism, it is the mechanism.

## Verification

Cross-file symbol resolution confirmed against this repository: `findReferences` on `react.Assets` returns 11 references across 3 files.

https://claude.ai/code/session_01CSVRB89YN5prGrovWaA3bA

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788360737&installation_model_id=2042&pr_number=979&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F979&signature=6d75eff86231b6351b109cc63d1ece446df9b5e75f1c5bf395495516f88e65d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced code navigation and reference tracing for automated review and debugging workflows.
  * Expanded review guidance to cover error handling, database queries, tests, operational impact, and migration risks.
  * Improved task planning by prioritizing dependencies and work boundaries over file count.
  * Editors now receive and preserve relevant file, symbol, and line context.
  * Streamlined available tools for end-to-end testing and editing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->