### PR TITLE
fix(release): bind npm package to provenance repository

### DIFF
--- a/scripts/verify-frontend-artifacts.mjs
+++ b/scripts/verify-frontend-artifacts.mjs
@@ -22,6 +22,9 @@ try {
 
   const installedPackage = JSON.parse(await readFile(path.join(consumer, 'node_modules/@iota-uz/sdk/package.json'), 'utf8'))
   if (installedPackage.version !== manifest.packageVersion) throw new Error('consumer installed the wrong package version')
+  if (installedPackage.repository?.url !== 'https://github.com/iota-uz/iota-sdk') {
+    throw new Error('published package repository must match the SDK provenance repository')
+  }
   if (Object.keys(installedPackage.dependencies ?? {}).length !== 0) {
     throw new Error('implementation dependencies leaked into the public package dependency graph')
   }

--- a/web/sdk/package.json
+++ b/web/sdk/package.json
@@ -3,6 +3,10 @@
   "version": "0.5.0",
   "description": "Canonical JavaScript distribution for iota-sdk.",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/iota-uz/iota-sdk"
+  },
   "private": false,
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
Fix the final npm OIDC provenance validation failure for v0.5.0.

- declare the canonical GitHub repository in the public package metadata
- verify the packed consumer artifact retains the exact repository URL expected by Sigstore/npm provenance

Release run: https://github.com/iota-uz/iota-sdk/actions/runs/31002100359

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788535918&installation_model_id=2042&pr_number=990&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F990&signature=85ebc3797401873cb0aad99805ff3a7428f5f2063e0dd6bab7415aabc0405f27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved frontend package verification by checking repository provenance metadata.
  * Added repository information to the SDK package, helping confirm packages originate from the expected source.
  * Verification now reports an error when package repository details do not match the official repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->