### PR TITLE
fix(lens): restore sales dashboard interactions

### DIFF
--- a/web/lens/src/charts/echarts/options.test.ts
+++ b/web/lens/src/charts/echarts/options.test.ts
@@ -849,6 +849,28 @@ describe('buildChartOption', () => {
     expect(tooltip).toContain('$1200')
   })
 
+  it('sorts tooltip series by amount before the total', () => {
+    const chartInput = input('bar')
+    chartInput.frame.rows = [
+      ['jan-small', 'Jan', 'Small', 20],
+      ['jan-largest', 'Jan', 'Largest', 300],
+      ['jan-middle', 'Jan', 'Middle', 80],
+    ]
+    chartInput.presentation = { stack: true }
+    chartInput.tooltipTotalLabel = 'Итого'
+    const chart = testOption(buildChartOption(chartInput, theme))
+
+    const tooltip = chart.tooltip.formatter?.([
+      { axisValueLabel: 'Jan', seriesName: 'Small', value: 20 },
+      { axisValueLabel: 'Jan', seriesName: 'Largest', value: 300 },
+      { axisValueLabel: 'Jan', seriesName: 'Middle', value: 80 },
+    ]) ?? ''
+
+    expect(tooltip.indexOf('Largest')).toBeLessThan(tooltip.indexOf('Middle'))
+    expect(tooltip.indexOf('Middle')).toBeLessThan(tooltip.indexOf('Small'))
+    expect(tooltip.indexOf('Small')).toBeLessThan(tooltip.indexOf('Итого'))
+  })
+
   it('does not add an overlaid line series to a stacked column total', () => {
     const chartInput = input('bar')
     chartInput.presentation = { stack: true, lineSeries: ['Cost'] }

--- a/web/lens/src/charts/echarts/options.ts
+++ b/web/lens/src/charts/echarts/options.ts
@@ -182,6 +182,11 @@ function nonZeroTooltipRecords(params: unknown): Record<string, unknown>[] {
       seen.add(key)
       return true
     })
+    // A stacked chart's declaration order is an implementation detail, not a
+    // useful reading order. Put the largest contribution first so the tooltip
+    // answers “what drove this column?” without making the reader scan every
+    // row. Array#sort is stable, so equal amounts keep the producer's order.
+    .sort((left, right) => (numericTooltipValue(right.value) ?? 0) - (numericTooltipValue(left.value) ?? 0))
 }
 
 function timeTooltipFormatter(input: ChartInput, categoryField: string, showSeriesName: (name: string) => boolean) {

--- a/web/lens/src/controls/FacetFilterMenu.tsx
+++ b/web/lens/src/controls/FacetFilterMenu.tsx
@@ -130,15 +130,14 @@ function FacetPane({ filter, draft, onToggle, onTarget }: PaneProps) {
  * the trigger and drops the rail — a menu of one is a question with no answer.
  *
  * Placement is `menuPlacement()`'s, the same measured rule the panel and export
- * menus use: the popover is bound to this trigger and flips or re-aligns only
- * when the viewport says it must, instead of the fixed right-alignment that used
- * to hang it 190px left of the button that opened it.
+ * menus use. Like an ordinary dropdown it starts at the trigger's leading edge;
+ * it flips or re-aligns only when the viewport says it must.
  */
 export function FacetFilterMenu({ filters }: { filters: Array<Filter> }) {
   const translate = useTranslate()
   const { applyURL } = useFilters()
   const menuID = useId()
-  const { close, container, menu, menuPlacementProps, open, overlay, setOpen, trigger } = useMenuButton('end')
+  const { close, container, menu, menuPlacementProps, open, overlay, setOpen, trigger } = useMenuButton('start')
   const [activeID, setActiveID] = useState(filters[0]?.id ?? '')
   const [drafts, setDrafts] = useState(new Map<string, ReadonlySet<string>>())
   const [targets, setTargets] = useState(new Map<string, string>())

--- a/web/lens/src/controls/controls.test.tsx
+++ b/web/lens/src/controls/controls.test.tsx
@@ -989,6 +989,9 @@ describe('facet filter menu', () => {
     fireEvent.click(trigger)
     await screen.findByRole('checkbox', { name: /Option 1/ })
     const menu = screen.getByRole('dialog', { name: 'Filters' })
+    // A conventional dropdown starts under the button's leading edge. The
+    // placement helper may still flip it at the viewport boundary.
+    expect(menu).toHaveAttribute('data-align', 'start')
     // Placement is measured in viewport coordinates, so the menu must live in
     // the shared body portal. Keeping it under the trigger would add the
     // trigger row's offset a second time and push the card to the screen edge.

--- a/web/lens/src/panels/data.ts
+++ b/web/lens/src/panels/data.ts
@@ -3,11 +3,13 @@ import { fallbackSeries, paletteAssignment, stablePaletteIndex } from '../charts
 
 /**
  * Resolves a datum's color the way the chart adapter does, so a React-rendered
- * legend cannot disagree with the plot: the panel's own `panelId:index` series
- * entry first, then a series entry keyed by label, then the palette order, then
- * the panel accent.
+ * legend cannot disagree with the plot: a semantic series entry keyed by label
+ * first, then the panel's own `panelId:index` entry, then the palette order,
+ * then the panel accent.
  *
- * `positional: false` drops the `panelId:index` entry. That entry pins a color
+ * A named entry wins because it identifies the business series even when a
+ * deferred frame contains a subset in a different order. `positional: false`
+ * drops the `panelId:index` entry. That entry pins a color
  * to the n-th row of the panel's *own* frame, so once the panel is showing a
  * drill level it describes rows that are no longer on screen — the legend was
  * printing the root's second color next to the level's second slice, which the
@@ -27,8 +29,8 @@ export function seriesColorResolver(
   // colours one datum at a time.
   const assigned = labels ? paletteAssignment(labels, colors.length) : undefined
   const paletteIndex = (key: string) => assigned?.get(key) ?? stablePaletteIndex(key, colors.length)
-  return (label, index) => (positional ? resolve(theme.series[`${panel.id}:${index}`]) : undefined)
-    ?? resolve(theme.series[label])
+  return (label, index) => resolve(theme.series[label])
+    ?? (positional ? resolve(theme.series[`${panel.id}:${index}`]) : undefined)
     ?? colors[paletteIndex(label || String(index))]
     ?? panel.accent
 }

--- a/web/lens/src/panels/panelActions.test.tsx
+++ b/web/lens/src/panels/panelActions.test.tsx
@@ -290,6 +290,25 @@ describe('charts with a panel-level navigate action', () => {
     expect(assign).toHaveBeenCalledWith(expect.stringContaining('/policies/KASKO'))
   })
 
+  it('fully navigates when a cube drill targets a different report page', async () => {
+    window.history.replaceState(null, '', '/insurance/sales-report')
+    const assign = vi.mocked(navigateTo)
+    const panel = chartPanel([{
+      kind: 'cube_drill', method: 'GET', urlTemplate: '/insurance/sales-report/drill/policies/breakdown',
+      params: [], payload: {},
+      filter: { dimension: 'product', value: { kind: 'field', name: 'id' } },
+    }])
+    const { container, activate } = renderChart(panel)
+
+    await waitFor(() => expect(container.querySelector('[data-drillable]')).not.toBeNull())
+    activate('broker')
+
+    expect(assign).toHaveBeenCalledWith(expect.stringMatching(
+      /^\/insurance\/sales-report\/drill\/policies\/breakdown\?_f=product%3Abroker$/,
+    ))
+    expect(window.location.pathname).toBe('/insurance/sales-report')
+  })
+
   it('leaves a chart without a drill root or an action inert', async () => {
     const assign = vi.mocked(navigateTo)
     const { container, activate } = renderChart(chartPanel([]))

--- a/web/lens/src/panels/panels.test.tsx
+++ b/web/lens/src/panels/panels.test.tsx
@@ -50,6 +50,7 @@ vi.mock('../runtime', () => ({
 import { legendLabels, legendRow, legendSwatches, legendValues, markRow } from './legend.test-utils'
 import { BarPanel, collapseExpandableTopN, collapseMinorDonutSlices, DistributionPanel, donutRemainderKey, LinePanel, PiePanel, rowIndexForKey } from './ChartPanel'
 import { CoveragePanel } from './CoveragePanel'
+import { seriesColorResolver } from './data'
 import { GaugePanel } from './GaugePanel'
 import { MapPanel } from './MapPanel'
 import { buildCascadeStages, buildWaterfallItems, buildWaterfallModel, CascadePanel, waterfallAxisStep } from './CascadePanel'
@@ -95,6 +96,17 @@ function panel(kind: PanelKind, overrides: Partial<Panel> = {}): Panel {
     ...overrides,
   } as Panel
 }
+
+describe('series colours', () => {
+  it('keeps a named business-series colour ahead of a positional skeleton pin', () => {
+    const resolve = seriesColorResolver({
+      palette: { osago: '#7c3aed' },
+      series: { OSAGO: 'osago', 'panel-bar:0': '#dc2626' },
+    }, panel('bar'))
+
+    expect(resolve('OSAGO', 0)).toBe('#7c3aed')
+  })
+})
 
 function state(name: 'loading' | 'empty' | 'error' | 'stale' | 'superseded' | 'data'): PanelFrameState {
   const retry = vi.fn()

--- a/web/lens/src/runtime/provider.tsx
+++ b/web/lens/src/runtime/provider.tsx
@@ -53,6 +53,7 @@ import { PanelClient } from './panel'
 import { QueryError, SnapshotGoneError } from './query'
 import { queryWithSnapshotRecovery } from './recovery'
 import { drawerNavigationFromSource, navigationFromURL, navigationToURL, sameNavigationURL, siteRelativeURL } from './url'
+import { navigateTo } from './navigate'
 import { X } from '../icons'
 
 /* eslint-disable react-refresh/only-export-components */
@@ -1566,6 +1567,14 @@ function RuntimeCore({
       return
     }
     const current = new URL(window.location.href)
+    // Cross-filtering belongs to the mounted document only while the target
+    // stays on that document. Cube drills may intentionally point at a
+    // separate report page; pushState would change the address without
+    // mounting that page, leaving the old dashboard visible until reload.
+    if (next.pathname !== current.pathname) {
+      navigateTo(siteRelativeURL(next.href, current) ?? next.href)
+      return
+    }
     if (!sameNavigationURL(current, next)) {
       window.history.pushState(browserStateFor(navigation, window.history.state), '', next)
     }


### PR DESCRIPTION
## What changed

- navigate fully when a chart drill targets another report page
- sort chart tooltip rows by amount, highest first, while keeping the total last
- open facet filters from the trigger leading edge like a conventional dropdown
- prefer semantic series colors over positional skeleton slots, restoring stable product colors for deferred charts

## Root cause

Lens treated cross-page drill URLs as in-document filter updates, preserved ECharts declaration order in tooltips, right-aligned the wide facet menu, and resolved positional palette slots before named business-series colors.

## User impact

Daily-sales drill-down opens immediately without reload; tooltip contributions are ranked by amount; filters stay visually attached to their button; and product colors retain the templ-runtime palette when deferred data contains only a subset of products.

## Validation

- `pnpm --dir web/lens check`
- 62 test files, 958 tests passed
- TypeScript typecheck and lint completed with no errors (17 existing warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart drill-down navigation so selected marks are correctly applied as filters.
  * Preserved the current report path when navigating to drill-down views.
  * Ensured filter changes navigate fully when switching pages, while same-page updates remain seamless.
  * Sorted stacked-bar tooltip entries by value for easier comparison.
  * Ensured named series colors take precedence over positional color settings.
  * Improved facet filter menu alignment and viewport repositioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->