### PR TITLE
fix(lens): localize empty map regions

### DIFF
--- a/web/lens/src/charts/adapter.ts
+++ b/web/lens/src/charts/adapter.ts
@@ -4,15 +4,15 @@ export type ChartKind = Extract<PanelKind, 'pie' | 'donut' | 'radial' | 'bar' | 
 export type ChartFormatResolver = (field: string, value: unknown) => string
 
 export interface ChartLabels {
-  previous: string
-  trend: string
-  movingAverage: (window: number) => string
-  estimate: string
-  ytd: string
-  forecast: string
-  forecastLower: (forecast: string) => string
-  forecastConfidence: (forecast: string) => string
-  boxplot: [min: string, q1: string, median: string, q3: string, max: string]
+  previous?: string
+  trend?: string
+  movingAverage?: (window: number) => string
+  estimate?: string
+  ytd?: string
+  forecast?: string
+  forecastLower?: (forecast: string) => string
+  forecastConfidence?: (forecast: string) => string
+  boxplot?: [min: string, q1: string, median: string, q3: string, max: string]
   /** What a mark with no reading behind it says instead of a formatted zero. */
   noData: string
   /** The tooltip's copy button, at rest and for the moment after it is used. */

--- a/web/lens/src/charts/echarts/options.ts
+++ b/web/lens/src/charts/echarts/options.ts
@@ -1531,7 +1531,7 @@ function axisOption(input: ChartInput, theme: EChartsTheme): EChartsOption {
     .filter((average) => shown.has(overlayId.average(average.window)))
     .flatMap((average) => seriesNames.map((name, index) => ({
       type: 'line' as const,
-      name: `${name ? `${name} · ` : ''}${average.label || input.labels?.movingAverage(average.window) || `SMA ${average.window}`}`,
+      name: `${name ? `${name} · ` : ''}${average.label || input.labels?.movingAverage?.(average.window) || `SMA ${average.window}`}`,
       silent: true,
       z: 5,
       showSymbol: false,
@@ -1572,7 +1572,7 @@ function axisOption(input: ChartInput, theme: EChartsTheme): EChartsOption {
       },
       {
         type: 'line' as const,
-        name: input.labels?.forecastLower(forecastLabel) ?? `${forecastLabel} lower`,
+        name: input.labels?.forecastLower?.(forecastLabel) ?? `${forecastLabel} lower`,
         silent: true,
         tooltip: { show: false },
         stack,
@@ -1584,7 +1584,7 @@ function axisOption(input: ChartInput, theme: EChartsTheme): EChartsOption {
       },
       {
         type: 'line' as const,
-        name: input.labels?.forecastConfidence(forecastLabel) ?? `${forecastLabel} confidence`,
+        name: input.labels?.forecastConfidence?.(forecastLabel) ?? `${forecastLabel} confidence`,
         silent: true,
         tooltip: { show: false },
         stack,

--- a/web/lens/src/charts/overlays.ts
+++ b/web/lens/src/charts/overlays.ts
@@ -189,7 +189,7 @@ export function chartOverlays(context: OverlayContext): ChartOverlay[] {
     push({
       id: overlayId.average(average.window),
       kind: 'average',
-      label: average.label || labels?.movingAverage(average.window) || `SMA ${average.window}`,
+      label: average.label || labels?.movingAverage?.(average.window) || `SMA ${average.window}`,
       tone: 'series',
       stroke: 'solid',
     })

--- a/web/lens/src/panels/MapPanel.tsx
+++ b/web/lens/src/panels/MapPanel.tsx
@@ -205,13 +205,14 @@ export function MapPanel({ panel, adapter, fetcher, frame: frameOverride }: MapP
     const format: ChartFormatResolver = (_field, value) => formatValue(value)
     return {
       kind: 'map', frame: frame.data, encoding: panel.encoding, format, formatAxis: format,
+      labels: { noData: translate('panel.empty', 'No data') },
       theme: document.theme,
       map: {
         name: `lens-map:${panel.id}`, geoJSON: geometry.data, featureProperty: config.featureProperty,
         labelProperty, fallbackLabelProperty: config.labelProperty,
       },
     }
-  }, [config, document.theme, formatValue, frame.data, geometry.data, joinError, labelProperty, panel.encoding, panel.id])
+  }, [config, document.theme, formatValue, frame.data, geometry.data, joinError, labelProperty, panel.encoding, panel.id, translate])
 
   const interactive = Boolean(panel.drillRoot || navigation.action)
   const select = useCallback((key: NodeKey, _anchor?: unknown, activation?: ChartActivation) => {


### PR DESCRIPTION
## Summary
- pass the active Lens panel.empty translation into choropleth map chart inputs
- allow map panels to provide only the chart label they consume
- preserve English fallbacks when a producer does not provide translations

## Verification
- pnpm build
- pnpm check:sdk
- pnpm --dir web/lens exec vitest run src/charts/echarts/map.test.ts src/panels/panels.test.tsx (198 passed)
- production diagnosis confirmed that the document sends panel.empty as Нет данных while MapPanel dropped it before the ECharts tooltip formatter

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1011"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789138185&installation_model_id=2042&pr_number=1011&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1011&signature=fa4f0d97d95ff8f326a73ad388f6ed93167485317dccad317f33ee78b9b70dcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Chart labels can now be omitted individually without affecting other labels.
  - Moving-average and forecast overlays use fallback text when custom labels are unavailable.
  - Maps now display a localized message when no data is available.
  - Improved localization updates when language settings change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->