### PR TITLE
[P1] fix(htmx): encode HX-Trigger payloads as valid ASCII-only JSON

### DIFF
--- a/pkg/htmx/htmx.go
+++ b/pkg/htmx/htmx.go
@@ -106,7 +106,14 @@ func triggerHeaderValue(event, detail string) string {
 	if detail == "" {
 		return event
 	}
-	name, _ := json.Marshal(event) // marshalling a string cannot fail
+	// Marshalling a string cannot fail, but the error is answered rather than
+	// discarded: emitting half a document would hand htmx a payload it cannot
+	// parse, whereas the bare event name is the form it already accepts for a
+	// detail-less event.
+	name, err := json.Marshal(event)
+	if err != nil {
+		return event
+	}
 	return escapeNonASCII(`{` + string(name) + `:` + detail + `}`)
 }
 
@@ -215,11 +222,17 @@ type toastDetail struct {
 // characters in a title or message stay valid JSON instead of breaking the
 // client-side parse.
 func toastPayload(variant ToastVariant, title, message string) string {
-	detail, _ := json.Marshal(toastDetail{ // marshalling strings cannot fail
+	// A struct of strings cannot fail to marshal, but the error is answered
+	// rather than discarded: an empty payload degrades to the bare `notify`
+	// event, while a truncated one would break the client-side parse.
+	detail, err := json.Marshal(toastDetail{
 		Variant: variant,
 		Title:   title,
 		Message: message,
 	})
+	if err != nil {
+		return ""
+	}
 	return string(detail)
 }
 

--- a/pkg/htmx/htmx.go
+++ b/pkg/htmx/htmx.go
@@ -56,18 +56,13 @@ func Reswap(w http.ResponseWriter, swapStyle string) {
 	w.Header().Add("Hx-Reswap", swapStyle)
 }
 
-// escapeNonASCII rewrites every rune above U+007F as a \uXXXX escape sequence.
+// escapeNonASCII rewrites every rune above U+007F as a \uXXXX escape sequence
+// (a surrogate pair outside the BMP, U+FFFD for invalid UTF-8), keeping a header
+// value pure ASCII. Browsers decode header bytes as ISO-8859-1, so raw UTF-8
+// reaches htmx as mojibake, while JSON.parse restores the escaped form intact.
 //
-// Header values are transported as bytes and decoded by browsers as ISO-8859-1
-// (XHR/fetch), so raw UTF-8 reaches htmx as mojibake. \uXXXX is valid JSON and
-// JSON.parse restores the original string, so the payload survives intact while
-// the header itself stays pure ASCII. Runes outside the BMP are emitted as a
-// UTF-16 surrogate pair, as JSON requires.
-//
-// Escaping is applied to an assembled JSON document rather than to its parts:
-// non-ASCII cannot legally appear outside a JSON string literal, so this cannot
-// corrupt a valid document, and a caller-supplied payload is never re-parsed or
-// re-marshalled. Invalid UTF-8 in the input is escaped as U+FFFD.
+// It takes an assembled JSON document rather than its parts, so a caller-supplied
+// payload is never re-parsed or re-marshalled.
 func escapeNonASCII(s string) string {
 	if isASCII(s) {
 		return s
@@ -106,10 +101,7 @@ func triggerHeaderValue(event, detail string) string {
 	if detail == "" {
 		return event
 	}
-	// Marshalling a string cannot fail, but the error is answered rather than
-	// discarded: emitting half a document would hand htmx a payload it cannot
-	// parse, whereas the bare event name is the form it already accepts for a
-	// detail-less event.
+	// Fall back to the bare event name if marshalling fails.
 	name, err := json.Marshal(event)
 	if err != nil {
 		return event
@@ -222,9 +214,8 @@ type toastDetail struct {
 // characters in a title or message stay valid JSON instead of breaking the
 // client-side parse.
 func toastPayload(variant ToastVariant, title, message string) string {
-	// A struct of strings cannot fail to marshal, but the error is answered
-	// rather than discarded: an empty payload degrades to the bare `notify`
-	// event, while a truncated one would break the client-side parse.
+	// Fall back to an empty detail, which degrades to the bare event, if
+	// marshalling fails.
 	detail, err := json.Marshal(toastDetail{
 		Variant: variant,
 		Title:   title,

--- a/pkg/htmx/htmx.go
+++ b/pkg/htmx/htmx.go
@@ -2,8 +2,11 @@
 package htmx
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
+	"unicode/utf16"
 )
 
 // ================= Setters =================
@@ -53,31 +56,73 @@ func Reswap(w http.ResponseWriter, swapStyle string) {
 	w.Header().Add("Hx-Reswap", swapStyle)
 }
 
+// escapeNonASCII rewrites every rune above U+007F as a \uXXXX escape sequence.
+//
+// Header values are transported as bytes and decoded by browsers as ISO-8859-1
+// (XHR/fetch), so raw UTF-8 reaches htmx as mojibake. \uXXXX is valid JSON and
+// JSON.parse restores the original string, so the payload survives intact while
+// the header itself stays pure ASCII. Runes outside the BMP are emitted as a
+// UTF-16 surrogate pair, as JSON requires.
+//
+// Escaping is applied to an assembled JSON document rather than to its parts:
+// non-ASCII cannot legally appear outside a JSON string literal, so this cannot
+// corrupt a valid document, and a caller-supplied payload is never re-parsed or
+// re-marshalled. Invalid UTF-8 in the input is escaped as U+FFFD.
+func escapeNonASCII(s string) string {
+	if isASCII(s) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		switch {
+		case r < 0x80:
+			b.WriteRune(r)
+		case r > 0xFFFF:
+			high, low := utf16.EncodeRune(r)
+			fmt.Fprintf(&b, `\u%04x\u%04x`, high, low)
+		default:
+			fmt.Fprintf(&b, `\u%04x`, r)
+		}
+	}
+	return b.String()
+}
+
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
+}
+
+// triggerHeaderValue builds the value for an HX-Trigger* header.
+//
+// An empty detail keeps the bare event-name form htmx accepts for detail-less
+// events. Otherwise the event name is marshalled as a JSON string and the
+// caller's detail is embedded verbatim as the event payload.
+func triggerHeaderValue(event, detail string) string {
+	if detail == "" {
+		return event
+	}
+	name, _ := json.Marshal(event) // marshalling a string cannot fail
+	return escapeNonASCII(`{` + string(name) + `:` + detail + `}`)
+}
+
 // SetTrigger sets the HX-Trigger header to trigger client-side events.
 func SetTrigger(w http.ResponseWriter, event, detail string) {
-	if detail == "" {
-		w.Header().Add("Hx-Trigger", event)
-	} else {
-		w.Header().Add("Hx-Trigger", `{"`+event+`": `+detail+`}`)
-	}
+	w.Header().Add("Hx-Trigger", triggerHeaderValue(event, detail))
 }
 
 // TriggerAfterSettle sets the HX-Trigger-After-Settle header to trigger client-side events after the settle step.
 func TriggerAfterSettle(w http.ResponseWriter, event, detail string) {
-	if detail == "" {
-		w.Header().Add("Hx-Trigger-After-Settle", event)
-	} else {
-		w.Header().Add("Hx-Trigger-After-Settle", `{"`+event+`": `+detail+`}`)
-	}
+	w.Header().Add("Hx-Trigger-After-Settle", triggerHeaderValue(event, detail))
 }
 
 // TriggerAfterSwap sets the HX-Trigger-After-Swap header to trigger client-side events after the swap step.
 func TriggerAfterSwap(w http.ResponseWriter, event, detail string) {
-	if detail == "" {
-		w.Header().Add("Hx-Trigger-After-Swap", event)
-	} else {
-		w.Header().Add("Hx-Trigger-After-Swap", `{"`+event+`": `+detail+`}`)
-	}
+	w.Header().Add("Hx-Trigger-After-Swap", triggerHeaderValue(event, detail))
 }
 
 // ================= Getters =================
@@ -160,23 +205,38 @@ const (
 	ToastVariantInfo    ToastVariant = "info"
 )
 
+type toastDetail struct {
+	Variant ToastVariant `json:"variant"`
+	Title   string       `json:"title"`
+	Message string       `json:"message"`
+}
+
+// toastPayload marshals the toast detail so that quotes, backslashes and control
+// characters in a title or message stay valid JSON instead of breaking the
+// client-side parse.
+func toastPayload(variant ToastVariant, title, message string) string {
+	detail, _ := json.Marshal(toastDetail{ // marshalling strings cannot fail
+		Variant: variant,
+		Title:   title,
+		Message: message,
+	})
+	return string(detail)
+}
+
 // TriggerToast triggers a toast notification with the specified variant, title, and message.
 // This uses the HX-Trigger header to dispatch a 'notify' event that the toast container listens for.
 func TriggerToast(w http.ResponseWriter, variant ToastVariant, title, message string) {
-	detail := fmt.Sprintf(`{"variant": "%s", "title": "%s", "message": "%s"}`, variant, title, message)
-	SetTrigger(w, "notify", detail)
+	SetTrigger(w, "notify", toastPayload(variant, title, message))
 }
 
 // TriggerToastAfterSwap triggers a toast notification after the swap step.
 func TriggerToastAfterSwap(w http.ResponseWriter, variant ToastVariant, title, message string) {
-	detail := fmt.Sprintf(`{"variant": "%s", "title": "%s", "message": "%s"}`, variant, title, message)
-	TriggerAfterSwap(w, "notify", detail)
+	TriggerAfterSwap(w, "notify", toastPayload(variant, title, message))
 }
 
 // TriggerToastAfterSettle triggers a toast notification after the settle step.
 func TriggerToastAfterSettle(w http.ResponseWriter, variant ToastVariant, title, message string) {
-	detail := fmt.Sprintf(`{"variant": "%s", "title": "%s", "message": "%s"}`, variant, title, message)
-	TriggerAfterSettle(w, "notify", detail)
+	TriggerAfterSettle(w, "notify", toastPayload(variant, title, message))
 }
 
 // Convenience functions for common toast types

--- a/pkg/htmx/htmx_test.go
+++ b/pkg/htmx/htmx_test.go
@@ -1,0 +1,296 @@
+package htmx
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// headerOnWire serializes the recorded response and returns the value of the
+// named header as it is actually written to the connection, rather than the Go
+// string held in the header map. Assertions that read the map instead would pass
+// on raw UTF-8 that a browser decodes as ISO-8859-1.
+func headerOnWire(t *testing.T, rec *httptest.ResponseRecorder, name string) string {
+	t.Helper()
+	res := rec.Result()
+	defer func() {
+		require.NoError(t, res.Body.Close())
+	}()
+	var buf bytes.Buffer
+	require.NoError(t, res.Write(&buf))
+	prefix := name + ": "
+	for _, line := range strings.Split(buf.String(), "\r\n") {
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimPrefix(line, prefix)
+		}
+	}
+	t.Fatalf("header %q not present on the wire:\n%s", name, buf.String())
+	return ""
+}
+
+func requireASCII(t *testing.T, value string) {
+	t.Helper()
+	for i := 0; i < len(value); i++ {
+		require.Lessf(t, value[i], byte(0x80),
+			"byte %d of the header is 0x%02x, above US-ASCII: %q", i, value[i], value)
+	}
+}
+
+type toastTrigger struct {
+	name   string
+	header string
+	send   func(w http.ResponseWriter, variant ToastVariant, title, message string)
+}
+
+func toastTriggers() []toastTrigger {
+	return []toastTrigger{
+		{name: "TriggerToast", header: "Hx-Trigger", send: TriggerToast},
+		{name: "TriggerToastAfterSwap", header: "Hx-Trigger-After-Swap", send: TriggerToastAfterSwap},
+		{name: "TriggerToastAfterSettle", header: "Hx-Trigger-After-Settle", send: TriggerToastAfterSettle},
+	}
+}
+
+// decodeToast parses the header value the way htmx does: JSON.parse of the whole
+// value, then the "notify" event's detail.
+func decodeToast(t *testing.T, value string) toastDetail {
+	t.Helper()
+	var payload map[string]toastDetail
+	require.NoErrorf(t, json.Unmarshal([]byte(value), &payload),
+		"header is not valid JSON, htmx would drop the event: %q", value)
+	detail, ok := payload["notify"]
+	require.Truef(t, ok, "no notify event in %q", value)
+	return detail
+}
+
+// TestTriggerToast_NonASCIISurvivesAsASCII pins the reported production bug: a
+// Cyrillic toast reached the operator as mojibake because the raw UTF-8 bytes in
+// the header are decoded as ISO-8859-1 by the browser.
+//
+// Falsely green if it asserted only that json.Unmarshal returns the original
+// text: raw UTF-8 unmarshals just fine in Go. The load-bearing assertion is that
+// every byte written to the wire is below 0x80.
+func TestTriggerToast_NonASCIISurvivesAsASCII(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		title   string
+		message string
+	}{
+		{
+			name:    "cyrillic",
+			title:   "Ошибка",
+			message: "Не удалось провести оплату…",
+		},
+		{
+			name:    "non-BMP rune needs a surrogate pair",
+			title:   "Готово 😀",
+			message: "Платёж принят 🎉",
+		},
+		{
+			name:    "mixed scripts",
+			title:   "Xatolik",
+			message: "Toʻlov amalga oshmadi — попробуйте ещё раз",
+		},
+	}
+
+	for _, trigger := range toastTriggers() {
+		for _, tt := range tests {
+			t.Run(trigger.name+"/"+tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				rec := httptest.NewRecorder()
+				trigger.send(rec, ToastVariantError, tt.title, tt.message)
+
+				value := headerOnWire(t, rec, trigger.header)
+				requireASCII(t, value)
+
+				detail := decodeToast(t, value)
+				assert.Equal(t, ToastVariantError, detail.Variant)
+				assert.Equal(t, tt.title, detail.Title)
+				assert.Equal(t, tt.message, detail.Message)
+			})
+		}
+	}
+}
+
+// TestTriggerToast_SpecialCharactersStayValidJSON covers the second defect: the
+// detail used to be built with fmt.Sprintf, so a quote, a backslash or a control
+// character produced JSON that htmx failed to parse and the toast never appeared.
+//
+// Falsely green if it only checked that the header contains the message text —
+// a broken document can still contain it. The assertion that matters is that the
+// value parses as JSON and the text comes back byte-identical.
+func TestTriggerToast_SpecialCharactersStayValidJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		message string
+	}{
+		{name: "double quote", message: `Полис "AB 1234567" не найден`},
+		{name: "backslash", message: `path C:\policies\2026`},
+		{name: "newline", message: "first line\nsecond line"},
+		{name: "control character", message: "before\x01after"},
+		{name: "all of them", message: "\"\\\n\x01 конец"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			TriggerToast(rec, ToastVariantWarning, `title with "quotes"`, tt.message)
+
+			value := headerOnWire(t, rec, "Hx-Trigger")
+			requireASCII(t, value)
+
+			detail := decodeToast(t, value)
+			assert.Equal(t, `title with "quotes"`, detail.Title)
+			assert.Equal(t, tt.message, detail.Message)
+		})
+	}
+}
+
+// TestTriggerToast_ASCIIOnlyKeepsBehaviour guards existing consumers: an
+// ASCII-only toast must still arrive as the same notify event with the same
+// three fields.
+//
+// Falsely green if it compared the header byte-for-byte against the old
+// fmt.Sprintf output — the separators changed (no space after the colon), while
+// the parsed payload, which is all the client sees, did not.
+func TestTriggerToast_ASCIIOnlyKeepsBehaviour(t *testing.T) {
+	t.Parallel()
+
+	for _, trigger := range toastTriggers() {
+		t.Run(trigger.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			trigger.send(rec, ToastVariantSuccess, "Server Response", "This toast was triggered by an HTMX request!")
+
+			value := headerOnWire(t, rec, trigger.header)
+			requireASCII(t, value)
+
+			detail := decodeToast(t, value)
+			assert.Equal(t, toastDetail{
+				Variant: ToastVariantSuccess,
+				Title:   "Server Response",
+				Message: "This toast was triggered by an HTMX request!",
+			}, detail)
+		})
+	}
+}
+
+// TestTriggers_EmptyDetailUnchanged pins the detail-less form: htmx reads a value
+// that is not JSON as a bare event name, so it must stay byte-for-byte identical.
+//
+// Falsely green if it asserted with Contains instead of Equal — a JSON-wrapped
+// value contains the event name too, yet would change what htmx dispatches.
+func TestTriggers_EmptyDetailUnchanged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		header string
+		send   func(w http.ResponseWriter, event, detail string)
+	}{
+		{name: "SetTrigger", header: "Hx-Trigger", send: SetTrigger},
+		{name: "TriggerAfterSwap", header: "Hx-Trigger-After-Swap", send: TriggerAfterSwap},
+		{name: "TriggerAfterSettle", header: "Hx-Trigger-After-Settle", send: TriggerAfterSettle},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			tt.send(rec, "refresh-content", "")
+
+			assert.Equal(t, "refresh-content", headerOnWire(t, rec, tt.header))
+		})
+	}
+}
+
+// TestSetTrigger_PreMarshalledDetailIsNormalised covers callers that hand
+// SetTrigger a payload they marshalled themselves: encoding/json emits non-ASCII
+// as raw UTF-8, so those triggers carried mojibake by the same route as toasts.
+//
+// Falsely green if it re-marshalled the detail before comparing — the fix must
+// escape the caller's document without reparsing it, leaving key order and
+// number formatting untouched.
+func TestSetTrigger_PreMarshalledDetailIsNormalised(t *testing.T) {
+	t.Parallel()
+
+	type importSummary struct {
+		Imported int    `json:"imported"`
+		Reason   string `json:"reason"`
+	}
+
+	original := importSummary{Imported: 12, Reason: "Шаблон импортирован 🎉"}
+	raw, err := json.Marshal(original)
+	require.NoError(t, err)
+	require.False(t, isASCII(string(raw)), "encoding/json is expected to emit raw UTF-8 here")
+
+	rec := httptest.NewRecorder()
+	SetTrigger(rec, "campaign:templates-imported", string(raw))
+
+	value := headerOnWire(t, rec, "Hx-Trigger")
+	requireASCII(t, value)
+
+	var payload map[string]importSummary
+	require.NoErrorf(t, json.Unmarshal([]byte(value), &payload), "header is not valid JSON: %q", value)
+	assert.Equal(t, original, payload["campaign:templates-imported"])
+}
+
+// TestSetTrigger_EventNameIsEncoded covers the event half of the header, which
+// used to be concatenated into the JSON unescaped.
+//
+// Falsely green if it used an event name without characters that need escaping —
+// every ASCII event name in the repository parses fine either way.
+func TestSetTrigger_EventNameIsEncoded(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	SetTrigger(rec, `weird"событие`, `{"ok":true}`)
+
+	value := headerOnWire(t, rec, "Hx-Trigger")
+	requireASCII(t, value)
+
+	var payload map[string]map[string]bool
+	require.NoErrorf(t, json.Unmarshal([]byte(value), &payload), "header is not valid JSON: %q", value)
+	assert.Equal(t, map[string]map[string]bool{`weird"событие`: {"ok": true}}, payload)
+}
+
+// TestEscapeNonASCII_SurrogatePairs checks the escaping itself, including the
+// two-escape form JSON requires outside the BMP.
+//
+// Falsely green if it only tested BMP runes: a single \uXXXX for U+1F600 is not
+// representable and would silently truncate the rune.
+func TestEscapeNonASCII_SurrogatePairs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "ascii untouched", input: `{"a":"b c"}`, expected: `{"a":"b c"}`},
+		{name: "cyrillic", input: "Не", expected: `\u041d\u0435`},
+		{name: "non-BMP becomes a surrogate pair", input: "😀", expected: `\ud83d\ude00`},
+		{name: "boundary rune", input: "\u0080", expected: `\u0080`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, escapeNonASCII(tt.input))
+		})
+	}
+}

