### PR TITLE
feat(billing): implement Click payment reversal

### DIFF
--- a/modules/billing/infrastructure/providers/click_provider.go
+++ b/modules/billing/infrastructure/providers/click_provider.go
@@ -3,12 +3,46 @@ package providers
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
+	"strconv"
+	"time"
 
 	"github.com/iota-uz/iota-sdk/modules/billing/domain/aggregates/billing"
 	"github.com/iota-uz/iota-sdk/modules/billing/domain/aggregates/details"
 )
+
+// DefaultClickAPIURL is the Click Merchant API base used when ClickConfig.APIURL
+// is empty. https://docs.click.uz/en/merchant-api-request/
+const DefaultClickAPIURL = "https://api.click.uz/v2/merchant"
+
+// ErrClickPartialRefund is returned when a refund asks for less than the full
+// transaction amount. The Click reversal endpoint takes no amount: it reverses
+// the whole payment or nothing.
+var ErrClickPartialRefund = errors.New("click supports full reversal only, not partial refund")
+
+// ErrClickPaymentIDMissing is returned when the transaction carries no Click
+// payment identifier, which happens when the payment never reached the Complete
+// callback. Nothing was captured, so there is nothing to reverse.
+var ErrClickPaymentIDMissing = errors.New("click transaction has no payment id to reverse")
+
+// ClickReversalError is a rejection reported by Click itself, carrying the
+// gateway's own code so the caller can tell "already reversed" from "refused by
+// the card processor" instead of collapsing both into a generic failure.
+type ClickReversalError struct {
+	Code int32
+	Note string
+}
+
+func (e ClickReversalError) Error() string {
+	return fmt.Sprintf("click reversal rejected: code=%d note=%s", e.Code, e.Note)
+}
 
 type ClickConfig struct {
 	URL            string
@@ -16,6 +50,12 @@ type ClickConfig struct {
 	SecretKey      string
 	MerchantID     int64
 	MerchantUserID int64
+	// APIURL overrides the Merchant API base (sandbox, or a recording proxy in
+	// tests). Empty means DefaultClickAPIURL.
+	APIURL string
+	// HTTPClient performs Merchant API calls. Supply one wrapping
+	// middleware.LogTransport to get the outbound request into the request log.
+	HTTPClient *http.Client
 }
 
 func NewClickProvider(
@@ -79,9 +119,106 @@ func (p *clickProvider) Cancel(ctx context.Context, t billing.Transaction) (bill
 	panic("implement me")
 }
 
+// Refund reverses a completed Click payment through the Merchant API.
+//
+// Click exposes reversal as DELETE payment/reversal/{service_id}/{payment_id};
+// there is no amount in the request, so only a full reversal exists. Click also
+// refuses a payment from the previous month on any day but the first, and the
+// card processor can refuse independently — both come back as a
+// ClickReversalError with the gateway's own code rather than as a transport
+// failure, because they are business answers, not outages.
 func (p *clickProvider) Refund(ctx context.Context, t billing.Transaction, quantity float64) (billing.Transaction, error) {
-	//TODO implement me
-	panic("implement me")
+	clickDetails, err := toClickDetails(t.Details())
+	if err != nil {
+		return nil, err
+	}
+
+	if quantity < t.Amount().Quantity() {
+		return nil, ErrClickPartialRefund
+	}
+
+	paymentID := clickDetails.PaymentID()
+	if paymentID == 0 {
+		return nil, ErrClickPaymentIDMissing
+	}
+
+	serviceID := clickDetails.ServiceID()
+	if serviceID == 0 {
+		serviceID = p.config.ServiceID
+	}
+
+	response, err := p.reverse(ctx, serviceID, paymentID)
+	if err != nil {
+		return nil, err
+	}
+
+	clickDetails = clickDetails.
+		SetErrorCode(response.ErrorCode).
+		SetErrorNote(response.ErrorNote)
+
+	if response.ErrorCode < 0 {
+		return nil, ClickReversalError{Code: response.ErrorCode, Note: response.ErrorNote}
+	}
+
+	return t.SetDetails(clickDetails).SetStatus(billing.Refunded), nil
+}
+
+type clickReversalResponse struct {
+	ErrorCode int32  `json:"error_code"`
+	ErrorNote string `json:"error_note"`
+	PaymentID int64  `json:"payment_id"`
+}
+
+func (p *clickProvider) reverse(ctx context.Context, serviceID, paymentID int64) (clickReversalResponse, error) {
+	var response clickReversalResponse
+
+	base := p.config.APIURL
+	if base == "" {
+		base = DefaultClickAPIURL
+	}
+	endpoint := fmt.Sprintf("%s/payment/reversal/%d/%d", base, serviceID, paymentID)
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return response, err
+	}
+	request.Header.Set("Auth", p.authHeader(time.Now()))
+	request.Header.Set("Accept", "application/json")
+
+	client := p.config.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+
+	httpResponse, err := client.Do(request)
+	if err != nil {
+		return response, err
+	}
+	defer func() {
+		_ = httpResponse.Body.Close()
+	}()
+
+	body, err := io.ReadAll(httpResponse.Body)
+	if err != nil {
+		return response, err
+	}
+	if httpResponse.StatusCode != http.StatusOK {
+		return response, fmt.Errorf("click reversal returned http %d: %s", httpResponse.StatusCode, string(body))
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return response, fmt.Errorf("failed to decode click reversal response %q: %w", string(body), err)
+	}
+
+	return response, nil
+}
+
+// authHeader builds the Merchant API credential:
+// merchant_user_id:sha1(timestamp + secret_key):timestamp.
+func (p *clickProvider) authHeader(now time.Time) string {
+	timestamp := strconv.FormatInt(now.Unix(), 10)
+	// SHA-1 is what the Merchant API specifies; the algorithm is not ours to choose.
+	digest := sha1.Sum([]byte(timestamp + p.config.SecretKey)) //nolint:gosec // required by the Click Merchant API
+	return fmt.Sprintf("%d:%s:%s", p.config.MerchantUserID, hex.EncodeToString(digest[:]), timestamp)
 }
 
 func toClickDetails(detailsObj details.Details) (details.ClickDetails, error) {

--- a/modules/billing/infrastructure/providers/click_provider.go
+++ b/modules/billing/infrastructure/providers/click_provider.go
@@ -22,10 +22,10 @@ import (
 // is empty. https://docs.click.uz/en/merchant-api-request/
 const DefaultClickAPIURL = "https://api.click.uz/v2/merchant"
 
-// ErrClickPartialRefund is returned when a refund asks for less than the full
-// transaction amount. The Click reversal endpoint takes no amount: it reverses
-// the whole payment or nothing.
-var ErrClickPartialRefund = errors.New("click supports full reversal only, not partial refund")
+// ErrClickPartialRefund is returned when a refund asks for anything other than
+// the exact captured amount. The Click reversal endpoint takes no amount: it
+// reverses the whole payment or nothing.
+var ErrClickPartialRefund = errors.New("click reverses the exact captured amount only")
 
 // ErrClickPaymentIDMissing is returned when the transaction carries no Click
 // payment identifier, which happens when the payment never reached the Complete
@@ -133,7 +133,11 @@ func (p *clickProvider) Refund(ctx context.Context, t billing.Transaction, quant
 		return nil, err
 	}
 
-	if quantity < t.Amount().Quantity() {
+	// Exact amount only. Less would be a partial refund the endpoint cannot
+	// express; more would let a caller believe it sent back something we never
+	// captured. Either way the reversal returns the captured amount, so a
+	// mismatch means the caller and the gateway disagree about the money.
+	if quantity != t.Amount().Quantity() {
 		return nil, ErrClickPartialRefund
 	}
 

--- a/modules/billing/infrastructure/providers/click_provider_test.go
+++ b/modules/billing/infrastructure/providers/click_provider_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -71,7 +70,7 @@ func TestClickRefundAddressesTheReversalEndpointAndSignsTheRequest(t *testing.T)
 	provider, _ := clickProvider(t, func(w http.ResponseWriter, r *http.Request) {
 		gotMethod, gotPath, gotAuth = r.Method, r.URL.Path, r.Header.Get("Auth")
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"error_code":0,"error_note":"Success","payment_id":%d}`, testPaymentID)
+		_, _ = fmt.Fprintf(w, `{"error_code":0,"error_note":"Success","payment_id":%d}`, testPaymentID)
 	})
 
 	before := time.Now().Unix()
@@ -105,7 +104,7 @@ func TestClickRefundSurfacesGatewayRefusalWithItsCode(t *testing.T) {
 
 	provider, _ := clickProvider(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"error_code":-31007,"error_note":"Payment was rejected"}`)
+		_, _ = fmt.Fprint(w, `{"error_code":-31007,"error_note":"Payment was rejected"}`)
 	})
 
 	transaction, err := provider.Refund(context.Background(), clickTransaction(t, 100_000), 100_000)
@@ -125,12 +124,29 @@ func TestClickRefundRejectsAPartialAmountWithoutCallingTheGateway(t *testing.T) 
 	called := false
 	provider, _ := clickProvider(t, func(w http.ResponseWriter, _ *http.Request) {
 		called = true
-		fmt.Fprint(w, `{"error_code":0}`)
+		_, _ = fmt.Fprint(w, `{"error_code":0}`)
 	})
 
 	_, err := provider.Refund(context.Background(), clickTransaction(t, 100_000), 40_000)
 	require.ErrorIs(t, err, providers.ErrClickPartialRefund)
 	require.False(t, called, "a partial refund must not reach Click")
+}
+
+// More than was captured is not a reversal either: the endpoint sends back the
+// captured amount, so accepting a larger figure would let the caller believe it
+// returned money that never arrived.
+func TestClickRefundRejectsAnAmountLargerThanWasCaptured(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	provider, _ := clickProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		_, _ = fmt.Fprint(w, `{"error_code":0}`)
+	})
+
+	_, err := provider.Refund(context.Background(), clickTransaction(t, 100_000), 140_000)
+	require.ErrorIs(t, err, providers.ErrClickPartialRefund)
+	require.False(t, called, "an amount that is not the captured one must not reach Click")
 }
 
 // Without the Complete callback there is no click_trans_id, and nothing was
