### PR TITLE
fix(spotlight): allow large rebuild batches to drain

### DIFF
--- a/pkg/spotlight/engine_meilisearch.go
+++ b/pkg/spotlight/engine_meilisearch.go
@@ -125,10 +125,12 @@ const defaultWaitForTaskDeadline = 60 * time.Second
 // one a generous budget so a slow Meili doesn't surface as a noisy
 // task failure in the periodic reindex log.
 //
-// 5 minutes accounts for cold-start Meili re-indexing a fresh tenant
-// with 2M+ docs on a single shared CPU. The drain returns as soon as
-// each task is done; the deadline only fires if something is wedged.
-const drainWaitDeadline = 5 * time.Minute
+// Production evidence from EAI showed Meili merging 565 queued writes for
+// 3.5M documents into one batch that legitimately ran longer than 5 minutes.
+// Thirty minutes covers that maintenance workload and the documented rebuild
+// window while still bounding a genuinely wedged task. The drain returns as
+// soon as each task is done.
+const drainWaitDeadline = 30 * time.Minute
 
 // waitTaskPollInterval is the poll interval the meilisearch client uses
 // while waiting for a task to reach a terminal state.
@@ -990,8 +992,8 @@ func buildMeiliRecords(docs []SearchDocument) []map[string]interface{} {
 // Meilisearch. Each pending task gets `drainWaitDeadline` of headroom
 // (not the inline 10s) because Meili can take 20-40s to digest a single
 // 80 MiB batch under CPU pressure. If the caller's ctx is already
-// deadlined, that deadline is honored — drainWaitDeadline only sets
-// the floor.
+// deadlined, that deadline is honored — drainWaitDeadline is only the
+// fallback for callers without one.
 func (e *MeilisearchEngine) WaitPending(ctx context.Context) error {
 	const op serrors.Op = "spotlight.MeilisearchEngine.WaitPending"
 
@@ -1015,7 +1017,7 @@ func (e *MeilisearchEngine) WaitPending(ctx context.Context) error {
 // parent already has *any* deadline, we propagate it as-is — the caller
 // owns the deadline and we must not tighten it (a long-running reindex
 // is the canonical case). Only when the parent has no deadline at all do
-// we apply drainWaitDeadline as a floor so background callers don't hang
+// we apply drainWaitDeadline as a fallback so background callers don't hang
 // indefinitely if Meili wedges.
 func drainTaskCtx(parent context.Context) (context.Context, context.CancelFunc) {
 	if parent == nil {

--- a/pkg/spotlight/engine_meilisearch_test.go
+++ b/pkg/spotlight/engine_meilisearch_test.go
@@ -130,6 +130,15 @@ func TestMeilisearchEngineWaitTaskCtxUsesMaintenanceOverride(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestDrainTaskCtxUsesMaintenanceFallback(t *testing.T) {
+	ctx, cancel := drainTaskCtx(context.Background())
+	defer cancel()
+
+	deadline, ok := ctx.Deadline()
+	require.True(t, ok)
+	require.Greater(t, time.Until(deadline), 29*time.Minute)
+}
+
 func TestMeilisearchEngine_SetupForSearchRetryWaitsForPendingSettingsTask(t *testing.T) {
 	service := meilimocks.NewMockmeilisearchServiceManager(t)
 	index := meilimocks.NewMockmeilisearchIndexManager(t)

--- a/pkg/spotlight/engine_meilisearch_test.go
+++ b/pkg/spotlight/engine_meilisearch_test.go
@@ -121,7 +121,7 @@ func TestMeilisearchEngineWaitTaskCtxUsesMaintenanceOverride(t *testing.T) {
 		Run(func(ctx context.Context, _ int64, _ time.Duration) {
 			deadline, ok := ctx.Deadline()
 			require.True(t, ok)
-			require.Greater(t, time.Until(deadline), 4*time.Minute)
+			require.Greater(t, time.Until(deadline), 29*time.Minute)
 		}).
 		Return(&meilisearch.Task{Status: meilisearch.TaskStatusSucceeded}, nil).
 		Once()


### PR DESCRIPTION
## Summary
- raise only the rebuild/drain task fallback from 5 to 30 minutes
- keep regular Spotlight operations at 60 seconds
- update the maintenance deadline regression assertion and comments

## Production evidence
A controlled EAI rebuild sent 3,485,816 documents. Meilisearch merged 565 writes into one healthy batch (about 152-176% CPU, 13-15 GiB / 32 GiB) that exceeded five minutes. `WaitPending` failed at exactly 300,144 ms and correctly avoided the atomic swap.

## Validation
- `go test ./pkg/spotlight`
- `golangci-lint run ./pkg/spotlight/...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789042844&installation_model_id=2042&pr_number=1005&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1005&signature=e7a530e70be176b07b1cbf04c06c5924dd406c271588ee1c3febe8b6355e84be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Extended the fallback wait period for pending operations from 5 minutes to 30 minutes.
  * Preserved caller-provided deadlines when waiting for operations to complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->