### PR TITLE
fix(lens): restore server spec compatibility

### DIFF
--- a/pkg/lens/color/palette.go
+++ b/pkg/lens/color/palette.go
@@ -3,7 +3,58 @@ package color
 
 import (
 	"slices"
+	"strings"
 )
+
+// Deprecated compatibility scopes kept for existing server-side Lens specs.
+// New runtime palettes are categorical; these constants preserve stable colors
+// for consumers that already persist or compare semantic categories.
+const (
+	ScopeProduct        = "PRODUCT"
+	ScopePaymentMethod  = "PAYMENT_METHOD"
+	ScopeContractSource = "CONTRACT_SOURCE"
+	ScopeAgency         = "AGENCY"
+	ScopeRegion         = "REGION"
+	ScopeGender         = "GENDER"
+	ScopeVehicleType    = "VEHICLE_TYPE"
+	ScopeDamageType     = "DAMAGE_TYPE"
+	ScopeDecision       = "DECISION"
+	ScopeClaimSource    = "CLAIM_SOURCE"
+)
+
+var productPalette = map[string]string{
+	"OSAGO":      "#7C3AED",
+	"TRAVEL":     "#2563EB",
+	"KASKO":      "#DC2626",
+	"EURO_KASKO": "#0F766E",
+	"OSGOR":      "#D97706",
+	"OSGOP":      "#DB2777",
+	"SMR":        "#EA580C",
+	"OPO":        "#16A34A",
+}
+
+var paymentMethodPalette = map[string]string{
+	"CLICK":  "#2563EB",
+	"PAYME":  "#10B981",
+	"OCTO":   "#F97316",
+	"STRIPE": "#7C3AED",
+	"CASH":   "#475569",
+}
+
+var productAliases = map[string]string{
+	"3":               "OSAGO",
+	"17":              "TRAVEL",
+	"144":             "OPO",
+	"334":             "SMR",
+	"347":             "EURO_KASKO",
+	"349":             "KASKO",
+	"4002":            "OSGOR",
+	"4003":            "OSGOP",
+	"ONLINE_KASKO":    "KASKO",
+	"WEB_CONSTRUCTOR": "EURO_KASKO",
+	"EOSGOR":          "OSGOR",
+	"EOSGOP":          "OSGOP",
+}
 
 // genericPalette is the Lens design system v2 categorical palette, and the only
 // place it is written down. cmd/lens-typegen reads it through Series and emits
@@ -53,4 +104,67 @@ func Categorical(n int) []string {
 		colors[i] = genericPalette[i%len(genericPalette)]
 	}
 	return colors
+}
+
+// Semantic returns a stable color for a scoped category.
+// Deprecated: new callers should use Categorical for presentation-only colors.
+func Semantic(scope, key string) string {
+	scope = normalizeToken(scope)
+	key = canonicalKey(scope, key)
+	switch scope {
+	case ScopeProduct:
+		if color, ok := productPalette[key]; ok {
+			return color
+		}
+	case ScopePaymentMethod:
+		if color, ok := paymentMethodPalette[key]; ok {
+			return color
+		}
+	}
+	if key == "" {
+		return genericPalette[0]
+	}
+	return genericPalette[stableIndex(scope+":"+key, len(genericPalette))]
+}
+
+// Palette maps each scoped category to its stable semantic color.
+// Deprecated: new callers should use Categorical for presentation-only colors.
+func Palette(scope string, keys []string) []string {
+	colors := make([]string, 0, len(keys))
+	for _, key := range keys {
+		colors = append(colors, Semantic(scope, key))
+	}
+	return colors
+}
+
+// CanonicalProductKey returns the stable product identifier used by Semantic.
+// Deprecated: consumers should normalize their own domain identifiers.
+func CanonicalProductKey(key string) string {
+	normalized := normalizeToken(key)
+	if alias, ok := productAliases[normalized]; ok {
+		return alias
+	}
+	return normalized
+}
+
+func normalizeToken(value string) string {
+	value = strings.ToUpper(strings.TrimSpace(value))
+	value = strings.ReplaceAll(value, "-", "_")
+	return strings.ReplaceAll(value, " ", "_")
+}
+
+func canonicalKey(scope, key string) string {
+	if scope == ScopeProduct {
+		return CanonicalProductKey(key)
+	}
+	return normalizeToken(key)
+}
+
+func stableIndex(key string, size int) int {
+	hash := uint64(14695981039346656037)
+	for _, ch := range key {
+		hash ^= uint64(ch)
+		hash *= 1099511628211
+	}
+	return int(hash % uint64(size))
 }

