### PR TITLE
fix(release): provide integration test services

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,34 @@ jobs:
   release:
     runs-on: ubuntu-24.04
     timeout-minutes: 45
+    services:
+      postgres:
+        image: postgres:17
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: iota_erp
+          POSTGRES_INITDB_ARGS: >-
+            -c max_connections=1000
+            -c fsync=off
+            -c synchronous_commit=off
+            -c full_page_writes=off
+            -c autovacuum=off
+            -c jit=off
+        options: >-
+          --tmpfs /var/lib/postgresql/data:rw,size=4g,noatime
+          --health-cmd="pg_isready -U postgres -d iota_erp"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=5
+      redis:
+        image: redis:latest
+        ports:
+          - 6379:6379
+        options: >-
+          --tmpfs /data:rw,size=1g
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -51,6 +79,13 @@ jobs:
           test "$(git rev-list -n 1 "$GITHUB_REF_NAME")" = "$GITHUB_SHA"
       - run: pnpm install --frozen-lockfile
       - name: Verify Go release graph
+        env:
+          DB_HOST: localhost
+          DB_PORT: 5432
+          DB_NAME: iota_erp
+          DB_USER: postgres
+          DB_PASSWORD: postgres
+          REDIS_URL: redis://localhost:6379
         run: |
           just test -v
           go vet ./...


### PR DESCRIPTION
## Summary
- provide PostgreSQL and Redis services to the canonical release job
- pass the same database connection contract used by the integration test workflow
- preserve the full Go test and vet release gate instead of bypassing it

## Context
The v0.5.0 release run reached the Go verification gate but all integration tests failed because the release runner had no PostgreSQL service. No npm package or GitHub release was created.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788518995&installation_model_id=2042&pr_number=986&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F986&signature=3171cb496ec0c6e26f5c9bf1e2d79c4ae46205cfaa9511242f88afab6d378cb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release verification by providing PostgreSQL 17 and Redis services during automated checks.
  * Added service health checks, configured connectivity, and temporary storage to support more consistent release validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->