### PR TITLE
fix(lens): make the loading KPI placeholder a box that exists

### DIFF
--- a/web/lens/src/Parity.stories.tsx
+++ b/web/lens/src/Parity.stories.tsx
@@ -235,6 +235,60 @@ export const MetricGroupSparkline: Story = () => {
 MetricGroupSparkline.storyName = 'Metric group sparkline'
 
 /**
+ * The same strip before any of its figures have landed.
+ *
+ * A KPI strip is the first thing on a board and the last thing to finish
+ * computing, so its loading state is what a reader looks at for the whole first
+ * second — and it was the one state nothing exercised. The figure slot has no
+ * text of its own while the panel is deferred, so a placeholder that borrowed
+ * its width from that slot resolved to zero and the strip painted a row of
+ * names over an empty gap: indistinguishable, for that whole second, from a
+ * board whose numbers had failed to arrive.
+ *
+ * The row beside the figure is crowded on purpose: the first metric is a link
+ * (so it draws its drill mark) and the second carries a sparkline, which are
+ * the two things the placeholder shares its flex row with.
+ */
+const loadingMetrics: Panel[] = metrics.map(({ panel }, index) => ({
+  ...panel,
+  deferred: true,
+  caption: ['Claims paid ÷ earned premium', 'Expenses ÷ earned premium', '(claims + expenses) ÷ earned premium', 'Earned premium − claims − expenses ± reserves'][index],
+  sparkline: index === 1 ? { values: [38.1, 39.4, 40.2, 40.9, 41.1, 41.4, 41.7] } : undefined,
+  terminal: index !== 0,
+  actions: index === 0
+    ? [{ kind: 'navigate' as const, urlTemplate: '/analytics/drill/loss-ratio', params: [], payload: {} }]
+    : [],
+}))
+
+/** A request that never settles: the panels stay in flight for the capture. */
+const neverSettles: typeof fetch = () => new Promise<Response>(() => undefined)
+
+export const MetricGroupLoading: Story = () => {
+  const doc: DashboardDocument = {
+    ...storyDocument(loadingMetrics, {}, {
+      rows: [{
+        heading: 'КЛЮЧЕВЫЕ КОЭФФИЦИЕНТЫ',
+        panels: loadingMetrics.map((panel) => ({
+          panelId: panel.id, span: 3,
+          groups: [{ id: 'earned', kind: 'metrics' as const, label: 'ПО ЗАРАБОТАННОЙ ПРЕМИИ', layout: 'columns' as const, span: 12 }],
+        })),
+      }],
+    }),
+    // Deferred panels are computed per panel after the document lands, which is
+    // the shape that puts every cell of the strip in flight at once.
+    endpoints: { panel: '/lens/panel' },
+  }
+  return (
+    <div className="lens-root">
+      <DocumentProvider fetcher={neverSettles} initialDocument={doc}>
+        <DashboardRuntimeProvider fetcher={neverSettles} locale="ru"><DashboardPanels /></DashboardRuntimeProvider>
+      </DocumentProvider>
+    </div>
+  )
+}
+MetricGroupLoading.storyName = 'Metric group loading'
+
+/**
  * A cube dashboard's KPI band is a headerless strip whose metrics carry both a
  * caption and a supporting note, and whose first metric is a link to its own
  * evidence. Three things have to hold at once here, and each of them broke a

--- a/web/lens/src/panels/shimmerPlaceholders.test.ts
+++ b/web/lens/src/panels/shimmerPlaceholders.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * What a loading placeholder is allowed to measure itself against.
+ *
+ * A percentage width is only a width when the box it is stated against has one.
+ * The strip's figure slot does not: `.lens-stat-metric-value` is a flex item
+ * that shrinks and never grows, so before its figure arrives it holds no text
+ * and is zero pixels wide — and `width: 60%` of zero is zero. The placeholder
+ * disappeared, the reserved line height stayed, and every loading KPI strip
+ * read as a row of names over an empty gap, which is the "no data" it exists to
+ * distinguish itself from.
+ *
+ * jsdom has no layout, so the pixels are asserted in the VR lane ("a loading
+ * KPI cell shows a placeholder the size of the figure it stands in for"). What
+ * is held here is the shape of the mistake: a placeholder may size itself in
+ * percent only inside a container that is known to have a width of its own.
+ */
+const declarations = readFileSync('src/styles.css', 'utf8').replace(/\/\*[\s\S]*?\*\//g, '')
+
+function rules(): Array<{ selector: string; body: string }> {
+  return [...declarations.matchAll(/(?<selector>[^{}]*)\{(?<body>[^{}]*)\}/g)]
+    .map((match) => ({ selector: (match.groups?.selector ?? '').trim(), body: match.groups?.body ?? '' }))
+    .filter(({ selector }) => !selector.startsWith('@') && selector !== '')
+}
+
+/** `width`, not `max-width` or `min-width`. */
+function width(body: string): string | undefined {
+  return /(?:^|[;{\s])width:\s*([^;]+)/.exec(body)?.[1]?.trim()
+}
+
+/**
+ * Containers whose own width is settled by the grid or the card around them, so
+ * a percentage stated inside them resolves to something. `.lens-skeleton-card`
+ * is a column flex container: width is its cross axis, and its children stretch
+ * to the card rather than to their own contents.
+ */
+const definiteContainers = ['.lens-skeleton-card']
+
+describe('loading placeholders', () => {
+  it('sizes the strip’s figure placeholder in its own units, not the empty slot’s', () => {
+    const slot = rules().find(({ selector }) => selector === '.lens-stat-metric-value')?.body ?? ''
+    const placeholder = rules().find(({ selector }) => selector === '.lens-stat-metric-value-shimmer')?.body ?? ''
+    expect(slot).not.toBe('')
+    expect(placeholder).not.toBe('')
+
+    // Either the slot claims width of its own while it is empty, or the
+    // placeholder brings its own. One of the two has to be true; the sheet
+    // shipped with neither.
+    const slotClaimsWidth = /(?:^|[;{\s])flex(?:-grow)?:\s*[1-9]/.test(slot)
+      || /@apply[^;]*\blens-(?:flex-1|grow)\b/.test(slot)
+    const placeholderWidth = width(placeholder)
+    expect(placeholderWidth).toBeDefined()
+    expect(slotClaimsWidth || !placeholderWidth?.endsWith('%')).toBe(true)
+  })
+
+  it('states a percentage width only inside a container that has one', () => {
+    const percentages = rules().filter(({ selector, body }) => (
+      selector.includes('shimmer') && (width(body)?.endsWith('%') ?? false)
+    ))
+
+    for (const { selector } of percentages) {
+      for (const part of selector.split(',').map((entry) => entry.trim()).filter(Boolean)) {
+        // The ancestor may carry an attribute or state of its own
+        // (`.lens-skeleton-card[data-kind="stat"]`); the container class is
+        // what says the width is settled.
+        const ancestors = part.split(/\s*>\s*|\s+/).slice(0, -1)
+        expect(ancestors.some((ancestor) => definiteContainers.some((container) => ancestor.startsWith(container))))
+          .toBe(true)
+      }
+    }
+  })
+})

--- a/web/lens/src/styles.css
+++ b/web/lens/src/styles.css
@@ -2323,11 +2323,24 @@
 
   /* The loading figure is the figure's own shape, not the «—» this product
      prints for a value that is genuinely absent: a slow strip and an empty one
-     must not look the same. */
+     must not look the same.
+
+     It carries its own width rather than borrowing the slot's. The slot holds
+     no text while the figure is loading, and a flex item sized by its content
+     is zero pixels wide — `width: 60%` resolved against that zero, so the
+     placeholder painted nothing and a loading strip read as a row of names over
+     an empty gap, which is exactly the "no data" it was added to distinguish
+     itself from. A width of its own also keeps the slot's flex base at the
+     placeholder's size, so the drill mark and the sparkline beside it sit where
+     a figure would put them instead of against the name.
+
+     `max-width` is what the percentage was really buying — a cell narrower than
+     the placeholder shrinks it rather than overflowing — and it is stated
+     against the slot, which by then has a width to state it against. */
   .lens-stat-metric-value-shimmer {
     height: var(--lens-type-2xl);
-    width: 60%;
-    max-width: 8rem;
+    width: 5.5rem;
+    max-width: 100%;
     border-radius: var(--lens-radius-badge);
   }
 

--- a/web/lens/vr/lens.spec.ts
+++ b/web/lens/vr/lens.spec.ts
@@ -140,6 +140,7 @@ const storyIds = [
   'parity--stat-beside-a-tall-table',
   'parity--metric-group',
   'parity--metric-group-info',
+  'parity--metric-group-loading',
   'parity--metric-group-responsive',
   'parity--metric-group-sparkline',
   'parity--panel-header-pressure',
@@ -404,6 +405,7 @@ test('VR manifest covers every Ladle story', async ({ request }) => {
   const covered = new Set<string>([
     ...staticStories.map(([storyId]) => storyId),
     ...keyframeCovered,
+    ...measuredStories,
     'parity--metric-group-responsive',
   ])
 
@@ -467,6 +469,74 @@ const keyframeCovered = [
   'parity--coverage-split',
   'parity--pie-with-legend-right--light',
 ] as const
+
+/**
+ * Stories whose contract is a measurement rather than a raster.
+ *
+ * A placeholder is a gradient sweeping under an animation; a screenshot of one
+ * is a picture of whichever frame the capture froze, and the defect it has to
+ * catch is not a colour but a box that was zero pixels wide. Measuring the box
+ * says that directly, and says it the same way on every platform.
+ */
+const measuredStories = ['parity--metric-group-loading'] as const
+
+/** The cells of the KPI strip, and the placeholder each one is showing. */
+async function loadingMetricBoxes(page: Page) {
+  return page.locator('.lens-stat-metric[aria-busy="true"]').evaluateAll((elements) => elements.map((element) => {
+    const box = element.querySelector('.lens-stat-metric-value-shimmer')?.getBoundingClientRect()
+    const neighbour = element
+      .querySelector('.lens-stat-metric-main > .lens-stat-sparkline, .lens-stat-metric-main > .lens-stat-drill-mark')
+      ?.getBoundingClientRect()
+    const cell = element.getBoundingClientRect()
+    return {
+      cellWidth: cell.width,
+      cellHeight: cell.height,
+      shimmer: box ? { width: box.width, height: box.height, right: box.right } : null,
+      neighbourLeft: neighbour?.left ?? null,
+      text: (element.querySelector('.lens-stat-metric-value')?.textContent ?? '').trim(),
+    }
+  }))
+}
+
+test('a loading KPI cell shows a placeholder the size of the figure it stands in for', async ({ page }) => {
+  await openStory(page, 'parity--metric-group-loading', 0)
+  const cells = await loadingMetricBoxes(page)
+  expect(cells).toHaveLength(4)
+
+  for (const { cellWidth, shimmer, neighbourLeft, text } of cells) {
+    // The figure slot carries no text while the panel is in flight, so it is a
+    // flex item zero pixels wide — a placeholder sized as a percentage of it
+    // measured 0 × 28 and painted nothing at all, leaving a KPI strip that read
+    // as a row of names over an empty gap for as long as the query ran.
+    expect(text).toBe('')
+    expect(shimmer?.width ?? 0).toBeGreaterThan(40)
+    expect(shimmer?.height ?? 0).toBeGreaterThan(12)
+    // It stands in for a figure, not for the card: a slab the width of the cell
+    // would read as a loading table rather than as a number on its way.
+    expect(shimmer?.width ?? 0).toBeLessThan(cellWidth)
+    // …and it keeps out of the drill mark and the sparkline that share its row.
+    if (neighbourLeft !== null) expect(shimmer?.right ?? 0).toBeLessThanOrEqual(neighbourLeft)
+  }
+  // Two of the four cells carry one of those neighbours; without them the
+  // collision clause above would pass by never running.
+  expect(cells.filter(({ neighbourLeft }) => neighbourLeft !== null).length).toBe(2)
+})
+
+test('the loading KPI strip is the height the settled one is', async ({ page }) => {
+  // A placeholder that reserves the wrong box moves the whole board when the
+  // figures land. Same four metrics, same captions, same spans — only the
+  // frames differ — so the cells must measure the same in both stories.
+  await openStory(page, 'parity--metric-group-loading', 0)
+  const loading = (await loadingMetricBoxes(page)).map(({ cellHeight }) => Math.round(cellHeight))
+
+  await openStory(page, 'parity--metric-group', 0)
+  const settled = await page.locator('.lens-stat-metric').evaluateAll((elements) => (
+    elements.map((element) => Math.round(element.getBoundingClientRect().height))
+  ))
+
+  expect(loading).toHaveLength(4)
+  expect(loading).toEqual(settled)
+})
 
 test('filter refetch failure keeps stale panels and surfaces the error', async ({ page }) => {
   await openStory(page, 'filter-controls--refetch-error', 0)


### PR DESCRIPTION
## The defect

A KPI metric strip shows **nothing** where its figures will be while the panel is in flight — just the names over an empty gap.

The placeholder is not missing. `aria-busy="true"` is set, the `.lens-shimmer` span is in the DOM, and its box measures **0 × 28**:

- `.lens-stat-metric-main` is `display: flex`
- `.lens-stat-metric-value` is `flex-shrink: 1` with no `flex-grow`, so its base size is its content size
- while loading, that slot holds no text — so it is zero pixels wide
- `.lens-stat-metric-value-shimmer` asked for `width: 60%`, and 60% of zero is zero

`min-height` still holds the row open, which is why it reads as a confident absence rather than as something broken — exactly the "no data" state this placeholder exists to be distinguishable from.

Measured live in Chrome on a real dashboard before the fix; measured again after: shimmer 88 × 28 in an 88 px slot, settled figures 67–85 px, cell height 127 px in both.

## The fix

The placeholder carries its own width (`5.5rem`, capped at the slot) instead of borrowing the slot's. `max-width: 100%` is what the percentage was really buying — a narrower cell shrinks it rather than overflowing.

**Not** an `[aria-busy='true'] { flex: 1 1 auto }` rule on the slot, which was the first idea: `aria-busy` also covers the **stale** state (`StatPanel.tsx:222`), where the slot does hold text. Growing it there would shove the drill mark and the sparkline to the cell's right edge on every refetch and snap them back when it settled.

Only the chrome-free metric-strip cell (`StatMetric`) was affected. The hero/standalone card path (`PanelFrame` → `PanelSkeletonBody kind="stat"`) is fine — its `70%` sits in `.lens-skeleton-card`, a column-flex container whose width comes from the grid (measured 177 × 28).

## Coverage

Nothing exercised a metric strip **in its loading state** — that is how a zero-width box shipped.

- New story `parity--metric-group-loading`: four deferred metrics with a fetcher that never settles; two of them carry the neighbours (drill mark, sparkline) that share the placeholder's flex row.
- Checked by **measurement, not by a screenshot**: the defect is a box that was zero pixels wide, and a raster of a sweeping gradient is a picture of whichever frame the capture froze. Registered through a new `measuredStories` list so the manifest completeness test still covers it; no baseline is generated and none was committed.
- Second test pins the loading strip's cell heights to the settled strip's, so a placeholder that reserves the wrong box can't move the board when figures land.
- Unit test encodes the audit: a shimmer may state a percentage width only inside a container whose own width is definite, so the next one added elsewhere fails rather than disappears. (`styles.css` has exactly three percentage-width shimmer rules; the other two are inside that column-flex card and are correct.)

## Verification

- `just lens check` — pass (typecheck + lint + 930 tests / 61 files)
- `just lens vr -g "KPI"` — 2 passed
- **Guard proven**: revert `styles.css` alone → `expect(shimmer?.width ?? 0).toBeGreaterThan(40)` receives `0`. The height-parity test still passes, matching the live symptom — the gap was the right size and simply empty. Reapply → both pass.
- Full `just lens vr` on this machine has widespread pre-existing Darwin baseline drift; verified not mine by reverting the fix and getting the identical 7 `metric-group*` screenshot failures with and without it.

## Note for EAI

This does not reach EAI users until `back/go.mod` is bumped — iota-uz/eai#3908.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788544724&installation_model_id=2042&pr_number=992&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F992&signature=3d1f1643a95e662eeea854de24863d9ac9b9379fc78eb3d3254cc4bd27edfc59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a loading-state example for KPI metric groups, including captions, linked metrics, sparklines, and deferred data.

- **Bug Fixes**
  - Improved loading metric placeholders so values remain visible while adapting to narrow panels.
  - Prevented loading placeholders from overlapping nearby chart and drill-in elements.

- **Tests**
  - Added coverage for placeholder sizing, visibility, spacing, and consistency between loading and completed metric panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->