--- a/pkg/lens/color/palette_test.go
+++ b/pkg/lens/color/palette_test.go
@@ -32,3 +32,11 @@ func TestNeutralAndAccentTokens(t *testing.T) {
 	require.Equal(t, "#94A3B8", Neutral)
 	require.Equal(t, "#2563EB", Accent())
 }
+
+func TestSemanticCompatibilityPreservesProductAliases(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "OSAGO", CanonicalProductKey("3"))
+	require.Equal(t, "#7C3AED", Semantic(ScopeProduct, "3"))
+	require.Equal(t, []string{"#7C3AED", "#2563EB"}, Palette(ScopeProduct, []string{"OSAGO", "TRAVEL"}))
+}

--- a/pkg/lens/color/palette_test.go
+++ b/pkg/lens/color/palette_test.go
@@ -36,7 +36,33 @@ func TestNeutralAndAccentTokens(t *testing.T) {
 func TestSemanticCompatibilityPreservesProductAliases(t *testing.T) {
 	t.Parallel()
 
-	require.Equal(t, "OSAGO", CanonicalProductKey("3"))
-	require.Equal(t, "#7C3AED", Semantic(ScopeProduct, "3"))
+	cases := []struct {
+		name      string
+		key       string
+		canonical string
+		color     string
+	}{
+		{name: "OSAGO legacy ID", key: "3", canonical: "OSAGO", color: "#7C3AED"},
+		{name: "TRAVEL legacy ID", key: "17", canonical: "TRAVEL", color: "#2563EB"},
+		{name: "OPO legacy ID", key: "144", canonical: "OPO", color: "#16A34A"},
+		{name: "SMR legacy ID", key: "334", canonical: "SMR", color: "#EA580C"},
+		{name: "EURO KASKO legacy ID", key: "347", canonical: "EURO_KASKO", color: "#0F766E"},
+		{name: "KASKO legacy ID", key: "349", canonical: "KASKO", color: "#DC2626"},
+		{name: "OSGOR legacy ID", key: "4002", canonical: "OSGOR", color: "#D97706"},
+		{name: "OSGOP legacy ID", key: "4003", canonical: "OSGOP", color: "#DB2777"},
+		{name: "online KASKO alias", key: "ONLINE_KASKO", canonical: "KASKO", color: "#DC2626"},
+		{name: "web constructor alias", key: "WEB_CONSTRUCTOR", canonical: "EURO_KASKO", color: "#0F766E"},
+		{name: "electronic OSGOR alias", key: "EOSGOR", canonical: "OSGOR", color: "#D97706"},
+		{name: "electronic OSGOP alias", key: "EOSGOP", canonical: "OSGOP", color: "#DB2777"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.canonical, CanonicalProductKey(tc.key))
+			require.Equal(t, tc.color, Semantic(ScopeProduct, tc.key))
+		})
+	}
+
 	require.Equal(t, []string{"#7C3AED", "#2563EB"}, Palette(ScopeProduct, []string{"OSAGO", "TRAVEL"}))
 }

--- a/pkg/lens/panel/panel.go
+++ b/pkg/lens/panel/panel.go
@@ -520,6 +520,18 @@ const (
 	GroupRows    GroupLayout = "rows"
 )
 
+// LegendPosition is retained for compatibility with existing server-side Lens
+// specifications. New renderers may instead express their preferred layout
+// through PresentationHints.
+type LegendPosition string
+
+const (
+	LegendTop    LegendPosition = "top"
+	LegendRight  LegendPosition = "right"
+	LegendBottom LegendPosition = "bottom"
+	LegendLeft   LegendPosition = "left"
+)
+
 type AxisScale string
 
 const (

--- a/pkg/lens/spec/builders.go
+++ b/pkg/lens/spec/builders.go
@@ -197,9 +197,41 @@ func newPanelBuilder(kind panel.Kind, id, title, dataset string) *PanelBuilder {
 	}
 }
 
-func (b *PanelBuilder) Span(span int) *PanelBuilder           { b.panel.Span = span; return b }
+func (b *PanelBuilder) Span(span int) *PanelBuilder { b.panel.Span = span; return b }
+
+// Height retains compatibility with existing Lens specifications.
+func (b *PanelBuilder) Height(height string) *PanelBuilder    { b.panel.Height = height; return b }
 func (b *PanelBuilder) Colors(colors ...string) *PanelBuilder { b.panel.Colors = colors; return b }
 func (b *PanelBuilder) Legend() *PanelBuilder                 { b.panel.ShowLegend = true; return b }
