### PR TITLE
fix(spotlight): allow rebuild tasks to wait under load

### DIFF
--- a/pkg/spotlight/engine_meilisearch.go
+++ b/pkg/spotlight/engine_meilisearch.go
@@ -56,6 +56,10 @@ type MeilisearchEngine struct {
 	pendingUIDs         []int64
 	logger              *logrus.Logger
 	metrics             Metrics
+	// taskWaitDeadline overrides the default single-task deadline for this
+	// engine. Rebuild engines use the maintenance budget because their index
+	// creation, settings, and bulk tasks may sit behind live projector writes.
+	taskWaitDeadline time.Duration
 }
 
 type meiliSearchIndexState struct {
@@ -140,7 +144,11 @@ func (e *MeilisearchEngine) waitTaskCtx(ctx context.Context, taskUID int64) (*me
 	}
 	if _, hasDeadline := ctx.Deadline(); !hasDeadline {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, defaultWaitForTaskDeadline)
+		deadline := e.taskWaitDeadline
+		if deadline <= 0 {
+			deadline = defaultWaitForTaskDeadline
+		}
+		ctx, cancel = context.WithTimeout(ctx, deadline)
 		defer cancel()
 	}
 	return e.client.WaitForTaskWithContext(ctx, taskUID, waitTaskPollInterval)
@@ -262,7 +270,7 @@ func (e *MeilisearchEngine) ensureIndexExists(indexName string) (bool, error) {
 			return false, serrors.E(op, err)
 		}
 
-		task, err := waitTaskCtxClient(context.Background(), e.client, taskInfo.TaskUID)
+		task, err := e.waitTaskCtx(context.Background(), taskInfo.TaskUID)
 		if err != nil {
 			return false, serrors.E(op, err)
 		}
@@ -330,7 +338,7 @@ func (e *MeilisearchEngine) configureIndex(indexName string) error {
 
 func (e *MeilisearchEngine) waitSettingsTask(op serrors.Op) error {
 	taskUID := e.settingsTaskUID
-	task, err := waitTaskCtxClient(context.Background(), e.client, taskUID)
+	task, err := e.waitTaskCtx(context.Background(), taskUID)
 	if err != nil {
 		// Keep the task UID: the task may still be processing server-side, and a
 		// later setup attempt must wait for it instead of creating a duplicate.
@@ -645,6 +653,11 @@ func (e *MeilisearchEngine) StartRebuild(ctx context.Context) (RebuildSession, e
 		activeName: e.activeName,
 		logger:     e.logger,
 		metrics:    e.metrics,
+		// A live index may continuously enqueue projector writes ahead of the
+		// scratch-index setup. The regular 60s request budget is intentionally
+		// too short for that maintenance queue; use the existing bulk-drain
+		// budget for every task belonging to this isolated rebuild engine.
+		taskWaitDeadline: drainWaitDeadline,
 	}
 	if err := buildEngine.setup(); err != nil {
 		return nil, serrors.E(op, err)

--- a/pkg/spotlight/engine_meilisearch_test.go
+++ b/pkg/spotlight/engine_meilisearch_test.go
@@ -109,6 +109,27 @@ func TestMeilisearchEngine_SetupForSearchMissingIndexBootstrapsIt(t *testing.T) 
 	require.True(t, engine.writeReady.Load())
 }
 
+func TestMeilisearchEngineWaitTaskCtxUsesMaintenanceOverride(t *testing.T) {
+	service := meilimocks.NewMockmeilisearchServiceManager(t)
+	engine := &MeilisearchEngine{
+		client:           service,
+		taskWaitDeadline: drainWaitDeadline,
+	}
+
+	service.EXPECT().
+		WaitForTaskWithContext(mock.Anything, int64(42), waitTaskPollInterval).
+		Run(func(ctx context.Context, _ int64, _ time.Duration) {
+			deadline, ok := ctx.Deadline()
+			require.True(t, ok)
+			require.Greater(t, time.Until(deadline), 4*time.Minute)
+		}).
+		Return(&meilisearch.Task{Status: meilisearch.TaskStatusSucceeded}, nil).
+		Once()
+
+	_, err := engine.waitTaskCtx(context.Background(), 42)
+	require.NoError(t, err)
+}
+
 func TestMeilisearchEngine_SetupForSearchRetryWaitsForPendingSettingsTask(t *testing.T) {
 	service := meilimocks.NewMockmeilisearchServiceManager(t)
 	index := meilimocks.NewMockmeilisearchIndexManager(t)


### PR DESCRIPTION
## Summary
- keep the 60s task timeout for regular Spotlight operations
- give isolated rebuild engines the existing 5-minute maintenance budget
- cover the deadline override with a regression test

## Production evidence
A controlled EAI rebuild queued scratch-index creation behind live projector tasks. Meilisearch completed it successfully after 2m14s, but the SDK aborted at 60s with `ensureIndexExists: context deadline exceeded`.

## Validation
- `go test ./pkg/spotlight`
- `golangci-lint run ./pkg/spotlight/...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789040296&installation_model_id=2042&pr_number=1004&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1004&signature=057feb96e6f1ce3ab84b90bd31aee2fd87eb636db4e61696e06b54a22c95481d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->