### PR TITLE
fix(spotlight): isolate full rebuild scratch indexes

### DIFF
--- a/pkg/spotlight/engine.go
+++ b/pkg/spotlight/engine.go
@@ -3,6 +3,7 @@ package spotlight
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 )
@@ -36,6 +37,38 @@ type RebuildSession interface {
 type RebuildableIndexEngine interface {
 	IndexEngine
 	StartRebuild(ctx context.Context) (RebuildSession, error)
+}
+
+// RebuildArtifactPruner removes abandoned rebuild indexes. Implementations
+// must leave a grace period large enough for an active rebuild to finish.
+// Callers are responsible for serializing this operation with StartRebuild.
+type RebuildArtifactPruner interface {
+	PruneOrphanBuildIndexes(ctx context.Context, minAge time.Duration) ([]PrunedIndex, error)
+}
+
+type rebuildRunIDKey struct{}
+
+// WithRebuildRunID attaches a caller-controlled run identifier to a full
+// rebuild. Meilisearch engines include it in the temporary build-index name,
+// which makes overlapping rebuilds non-destructive and lets operators relate
+// logs to the corresponding Meili artifact. An empty or invalid identifier is
+// replaced with a generated UUID by the engine.
+func WithRebuildRunID(ctx context.Context, runID string) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, rebuildRunIDKey{}, runID)
+}
+
+func rebuildRunID(ctx context.Context) string {
+	if ctx != nil {
+		if runID, ok := ctx.Value(rebuildRunIDKey{}).(string); ok {
+			if parsed, err := uuid.Parse(runID); err == nil {
+				return parsed.String()
+			}
+		}
+	}
+	return uuid.NewString()
 }
 
 type DocumentRef struct {

--- a/pkg/spotlight/engine_meilisearch.go
+++ b/pkg/spotlight/engine_meilisearch.go
@@ -342,16 +342,47 @@ func (e *MeilisearchEngine) resolveSearchIndexName() (string, error) {
 		return e.activeName, nil
 	}
 
-	buildIndexName := rebuildIndexName(e.activeName)
-	buildState, err := e.inspectSearchIndex(buildIndexName)
+	buildIndexName, err := e.latestReadyBuildIndex()
 	if err != nil {
 		return "", err
 	}
-	if buildState.currentSchemaReady() {
+	if buildIndexName != "" {
 		return buildIndexName, nil
 	}
 
 	return e.activeName, nil
+}
+
+// latestReadyBuildIndex preserves the startup fallback used while an initial
+// rebuild is ready to swap but the active index is still empty. Build names
+// include a unique run UUID, so unlike the old fixed-name lookup we discover
+// the newest valid candidate from Meili.
+func (e *MeilisearchEngine) latestReadyBuildIndex() (string, error) {
+	results, err := e.client.ListIndexesWithContext(context.Background(), &meilisearch.IndexesQuery{Limit: 200})
+	if err != nil || results == nil {
+		return "", err
+	}
+
+	indexes := append([]*meilisearch.IndexResult(nil), results.Results...)
+	slices.SortFunc(indexes, func(a, b *meilisearch.IndexResult) int {
+		if a == nil || b == nil {
+			return 0
+		}
+		return b.UpdatedAt.Compare(a.UpdatedAt)
+	})
+	for _, idx := range indexes {
+		if idx == nil || !strings.HasPrefix(idx.UID, e.buildIndexPrefix()) {
+			continue
+		}
+		state, err := e.inspectSearchIndex(idx.UID)
+		if err != nil {
+			return "", err
+		}
+		if state.currentSchemaReady() {
+			return idx.UID, nil
+		}
+	}
+	return "", nil
 }
 
 func (e *MeilisearchEngine) inspectSearchIndex(indexName string) (meiliSearchIndexState, error) {
@@ -535,15 +566,18 @@ func (s *meiliRebuildSession) Abort(ctx context.Context) error {
 func (e *MeilisearchEngine) StartRebuild(ctx context.Context) (RebuildSession, error) {
 	const op serrors.Op = "spotlight.MeilisearchEngine.StartRebuild"
 
-	buildIndexName := rebuildIndexName(e.activeName)
-	if err := e.resetIndex(ctx, buildIndexName); err != nil {
-		return nil, serrors.E(op, err)
-	}
+	// A rebuild must never reuse a static scratch index. A second replica,
+	// manual CLI invocation, or a process restart used to delete the other
+	// run's work through resetIndex. The caller normally supplies the same UUID
+	// it logs for the run; a UUID is generated for SDK-only callers.
+	buildIndexName := rebuildIndexName(e.activeName, rebuildRunID(ctx))
 
 	buildEngine := &MeilisearchEngine{
 		client:     e.client,
 		indexName:  buildIndexName,
 		activeName: e.activeName,
+		logger:     e.logger,
+		metrics:    e.metrics,
 	}
 	if err := buildEngine.setup(); err != nil {
 		return nil, serrors.E(op, err)
@@ -557,27 +591,9 @@ func (e *MeilisearchEngine) StartRebuild(ctx context.Context) (RebuildSession, e
 	}, nil
 }
 
-func (e *MeilisearchEngine) resetIndex(ctx context.Context, indexName string) error {
-	if _, err := e.client.GetIndex(indexName); err == nil {
-		task, err := e.client.DeleteIndexWithContext(ctx, indexName)
-		if err != nil {
-			return err
-		}
-		if task != nil {
-			if _, err := e.waitTaskCtx(ctx, task.TaskUID); err != nil {
-				return err
-			}
-		}
-		return nil
-	} else if !isMeiliNotFound(err) {
-		return err
-	}
-	return nil
-}
-
-func rebuildIndexName(active string) string {
+func rebuildIndexName(active, runID string) string {
 	sanitizedVersion := strings.NewReplacer("-", "_", ".", "_").Replace(IndexSchemaVersion)
-	return fmt.Sprintf("%s_build_%s", active, sanitizedVersion)
+	return fmt.Sprintf("%s_build_%s_%s", active, sanitizedVersion, runID)
 }
 
 // buildIndexPrefix returns the prefix used to identify rebuild scratch
@@ -595,8 +611,7 @@ type PrunedIndex struct {
 }
 
 // PruneOrphanBuildIndexes scans Meili for rebuild scratch indexes that no
-// longer match the current schema version, are older than the supplied
-// minAge, and removes them. Returns the list of pruned indexes for
+// are older than the supplied minAge, and removes them. Returns the list of pruned indexes for
 // callers that want to log or metric the action. The janitor task in EAI
 // calls this on an hourly schedule.
 //
@@ -615,7 +630,6 @@ func (e *MeilisearchEngine) PruneOrphanBuildIndexes(ctx context.Context, minAge 
 	}
 
 	prefix := e.buildIndexPrefix()
-	current := rebuildIndexName(e.activeName)
 	cutoff := time.Now().Add(-minAge)
 
 	pruned := make([]PrunedIndex, 0)
@@ -624,10 +638,6 @@ func (e *MeilisearchEngine) PruneOrphanBuildIndexes(ctx context.Context, minAge 
 			continue
 		}
 		if !strings.HasPrefix(idx.UID, prefix) {
-			continue
-		}
-		if idx.UID == current {
-			// Active rebuild target; never prune.
 			continue
 		}
 		if minAge > 0 && !idx.UpdatedAt.IsZero() && idx.UpdatedAt.After(cutoff) {
@@ -653,9 +663,8 @@ func (e *MeilisearchEngine) PruneOrphanBuildIndexes(ctx context.Context, minAge 
 		})
 		if e.logger != nil {
 			e.logger.WithFields(logrus.Fields{
-				"index":   idx.UID,
-				"age":     time.Since(idx.UpdatedAt).String(),
-				"current": current,
+				"index": idx.UID,
+				"age":   time.Since(idx.UpdatedAt).String(),
 			}).Info("spotlight janitor pruned orphan build index")
 		}
 	}

--- a/pkg/spotlight/engine_meilisearch_test.go
+++ b/pkg/spotlight/engine_meilisearch_test.go
@@ -205,7 +205,7 @@ func TestMeilisearchEngine_SetupForSearchFallsBackToReadyBuildIndexWhenActiveEmp
 		indexName:  "spotlight",
 		activeName: "spotlight",
 	}
-	buildIndexName := rebuildIndexName("spotlight")
+	buildIndexName := rebuildIndexName("spotlight", "00000000-0000-0000-0000-000000000001")
 
 	service.EXPECT().
 		Index("spotlight").
@@ -213,11 +213,15 @@ func TestMeilisearchEngine_SetupForSearchFallsBackToReadyBuildIndexWhenActiveEmp
 		Once()
 	activeIndex.EXPECT().
 		GetStats().
-		Return(&meilisearch.StatsIndex{
-			NumberOfDocuments: 0,
-		}, nil).
+		Return(&meilisearch.StatsIndex{NumberOfDocuments: 0}, nil).
 		Once()
-
+	service.EXPECT().
+		ListIndexesWithContext(mock.Anything, mock.AnythingOfType("*meilisearch.IndexesQuery")).
+		Return(&meilisearch.IndexesResults{Results: []*meilisearch.IndexResult{{
+			UID:       buildIndexName,
+			UpdatedAt: time.Now(),
+		}}}, nil).
+		Once()
 	service.EXPECT().
 		Index(buildIndexName).
 		Return(buildIndex).
@@ -242,13 +246,9 @@ func TestMeilisearchEngine_SetupForSearchFallsBackToReadyBuildIndexWhenActiveEmp
 		Once()
 	buildIndex.EXPECT().
 		Search("", mock.AnythingOfType("*meilisearch.SearchRequest")).
-		Return(&meilisearch.SearchResponse{
-			Hits: meilisearch.Hits{
-				meilisearch.Hit{
-					"schema_version": json.RawMessage(`"` + IndexSchemaVersion + `"`),
-				},
-			},
-		}, nil).
+		Return(&meilisearch.SearchResponse{Hits: meilisearch.Hits{
+			meilisearch.Hit{"schema_version": json.RawMessage(`"` + IndexSchemaVersion + `"`)},
+		}}, nil).
 		Once()
 	buildIndex.EXPECT().
 		GetSettings().
@@ -261,6 +261,22 @@ func TestMeilisearchEngine_SetupForSearchFallsBackToReadyBuildIndexWhenActiveEmp
 
 	require.NoError(t, engine.setupForSearch())
 	require.True(t, engine.searchReady.Load())
+}
+
+func TestRebuildIndexNameIncludesSchemaAndRunID(t *testing.T) {
+	t.Parallel()
+
+	name := rebuildIndexName("spotlight", "00000000-0000-0000-0000-000000000001")
+
+	require.Equal(t, "spotlight_build_2026_03_30_search_v4_00000000-0000-0000-0000-000000000001", name)
+}
+
+func TestRebuildRunIDUsesValidContextValue(t *testing.T) {
+	t.Parallel()
+
+	ctx := WithRebuildRunID(context.Background(), "00000000-0000-0000-0000-000000000001")
+
+	require.Equal(t, "00000000-0000-0000-0000-000000000001", rebuildRunID(ctx))
 }
 
 func TestBuildSearchFilterEscapesDynamicValues(t *testing.T) {

--- a/pkg/spotlight/service.go
+++ b/pkg/spotlight/service.go
@@ -403,6 +403,19 @@ func (s *SpotlightService) ReindexTenant(ctx context.Context, tenantID uuid.UUID
 	return nil
 }
 
+// PruneOrphanBuildIndexes removes expired temporary indexes left by failed
+// full rebuilds. Deployment-specific callers must hold their global rebuild
+// lease before calling it so the grace period remains the only fallback guard.
+func (s *SpotlightService) PruneOrphanBuildIndexes(ctx context.Context, minAge time.Duration) ([]PrunedIndex, error) {
+	const op serrors.Op = "spotlight.SpotlightService.PruneOrphanBuildIndexes"
+
+	pruner, ok := s.engine.(RebuildArtifactPruner)
+	if !ok {
+		return nil, serrors.E(op, errors.New("spotlight engine does not support rebuild artifact pruning"))
+	}
+	return pruner.PruneOrphanBuildIndexes(ctx, minAge)
+}
+
 func (s *SpotlightService) Readiness(ctx context.Context) error {
 	return s.engine.Health(ctx)
 }


### PR DESCRIPTION
## Что меняется

- каждый full rebuild получает уникальный build-index с UUID запуска; запуск больше не сбрасывает чужой scratch-index;
- возвращён startup fallback на готовый build-index через поиск по префиксу;
- janitor удаляет все build-index старше grace period, включая индекс текущей schema;
- SDK даёт `WithRebuildRunID` и capability очистки для deployment-level coordinator.

## Проверка

- `go test ./pkg/spotlight`

Связано с iota-uz/eai#4005.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788965642&installation_model_id=2042&pr_number=1001&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1001&signature=71c239350a08e87ad84881773f8aeff0030a2484563f66d14fbc737123da2d7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->