### PR TITLE
fix(spotlight): skip unchanged Meilisearch settings

### DIFF
--- a/pkg/lens/spec/builders_compat_test.go
+++ b/pkg/lens/spec/builders_compat_test.go
@@ -15,13 +15,15 @@ func TestPanelBuilderHeightCompatibility(t *testing.T) {
 	panel := StackedBar("daily", "Daily", "daily").Height("320px").Build()
 
 	require.Equal(t, "320px", panel.Height)
-	payload, err := json.Marshal(panel)
+	// Marshal the public builder result itself: this compatibility test intentionally
+	// exercises the complete wire type, including nested SDK structs outside its scope.
+	payload, err := json.Marshal(panel) //nolint:musttag
 	require.NoError(t, err)
 	var wire map[string]json.RawMessage
 	require.NoError(t, json.Unmarshal(payload, &wire))
 	height, ok := wire["height"]
 	require.True(t, ok)
-	assert.Equal(t, json.RawMessage(`"320px"`), height)
+	assert.JSONEq(t, `"320px"`, string(height))
 }
 
 func TestPanelBuilderLegacyPresentationCompatibility(t *testing.T) {

--- a/pkg/spotlight/engine_meilisearch.go
+++ b/pkg/spotlight/engine_meilisearch.go
@@ -264,8 +264,12 @@ func (e *MeilisearchEngine) configureIndex(indexName string) error {
 	const op serrors.Op = "spotlight.MeilisearchEngine.configureIndex"
 
 	index := e.client.Index(indexName)
+	settings, err := index.GetSettings()
+	if err != nil {
+		return serrors.E(op, err)
+	}
 
-	filterableAttrs := []interface{}{
+	filterableAttrs := []string{
 		"tenant_id",
 		"provider",
 		"entity_type",
@@ -278,30 +282,40 @@ func (e *MeilisearchEngine) configureIndex(indexName string) error {
 		"allowed_roles",
 		"allowed_permissions",
 	}
-	filterTask, err := index.UpdateFilterableAttributes(&filterableAttrs)
-	if err != nil {
-		return serrors.E(op, err)
-	}
-	if _, err := waitTaskCtxClient(context.Background(), e.client, filterTask.TaskUID); err != nil {
-		return serrors.E(op, err)
+	if !slices.Equal(settings.FilterableAttributes, filterableAttrs) {
+		attrs := make([]interface{}, len(filterableAttrs))
+		for i, attr := range filterableAttrs {
+			attrs[i] = attr
+		}
+		filterTask, err := index.UpdateFilterableAttributes(&attrs)
+		if err != nil {
+			return serrors.E(op, err)
+		}
+		if _, err := waitTaskCtxClient(context.Background(), e.client, filterTask.TaskUID); err != nil {
+			return serrors.E(op, err)
+		}
 	}
 
 	searchableAttrs := []string{"title", "description", "search_text"}
-	searchTask, err := index.UpdateSearchableAttributes(&searchableAttrs)
-	if err != nil {
-		return serrors.E(op, err)
-	}
-	if _, err := waitTaskCtxClient(context.Background(), e.client, searchTask.TaskUID); err != nil {
-		return serrors.E(op, err)
+	if !slices.Equal(settings.SearchableAttributes, searchableAttrs) {
+		searchTask, err := index.UpdateSearchableAttributes(&searchableAttrs)
+		if err != nil {
+			return serrors.E(op, err)
+		}
+		if _, err := waitTaskCtxClient(context.Background(), e.client, searchTask.TaskUID); err != nil {
+			return serrors.E(op, err)
+		}
 	}
 
 	sortableAttrs := []string{"updated_at"}
-	sortTask, err := index.UpdateSortableAttributes(&sortableAttrs)
-	if err != nil {
-		return serrors.E(op, err)
-	}
-	if _, err := waitTaskCtxClient(context.Background(), e.client, sortTask.TaskUID); err != nil {
-		return serrors.E(op, err)
+	if !slices.Equal(settings.SortableAttributes, sortableAttrs) {
+		sortTask, err := index.UpdateSortableAttributes(&sortableAttrs)
+		if err != nil {
+			return serrors.E(op, err)
+		}
+		if _, err := waitTaskCtxClient(context.Background(), e.client, sortTask.TaskUID); err != nil {
+			return serrors.E(op, err)
+		}
 	}
 
 	return nil

--- a/pkg/spotlight/engine_meilisearch.go
+++ b/pkg/spotlight/engine_meilisearch.go
@@ -269,19 +269,7 @@ func (e *MeilisearchEngine) configureIndex(indexName string) error {
 		return serrors.E(op, err)
 	}
 
-	filterableAttrs := []string{
-		"tenant_id",
-		"provider",
-		"entity_type",
-		"domain",
-		"schema_version",
-		"exact_terms",
-		"access_visibility",
-		"owner_id",
-		"allowed_users",
-		"allowed_roles",
-		"allowed_permissions",
-	}
+	filterableAttrs := requiredFilterableAttributes()
 	if !slices.Equal(settings.FilterableAttributes, filterableAttrs) {
 		attrs := make([]interface{}, len(filterableAttrs))
 		for i, attr := range filterableAttrs {
@@ -296,7 +284,7 @@ func (e *MeilisearchEngine) configureIndex(indexName string) error {
 		}
 	}
 
-	searchableAttrs := []string{"title", "description", "search_text"}
+	searchableAttrs := requiredSearchableAttributes()
 	if !slices.Equal(settings.SearchableAttributes, searchableAttrs) {
 		searchTask, err := index.UpdateSearchableAttributes(&searchableAttrs)
 		if err != nil {
@@ -307,7 +295,7 @@ func (e *MeilisearchEngine) configureIndex(indexName string) error {
 		}
 	}
 
-	sortableAttrs := []string{"updated_at"}
+	sortableAttrs := requiredSortableAttributes()
 	if !slices.Equal(settings.SortableAttributes, sortableAttrs) {
 		sortTask, err := index.UpdateSortableAttributes(&sortableAttrs)
 		if err != nil {

--- a/pkg/spotlight/engine_meilisearch.go
+++ b/pkg/spotlight/engine_meilisearch.go
@@ -46,10 +46,15 @@ type MeilisearchEngine struct {
 	setupMu     sync.Mutex
 	searchReady atomic.Bool
 	writeReady  atomic.Bool
-	pendingMu   sync.Mutex
-	pendingUIDs []int64
-	logger      *logrus.Logger
-	metrics     Metrics
+	// settingsTaskUID is retained when waiting for a settings update times out.
+	// setupMu serializes configureIndex calls, so the next setup attempt waits
+	// for the same Meilisearch task instead of enqueueing an identical one.
+	settingsTaskUID   int64
+	settingsTaskIndex string
+	pendingMu         sync.Mutex
+	pendingUIDs       []int64
+	logger            *logrus.Logger
+	metrics           Metrics
 }
 
 type meiliSearchIndexState struct {
@@ -263,50 +268,94 @@ func (e *MeilisearchEngine) ensureIndexExists(indexName string) (bool, error) {
 func (e *MeilisearchEngine) configureIndex(indexName string) error {
 	const op serrors.Op = "spotlight.MeilisearchEngine.configureIndex"
 
+	if e.settingsTaskUID != 0 && e.settingsTaskIndex == indexName {
+		return e.waitSettingsTask(op)
+	}
+
 	index := e.client.Index(indexName)
 	settings, err := index.GetSettings()
 	if err != nil {
 		return serrors.E(op, err)
 	}
 
+	update := &meilisearch.Settings{}
+	drifted := false
+
 	filterableAttrs := requiredFilterableAttributes()
-	if !slices.Equal(settings.FilterableAttributes, filterableAttrs) {
-		attrs := make([]interface{}, len(filterableAttrs))
-		for i, attr := range filterableAttrs {
-			attrs[i] = attr
-		}
-		filterTask, err := index.UpdateFilterableAttributes(&attrs)
-		if err != nil {
-			return serrors.E(op, err)
-		}
-		if _, err := waitTaskCtxClient(context.Background(), e.client, filterTask.TaskUID); err != nil {
-			return serrors.E(op, err)
-		}
+	if !equalStringSets(settings.FilterableAttributes, filterableAttrs) {
+		update.FilterableAttributes = filterableAttrs
+		drifted = true
 	}
 
 	searchableAttrs := requiredSearchableAttributes()
 	if !slices.Equal(settings.SearchableAttributes, searchableAttrs) {
-		searchTask, err := index.UpdateSearchableAttributes(&searchableAttrs)
-		if err != nil {
-			return serrors.E(op, err)
-		}
-		if _, err := waitTaskCtxClient(context.Background(), e.client, searchTask.TaskUID); err != nil {
-			return serrors.E(op, err)
-		}
+		update.SearchableAttributes = searchableAttrs
+		drifted = true
 	}
 
 	sortableAttrs := requiredSortableAttributes()
-	if !slices.Equal(settings.SortableAttributes, sortableAttrs) {
-		sortTask, err := index.UpdateSortableAttributes(&sortableAttrs)
-		if err != nil {
-			return serrors.E(op, err)
-		}
-		if _, err := waitTaskCtxClient(context.Background(), e.client, sortTask.TaskUID); err != nil {
-			return serrors.E(op, err)
-		}
+	if !equalStringSets(settings.SortableAttributes, sortableAttrs) {
+		update.SortableAttributes = sortableAttrs
+		drifted = true
 	}
 
+	if !drifted {
+		return nil
+	}
+
+	settingsTask, err := index.UpdateSettings(update)
+	if err != nil {
+		return serrors.E(op, err)
+	}
+	if settingsTask == nil {
+		return serrors.E(op, "Meilisearch returned no settings task")
+	}
+	e.settingsTaskUID = settingsTask.TaskUID
+	e.settingsTaskIndex = indexName
+	return e.waitSettingsTask(op)
+}
+
+func (e *MeilisearchEngine) waitSettingsTask(op serrors.Op) error {
+	taskUID := e.settingsTaskUID
+	task, err := waitTaskCtxClient(context.Background(), e.client, taskUID)
+	if err != nil {
+		// Keep the task UID: the task may still be processing server-side, and a
+		// later setup attempt must wait for it instead of creating a duplicate.
+		return serrors.E(op, err)
+	}
+	e.settingsTaskUID = 0
+	e.settingsTaskIndex = ""
+
+	if task == nil {
+		return serrors.E(op, fmt.Errorf("meilisearch settings task %d returned no result", taskUID))
+	}
+	switch task.Status {
+	case meilisearch.TaskStatusFailed:
+		return serrors.E(op, fmt.Errorf("meilisearch settings task %d failed: %s", taskUID, task.Error.Message))
+	case meilisearch.TaskStatusCanceled:
+		return serrors.E(op, fmt.Errorf("meilisearch settings task %d was canceled", taskUID))
+	case meilisearch.TaskStatusUnknown, meilisearch.TaskStatusEnqueued, meilisearch.TaskStatusProcessing:
+		return serrors.E(op, fmt.Errorf("meilisearch settings task %d returned non-terminal status %q", taskUID, task.Status))
+	case meilisearch.TaskStatusSucceeded:
+	}
 	return nil
+}
+
+func equalStringSets(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	counts := make(map[string]int, len(left))
+	for _, value := range left {
+		counts[value]++
+	}
+	for _, value := range right {
+		counts[value]--
+		if counts[value] < 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func (e *MeilisearchEngine) validateSearchSettings(indexName string) error {

--- a/pkg/spotlight/engine_meilisearch.go
+++ b/pkg/spotlight/engine_meilisearch.go
@@ -208,7 +208,15 @@ func (e *MeilisearchEngine) setupForSearch() error {
 	if err != nil {
 		return serrors.E("spotlight.MeilisearchEngine.setupForSearch", err)
 	}
-	if created {
+	// A previous setup may have created the index and then timed out while
+	// waiting for its settings task. On retry ensureSearchIndex now reports an
+	// existing index, so resume that task before taking the validation branch.
+	if e.settingsTaskPending {
+		if err := e.configureIndex(indexName); err != nil {
+			return err
+		}
+		e.writeReady.Store(true)
+	} else if created {
 		if err := e.configureIndex(indexName); err != nil {
 			return err
 		}

--- a/pkg/spotlight/engine_meilisearch.go
+++ b/pkg/spotlight/engine_meilisearch.go
@@ -49,12 +49,13 @@ type MeilisearchEngine struct {
 	// settingsTaskUID is retained when waiting for a settings update times out.
 	// setupMu serializes configureIndex calls, so the next setup attempt waits
 	// for the same Meilisearch task instead of enqueueing an identical one.
-	settingsTaskUID   int64
-	settingsTaskIndex string
-	pendingMu         sync.Mutex
-	pendingUIDs       []int64
-	logger            *logrus.Logger
-	metrics           Metrics
+	settingsTaskPending bool
+	settingsTaskUID     int64
+	settingsTaskIndex   string
+	pendingMu           sync.Mutex
+	pendingUIDs         []int64
+	logger              *logrus.Logger
+	metrics             Metrics
 }
 
 type meiliSearchIndexState struct {
@@ -268,7 +269,10 @@ func (e *MeilisearchEngine) ensureIndexExists(indexName string) (bool, error) {
 func (e *MeilisearchEngine) configureIndex(indexName string) error {
 	const op serrors.Op = "spotlight.MeilisearchEngine.configureIndex"
 
-	if e.settingsTaskUID != 0 && e.settingsTaskIndex == indexName {
+	if e.settingsTaskPending {
+		if e.settingsTaskIndex != indexName {
+			return serrors.E(op, fmt.Errorf("settings task %d is pending for index %q", e.settingsTaskUID, e.settingsTaskIndex))
+		}
 		return e.waitSettingsTask(op)
 	}
 
@@ -312,6 +316,7 @@ func (e *MeilisearchEngine) configureIndex(indexName string) error {
 	}
 	e.settingsTaskUID = settingsTask.TaskUID
 	e.settingsTaskIndex = indexName
+	e.settingsTaskPending = true
 	return e.waitSettingsTask(op)
 }
 
@@ -325,20 +330,23 @@ func (e *MeilisearchEngine) waitSettingsTask(op serrors.Op) error {
 	}
 	e.settingsTaskUID = 0
 	e.settingsTaskIndex = ""
+	e.settingsTaskPending = false
 
 	if task == nil {
 		return serrors.E(op, fmt.Errorf("meilisearch settings task %d returned no result", taskUID))
 	}
 	switch task.Status {
+	case meilisearch.TaskStatusSucceeded:
+		return nil
 	case meilisearch.TaskStatusFailed:
 		return serrors.E(op, fmt.Errorf("meilisearch settings task %d failed: %s", taskUID, task.Error.Message))
 	case meilisearch.TaskStatusCanceled:
 		return serrors.E(op, fmt.Errorf("meilisearch settings task %d was canceled", taskUID))
 	case meilisearch.TaskStatusUnknown, meilisearch.TaskStatusEnqueued, meilisearch.TaskStatusProcessing:
 		return serrors.E(op, fmt.Errorf("meilisearch settings task %d returned non-terminal status %q", taskUID, task.Status))
-	case meilisearch.TaskStatusSucceeded:
+	default:
+		return serrors.E(op, fmt.Errorf("meilisearch settings task %d returned unexpected status %q", taskUID, task.Status))
 	}
-	return nil
 }
 
 func equalStringSets(left, right []string) bool {

--- a/pkg/spotlight/engine_meilisearch_test.go
+++ b/pkg/spotlight/engine_meilisearch_test.go
@@ -101,7 +101,7 @@ func TestMeilisearchEngine_SetupForSearchMissingIndexBootstrapsIt(t *testing.T) 
 		Once()
 	service.EXPECT().
 		WaitForTaskWithContext(mock.Anything, int64(11), 100*time.Millisecond).
-		Return(&meilisearch.Task{}, nil).
+		Return(&meilisearch.Task{Status: meilisearch.TaskStatusSucceeded}, nil).
 		Once()
 
 	require.NoError(t, engine.setupForSearch())
@@ -109,7 +109,7 @@ func TestMeilisearchEngine_SetupForSearchMissingIndexBootstrapsIt(t *testing.T) 
 	require.True(t, engine.writeReady.Load())
 }
 
-func TestMeilisearchEngineConfigureIndexUpdatesOnlyDriftedSetting(t *testing.T) {
+func TestMeilisearchEngineConfigureIndex_UpdatesOnlyDriftedSetting(t *testing.T) {
 	tests := []struct {
 		name     string
 		settings *meilisearch.Settings
@@ -160,7 +160,8 @@ func TestMeilisearchEngineConfigureIndexUpdatesOnlyDriftedSetting(t *testing.T) 
 			index.EXPECT().UpdateSettings(mock.Anything).Run(func(settings *meilisearch.Settings) {
 				got = settings
 			}).Return(&meilisearch.TaskInfo{TaskUID: tt.taskUID}, nil).Once()
-			service.EXPECT().WaitForTaskWithContext(mock.Anything, tt.taskUID, 100*time.Millisecond).Return(&meilisearch.Task{}, nil).Once()
+			service.EXPECT().WaitForTaskWithContext(mock.Anything, tt.taskUID, 100*time.Millisecond).
+				Return(&meilisearch.Task{Status: meilisearch.TaskStatusSucceeded}, nil).Once()
 
 			require.NoError(t, engine.configureIndex("spotlight"))
 			require.Equal(t, tt.want, got)
@@ -195,17 +196,19 @@ func TestMeilisearchEngineConfigureIndex_RetryWaitsForExistingSettingsTask(t *te
 
 	service.EXPECT().Index("spotlight").Return(index).Once()
 	index.EXPECT().GetSettings().Return(&meilisearch.Settings{}, nil).Once()
-	index.EXPECT().UpdateSettings(mock.Anything).Return(&meilisearch.TaskInfo{TaskUID: 41}, nil).Once()
-	service.EXPECT().WaitForTaskWithContext(mock.Anything, int64(41), 100*time.Millisecond).
+	index.EXPECT().UpdateSettings(mock.Anything).Return(&meilisearch.TaskInfo{TaskUID: 0}, nil).Once()
+	service.EXPECT().WaitForTaskWithContext(mock.Anything, int64(0), 100*time.Millisecond).
 		Return(nil, context.DeadlineExceeded).Once()
 
 	require.ErrorIs(t, engine.configureIndex("spotlight"), context.DeadlineExceeded)
-	require.Equal(t, int64(41), engine.settingsTaskUID)
+	require.True(t, engine.settingsTaskPending)
+	require.Zero(t, engine.settingsTaskUID)
 
-	service.EXPECT().WaitForTaskWithContext(mock.Anything, int64(41), 100*time.Millisecond).
+	service.EXPECT().WaitForTaskWithContext(mock.Anything, int64(0), 100*time.Millisecond).
 		Return(&meilisearch.Task{Status: meilisearch.TaskStatusSucceeded}, nil).Once()
 
 	require.NoError(t, engine.configureIndex("spotlight"))
+	require.False(t, engine.settingsTaskPending)
 	require.Zero(t, engine.settingsTaskUID)
 }
 
@@ -224,6 +227,22 @@ func TestMeilisearchEngineConfigureIndex_FailedSettingsTaskIsNotAccepted(t *test
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "settings task 42 failed")
 	require.Zero(t, engine.settingsTaskUID)
+}
+
+func TestMeilisearchEngineConfigureIndex_EmptyTaskStatusIsNotAccepted(t *testing.T) {
+	service := meilimocks.NewMockmeilisearchServiceManager(t)
+	index := meilimocks.NewMockmeilisearchIndexManager(t)
+	engine := &MeilisearchEngine{client: service, indexName: "spotlight"}
+
+	service.EXPECT().Index("spotlight").Return(index).Once()
+	index.EXPECT().GetSettings().Return(&meilisearch.Settings{}, nil).Once()
+	index.EXPECT().UpdateSettings(mock.Anything).Return(&meilisearch.TaskInfo{TaskUID: 43}, nil).Once()
+	service.EXPECT().WaitForTaskWithContext(mock.Anything, int64(43), 100*time.Millisecond).
+		Return(&meilisearch.Task{}, nil).Once()
+
+	err := engine.configureIndex("spotlight")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected status")
 }
 
 func TestMeilisearchEngineConfigureIndex_MissingSettingsTaskIsRejected(t *testing.T) {

--- a/pkg/spotlight/engine_meilisearch_test.go
+++ b/pkg/spotlight/engine_meilisearch_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -95,27 +96,11 @@ func TestMeilisearchEngine_SetupForSearchMissingIndexBootstrapsIt(t *testing.T) 
 		Return(&meilisearch.Settings{}, nil).
 		Once()
 	index.EXPECT().
-		UpdateFilterableAttributes(mock.Anything).
+		UpdateSettings(mock.Anything).
 		Return(&meilisearch.TaskInfo{TaskUID: 11}, nil).
 		Once()
 	service.EXPECT().
 		WaitForTaskWithContext(mock.Anything, int64(11), 100*time.Millisecond).
-		Return(&meilisearch.Task{}, nil).
-		Once()
-	index.EXPECT().
-		UpdateSearchableAttributes(mock.Anything).
-		Return(&meilisearch.TaskInfo{TaskUID: 12}, nil).
-		Once()
-	service.EXPECT().
-		WaitForTaskWithContext(mock.Anything, int64(12), 100*time.Millisecond).
-		Return(&meilisearch.Task{}, nil).
-		Once()
-	index.EXPECT().
-		UpdateSortableAttributes(mock.Anything).
-		Return(&meilisearch.TaskInfo{TaskUID: 13}, nil).
-		Once()
-	service.EXPECT().
-		WaitForTaskWithContext(mock.Anything, int64(13), 100*time.Millisecond).
 		Return(&meilisearch.Task{}, nil).
 		Once()
 
@@ -129,7 +114,7 @@ func TestMeilisearchEngineConfigureIndexUpdatesOnlyDriftedSetting(t *testing.T) 
 		name     string
 		settings *meilisearch.Settings
 		taskUID  int64
-		update   func(*meilimocks.MockmeilisearchIndexManager, *meilimocks.MockmeilisearchServiceManager, int64)
+		want     *meilisearch.Settings
 	}{
 		{
 			name: "filterable",
@@ -139,10 +124,7 @@ func TestMeilisearchEngineConfigureIndexUpdatesOnlyDriftedSetting(t *testing.T) 
 				SortableAttributes:   requiredSortableAttributes(),
 			},
 			taskUID: 21,
-			update: func(index *meilimocks.MockmeilisearchIndexManager, service *meilimocks.MockmeilisearchServiceManager, taskUID int64) {
-				index.EXPECT().UpdateFilterableAttributes(mock.Anything).Return(&meilisearch.TaskInfo{TaskUID: taskUID}, nil).Once()
-				service.EXPECT().WaitForTaskWithContext(mock.Anything, taskUID, 100*time.Millisecond).Return(&meilisearch.Task{}, nil).Once()
-			},
+			want:    &meilisearch.Settings{FilterableAttributes: requiredFilterableAttributes()},
 		},
 		{
 			name: "searchable",
@@ -152,10 +134,7 @@ func TestMeilisearchEngineConfigureIndexUpdatesOnlyDriftedSetting(t *testing.T) 
 				SortableAttributes:   requiredSortableAttributes(),
 			},
 			taskUID: 22,
-			update: func(index *meilimocks.MockmeilisearchIndexManager, service *meilimocks.MockmeilisearchServiceManager, taskUID int64) {
-				index.EXPECT().UpdateSearchableAttributes(mock.Anything).Return(&meilisearch.TaskInfo{TaskUID: taskUID}, nil).Once()
-				service.EXPECT().WaitForTaskWithContext(mock.Anything, taskUID, 100*time.Millisecond).Return(&meilisearch.Task{}, nil).Once()
-			},
+			want:    &meilisearch.Settings{SearchableAttributes: requiredSearchableAttributes()},
 		},
 		{
 			name: "sortable",
@@ -165,10 +144,7 @@ func TestMeilisearchEngineConfigureIndexUpdatesOnlyDriftedSetting(t *testing.T) 
 				SortableAttributes:   nil,
 			},
 			taskUID: 23,
-			update: func(index *meilimocks.MockmeilisearchIndexManager, service *meilimocks.MockmeilisearchServiceManager, taskUID int64) {
-				index.EXPECT().UpdateSortableAttributes(mock.Anything).Return(&meilisearch.TaskInfo{TaskUID: taskUID}, nil).Once()
-				service.EXPECT().WaitForTaskWithContext(mock.Anything, taskUID, 100*time.Millisecond).Return(&meilisearch.Task{}, nil).Once()
-			},
+			want:    &meilisearch.Settings{SortableAttributes: requiredSortableAttributes()},
 		},
 	}
 
@@ -180,11 +156,88 @@ func TestMeilisearchEngineConfigureIndexUpdatesOnlyDriftedSetting(t *testing.T) 
 
 			service.EXPECT().Index("spotlight").Return(index).Once()
 			index.EXPECT().GetSettings().Return(tt.settings, nil).Once()
-			tt.update(index, service, tt.taskUID)
+			var got *meilisearch.Settings
+			index.EXPECT().UpdateSettings(mock.Anything).Run(func(settings *meilisearch.Settings) {
+				got = settings
+			}).Return(&meilisearch.TaskInfo{TaskUID: tt.taskUID}, nil).Once()
+			service.EXPECT().WaitForTaskWithContext(mock.Anything, tt.taskUID, 100*time.Millisecond).Return(&meilisearch.Task{}, nil).Once()
 
 			require.NoError(t, engine.configureIndex("spotlight"))
+			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestMeilisearchEngineConfigureIndex_IgnoresUnorderedSettings(t *testing.T) {
+	service := meilimocks.NewMockmeilisearchServiceManager(t)
+	index := meilimocks.NewMockmeilisearchIndexManager(t)
+	engine := &MeilisearchEngine{client: service, indexName: "spotlight"}
+
+	filterable := requiredFilterableAttributes()
+	slices.Reverse(filterable)
+	sortable := requiredSortableAttributes()
+	slices.Reverse(sortable)
+
+	service.EXPECT().Index("spotlight").Return(index).Once()
+	index.EXPECT().GetSettings().Return(&meilisearch.Settings{
+		FilterableAttributes: filterable,
+		SearchableAttributes: requiredSearchableAttributes(),
+		SortableAttributes:   sortable,
+	}, nil).Once()
+
+	require.NoError(t, engine.configureIndex("spotlight"))
+}
+
+func TestMeilisearchEngineConfigureIndex_RetryWaitsForExistingSettingsTask(t *testing.T) {
+	service := meilimocks.NewMockmeilisearchServiceManager(t)
+	index := meilimocks.NewMockmeilisearchIndexManager(t)
+	engine := &MeilisearchEngine{client: service, indexName: "spotlight"}
+
+	service.EXPECT().Index("spotlight").Return(index).Once()
+	index.EXPECT().GetSettings().Return(&meilisearch.Settings{}, nil).Once()
+	index.EXPECT().UpdateSettings(mock.Anything).Return(&meilisearch.TaskInfo{TaskUID: 41}, nil).Once()
+	service.EXPECT().WaitForTaskWithContext(mock.Anything, int64(41), 100*time.Millisecond).
+		Return(nil, context.DeadlineExceeded).Once()
+
+	require.ErrorIs(t, engine.configureIndex("spotlight"), context.DeadlineExceeded)
+	require.Equal(t, int64(41), engine.settingsTaskUID)
+
+	service.EXPECT().WaitForTaskWithContext(mock.Anything, int64(41), 100*time.Millisecond).
+		Return(&meilisearch.Task{Status: meilisearch.TaskStatusSucceeded}, nil).Once()
+
+	require.NoError(t, engine.configureIndex("spotlight"))
+	require.Zero(t, engine.settingsTaskUID)
+}
+
+func TestMeilisearchEngineConfigureIndex_FailedSettingsTaskIsNotAccepted(t *testing.T) {
+	service := meilimocks.NewMockmeilisearchServiceManager(t)
+	index := meilimocks.NewMockmeilisearchIndexManager(t)
+	engine := &MeilisearchEngine{client: service, indexName: "spotlight"}
+
+	service.EXPECT().Index("spotlight").Return(index).Once()
+	index.EXPECT().GetSettings().Return(&meilisearch.Settings{}, nil).Once()
+	index.EXPECT().UpdateSettings(mock.Anything).Return(&meilisearch.TaskInfo{TaskUID: 42}, nil).Once()
+	service.EXPECT().WaitForTaskWithContext(mock.Anything, int64(42), 100*time.Millisecond).
+		Return(&meilisearch.Task{Status: meilisearch.TaskStatusFailed}, nil).Once()
+
+	err := engine.configureIndex("spotlight")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "settings task 42 failed")
+	require.Zero(t, engine.settingsTaskUID)
+}
+
+func TestMeilisearchEngineConfigureIndex_MissingSettingsTaskIsRejected(t *testing.T) {
+	service := meilimocks.NewMockmeilisearchServiceManager(t)
+	index := meilimocks.NewMockmeilisearchIndexManager(t)
+	engine := &MeilisearchEngine{client: service, indexName: "spotlight"}
+
+	service.EXPECT().Index("spotlight").Return(index).Once()
+	index.EXPECT().GetSettings().Return(&meilisearch.Settings{}, nil).Once()
+	index.EXPECT().UpdateSettings(mock.Anything).Return(nil, nil).Once()
+
+	err := engine.configureIndex("spotlight")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "returned no settings task")
 }
 
 func TestMeilisearchEngine_SetupForSearchRejectsExistingIndexWithoutRequiredSettings(t *testing.T) {

--- a/pkg/spotlight/engine_meilisearch_test.go
+++ b/pkg/spotlight/engine_meilisearch_test.go
@@ -124,6 +124,69 @@ func TestMeilisearchEngine_SetupForSearchMissingIndexBootstrapsIt(t *testing.T) 
 	require.True(t, engine.writeReady.Load())
 }
 
+func TestMeilisearchEngineConfigureIndexUpdatesOnlyDriftedSetting(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings *meilisearch.Settings
+		taskUID  int64
+		update   func(*meilimocks.MockmeilisearchIndexManager, *meilimocks.MockmeilisearchServiceManager, int64)
+	}{
+		{
+			name: "filterable",
+			settings: &meilisearch.Settings{
+				FilterableAttributes: []string{"tenant_id"},
+				SearchableAttributes: requiredSearchableAttributes(),
+				SortableAttributes:   requiredSortableAttributes(),
+			},
+			taskUID: 21,
+			update: func(index *meilimocks.MockmeilisearchIndexManager, service *meilimocks.MockmeilisearchServiceManager, taskUID int64) {
+				index.EXPECT().UpdateFilterableAttributes(mock.Anything).Return(&meilisearch.TaskInfo{TaskUID: taskUID}, nil).Once()
+				service.EXPECT().WaitForTaskWithContext(mock.Anything, taskUID, 100*time.Millisecond).Return(&meilisearch.Task{}, nil).Once()
+			},
+		},
+		{
+			name: "searchable",
+			settings: &meilisearch.Settings{
+				FilterableAttributes: requiredFilterableAttributes(),
+				SearchableAttributes: []string{"title"},
+				SortableAttributes:   requiredSortableAttributes(),
+			},
+			taskUID: 22,
+			update: func(index *meilimocks.MockmeilisearchIndexManager, service *meilimocks.MockmeilisearchServiceManager, taskUID int64) {
+				index.EXPECT().UpdateSearchableAttributes(mock.Anything).Return(&meilisearch.TaskInfo{TaskUID: taskUID}, nil).Once()
+				service.EXPECT().WaitForTaskWithContext(mock.Anything, taskUID, 100*time.Millisecond).Return(&meilisearch.Task{}, nil).Once()
+			},
+		},
+		{
+			name: "sortable",
+			settings: &meilisearch.Settings{
+				FilterableAttributes: requiredFilterableAttributes(),
+				SearchableAttributes: requiredSearchableAttributes(),
+				SortableAttributes:   nil,
+			},
+			taskUID: 23,
+			update: func(index *meilimocks.MockmeilisearchIndexManager, service *meilimocks.MockmeilisearchServiceManager, taskUID int64) {
+				index.EXPECT().UpdateSortableAttributes(mock.Anything).Return(&meilisearch.TaskInfo{TaskUID: taskUID}, nil).Once()
+				service.EXPECT().WaitForTaskWithContext(mock.Anything, taskUID, 100*time.Millisecond).Return(&meilisearch.Task{}, nil).Once()
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := meilimocks.NewMockmeilisearchServiceManager(t)
+			index := meilimocks.NewMockmeilisearchIndexManager(t)
+			engine := &MeilisearchEngine{client: service, indexName: "spotlight"}
+
+			service.EXPECT().Index("spotlight").Return(index).Once()
+			index.EXPECT().GetSettings().Return(tt.settings, nil).Once()
+			tt.update(index, service, tt.taskUID)
+
+			require.NoError(t, engine.configureIndex("spotlight"))
+		})
+	}
+}
+
 func TestMeilisearchEngine_SetupForSearchRejectsExistingIndexWithoutRequiredSettings(t *testing.T) {
 	service := meilimocks.NewMockmeilisearchServiceManager(t)
 	index := meilimocks.NewMockmeilisearchIndexManager(t)

--- a/pkg/spotlight/engine_meilisearch_test.go
+++ b/pkg/spotlight/engine_meilisearch_test.go
@@ -109,6 +109,39 @@ func TestMeilisearchEngine_SetupForSearchMissingIndexBootstrapsIt(t *testing.T) 
 	require.True(t, engine.writeReady.Load())
 }
 
+func TestMeilisearchEngine_SetupForSearchRetryWaitsForPendingSettingsTask(t *testing.T) {
+	service := meilimocks.NewMockmeilisearchServiceManager(t)
+	index := meilimocks.NewMockmeilisearchIndexManager(t)
+	engine := &MeilisearchEngine{client: service, indexName: "spotlight"}
+
+	service.EXPECT().GetIndex("spotlight").
+		Return(nil, &meilisearch.Error{StatusCode: http.StatusNotFound}).Once()
+	service.EXPECT().CreateIndex(mock.AnythingOfType("*meilisearch.IndexConfig")).
+		Return(&meilisearch.TaskInfo{TaskUID: 10}, nil).Once()
+	service.EXPECT().WaitForTaskWithContext(mock.Anything, int64(10), 100*time.Millisecond).
+		Return(&meilisearch.Task{}, nil).Once()
+	service.EXPECT().Index("spotlight").Return(index).Once()
+	index.EXPECT().GetSettings().Return(&meilisearch.Settings{}, nil).Once()
+	index.EXPECT().UpdateSettings(mock.Anything).
+		Return(&meilisearch.TaskInfo{TaskUID: 11}, nil).Once()
+	service.EXPECT().WaitForTaskWithContext(mock.Anything, int64(11), 100*time.Millisecond).
+		Return(nil, context.DeadlineExceeded).Once()
+
+	require.ErrorIs(t, engine.setupForSearch(), context.DeadlineExceeded)
+	require.True(t, engine.settingsTaskPending)
+	require.False(t, engine.searchReady.Load())
+
+	service.EXPECT().GetIndex("spotlight").
+		Return(&meilisearch.IndexResult{UID: "spotlight"}, nil).Once()
+	service.EXPECT().WaitForTaskWithContext(mock.Anything, int64(11), 100*time.Millisecond).
+		Return(&meilisearch.Task{Status: meilisearch.TaskStatusSucceeded}, nil).Once()
+
+	require.NoError(t, engine.setupForSearch())
+	require.False(t, engine.settingsTaskPending)
+	require.True(t, engine.searchReady.Load())
+	require.True(t, engine.writeReady.Load())
+}
+
 func TestMeilisearchEngineConfigureIndex_UpdatesOnlyDriftedSetting(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/pkg/spotlight/engine_meilisearch_test.go
+++ b/pkg/spotlight/engine_meilisearch_test.go
@@ -53,28 +53,12 @@ func TestMeilisearchEngine_SetupForSearchExistingIndexStaysReadOnly(t *testing.T
 		Return(index).
 		Once()
 	index.EXPECT().
-		UpdateFilterableAttributes(mock.Anything).
-		Return(&meilisearch.TaskInfo{TaskUID: 1}, nil).
-		Once()
-	service.EXPECT().
-		WaitForTaskWithContext(mock.Anything, int64(1), 100*time.Millisecond).
-		Return(&meilisearch.Task{}, nil).
-		Once()
-	index.EXPECT().
-		UpdateSearchableAttributes(mock.Anything).
-		Return(&meilisearch.TaskInfo{TaskUID: 2}, nil).
-		Once()
-	service.EXPECT().
-		WaitForTaskWithContext(mock.Anything, int64(2), 100*time.Millisecond).
-		Return(&meilisearch.Task{}, nil).
-		Once()
-	index.EXPECT().
-		UpdateSortableAttributes(mock.Anything).
-		Return(&meilisearch.TaskInfo{TaskUID: 3}, nil).
-		Once()
-	service.EXPECT().
-		WaitForTaskWithContext(mock.Anything, int64(3), 100*time.Millisecond).
-		Return(&meilisearch.Task{}, nil).
+		GetSettings().
+		Return(&meilisearch.Settings{
+			FilterableAttributes: requiredFilterableAttributes(),
+			SearchableAttributes: requiredSearchableAttributes(),
+			SortableAttributes:   requiredSortableAttributes(),
+		}, nil).
 		Once()
 
 	require.NoError(t, engine.setup())
@@ -105,6 +89,10 @@ func TestMeilisearchEngine_SetupForSearchMissingIndexBootstrapsIt(t *testing.T) 
 	service.EXPECT().
 		Index("spotlight").
 		Return(index).
+		Once()
+	index.EXPECT().
+		GetSettings().
+		Return(&meilisearch.Settings{}, nil).
 		Once()
 	index.EXPECT().
 		UpdateFilterableAttributes(mock.Anything).
@@ -466,28 +454,12 @@ func TestMeilisearchEngine_DeleteTenant_RemovesOnlyRequestedTenantDocuments(t *t
 		Return(index).
 		Once()
 	index.EXPECT().
-		UpdateFilterableAttributes(mock.Anything).
-		Return(&meilisearch.TaskInfo{TaskUID: 31}, nil).
-		Once()
-	service.EXPECT().
-		WaitForTaskWithContext(mock.Anything, int64(31), 100*time.Millisecond).
-		Return(&meilisearch.Task{}, nil).
-		Once()
-	index.EXPECT().
-		UpdateSearchableAttributes(mock.Anything).
-		Return(&meilisearch.TaskInfo{TaskUID: 32}, nil).
-		Once()
-	service.EXPECT().
-		WaitForTaskWithContext(mock.Anything, int64(32), 100*time.Millisecond).
-		Return(&meilisearch.Task{}, nil).
-		Once()
-	index.EXPECT().
-		UpdateSortableAttributes(mock.Anything).
-		Return(&meilisearch.TaskInfo{TaskUID: 33}, nil).
-		Once()
-	service.EXPECT().
-		WaitForTaskWithContext(mock.Anything, int64(33), 100*time.Millisecond).
-		Return(&meilisearch.Task{}, nil).
+		GetSettings().
+		Return(&meilisearch.Settings{
+			FilterableAttributes: requiredFilterableAttributes(),
+			SearchableAttributes: requiredSearchableAttributes(),
+			SortableAttributes:   requiredSortableAttributes(),
+		}, nil).
 		Once()
 	service.EXPECT().
 		Index("spotlight").


### PR DESCRIPTION
## Summary

- avoid Meilisearch settings tasks when the index already has the required schema
- treat filterable/sortable order as irrelevant while preserving searchable ranking order
- collapse real schema drift into one settings task instead of three full-index passes
- retain and await a timed-out task UID so retries do not enqueue duplicates
- reject failed, canceled, non-terminal, and missing task results

## Verification

- `go test -race ./pkg/spotlight`
- `go vet ./...`
- `just check lint`
- full `go test ./...` / CI

## Operational impact

Updating `searchableAttributes` reindexes all documents. This change prevents unchanged settings from repeatedly reindexing large production indexes and keeps genuine schema changes bounded to one task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Reliability Improvements**
  - Search index configuration is more reliable when settings updates take longer than expected.
  - Incomplete, missing, or failed configuration updates are handled safely instead of being accepted as successful.
  - Existing settings updates are reused during retries, helping prevent inconsistent index configuration.

- **Performance Improvements**
  - Unchanged search settings are no longer updated unnecessarily.
  - Attribute ordering differences are recognized correctly, reducing redundant configuration work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->