### PR TITLE
fix(lens): preserve cube visual spec compatibility

### DIFF
--- a/pkg/lens/compile/compile.go
+++ b/pkg/lens/compile/compile.go
@@ -37,6 +37,10 @@ type CompiledDocument struct {
 }
 
 func Document(doc lensspec.Document, opts Options) (CompiledDocument, error) {
+	// Documents created through the builder API predate the explicit terminal
+	// marker. Normalize their interaction contract before validation so those
+	// inert legacy leaves remain valid without changing their rendered behavior.
+	doc = lensspec.FinalizeInteractionContract(doc)
 	if err := doc.Validate(); err != nil {
 		return CompiledDocument{}, err
 	}
@@ -377,10 +381,12 @@ func compileDimension(item lensspec.DimensionSpec, opts Options) (cube.Dimension
 		LabelField:   resolveString(item.LabelField, opts.Values),
 		ColorField:   resolveString(item.ColorField, opts.Values),
 		PanelKind:    item.PanelKind,
+		Height:       resolveString(item.Height, opts.Values),
 		Description:  resolveText(item.Description, opts),
 		RequiresJoin: resolveStringSlice(item.RequiresJoin, opts.Values),
 		Colors:       resolveStringSlice(item.Colors, opts.Values),
 		ValueAxis:    item.ValueAxis,
+		ColorScale:   resolveString(item.ColorScale, opts.Values),
 		Presentation: item.Presentation,
 	}
 	if item.Map != nil {

--- a/pkg/lens/compile/compile_test.go
+++ b/pkg/lens/compile/compile_test.go
@@ -158,6 +158,29 @@ func TestDocumentCompilesManualStaticDashboard(t *testing.T) {
 	require.Equal(t, "total", compiled.Spec.Rows[0].Panels[0].ID)
 }
 
+func TestDocumentFinalizesLegacyInertPanels(t *testing.T) {
+	t.Parallel()
+
+	stats, err := frame.FromRows("stats", frame.Row{"value": 7})
+	require.NoError(t, err)
+	doc := lensspec.Document{
+		Version:     lensspec.DocumentVersion,
+		ID:          "legacy-static",
+		Title:       lensspec.LiteralText("Legacy"),
+		Description: lensspec.LiteralText("Static"),
+		Datasets: []lensspec.DatasetSpec{{
+			Name: "stats", Kind: lens.DatasetKindStatic, StaticRef: "stats_dataset",
+		}},
+		Rows: []lensspec.RowSpec{{Panels: []lensspec.PanelSpec{{
+			ID: "total", Title: lensspec.LiteralText("Total"), Kind: panel.KindStat, Dataset: "stats",
+		}}}},
+	}
+
+	compiled, err := Document(doc, Options{Locale: "en", Values: map[string]any{"stats_dataset": stats}})
+	require.NoError(t, err)
+	require.True(t, compiled.Spec.Rows[0].Panels[0].Terminal)
+}
+
 func TestCompilePanelPreservesDrillTree(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/lens/cube/cube.go
+++ b/pkg/lens/cube/cube.go
@@ -68,12 +68,14 @@ type DimensionSpec struct {
 	LabelField   string
 	ColorField   string
 	PanelKind    panel.Kind
+	Height       string
 	Description  string
 	RequiresJoin []string
 	Override     *lens.DatasetSpec
 	Transforms   []transform.Spec
 	Colors       []string
 	ValueAxis    panel.ValueAxis
+	ColorScale   string
 	// Presentation carries renderer-level density choices onto the dimension's
 	// panel. A cube dimension is a panel like any other, and some of these are
 	// statements about the data rather than about density — ColorBySequence

--- a/pkg/lens/cube/resolve.go
+++ b/pkg/lens/cube/resolve.go
@@ -304,6 +304,7 @@ func buildDimensionPanel(spec CubeSpec, dim DimensionSpec, resolved dimensionDat
 	actionURL := baseURL
 	builder := panelBuilder(dim.PanelKind, "panel_"+dim.Name, dim.Label, resolved.Name, dim.Map).
 		Span(dimensionSpan(remainingCount, index)).
+		Height("360px").
 		Description(dim.Description).
 		Fields(panel.FieldMapping{
 			Label:    panel.Ref("label"),
@@ -318,6 +319,9 @@ func buildDimensionPanel(spec CubeSpec, dim DimensionSpec, resolved dimensionDat
 			ID: panel.Ref("filter_value"),
 		}).
 		Action(action.CrossFilter(actionURL, dim.Name))
+	if strings.TrimSpace(dim.Height) != "" {
+		builder.Height(dim.Height)
+	}
 	if measure.Formatter != nil {
 		builder.Format(*measure.Formatter)
 	}
@@ -326,6 +330,16 @@ func buildDimensionPanel(spec CubeSpec, dim DimensionSpec, resolved dimensionDat
 	}
 	if !dim.Presentation.IsZero() {
 		builder.Presentation(dim.Presentation)
+	}
+	if strings.TrimSpace(dim.ColorScale) != "" {
+		colorField := panel.Ref("filter_value")
+		if resolved.HasColorValue {
+			colorField = panel.Ref("color_value")
+		}
+		builder.SemanticColors(dim.ColorScale, colorField)
+		if dim.PanelKind == panel.KindBar || dim.PanelKind == panel.KindHorizontalBar {
+			builder.DistributedColors()
+		}
 	}
 	if len(dim.Colors) > 0 {
 		builder.Colors(dim.Colors...)
@@ -336,6 +350,7 @@ func buildDimensionPanel(spec CubeSpec, dim DimensionSpec, resolved dimensionDat
 	if dim.PanelKind == panel.KindTable && resolved.Compared {
 		builder = panel.Table("panel_"+dim.Name, dim.Label, resolved.Name).
 			Span(dimensionSpan(remainingCount, index)).
+			Height("360px").
 			Action(action.CrossFilter(actionURL, dim.Name)).
 			Columns(
 				panel.TableColumn{Field: panel.Ref("label"), Label: dim.Label},
@@ -346,6 +361,9 @@ func buildDimensionPanel(spec CubeSpec, dim DimensionSpec, resolved dimensionDat
 					Cell: &panel.TableCellSpec{Kind: panel.TableCellDelta, PercentField: panel.Ref(comparison.DeltaPercentField(measure.Name))},
 				},
 			)
+		if strings.TrimSpace(dim.Height) != "" {
+			builder.Height(dim.Height)
+		}
 	}
 	return builder.Build()
 }

--- a/pkg/lens/jsonspec/cube.go
+++ b/pkg/lens/jsonspec/cube.go
@@ -83,12 +83,14 @@ type DimensionSpec struct {
 	LabelField   string                  `json:"labelField"`
 	ColorField   string                  `json:"colorField"`
 	PanelKind    panel.Kind              `json:"panelKind"`
+	Height       string                  `json:"height"`
 	Description  Text                    `json:"description"`
 	RequiresJoin []string                `json:"requiresJoin"`
 	Override     *DatasetSpec            `json:"override"`
 	Transforms   []transform.Spec        `json:"transforms"`
 	Colors       []string                `json:"colors"`
 	ValueAxis    panel.ValueAxis         `json:"valueAxis"`
+	ColorScale   string                  `json:"colorScale"`
 	Presentation panel.PresentationHints `json:"presentation"`
 	Map          *panel.MapSpec          `json:"map"`
 }
@@ -282,10 +284,12 @@ func (s DimensionSpec) resolve(opts ResolveOptions) (cube.DimensionSpec, error) 
 		LabelField:   resolveString(s.LabelField, opts.Values),
 		ColorField:   resolveString(s.ColorField, opts.Values),
 		PanelKind:    s.PanelKind,
+		Height:       resolveString(s.Height, opts.Values),
 		Description:  resolveText(s.Description, opts),
 		RequiresJoin: resolveStringSlice(s.RequiresJoin, opts.Values),
 		Colors:       resolveStringSlice(s.Colors, opts.Values),
 		ValueAxis:    s.ValueAxis,
+		ColorScale:   resolveString(s.ColorScale, opts.Values),
 		Presentation: s.Presentation,
 	}
 	if s.Map != nil {

--- a/pkg/lens/jsonspec/cube_test.go
+++ b/pkg/lens/jsonspec/cube_test.go
@@ -220,6 +220,31 @@ func TestLoadCubeResolvesMapDimension(t *testing.T) {
 	require.Equal(t, "© Example Maps", spec.Dimensions[0].Map.Attribution)
 }
 
+func TestLoadCubeResolvesLegacyDimensionPresentation(t *testing.T) {
+	t.Parallel()
+
+	spec, err := LoadCube([]byte(`{
+		"version": 1,
+		"id": "product-sales",
+		"title": "Product sales",
+		"dataMode": "sql",
+		"dataSource": "primary",
+		"fromSQL": "sales",
+		"dimensions": [{
+			"name": "product",
+			"label": "Product",
+			"column": "product_code",
+			"height": "420px",
+			"colorScale": "{{product_color_scale}}"
+		}],
+		"measures": [{"name": "premium", "label": "Premium", "column": "premium", "aggregation": "sum"}]
+	}`), ResolveOptions{Values: map[string]any{"product_color_scale": "product"}})
+
+	require.NoError(t, err)
+	require.Equal(t, "420px", spec.Dimensions[0].Height)
+	require.Equal(t, "product", spec.Dimensions[0].ColorScale)
+}
+
 func TestLoadCubeResolvesVariableDefaults(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/lens/panel/panel.go
+++ b/pkg/lens/panel/panel.go
@@ -693,15 +693,23 @@ func (f FieldRef) Empty() bool {
 }
 
 type Spec struct {
-	ID          string
-	Title       string
-	Description string
-	Info        string
-	Kind        Kind
-	Dataset     string
-	Span        int
-	Colors      []string
-	ShowLegend  bool
+	ID              string
+	Title           string
+	Description     string
+	Info            string
+	Kind            Kind
+	Dataset         string
+	Span            int
+	Height          string
+	Colors          []string
+	ShowLegend      bool
+	LegendPosition  LegendPosition
+	LegendWidthPx   int
+	LegendOffsetY   int
+	LegendFloating  bool
+	CircularScale   float64
+	CircularOffsetX int
+	ShowTotalBadge  bool
 	// TotalBadgeValue, when set, renders the total badge with this
 	// server-computed value instead of summing the plotted data points
 	// client-side. Required for panels whose plotted series are not the raw
@@ -747,9 +755,12 @@ type Spec struct {
 	// represented by its chart kind. Renderers localize the explanatory notice.
 	ComparisonUnsupported bool
 	Children              []Spec
+	ClassName             string
 	Chrome                chrome.Spec
 	ValueAxis             ValueAxis
 	Distributed           bool
+	ColorField            FieldRef
+	ColorScale            string
 	Export                exportmeta.Spec
 	// FlowStages, when set (KindMetricFlow), declares the panel's ordered
 	// operand stages.
@@ -1055,9 +1066,40 @@ func newBuilder(kind Kind, id, title, dataset string) *Builder {
 }
 
 func (b *Builder) Span(span int) *Builder           { b.spec.Span = span; return b }
+func (b *Builder) Height(height string) *Builder    { b.spec.Height = height; return b }
 func (b *Builder) Colors(colors ...string) *Builder { b.spec.Colors = colors; return b }
 func (b *Builder) Legend() *Builder                 { b.spec.ShowLegend = true; return b }
+func (b *Builder) LegendAt(position LegendPosition) *Builder {
+	b.spec.ShowLegend = true
+	b.spec.LegendPosition = position
+	return b
+}
+func (b *Builder) LegendWidth(px int) *Builder {
+	b.spec.ShowLegend = true
+	b.spec.LegendWidthPx = px
+	return b
+}
+func (b *Builder) LegendOffsetY(px int) *Builder {
+	b.spec.ShowLegend = true
+	b.spec.LegendOffsetY = px
+	return b
+}
+func (b *Builder) FloatingLegend() *Builder {
+	b.spec.ShowLegend = true
+	b.spec.LegendFloating = true
+	return b
+}
+func (b *Builder) CircularScale(scale float64) *Builder {
+	b.spec.CircularScale = scale
+	return b
+}
+func (b *Builder) CircularOffsetX(px int) *Builder {
+	b.spec.CircularOffsetX = px
+	return b
+}
+func (b *Builder) TotalBadge() *Builder { b.spec.ShowTotalBadge = true; return b }
 func (b *Builder) TotalBadgeValue(v float64) *Builder {
+	b.spec.ShowTotalBadge = true
 	b.spec.TotalBadgeValue = &v
 	return b
 }
@@ -1231,6 +1273,7 @@ func (b *Builder) Export(url string, evidenceDatasets ...string) *Builder {
 	b.spec.Export = exportmeta.Spec{Enabled: true, URL: url, EvidenceDatasets: append([]string(nil), evidenceDatasets...)}
 	return b
 }
+func (b *Builder) ClassName(name string) *Builder { b.spec.ClassName = name; return b }
 func (b *Builder) ValueAxisScale(scale AxisScale, base int) *Builder {
 	b.spec.ValueAxis.Scale = scale
 	if base > 1 {
@@ -1251,6 +1294,11 @@ func (b *Builder) AccentColor(color string) *Builder {
 }
 func (b *Builder) DistributedColors() *Builder {
 	b.spec.Distributed = true
+	return b
+}
+func (b *Builder) SemanticColors(scale string, field FieldRef) *Builder {
+	b.spec.ColorScale = strings.TrimSpace(scale)
+	b.spec.ColorField = field
 	return b
 }
 func (b *Builder) Fields(mapping FieldMapping) *Builder {

--- a/pkg/lens/spec/document.go
+++ b/pkg/lens/spec/document.go
@@ -91,12 +91,14 @@ type DimensionSpec struct {
 	LabelField   string                  `json:"labelField,omitempty"`
 	ColorField   string                  `json:"colorField,omitempty"`
 	PanelKind    panel.Kind              `json:"panelKind,omitempty"`
+	Height       string                  `json:"height,omitempty"`
 	Description  Text                    `json:"description"`
 	RequiresJoin []string                `json:"requiresJoin,omitempty"`
 	Override     *DatasetSpec            `json:"override,omitempty"`
 	Transforms   []transform.Spec        `json:"transforms,omitempty"`
 	Colors       []string                `json:"colors,omitempty"`
 	ValueAxis    panel.ValueAxis         `json:"valueAxis,omitempty"`
+	ColorScale   string                  `json:"colorScale,omitempty"`
 	Presentation panel.PresentationHints `json:"presentation,omitempty"`
 	Map          *panel.MapSpec          `json:"map,omitempty"`
 }


### PR DESCRIPTION
Restores legacy cube `height` and `colorScale` JSON contracts, their compiled panel behavior, and automatic terminal normalization for pre-contract builder documents. Required to keep EAI dashboards compatible with the P0 Spotlight rebuild SDK pin.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788971063&installation_model_id=2042&pr_number=1003&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1003&signature=28cf4d9b53b883a32b8c1d6abb8aef2eadb77c1c23a64850d6cf09735a9a8cdd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->