--- a/pkg/htmx/htmx_test.go
+++ b/pkg/htmx/htmx_test.go
@@ -69,12 +69,10 @@ func decodeToast(t *testing.T, value string) toastDetail {
 }
 
 // TestTriggerToast_NonASCIISurvivesAsASCII pins the reported production bug: a
-// Cyrillic toast reached the operator as mojibake because the raw UTF-8 bytes in
-// the header are decoded as ISO-8859-1 by the browser.
-//
-// Falsely green if it asserted only that json.Unmarshal returns the original
-// text: raw UTF-8 unmarshals just fine in Go. The load-bearing assertion is that
-// every byte written to the wire is below 0x80.
+// Cyrillic toast reached the operator as mojibake because the browser decodes
+// the raw UTF-8 bytes in the header as ISO-8859-1. The load-bearing assertion is
+// requireASCII — raw UTF-8 unmarshals fine in Go, so a round trip alone would
+// pass on the broken code.
 func TestTriggerToast_NonASCIISurvivesAsASCII(t *testing.T) {
 	t.Parallel()
 
@@ -122,11 +120,8 @@ func TestTriggerToast_NonASCIISurvivesAsASCII(t *testing.T) {
 
 // TestTriggerToast_SpecialCharactersStayValidJSON covers the second defect: the
 // detail used to be built with fmt.Sprintf, so a quote, a backslash or a control
-// character produced JSON that htmx failed to parse and the toast never appeared.
-//
-// Falsely green if it only checked that the header contains the message text —
-// a broken document can still contain it. The assertion that matters is that the
-// value parses as JSON and the text comes back byte-identical.
+// character produced JSON that htmx failed to parse. It asserts a successful
+// parse rather than substring containment, which a broken document also passes.
 func TestTriggerToast_SpecialCharactersStayValidJSON(t *testing.T) {
 	t.Parallel()
 
@@ -160,11 +155,8 @@ func TestTriggerToast_SpecialCharactersStayValidJSON(t *testing.T) {
 
 // TestTriggerToast_ASCIIOnlyKeepsBehaviour guards existing consumers: an
 // ASCII-only toast must still arrive as the same notify event with the same
-// three fields.
-//
-// Falsely green if it compared the header byte-for-byte against the old
-// fmt.Sprintf output — the separators changed (no space after the colon), while
-// the parsed payload, which is all the client sees, did not.
+// three fields. It compares the parsed payload, not the raw header — the
+// separators changed (no space after the colon), what the client sees did not.
 func TestTriggerToast_ASCIIOnlyKeepsBehaviour(t *testing.T) {
 	t.Parallel()
 
@@ -190,9 +182,8 @@ func TestTriggerToast_ASCIIOnlyKeepsBehaviour(t *testing.T) {
 
 // TestTriggers_EmptyDetailUnchanged pins the detail-less form: htmx reads a value
 // that is not JSON as a bare event name, so it must stay byte-for-byte identical.
-//
-// Falsely green if it asserted with Contains instead of Equal — a JSON-wrapped
-// value contains the event name too, yet would change what htmx dispatches.
+// Equal, not Contains — a JSON-wrapped value contains the event name too, yet
+// changes what htmx dispatches.
 func TestTriggers_EmptyDetailUnchanged(t *testing.T) {
 	t.Parallel()
 
@@ -221,10 +212,8 @@ func TestTriggers_EmptyDetailUnchanged(t *testing.T) {
 // TestSetTrigger_PreMarshalledDetailIsNormalised covers callers that hand
 // SetTrigger a payload they marshalled themselves: encoding/json emits non-ASCII
 // as raw UTF-8, so those triggers carried mojibake by the same route as toasts.
-//
-// Falsely green if it re-marshalled the detail before comparing — the fix must
-// escape the caller's document without reparsing it, leaving key order and
-// number formatting untouched.
+// The caller's document is compared as it was handed over, never re-marshalled:
+// escaping must leave key order and number formatting untouched.
 func TestSetTrigger_PreMarshalledDetailIsNormalised(t *testing.T) {
 	t.Parallel()
 
@@ -250,10 +239,9 @@ func TestSetTrigger_PreMarshalledDetailIsNormalised(t *testing.T) {
 }
 
 // TestSetTrigger_EventNameIsEncoded covers the event half of the header, which
-// used to be concatenated into the JSON unescaped.
-//
-// Falsely green if it used an event name without characters that need escaping —
-// every ASCII event name in the repository parses fine either way.
+// used to be concatenated into the JSON unescaped. The event name deliberately
+// carries a quote and Cyrillic; every plain ASCII name in the repository parses
+// fine either way.
 func TestSetTrigger_EventNameIsEncoded(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

Toast details were assembled with `fmt.Sprintf` and written as raw UTF-8 into the
`HX-Trigger` header. Go writes header values as bytes, and browsers decode
response header values as ISO-8859-1 (XHR/fetch), so anything above U+007F is
re-interpreted one byte at a time before htmx ever calls `JSON.parse`. A
production operator saw `Ð\x9De ÑÐ´Ð°Ð»Ð¾ÑÑ Ð¿ÑÐ¾Ð²ÐµÑÑÐ¸ Ð¾Ð¿Ð»Ð°ÑÑ…`
where the server sent «Не удалось провести оплату…». English toasts are
unaffected, which is why this went unnoticed.

Two defects:

1. **Non-ASCII does not survive the header** — every Cyrillic (and Uzbek Cyrillic,
   and any non-Latin) toast in every consumer arrives as mojibake.
2. **The JSON was built by string formatting** — a `"`, `\`, newline or control
   character in a title or message produced an invalid document, htmx's parse
   failed, and the toast silently never appeared. It was also an injection into
   the client's `JSON.parse`.

## Fix

- Toast details are marshalled with `encoding/json` (a struct, so field order is
  deterministic) instead of `fmt.Sprintf`.
- The event name is marshalled as a JSON string rather than concatenated.
- Every rune above U+007F in the assembled header value is escaped as `\uXXXX`,
  with a UTF-16 surrogate pair for runes outside the BMP.

The escaping is applied to `SetTrigger`, `TriggerAfterSwap` and
`TriggerAfterSettle` — not just to the toast helpers — because `detail` is
contractually a raw JSON fragment and several callers pass a payload they
marshalled themselves; `encoding/json` emits non-ASCII as raw UTF-8, so those
triggers carried mojibake by exactly the same route. Escaping the finished
document (rather than re-marshalling it) is safe because non-ASCII cannot legally
appear outside a JSON string literal, and it leaves a caller's key order and
number formatting untouched.

**The client needs no change.** `\uXXXX` is valid JSON and `JSON.parse` restores
the original string, verified end to end against the listener in
`components/base/toast/toast.templ` (`@notify.window="addNotification($event.detail)"`).

Before:

    Hx-Trigger: {"notify": {"variant": "error", "title": "Ошибка", "message": "Не удалось провести оплату \"AB 1234567\""}}

After:

    Hx-Trigger: {"notify":{"variant":"error","title":"Ошибка","message":"Не удалось провести оплату \"AB 1234567\""}}

Note the separators are now compact (`{"notify":{…}}` rather than
`{"notify": {…}}`). That is invisible to `JSON.parse` and to the `Contains`-based
HTMX trigger assertions in `pkg/itf`.

The detail-less form (`SetTrigger(w, "event", "")` → a bare event name, which is
what htmx expects for an event without a payload) is unchanged byte for byte.

## Tests

Table-driven tests in `pkg/htmx` assert on the header **as serialized to the
wire**, not on the Go string in the header map — asserting on the map would pass
on raw UTF-8 while the browser still receives mojibake, so every unicode case
requires each byte to be below `0x80`. Covered: Cyrillic and a non-BMP emoji
through all three toast helpers; `"`, `\`, a newline and a control character;
a pre-marshalled UTF-8 `detail` passed straight to `SetTrigger`; an event name
containing a quote; the empty-detail path (asserted with `Equal`); and an
ASCII-only toast, whose parsed payload is unchanged.

Verified against the pre-fix code with public-API-only equivalents: the Cyrillic,
quote-in-message and pre-marshalled-detail assertions fail, the empty-detail
assertion passes.

## Not in this PR

- `Location` has the same string-concatenation defect (`{"path":"`+path+`", …`)
  and the same raw non-ASCII exposure. Left for a separate change.
- `Redirect`/`PushURL`/`ReplaceURL` pass URLs through unchanged — percent-encoding
  is the caller's responsibility there.
- A non-ASCII *event name* with an empty detail still travels raw, because that
  form is not JSON and escaping it would change the dispatched event name.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789212262&installation_model_id=2042&pr_number=1013&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1013&signature=9ba1ab32585eade8088c8731420fce7c9f4c68ff179a127a384718bc6bf8223d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HTMX event and toast notifications containing non-ASCII characters.
  - Preserved valid JSON formatting for quotes, backslashes, control characters, Unicode, and surrogate pairs.
  - Maintained existing behavior for ASCII content and events without details.
  - Safely normalized preformatted event details while preserving caller-provided data.
  - Ensured notification titles and messages remain intact when containing special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->