### PR TITLE
fix(config): let a source turn a default-on flag off

### DIFF
--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -17,10 +17,11 @@ import (
 // uint32/uint64, float32, float64, time.Duration, []string (comma-split, trimmed),
 // and nested structs (recursed via pointer).
 //
-// Documented limitation: an explicit empty string set by a source is
-// indistinguishable from "absent" because reflect.Value.IsZero returns true for
-// an empty string. Tag defaults fire in both cases, matching the previous
-// SetDefaults() semantic.
+// This function cannot tell "absent" from "explicitly zero" — reflect.IsZero
+// is true for false, 0 and "" alike — which is why RegisterAt calls it to seed
+// a fresh struct *before* reading the source rather than to patch one after.
+// Called the other way round it silently discards every explicit zero a
+// source provides, and a `default:"true"` bool becomes impossible to turn off.
 func applyTagDefaults(v any) error {
 	rv := reflect.ValueOf(v)
 	if rv.Kind() != reflect.Ptr || rv.IsNil() {

--- a/pkg/config/registry.go
+++ b/pkg/config/registry.go
@@ -91,11 +91,21 @@ func (r *Registry) SetStrict(mode StrictMode) {
 // populated config struct. It is the escape hatch for non-Prefixed types or tests.
 //
 // Order of operations:
-//  1. Source.Unmarshal fills fields from env / yaml / etc.
-//  2. applyTagDefaults fills zero-valued fields from `default:"X"` struct tags.
+//  1. applyTagDefaults seeds every field carrying a `default:"X"` struct tag.
+//  2. Source.Unmarshal overwrites those fields the source actually provides,
+//     from env / yaml / etc.
 //  3. resolveState computes FeatureState using Configured + Source.HasPrefix.
 //  4. If state is StatePartiallyConfigured and strict mode is on, abort with error.
 //  5. If state is StateActive and T implements Validatable, Validate checks values.
+//
+// Defaults are seeded *before* the source is read, not applied to whatever the
+// source left zero afterwards. The latter cannot express "turn this off": a
+// `bool` field with `default:"true"` set to false by the source is
+// indistinguishable from one the source never mentioned, so the default won
+// and the setting was unreachable. The same held for an int default set to 0
+// and a string default set to "". Unmarshal leaves fields the source has no
+// key for untouched, so seeding first keeps defaults for everything unset
+// while letting an explicit value — including a zero one — through.
 //
 // A non-nil Validate error aborts registration and returns an error.
 //
@@ -111,12 +121,12 @@ func RegisterAt[T any](r *Registry, prefix string) (*T, error) {
 	}
 
 	var cfg T
-	if err := r.src.Unmarshal(prefix, &cfg); err != nil {
-		return nil, fmt.Errorf("config: unmarshal %T at %q: %w", cfg, prefix, err)
-	}
-
 	if err := applyTagDefaults(&cfg); err != nil {
 		return nil, fmt.Errorf("config: apply defaults %T: %w", cfg, err)
+	}
+
+	if err := r.src.Unmarshal(prefix, &cfg); err != nil {
+		return nil, fmt.Errorf("config: unmarshal %T at %q: %w", cfg, prefix, err)
 	}
 
 	state := resolveState(r.src, prefix, &cfg)

--- a/pkg/config/registry_test.go
+++ b/pkg/config/registry_test.go
@@ -130,5 +130,76 @@ func TestGet_Lookup_WhenRegistered(t *testing.T) {
 	}
 }
 
+// featureToggle mirrors the shape every periodic task, request log and feature
+// flag in the wild uses: an on-by-default switch plus values whose defaults are
+// non-zero.
+type featureToggle struct {
+	Enabled    bool   `koanf:"enabled"    default:"true"`
+	MaxRetries int    `koanf:"maxretries" default:"3"`
+	Schedule   string `koanf:"schedule"   default:"*/15 * * * *"`
+}
+
+// A source that says "off" must be able to turn a default-on switch off.
+// Applying tag defaults to whatever the source left zero cannot express this -
+// false is indistinguishable from absent - so the setting was unreachable and
+// every on-by-default feature was permanently on.
+func TestRegisterAt_SourceCanTurnOffADefaultOnFlag(t *testing.T) {
+	t.Parallel()
+
+	src := buildSource(t, map[string]any{
+		"feature.enabled":    false,
+		"feature.maxretries": 0,
+		"feature.schedule":   "",
+	})
+	cfg, err := RegisterAt[featureToggle](NewRegistry(src), "feature")
+	if err != nil {
+		t.Fatalf("RegisterAt: %v", err)
+	}
+	if cfg.Enabled {
+		t.Error("Enabled: got true, want false — the source said off")
+	}
+	if cfg.MaxRetries != 0 {
+		t.Errorf("MaxRetries: got %d, want 0 — the source said 0", cfg.MaxRetries)
+	}
+	if cfg.Schedule != "" {
+		t.Errorf("Schedule: got %q, want empty — the source said empty", cfg.Schedule)
+	}
+}
+
+// Env vars arrive as strings; koanf decodes them weakly. "false" must not be
+// read as "unset" either.
+func TestRegisterAt_SourceCanTurnOffADefaultOnFlagWithStrings(t *testing.T) {
+	t.Parallel()
+
+	src := buildSource(t, map[string]any{"feature.enabled": "false"})
+	cfg, err := RegisterAt[featureToggle](NewRegistry(src), "feature")
+	if err != nil {
+		t.Fatalf("RegisterAt: %v", err)
+	}
+	if cfg.Enabled {
+		t.Error("Enabled: got true, want false")
+	}
+	// Everything the source did not mention still gets its default.
+	if cfg.MaxRetries != 3 {
+		t.Errorf("MaxRetries: got %d, want the default 3", cfg.MaxRetries)
+	}
+	if cfg.Schedule != "*/15 * * * *" {
+		t.Errorf("Schedule: got %q, want the default", cfg.Schedule)
+	}
+}
+
+// The other half of the contract: a silent source leaves every default alone.
+func TestRegisterAt_DefaultsSurviveASilentSource(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := RegisterAt[featureToggle](NewRegistry(buildSource(t, map[string]any{})), "feature")
+	if err != nil {
+		t.Fatalf("RegisterAt: %v", err)
+	}
+	if !cfg.Enabled || cfg.MaxRetries != 3 || cfg.Schedule != "*/15 * * * *" {
+		t.Errorf("defaults not applied: %+v", *cfg)
+	}
+}
+
 // Ensure staticTestProvider (declared in source_test.go) satisfies Provider.
 var _ Provider = (*staticTestProvider)(nil)


### PR DESCRIPTION
## Problem

`config.RegisterAt` unmarshaled the source and *then* applied `default:"X"` struct tags to every field still zero-valued. `reflect.IsZero` cannot distinguish an explicit zero from an absent key, so a source that says `false` for a `default:"true"` bool loses to the default — the setting cannot be expressed at all. The same applies to an int default set to `0` and a string default set to `""`.

Observed downstream (EAI): no periodic task can be disabled via `PERIODIC_*_ENABLED`, and request-body logging cannot be turned off. Verified directly — the source contains `periodic.crm.processclientreadmodelqueue.enabled = "false"` while the registered config reads `Enabled=true`.

## Fix

Seed the defaults into the fresh struct **before** reading the source, and let `Unmarshal` overwrite what the source actually provides. `koanf.Unmarshal` leaves fields the source has no key for untouched, so unset fields keep their defaults while an explicit value — including a zero one — survives.

## Tests

Three regression tests in `pkg/config/registry_test.go`, over the shape real feature flags use (on-by-default bool + non-zero int + non-empty string default):

- a source saying `false` / `0` / `""` wins over the defaults;
- the same via the string form env vars arrive in (`"false"`), with untouched fields still defaulted;
- a silent source still gets every default.

The first two fail on `main` and pass here. `go test ./pkg/...` and `go vet ./pkg/...` are clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788812061&installation_model_id=2042&pr_number=999&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F999&signature=a4d2bcc196a6797753210a5c3907f08dbdc3ffa0da804c48404c4795375adb2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration defaults are now applied correctly when values are omitted.
  * Explicit `false`, `0`, empty, and string-decoded values now properly override configured defaults.
  * Feature toggles and other zero-value settings can be intentionally disabled without being replaced by defaults.

* **Tests**
  * Added coverage for default handling across omitted and explicitly provided values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->