@@ -141,7 +157,7 @@ func TestClickRefundRefusesATransactionThatNeverCompleted(t *testing.T) {
 	called := false
 	provider, _ := clickProvider(t, func(w http.ResponseWriter, _ *http.Request) {
 		called = true
-		fmt.Fprint(w, `{"error_code":0}`)
+		_, _ = fmt.Fprint(w, `{"error_code":0}`)
 	})
 
 	transaction := billing.New(100_000, billing.UZS, billing.Click, details.NewClickDetails("sale-1",
@@ -160,7 +176,7 @@ func TestClickRefundTreatsANonJSONErrorPageAsAFailure(t *testing.T) {
 
 	provider, _ := clickProvider(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadGateway)
-		fmt.Fprint(w, "<html>502</html>")
+		_, _ = fmt.Fprint(w, "<html>502</html>")
 	})
 
 	transaction, err := provider.Refund(context.Background(), clickTransaction(t, 100_000), 100_000)
@@ -168,6 +184,6 @@ func TestClickRefundTreatsANonJSONErrorPageAsAFailure(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "502")
 
-	var refusal providers.ClickReversalError
-	require.False(t, errors.As(err, &refusal), "a transport failure is not a gateway refusal")
+	// A transport failure is not a gateway refusal.
+	require.NotErrorAs(t, err, &providers.ClickReversalError{})
 }

--- a/modules/billing/infrastructure/providers/click_provider_test.go
+++ b/modules/billing/infrastructure/providers/click_provider_test.go
@@ -1,0 +1,173 @@
+package providers_test
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/iota-uz/iota-sdk/modules/billing/domain/aggregates/billing"
+	"github.com/iota-uz/iota-sdk/modules/billing/domain/aggregates/details"
+	"github.com/iota-uz/iota-sdk/modules/billing/infrastructure/providers"
+)
+
+const (
+	testServiceID      int64 = 12345
+	testMerchantUserID int64 = 6789
+	testPaymentID      int64 = 987654321
+	testSecretKey            = "click-secret"
+)
+
+func clickTransaction(t *testing.T, quantity float64, opts ...func(details.ClickDetails) details.ClickDetails) billing.Transaction {
+	t.Helper()
+
+	clickDetails := details.NewClickDetails("sale-1",
+		details.ClickWithServiceID(testServiceID),
+		details.ClickWithMerchantUserID(testMerchantUserID),
+		details.ClickWithPaymentID(testPaymentID),
+	)
+	for _, opt := range opts {
+		clickDetails = opt(clickDetails)
+	}
+
+	return billing.New(quantity, billing.UZS, billing.Click, clickDetails)
+}
+
+func clickProvider(t *testing.T, handler http.HandlerFunc) (billing.Provider, *httptest.Server) {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	return providers.NewClickProvider(providers.ClickConfig{
+		ServiceID:      testServiceID,
+		SecretKey:      testSecretKey,
+		MerchantUserID: testMerchantUserID,
+		APIURL:         server.URL,
+		HTTPClient:     server.Client(),
+	}), server
+}
+
+// The reversal endpoint identifies the payment entirely by URL, and the caller
+// by a hand-rolled header. A mistake in either is invisible locally and shows up
+// as somebody else's money not coming back, so both are asserted literally.
+func TestClickRefundAddressesTheReversalEndpointAndSignsTheRequest(t *testing.T) {
+	t.Parallel()
+
+	var (
+		gotMethod string
+		gotPath   string
+		gotAuth   string
+	)
+	provider, _ := clickProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath, gotAuth = r.Method, r.URL.Path, r.Header.Get("Auth")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"error_code":0,"error_note":"Success","payment_id":%d}`, testPaymentID)
+	})
+
+	before := time.Now().Unix()
+	transaction, err := provider.Refund(context.Background(), clickTransaction(t, 100_000), 100_000)
+	after := time.Now().Unix()
+	require.NoError(t, err)
+
+	require.Equal(t, http.MethodDelete, gotMethod)
+	require.Equal(t, fmt.Sprintf("/payment/reversal/%d/%d", testServiceID, testPaymentID), gotPath)
+
+	parts := strings.Split(gotAuth, ":")
+	require.Len(t, parts, 3, "Auth is merchant_user_id:digest:timestamp")
+	require.Equal(t, strconv.FormatInt(testMerchantUserID, 10), parts[0])
+
+	timestamp, err := strconv.ParseInt(parts[2], 10, 64)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, timestamp, before)
+	require.LessOrEqual(t, timestamp, after)
+
+	digest := sha1.Sum([]byte(parts[2] + testSecretKey)) //nolint:gosec // mirrors the Click contract under test
+	require.Equal(t, hex.EncodeToString(digest[:]), parts[1])
+
+	require.Equal(t, billing.Refunded, transaction.Status())
+}
+
+// A refusal by Click is an answer, not an outage: it must surface with the
+// gateway's own code so the operator learns why, and it must not leave the
+// transaction looking refunded.
+func TestClickRefundSurfacesGatewayRefusalWithItsCode(t *testing.T) {
+	t.Parallel()
+
+	provider, _ := clickProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"error_code":-31007,"error_note":"Payment was rejected"}`)
+	})
+
+	transaction, err := provider.Refund(context.Background(), clickTransaction(t, 100_000), 100_000)
+	require.Nil(t, transaction)
+
+	var refusal providers.ClickReversalError
+	require.ErrorAs(t, err, &refusal)
+	require.Equal(t, int32(-31007), refusal.Code)
+	require.Equal(t, "Payment was rejected", refusal.Note)
+}
+
+// The endpoint takes no amount. Accepting a smaller quantity would silently
+// reverse the whole payment, so it is refused before the call is made.
+func TestClickRefundRejectsAPartialAmountWithoutCallingTheGateway(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	provider, _ := clickProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		fmt.Fprint(w, `{"error_code":0}`)
+	})
+
+	_, err := provider.Refund(context.Background(), clickTransaction(t, 100_000), 40_000)
+	require.ErrorIs(t, err, providers.ErrClickPartialRefund)
+	require.False(t, called, "a partial refund must not reach Click")
+}
+
+// Without the Complete callback there is no click_trans_id, and nothing was
+// captured. Reversing "payment 0" would be a request about someone else's money.
+func TestClickRefundRefusesATransactionThatNeverCompleted(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	provider, _ := clickProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		fmt.Fprint(w, `{"error_code":0}`)
+	})
+
+	transaction := billing.New(100_000, billing.UZS, billing.Click, details.NewClickDetails("sale-1",
+		details.ClickWithServiceID(testServiceID),
+	))
+
+	_, err := provider.Refund(context.Background(), transaction, 100_000)
+	require.ErrorIs(t, err, providers.ErrClickPaymentIDMissing)
+	require.False(t, called)
+}
+
+// An HTTP error page is not a reversal verdict. It must not be read as success
+// and must not be read as a refusal either.
+func TestClickRefundTreatsANonJSONErrorPageAsAFailure(t *testing.T) {
+	t.Parallel()
+
+	provider, _ := clickProvider(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		fmt.Fprint(w, "<html>502</html>")
+	})
+
+	transaction, err := provider.Refund(context.Background(), clickTransaction(t, 100_000), 100_000)
+	require.Nil(t, transaction)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "502")
+
+	var refusal providers.ClickReversalError
+	require.False(t, errors.As(err, &refusal), "a transport failure is not a gateway refusal")
+}


