### PR TITLE
Support OpenAI Go v3.44 response unions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/mileusna/useragent v1.3.5
 	github.com/openai/openai-go v1.3.0
-	github.com/openai/openai-go/v3 v3.18.0
+	github.com/openai/openai-go/v3 v3.44.0
 	github.com/pkg/errors v0.9.1
 	github.com/pkoukk/tiktoken-go v0.1.8
 	github.com/pquerna/otp v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -372,8 +372,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/openai/openai-go v1.3.0 h1:lBpvgXxGHUufk9DNTguval40y2oK0GHZwgWQyUtjPIQ=
 github.com/openai/openai-go v1.3.0/go.mod h1:g461MYGXEXBVdV5SaR/5tNzNbSfwTBBefwc+LlDCK0Y=
-github.com/openai/openai-go/v3 v3.18.0 h1:PpheJdvPgi8Ou77rJ1zsNmJTdmC7kvqDrGxbwAYq2nQ=
-github.com/openai/openai-go/v3 v3.18.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
+github.com/openai/openai-go/v3 v3.44.0 h1:kkGh+jb/sKfSh5P74Jk5mCRufaQ0q7oH+lq+pNlWjsk=
+github.com/openai/openai-go/v3 v3.44.0/go.mod h1:cdufnVK14cWcT9qA1rRtrXx4FTRsgbDPW7Ia7SS5cZo=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkoukk/tiktoken-go v0.1.8 h1:85ENo+3FpWgAACBaEUVp+lctuTcYUO7BtmfhlN/QTRo=

--- a/modules/bichat/infrastructure/llmproviders/openai_model.go
+++ b/modules/bichat/infrastructure/llmproviders/openai_model.go
@@ -320,14 +320,14 @@ func (m *OpenAIModel) consumeOpenAIStream(
 						a.name = event.Item.Name
 					}
 					if a.args == "" {
-						a.args = event.Item.Arguments
+						a.args = event.Item.Arguments.OfString
 					}
 				} else {
 					toolCallAccum[itemID] = &toolCallAccumEntry{
 						id:     itemID,
 						callID: event.Item.CallID,
 						name:   event.Item.Name,
-						args:   event.Item.Arguments,
+						args:   event.Item.Arguments.OfString,
 					}
 					toolCallOrder = append(toolCallOrder, itemID)
 				}

--- a/modules/bichat/infrastructure/llmproviders/openai_model_test.go
+++ b/modules/bichat/infrastructure/llmproviders/openai_model_test.go
@@ -578,10 +578,12 @@ func TestOpenAIModel_MapResponse_FunctionCalls(t *testing.T) {
 	resp := &responses.Response{
 		Output: []responses.ResponseOutputItemUnion{
 			{
-				Type:      "function_call",
-				CallID:    "call_abc",
-				Name:      "sql_execute",
-				Arguments: `{"query":"SELECT 1"}`,
+				Type:   "function_call",
+				CallID: "call_abc",
+				Name:   "sql_execute",
+				Arguments: responses.ResponseOutputItemUnionArguments{
+					OfString: `{"query":"SELECT 1"}`,
+				},
 			},
 		},
 		Usage: responses.ResponseUsage{

--- a/modules/bichat/infrastructure/llmproviders/openai_response_mapper.go
+++ b/modules/bichat/infrastructure/llmproviders/openai_response_mapper.go
@@ -60,7 +60,7 @@ func (m *OpenAIModel) mapResponse(resp *responses.Response) (*agents.Response, e
 			toolCalls = append(toolCalls, types.ToolCall{
 				ID:        item.CallID,
 				Name:      item.Name,
-				Arguments: item.Arguments,
+				Arguments: item.Arguments.OfString,
 			})
 
 		case "code_interpreter_call":


### PR DESCRIPTION
## Summary

- update the official OpenAI Go v3 client from v3.18.0 to v3.44.0
- read Responses API function-call arguments from the generated string union
- update the mapper test fixture for the new union type

## Validation

- `GOTOOLCHAIN=go1.24.10 go test ./modules/bichat/...`
- `GOTOOLCHAIN=go1.24.10 go vet ./modules/bichat/...`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788420305&installation_model_id=2042&pr_number=980&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F980&signature=800ca7784837f5e1cb80d6e9513e09e60c37dd5c030eea6fe21766ecc11b9a5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of streamed function-call arguments from OpenAI responses.
  * Ensured tool-call arguments are correctly mapped and available during response processing.
  * Updated compatibility with the latest OpenAI SDK version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->