### PR TITLE
fix(sidebar): prefer most specific active route

### DIFF
--- a/components/sidebar/sidebar_test.go
+++ b/components/sidebar/sidebar_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/iota-uz/go-i18n/v2/i18n"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
 	"github.com/iota-uz/iota-sdk/pkg/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/text/language"
 )
@@ -66,8 +67,8 @@ func TestBuildSidebarNavTabs_SelectsMostSpecificMatchingRoute(t *testing.T) {
 			require.Len(t, tabs[0].Nodes, 1)
 			require.True(t, tabs[0].Nodes[0].IsActive)
 			require.Len(t, tabs[0].Nodes[0].Children, 2)
-			require.Equal(t, testCase.currentActive, tabs[0].Nodes[0].Children[0].IsActive)
-			require.Equal(t, testCase.archiveActive, tabs[0].Nodes[0].Children[1].IsActive)
+			assert.Equal(t, testCase.currentActive, tabs[0].Nodes[0].Children[0].IsActive)
+			assert.Equal(t, testCase.archiveActive, tabs[0].Nodes[0].Children[1].IsActive)
 		})
 	}
 }

--- a/components/sidebar/sidebar_test.go
+++ b/components/sidebar/sidebar_test.go
@@ -19,12 +19,57 @@ import (
 // look up. Rendering with a nil localizer is covered by the base components
 // themselves, which fall back rather than panic.
 func renderContext() context.Context {
+	return renderContextForPath("/")
+}
+
+func renderContextForPath(path string) context.Context {
 	bundle := i18n.NewBundle(language.English)
 	bundle.MustAddMessages(language.English, &i18n.Message{ID: "Common.TabNavigation", Other: "Tab navigation"})
 	return composables.WithPageCtx(
 		context.Background(),
-		types.NewPageContext(language.English, &url.URL{Path: "/"}, i18n.NewLocalizer(bundle, language.English.String())),
+		types.NewPageContext(language.English, &url.URL{Path: path}, i18n.NewLocalizer(bundle, language.English.String())),
 	)
+}
+
+func TestBuildSidebarNavTabs_SelectsMostSpecificMatchingRoute(t *testing.T) {
+	t.Parallel()
+
+	claims := NewGroup("Claims", nil, []Item{
+		NewLink("/claims", "Current claims", nil),
+		NewLink("/claims/archive", "Archived claims", nil),
+	})
+	testCases := []struct {
+		name          string
+		path          string
+		currentActive bool
+		archiveActive bool
+	}{
+		{name: "current claims list", path: "/claims", currentActive: true},
+		{name: "current claim detail", path: "/claims/123", currentActive: true},
+		{name: "archive list", path: "/claims/archive", archiveActive: true},
+		{name: "archive claim detail", path: "/claims/archive/123", archiveActive: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			tabs := BuildSidebarNavTabs(renderContextForPath(testCase.path), TabGroupCollection{
+				Groups: []TabGroup{{
+					Label: "ERP",
+					Value: "erp",
+					Items: []Item{claims},
+				}},
+			})
+
+			require.Len(t, tabs, 1)
+			require.Len(t, tabs[0].Nodes, 1)
+			require.True(t, tabs[0].Nodes[0].IsActive)
+			require.Len(t, tabs[0].Nodes[0].Children, 2)
+			require.Equal(t, testCase.currentActive, tabs[0].Nodes[0].Children[0].IsActive)
+			require.Equal(t, testCase.archiveActive, tabs[0].Nodes[0].Children[1].IsActive)
+		})
+	}
 }
 
 func TestSidebar_CollapsedFlyoutUsesTeleportSafeStore(t *testing.T) {

--- a/components/sidebar/view_model.go
+++ b/components/sidebar/view_model.go
@@ -45,8 +45,22 @@ func BuildSidebarNavTabs(ctx context.Context, groups TabGroupCollection) []NavTa
 }
 
 func buildSidebarNavNodes(ctx context.Context, items []Item) []NavNode {
+	return buildSidebarNavNodesForActivePath(ctx, items, true)
+}
+
+// buildSidebarNavNodesForActivePath resolves the active item once for each
+// collection. A parent route (for example, /claims) can therefore keep its
+// descendants active without also highlighting a more-specific sibling such as
+// /claims/archive.
+func buildSidebarNavNodesForActivePath(ctx context.Context, items []Item, onActivePath bool) []NavNode {
 	nodes := make([]NavNode, 0, len(items))
-	for _, item := range items {
+	activeItemIndex := -1
+	if onActivePath {
+		activeItemIndex = mostSpecificActiveItemIndex(ctx, items)
+	}
+
+	for index, item := range items {
+		isActive := index == activeItemIndex
 		if item.IsLink() {
 			link := asLink(item)
 			nodes = append(nodes, NavNode{
@@ -55,7 +69,7 @@ func buildSidebarNavNodes(ctx context.Context, items []Item) []NavNode {
 				Href:     link.Href(),
 				Icon:     link.Icon(),
 				IsBeta:   link.IsBeta(),
-				IsActive: link.IsActive(ctx),
+				IsActive: isActive,
 			})
 			continue
 		}
@@ -67,10 +81,45 @@ func buildSidebarNavNodes(ctx context.Context, items []Item) []NavNode {
 			Text:     group.Text(),
 			Icon:     group.Icon(),
 			IsBeta:   group.IsBeta(),
-			IsActive: group.IsActive(ctx),
-			Children: buildSidebarNavNodes(ctx, group.Children()),
+			IsActive: isActive,
+			Children: buildSidebarNavNodesForActivePath(ctx, group.Children(), isActive),
 		})
 	}
 
 	return nodes
+}
+
+// mostSpecificActiveItemIndex returns the matching item whose descendant link
+// has the longest href. This lets nested routes select their dedicated sidebar
+// entry over a broader sibling route.
+func mostSpecificActiveItemIndex(ctx context.Context, items []Item) int {
+	activeItemIndex := -1
+	longestMatch := -1
+	for index, item := range items {
+		matchLength := activeMatchLength(ctx, item)
+		if matchLength > longestMatch {
+			longestMatch = matchLength
+			activeItemIndex = index
+		}
+	}
+
+	return activeItemIndex
+}
+
+func activeMatchLength(ctx context.Context, item Item) int {
+	if item.IsLink() {
+		link := asLink(item)
+		if link.IsActive(ctx) {
+			return len(link.Href())
+		}
+		return -1
+	}
+
+	longestMatch := -1
+	for _, child := range asGroup(item).Children() {
+		if matchLength := activeMatchLength(ctx, child); matchLength > longestMatch {
+			longestMatch = matchLength
+		}
+	}
+	return longestMatch
 }


### PR DESCRIPTION
## Summary
- resolve the active sidebar item per navigation level
- prefer the deepest matching route over broader sibling routes
- cover current and archived claim routes

## Verification
- `go test ./components/sidebar`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789056446&installation_model_id=2042&pr_number=1007&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1007&signature=1b3c8621cc8fc5354f15ff8d908ab2ce31b61a60cfe958a8b3ea0613f326fb05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar navigation highlighting to select the most specific matching route.
  * Parent sections and their selected child links now remain consistently highlighted.
  * Prevented broader sibling routes from being highlighted at the same time.
  * Corrected highlighting for current and archived claims list and detail pages.
  * Sidebar state now updates reliably when navigating between related routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->