### PR DESCRIPTION
## Problem

`clickProvider.Refund` and `clickProvider.Cancel` are `panic("implement me")`. Any caller that reaches `BillingService.Refund` for a Click transaction crashes the process, so in practice no product can offer a refund on the gateway that carries the largest share of Uzbek card payments.

## Solution

Implement `Refund` against the documented Merchant API reversal endpoint:

```
DELETE {api}/payment/reversal/{service_id}/{payment_id}
Auth: {merchant_user_id}:{sha1(timestamp + secret_key)}:{timestamp}
```

(https://docs.click.uz/en/merchant-api-request/)

Behaviour that the contract forces:

- **Full reversal only.** The request carries no amount. A `quantity` smaller than the transaction amount is refused with `ErrClickPartialRefund` *before* the call, rather than silently reversing the whole payment.
- **No payment id, no reversal.** Without the Complete callback there is no `click_trans_id` and nothing was captured; refused with `ErrClickPaymentIDMissing`.
- **A refusal is an answer, not an outage.** Click's negative `error_code` (already reversed, previous-month window, card-processor refusal) surfaces as `ClickReversalError{Code, Note}`, so a caller can distinguish it from a transport failure and show the operator why. Only a non-negative `error_code` marks the transaction `refunded`.
- An HTTP error page is neither success nor refusal — it is an error.

`ClickConfig` gains two optional fields, both backward compatible:

- `APIURL` — override the Merchant API base (sandbox, or a test server).
- `HTTPClient` — supply a client wrapping `middleware.LogTransport` so the outbound call lands in the request log.

`Cancel` is left as-is; it is a different operation and out of scope here.

**Payme is deliberately not implemented.** Its Merchant API is inbound-only — `CancelTransaction` is a callback the merchant *implements*, not a method it calls — and a checkout-link payment can only be refunded from the Payme cabinet or via support. `receipts.cancel` belongs to the Subscribe API and is not documented to accept a checkout-link transaction id. Leaving the panic is honest; a fake implementation would not be.

## Verification

`go test ./modules/billing/infrastructure/providers/...` — new `click_provider_test.go` covers, against an `httptest` server:

- the exact method, path and `Auth` header, including recomputing the SHA-1 digest and bounding the timestamp;
- a gateway refusal surfacing as `ClickReversalError` with code `-31007`;
- a partial amount refused without any request reaching the gateway;
- a transaction with no `click_trans_id` refused without a request;
- a 502 HTML page treated as a failure and explicitly *not* as a refusal.

`go vet ./modules/billing/...` clean.

Not exercised against the live Click sandbox — the endpoint contract is asserted from the documentation and the request is asserted literally in tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788706823&installation_model_id=2042&pr_number=993&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F993&signature=2fa0b83864eb33db9dac44de1de045722800be032f8ae9e1c52082cf46f25d91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for full payment refunds through Click’s reversal service.
  * Refund requests now include secure authentication and configurable API connectivity.
  * Gateway refusal details and refund status updates are surfaced clearly.

* **Bug Fixes**
  * Partial refunds and refunds without a completed payment are rejected before submission.
  * Improved handling of malformed or non-standard gateway error responses.

* **Tests**
  * Added coverage for successful refunds, authentication, validation, gateway refusals, and connection failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->