+func (b *PanelBuilder) LegendAt(position panel.LegendPosition) *PanelBuilder {
+	b.panel.ShowLegend = true
+	b.panel.LegendPosition = position
+	return b
+}
+func (b *PanelBuilder) LegendWidth(px int) *PanelBuilder {
+	b.panel.ShowLegend = true
+	b.panel.LegendWidthPx = px
+	return b
+}
+func (b *PanelBuilder) LegendOffsetY(px int) *PanelBuilder {
+	b.panel.ShowLegend = true
+	b.panel.LegendOffsetY = px
+	return b
+}
+func (b *PanelBuilder) FloatingLegend() *PanelBuilder {
+	b.panel.ShowLegend = true
+	b.panel.LegendFloating = true
+	return b
+}
+func (b *PanelBuilder) CircularScale(scale float64) *PanelBuilder {
+	b.panel.CircularScale = scale
+	return b
+}
+func (b *PanelBuilder) CircularOffsetX(px int) *PanelBuilder {
+	b.panel.CircularOffsetX = px
+	return b
+}
+func (b *PanelBuilder) TotalBadge() *PanelBuilder { b.panel.ShowTotalBadge = true; return b }
 
 // TotalBadgeValue shows the total badge with a server-computed value instead
 // of the client-side sum of plotted points. Use when the plotted series are
@@ -292,6 +324,7 @@ func (b *PanelBuilder) Info(text string) *PanelBuilder {
 	b.panel.Info = LiteralText(text)
 	return b
 }
+func (b *PanelBuilder) ClassName(name string) *PanelBuilder { b.panel.ClassName = name; return b }
 func (b *PanelBuilder) ValueAxisScale(scale panel.AxisScale, base int) *PanelBuilder {
 	b.panel.ValueAxis.Scale = scale
 	if base > 1 {
@@ -312,6 +345,11 @@ func (b *PanelBuilder) AccentColor(color string) *PanelBuilder {
 }
 func (b *PanelBuilder) DistributedColors() *PanelBuilder {
 	b.panel.Distributed = true
+	return b
+}
+func (b *PanelBuilder) SemanticColors(scale, field string) *PanelBuilder {
+	b.panel.ColorScale = strings.TrimSpace(scale)
+	b.panel.ColorField = field
 	return b
 }
 func (b *PanelBuilder) Fields(mapping FieldMappingSpec) *PanelBuilder {

--- a/pkg/lens/spec/builders_compat_test.go
+++ b/pkg/lens/spec/builders_compat_test.go
@@ -1,9 +1,11 @@
 package spec
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/iota-uz/iota-sdk/pkg/lens/panel"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,13 +15,37 @@ func TestPanelBuilderHeightCompatibility(t *testing.T) {
 	panel := StackedBar("daily", "Daily", "daily").Height("320px").Build()
 
 	require.Equal(t, "320px", panel.Height)
+	payload, err := json.Marshal(panel)
+	require.NoError(t, err)
+	var wire map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(payload, &wire))
+	height, ok := wire["height"]
+	require.True(t, ok)
+	assert.Equal(t, json.RawMessage(`"320px"`), height)
 }
 
 func TestPanelBuilderLegacyPresentationCompatibility(t *testing.T) {
 	t.Parallel()
 
+	legendCases := []struct {
+		name     string
+		position panel.LegendPosition
+	}{
+		{name: "top", position: panel.LegendTop},
+		{name: "right", position: panel.LegendRight},
+		{name: "bottom", position: panel.LegendBottom},
+		{name: "left", position: panel.LegendLeft},
+	}
+	for _, tc := range legendCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			chart := Pie("products", "Products", "products").LegendAt(tc.position).Build()
+			assert.Equal(t, tc.position, chart.LegendPosition)
+		})
+	}
+
 	chart := Pie("products", "Products", "products").
-		LegendAt(panel.LegendRight).
 		LegendWidth(300).
 		LegendOffsetY(48).
 		FloatingLegend().
