### PR TITLE
chore(release): prepare v0.5.2

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -12,7 +12,7 @@ This repo ships one public NPM package alongside the Go module:
 Install it with React peers:
 
 ```bash
-pnpm add @iota-uz/sdk@0.5.1 react react-dom
+pnpm add @iota-uz/sdk@0.5.2 react react-dom
 ```
 
 ```ts

--- a/docs/content/getting-started/npm-package.mdx
+++ b/docs/content/getting-started/npm-package.mdx
@@ -13,7 +13,7 @@ Tailwind, or asset surfaces.
 ## Install
 
 ```bash
-pnpm add @iota-uz/sdk@0.5.1 react react-dom
+pnpm add @iota-uz/sdk@0.5.2 react react-dom
 ```
 
 Production consumers should pin an exact SDK version matching their Go module.

--- a/pkg/clienthost/host_test.go
+++ b/pkg/clienthost/host_test.go
@@ -45,7 +45,7 @@ func TestController_ServesCanonicalBootstrapAndDescriptor(t *testing.T) {
 	require.Contains(t, body, `data-sdk-commit="0123456789abcdef0123456789abcdef01234567"`)
 	require.Contains(t, body, `integrity="sha384-example"`)
 	require.Contains(t, body, `"protocolVersion":"1.0.0"`)
-	require.Contains(t, body, `"sdkReleaseVersion":"0.5.1"`)
+	require.Contains(t, body, `"sdkReleaseVersion":"0.5.2"`)
 	require.Contains(t, body, `"sdkCommit":"0123456789abcdef0123456789abcdef01234567"`)
 	require.Contains(t, body, `"theme":"dark"`)
 	require.Contains(t, body, `"csrf":"token"`)

--- a/pkg/sdkidentity/identity.go
+++ b/pkg/sdkidentity/identity.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	ReleaseVersion  = "0.5.1"
+	ReleaseVersion  = "0.5.2"
 	ProtocolVersion = "1.0.0"
 )
 

--- a/web/client-host/src/identity.ts
+++ b/web/client-host/src/identity.ts
@@ -1,6 +1,6 @@
 import { CLIENT_HOST_PROTOCOL_VERSION } from './protocol'
 
-export const SDK_RELEASE_VERSION = '0.5.1'
+export const SDK_RELEASE_VERSION = '0.5.2'
 export const SDK_SOURCE_COMMIT = '__IOTA_SDK_SOURCE_COMMIT__'
 export const SDK_PROTOCOL_VERSION = CLIENT_HOST_PROTOCOL_VERSION
 export const SDK_IDENTITY = Object.freeze({

--- a/web/sdk/package.json
+++ b/web/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iota-uz/sdk",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Canonical JavaScript distribution for iota-sdk.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Version bump for the release that ships #996 (period picker redesign, honest cascade unknown-value gaps, failure-kind copy) and its post-merge follow-up #997 (gofmt + two corrected VR baselines).

Bumps the five version-carrying spots: \`web/sdk/package.json\`, \`pkg/sdkidentity/identity.go\` (\`ReleaseVersion\`), \`web/client-host/src/identity.ts\` (\`SDK_RELEASE_VERSION\`), \`pkg/clienthost/host_test.go\`'s matching assertion, and both install-command docs (\`README.MD\`, \`docs/content/getting-started/npm-package.mdx\`).

After merge: tag the merge commit \`v0.5.2\` and push the tag to trigger the \`Release iota-sdk\` workflow (npm publish + GitHub release).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788788620&installation_model_id=2042&pr_number=998&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F998&signature=ad07e00716c80790dc373e2688f9568731cf19ff3903d1e99316479e992be6a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->