### PR TITLE
fix(spotlight): use rebuild budget for commit tasks

### DIFF
--- a/pkg/spotlight/engine_meilisearch.go
+++ b/pkg/spotlight/engine_meilisearch.go
@@ -580,7 +580,7 @@ func (s *meiliRebuildSession) Commit(ctx context.Context) error {
 		if err != nil {
 			return serrors.E("spotlight.MeilisearchEngine.CommitRebuild", err)
 		}
-		if _, err := waitTaskCtxClient(ctx, s.client, task.TaskUID); err != nil {
+		if _, err := s.engine.waitTaskCtx(ctx, task.TaskUID); err != nil {
 			return serrors.E("spotlight.MeilisearchEngine.CommitRebuild", err)
 		}
 		createdPlaceholder = true
@@ -592,7 +592,7 @@ func (s *meiliRebuildSession) Commit(ctx context.Context) error {
 	if err != nil {
 		return serrors.E("spotlight.MeilisearchEngine.CommitRebuild", err)
 	}
-	if _, err := waitTaskCtxClient(ctx, s.client, task.TaskUID); err != nil {
+	if _, err := s.engine.waitTaskCtx(ctx, task.TaskUID); err != nil {
 		return serrors.E("spotlight.MeilisearchEngine.CommitRebuild", err)
 	}
 
@@ -604,7 +604,7 @@ func (s *meiliRebuildSession) Commit(ctx context.Context) error {
 		return nil
 	}
 	if cleanupTask != nil {
-		if _, err := waitTaskCtxClient(ctx, s.client, cleanupTask.TaskUID); err != nil {
+		if _, err := s.engine.waitTaskCtx(ctx, cleanupTask.TaskUID); err != nil {
 			return serrors.E("spotlight.MeilisearchEngine.CommitRebuild", err)
 		}
 	}
@@ -633,7 +633,7 @@ func (s *meiliRebuildSession) Abort(ctx context.Context) error {
 		return serrors.E("spotlight.MeilisearchEngine.AbortRebuild", err)
 	}
 	if task != nil {
-		if _, err := waitTaskCtxClient(ctx, s.client, task.TaskUID); err != nil {
+		if _, err := s.engine.waitTaskCtx(ctx, task.TaskUID); err != nil {
 			return serrors.E("spotlight.MeilisearchEngine.AbortRebuild", err)
 		}
 	}

--- a/pkg/spotlight/engine_meilisearch_test.go
+++ b/pkg/spotlight/engine_meilisearch_test.go
@@ -558,8 +558,9 @@ func TestMeiliRebuildSessionCommitCreatesActiveIndexBeforeSwapWhenMissing(t *tes
 		activeIndexName: "spotlight",
 		buildIndexName:  "spotlight_build_v4",
 		engine: &MeilisearchEngine{
-			client:    service,
-			indexName: "spotlight",
+			client:           service,
+			indexName:        "spotlight",
+			taskWaitDeadline: drainWaitDeadline,
 		},
 	}
 
@@ -583,6 +584,11 @@ func TestMeiliRebuildSessionCommitCreatesActiveIndexBeforeSwapWhenMissing(t *tes
 		Once()
 	service.EXPECT().
 		WaitForTaskWithContext(mock.Anything, int64(21), 100*time.Millisecond).
+		Run(func(ctx context.Context, _ int64, _ time.Duration) {
+			deadline, ok := ctx.Deadline()
+			require.True(t, ok)
+			require.Greater(t, time.Until(deadline), 29*time.Minute)
+		}).
 		Return(&meilisearch.Task{}, nil).
 		Once()
 	service.EXPECT().


### PR DESCRIPTION
## Summary
- route rebuild placeholder, swap, cleanup, and abort waits through the rebuild engine deadline
- preserve caller deadlines (including the 10s abort cleanup context)
- assert that commit swap waits receive the 30-minute maintenance fallback

## Production evidence
The 3,485,947-document rebuild and atomic swap succeeded, but the CLI returned failure because swap task `497682` waited 83s in queue while `Commit` still used the regular 60s fallback. The task later succeeded and active `spotlight` has the rebuilt document count.

## Validation
- `go test ./pkg/spotlight`
- `golangci-lint run ./pkg/spotlight/...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789045608&installation_model_id=2042&pr_number=1006&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1006&signature=38c93f36f6d7084ead6814ac7e65ccf280f5527acd074890a5de2f9d0a77c93e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->