@@ -28,7 +54,6 @@ func TestPanelBuilderLegacyPresentationCompatibility(t *testing.T) {
 		SemanticColors("product", "product").
 		Build()
 
-	require.Equal(t, panel.LegendRight, chart.LegendPosition)
 	require.Equal(t, 300, chart.LegendWidthPx)
 	require.Equal(t, 48, chart.LegendOffsetY)
 	require.True(t, chart.LegendFloating)

--- a/pkg/lens/spec/builders_compat_test.go
+++ b/pkg/lens/spec/builders_compat_test.go
@@ -1,0 +1,39 @@
+package spec
+
+import (
+	"testing"
+
+	"github.com/iota-uz/iota-sdk/pkg/lens/panel"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPanelBuilderHeightCompatibility(t *testing.T) {
+	t.Parallel()
+
+	panel := StackedBar("daily", "Daily", "daily").Height("320px").Build()
+
+	require.Equal(t, "320px", panel.Height)
+}
+
+func TestPanelBuilderLegacyPresentationCompatibility(t *testing.T) {
+	t.Parallel()
+
+	chart := Pie("products", "Products", "products").
+		LegendAt(panel.LegendRight).
+		LegendWidth(300).
+		LegendOffsetY(48).
+		FloatingLegend().
+		CircularScale(0.9).
+		CircularOffsetX(-130).
+		SemanticColors("product", "product").
+		Build()
+
+	require.Equal(t, panel.LegendRight, chart.LegendPosition)
+	require.Equal(t, 300, chart.LegendWidthPx)
+	require.Equal(t, 48, chart.LegendOffsetY)
+	require.True(t, chart.LegendFloating)
+	require.InDelta(t, 0.9, chart.CircularScale, 0.001)
+	require.Equal(t, -130, chart.CircularOffsetX)
+	require.Equal(t, "product", chart.ColorScale)
+	require.Equal(t, "product", chart.ColorField)
+}

--- a/pkg/lens/spec/document.go
+++ b/pkg/lens/spec/document.go
@@ -148,15 +148,25 @@ type RowSpec struct {
 }
 
 type PanelSpec struct {
-	ID              string               `json:"id"`
-	Title           Text                 `json:"title"`
-	Description     Text                 `json:"description"`
-	Info            Text                 `json:"info"`
-	Kind            panel.Kind           `json:"kind"`
-	Dataset         string               `json:"dataset,omitempty"`
-	Span            int                  `json:"span,omitempty"`
+	ID          string     `json:"id"`
+	Title       Text       `json:"title"`
+	Description Text       `json:"description"`
+	Info        Text       `json:"info"`
+	Kind        panel.Kind `json:"kind"`
+	Dataset     string     `json:"dataset,omitempty"`
+	Span        int        `json:"span,omitempty"`
+	// Height is retained for wire compatibility with existing server-side Lens
+	// specs. Renderers that do not support an explicit height safely ignore it.
+	Height          string               `json:"height,omitempty"`
 	Colors          []string             `json:"colors,omitempty"`
 	ShowLegend      bool                 `json:"showLegend,omitempty"`
+	LegendPosition  panel.LegendPosition `json:"legendPosition,omitempty"`
+	LegendWidthPx   int                  `json:"legendWidth,omitempty"`
+	LegendOffsetY   int                  `json:"legendOffsetY,omitempty"`
+	LegendFloating  bool                 `json:"legendFloating,omitempty"`
+	CircularScale   float64              `json:"circularScale,omitempty"`
+	CircularOffsetX int                  `json:"circularOffsetX,omitempty"`
+	ShowTotalBadge  bool                 `json:"showTotalBadge,omitempty"`
 	TotalBadgeValue *float64             `json:"totalBadgeValue,omitempty"`
 	HeadlineValue   *float64             `json:"headlineValue,omitempty"`
 	DrillTree       *panel.DrillTree     `json:"drillTree,omitempty"`
@@ -184,11 +194,14 @@ type PanelSpec struct {
 	// visualize the active comparison. The renderer owns localized messaging.
 	ComparisonUnsupported bool            `json:"comparisonUnsupported,omitempty"`
 	Children              []PanelSpec     `json:"children,omitempty"`
+	ClassName             string          `json:"className,omitempty"`
 	Chrome                chrome.Spec     `json:"-"`
 	ChromeIcon            string          `json:"icon,omitempty"`
 	AccentColor           string          `json:"accentColor,omitempty"`
 	ValueAxis             panel.ValueAxis `json:"valueAxis,omitempty"`
 	Distributed           bool            `json:"distributed,omitempty"`
+	ColorField            string          `json:"colorField,omitempty"`
+	ColorScale            string          `json:"colorScale,omitempty"`
 	Export                exportmeta.Spec `json:"export,omitempty"`
 	// FlowStages declares a metric_flow panel's ordered operand stages.
 	FlowStages []panel.FlowStage `json:"flowStages,omitempty"`


### PR DESCRIPTION
Restores deprecated generic Lens APIs still used by downstream server specs:

- scoped semantic color helpers and product aliases;
- `PanelBuilder.Height` / serialized `PanelSpec.Height`.

The current EAI main production build proves these are still public consumer APIs.

Tests: `go test ./pkg/lens/color ./pkg/lens/spec`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788969363&installation_model_id=2042&pr_number=1002&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1002&signature=9d4a6a0d563b1947860de1e751ab45caa0537a5b9255960f442e9a2ba8d63943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stable semantic color mappings for products and payment methods.
  * Added bulk palette lookup with alias normalization and deterministic fallback colors.
  * Added panel height, CSS class, and semantic color configuration.
  * Added configurable legend positions for Lens panels.

* **Compatibility**
  * Preserved legacy color scopes, aliases, panel height, and presentation settings.
  * Serialized panel height and semantic color settings when configured.

* **Tests**
  * Added coverage for color alias resolution and legacy panel settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->