### PR TITLE
test(bichat): read stream results from committed state

### DIFF
--- a/modules/bichat/presentation/controllers/controllers_mount_test.go
+++ b/modules/bichat/presentation/controllers/controllers_mount_test.go
@@ -386,8 +386,10 @@ func TestStreamController_ReplaceFromMessageID_TruncatesHistory_Integration(t *t
 	req1 := httptest.NewRequest(http.MethodPost, "/bi-chat/stream", bytes.NewReader(firstData))
 	r.ServeHTTP(w1, req1)
 	require.Equal(t, http.StatusOK, w1.Code, w1.Body.String())
+	require.Contains(t, w1.Body.String(), `"type":"done"`)
 
-	msgs, err := deps.chatRepo.GetSessionMessages(env.Ctx, session.ID(), bichatdomain.ListOptions{Limit: 100, Offset: 0})
+	committedCtx := context.WithValue(env.Ctx, constants.TxKey, nil)
+	msgs, err := deps.chatRepo.GetSessionMessages(committedCtx, session.ID(), bichatdomain.ListOptions{Limit: 100, Offset: 0})
 	require.NoError(t, err)
 	require.NotEmpty(t, msgs)
 
@@ -412,8 +414,9 @@ func TestStreamController_ReplaceFromMessageID_TruncatesHistory_Integration(t *t
 	req2 := httptest.NewRequest(http.MethodPost, "/bi-chat/stream", bytes.NewReader(secondData))
 	r.ServeHTTP(w2, req2)
 	require.Equal(t, http.StatusOK, w2.Code, w2.Body.String())
+	require.Contains(t, w2.Body.String(), `"type":"done"`)
 
-	msgs2, err := deps.chatRepo.GetSessionMessages(env.Ctx, session.ID(), bichatdomain.ListOptions{Limit: 100, Offset: 0})
+	msgs2, err := deps.chatRepo.GetSessionMessages(committedCtx, session.ID(), bichatdomain.ListOptions{Limit: 100, Offset: 0})
 	require.NoError(t, err)
 	require.Len(t, msgs2, 2)
 
@@ -460,7 +463,8 @@ func TestStreamController_AttachmentUpload_PersistsOnUserMessage_Integration(t *
 	r.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code, w.Body.String())
 
-	msgs, err := deps.chatRepo.GetSessionMessages(env.Ctx, session.ID(), bichatdomain.ListOptions{Limit: 20, Offset: 0})
+	committedCtx := context.WithValue(env.Ctx, constants.TxKey, nil)
+	msgs, err := deps.chatRepo.GetSessionMessages(committedCtx, session.ID(), bichatdomain.ListOptions{Limit: 20, Offset: 0})
 	require.NoError(t, err)
 	require.NotEmpty(t, msgs)
 


### PR DESCRIPTION
## Summary
- read controller stream persistence through a committed context rather than the harness rollback transaction
- require both SSE requests to reach the terminal `done` event before asserting database state
- apply the same committed read boundary to the attachment persistence assertion

## Verification
- `go test -tags dev ./modules/bichat/presentation/controllers -run ^TestStreamController_ReplaceFromMessageID_TruncatesHistory_Integration$ -count=10`

## Context
The full v0.5.0 release gate exposed this flaky read boundary on the slower release runner; main CI had passed the same commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788520253&installation_model_id=2042&pr_number=987&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F987&signature=b675671cad42fbf6796df1a829636ea85a3f6476127a2c657e8bd7e19d5666b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test coverage for streamed responses and persisted session data.
  * Tests now verify completion events and reliably validate replacement history and attachment persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->