### PR TITLE
fix(components): merge Tailwind classes without racing

### DIFF
--- a/components/base/avatar/avatar.templ
+++ b/components/base/avatar/avatar.templ
@@ -2,7 +2,7 @@ package avatar
 
 import (
 	"fmt"
-	twmerge "github.com/Oudwins/tailwind-merge-go"
+	"github.com/iota-uz/iota-sdk/pkg/twmerge"
 )
 
 type Variant string

--- a/components/base/avatar/avatar_templ.go
+++ b/components/base/avatar/avatar_templ.go
@@ -10,7 +10,7 @@ import templruntime "github.com/a-h/templ/runtime"
 
 import (
 	"fmt"
-	twmerge "github.com/Oudwins/tailwind-merge-go"
+	"github.com/iota-uz/iota-sdk/pkg/twmerge"
 )
 
 type Variant string

--- a/components/base/card/card.templ
+++ b/components/base/card/card.templ
@@ -1,6 +1,6 @@
 package card
 
-import twmerge "github.com/Oudwins/tailwind-merge-go"
+import "github.com/iota-uz/iota-sdk/pkg/twmerge"
 
 type Props struct {
 	Class        string

--- a/components/base/card/card_templ.go
+++ b/components/base/card/card_templ.go
@@ -8,7 +8,7 @@ package card
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import twmerge "github.com/Oudwins/tailwind-merge-go"
+import "github.com/iota-uz/iota-sdk/pkg/twmerge"
 
 type Props struct {
 	Class        string

--- a/components/base/description-list/description_list.templ
+++ b/components/base/description-list/description_list.templ
@@ -1,9 +1,9 @@
 package descriptionlist
 
 import (
-	"github.com/Oudwins/tailwind-merge-go"
 	icons "github.com/iota-uz/icons/phosphor"
 	"github.com/iota-uz/iota-sdk/components/base/card"
+	"github.com/iota-uz/iota-sdk/pkg/twmerge"
 )
 
 templ RegularItem(label templ.Component, value templ.Component) {

--- a/components/base/description-list/description_list_templ.go
+++ b/components/base/description-list/description_list_templ.go
@@ -9,9 +9,9 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
-	"github.com/Oudwins/tailwind-merge-go"
 	icons "github.com/iota-uz/icons/phosphor"
 	"github.com/iota-uz/iota-sdk/components/base/card"
+	"github.com/iota-uz/iota-sdk/pkg/twmerge"
 )
 
 func RegularItem(label templ.Component, value templ.Component) templ.Component {

--- a/components/base/dialog/drawer.templ
+++ b/components/base/dialog/drawer.templ
@@ -2,8 +2,8 @@ package dialog
 
 import (
 	"fmt"
-	"github.com/Oudwins/tailwind-merge-go/pkg/twmerge"
 	icons "github.com/iota-uz/icons/phosphor"
+	"github.com/iota-uz/iota-sdk/pkg/twmerge"
 )
 
 type Direction int

--- a/components/base/dialog/drawer_templ.go
+++ b/components/base/dialog/drawer_templ.go
@@ -10,8 +10,8 @@ import templruntime "github.com/a-h/templ/runtime"
 
 import (
 	"fmt"
-	"github.com/Oudwins/tailwind-merge-go/pkg/twmerge"
 	icons "github.com/iota-uz/icons/phosphor"
+	"github.com/iota-uz/iota-sdk/pkg/twmerge"
 )
 
 type Direction int

--- a/components/base/input/input.templ
+++ b/components/base/input/input.templ
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Oudwins/tailwind-merge-go/pkg/twmerge"
 	icons "github.com/iota-uz/icons/phosphor"
 	"github.com/iota-uz/iota-sdk/pkg/money"
+	"github.com/iota-uz/iota-sdk/pkg/twmerge"
 	"github.com/iota-uz/utils/random"
 )
 

--- a/components/base/input/input_templ.go
+++ b/components/base/input/input_templ.go
@@ -13,9 +13,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/Oudwins/tailwind-merge-go/pkg/twmerge"
 	icons "github.com/iota-uz/icons/phosphor"
 	"github.com/iota-uz/iota-sdk/pkg/money"
+	"github.com/iota-uz/iota-sdk/pkg/twmerge"
 	"github.com/iota-uz/utils/random"
 )
 

--- a/components/base/input/switch.templ
+++ b/components/base/input/switch.templ
@@ -1,7 +1,7 @@
 package input
 
 import (
-	twmerge "github.com/Oudwins/tailwind-merge-go"
+	"github.com/iota-uz/iota-sdk/pkg/twmerge"
 	"github.com/iota-uz/utils/random"
 )
 

--- a/components/base/input/switch_templ.go
+++ b/components/base/input/switch_templ.go
@@ -9,7 +9,7 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
-	twmerge "github.com/Oudwins/tailwind-merge-go"
+	"github.com/iota-uz/iota-sdk/pkg/twmerge"
 	"github.com/iota-uz/utils/random"
 )
 

--- a/components/base/phone/phone.templ
+++ b/components/base/phone/phone.templ
@@ -1,9 +1,9 @@
 package phone
 
 import (
-	"github.com/Oudwins/tailwind-merge-go/pkg/twmerge"
 	icons "github.com/iota-uz/icons/phosphor"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/value_objects/phone"
+	"github.com/iota-uz/iota-sdk/pkg/twmerge"
 )
 
 type DisplayStyle int

--- a/components/base/phone/phone_templ.go
+++ b/components/base/phone/phone_templ.go
@@ -9,9 +9,9 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
-	"github.com/Oudwins/tailwind-merge-go/pkg/twmerge"
 	icons "github.com/iota-uz/icons/phosphor"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/value_objects/phone"
+	"github.com/iota-uz/iota-sdk/pkg/twmerge"
 )
 
 type DisplayStyle int

--- a/components/base/radio/radio.templ
+++ b/components/base/radio/radio.templ
@@ -24,7 +24,7 @@
 //	}
 package radio
 
-import twmerge "github.com/Oudwins/tailwind-merge-go"
+import "github.com/iota-uz/iota-sdk/pkg/twmerge"
 
 // Orientation defines the layout direction of radio items
 type Orientation string

--- a/components/base/radio/radio_templ.go
+++ b/components/base/radio/radio_templ.go
@@ -56,7 +56,7 @@ package radio
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import twmerge "github.com/Oudwins/tailwind-merge-go"
+import "github.com/iota-uz/iota-sdk/pkg/twmerge"
 
 // Orientation defines the layout direction of radio items
 type Orientation string

--- a/components/base/table.templ
+++ b/components/base/table.templ
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strconv"
 
-	twmerge "github.com/Oudwins/tailwind-merge-go"
 	icons "github.com/iota-uz/icons/phosphor"
+	"github.com/iota-uz/iota-sdk/pkg/twmerge"
 )
 
 // truncateStyle returns an inline max-width style (px) for truncated labels.

--- a/components/base/table_empty_state.templ
+++ b/components/base/table_empty_state.templ
@@ -1,8 +1,8 @@
 package base
 
 import (
-	twmerge "github.com/Oudwins/tailwind-merge-go"
 	"github.com/iota-uz/iota-sdk/components/illustrations"
+	"github.com/iota-uz/iota-sdk/pkg/twmerge"
 )
 
 type TableEmptyStateProps struct {

--- a/components/base/table_empty_state_templ.go
+++ b/components/base/table_empty_state_templ.go
@@ -9,8 +9,8 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
-	twmerge "github.com/Oudwins/tailwind-merge-go"
 	"github.com/iota-uz/iota-sdk/components/illustrations"
+	"github.com/iota-uz/iota-sdk/pkg/twmerge"
 )
 
 type TableEmptyStateProps struct {

--- a/components/base/table_templ.go
+++ b/components/base/table_templ.go
@@ -12,8 +12,8 @@ import (
 	"fmt"
 	"strconv"
 
-	twmerge "github.com/Oudwins/tailwind-merge-go"
 	icons "github.com/iota-uz/icons/phosphor"
+	"github.com/iota-uz/iota-sdk/pkg/twmerge"
 )
 
 // truncateStyle returns an inline max-width style (px) for truncated labels.

--- a/components/loaders/lazy.templ
+++ b/components/loaders/lazy.templ
@@ -1,8 +1,8 @@
 package loaders
 
 import (
-	twmerge "github.com/Oudwins/tailwind-merge-go"
 	"github.com/iota-uz/iota-sdk/pkg/mapping"
+	"github.com/iota-uz/iota-sdk/pkg/twmerge"
 	"net/url"
 )
 

--- a/components/loaders/lazy_templ.go
+++ b/components/loaders/lazy_templ.go
@@ -9,8 +9,8 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
-	twmerge "github.com/Oudwins/tailwind-merge-go"
 	"github.com/iota-uz/iota-sdk/pkg/mapping"
+	"github.com/iota-uz/iota-sdk/pkg/twmerge"
 	"net/url"
 )
 

--- a/components/loaders/skeleton.templ
+++ b/components/loaders/skeleton.templ
@@ -1,6 +1,6 @@
 package loaders
 
-import twmerge "github.com/Oudwins/tailwind-merge-go"
+import "github.com/iota-uz/iota-sdk/pkg/twmerge"
 
 type SkeletonProps struct {
 	ContainerClass templ.CSSClasses

--- a/components/loaders/skeleton_templ.go
+++ b/components/loaders/skeleton_templ.go
@@ -8,7 +8,7 @@ package loaders
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import twmerge "github.com/Oudwins/tailwind-merge-go"
+import "github.com/iota-uz/iota-sdk/pkg/twmerge"
 
 type SkeletonProps struct {
 	ContainerClass templ.CSSClasses

--- a/components/loaders/spinner.templ
+++ b/components/loaders/spinner.templ
@@ -1,6 +1,6 @@
 package loaders
 
-import twmerge "github.com/Oudwins/tailwind-merge-go"
+import "github.com/iota-uz/iota-sdk/pkg/twmerge"
 
 type SpinnerProps struct {
 	ContainerClass templ.CSSClasses

--- a/components/loaders/spinner_templ.go
+++ b/components/loaders/spinner_templ.go
@@ -8,7 +8,7 @@ package loaders
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-import twmerge "github.com/Oudwins/tailwind-merge-go"
+import "github.com/iota-uz/iota-sdk/pkg/twmerge"
 
 type SpinnerProps struct {
 	ContainerClass templ.CSSClasses

--- a/components/scaffold/filters/filters.templ
+++ b/components/scaffold/filters/filters.templ
@@ -1,11 +1,11 @@
 package filters
 
 import (
-	"github.com/Oudwins/tailwind-merge-go"
 	icons "github.com/iota-uz/icons/phosphor"
 	"github.com/iota-uz/iota-sdk/components/base"
 	"github.com/iota-uz/iota-sdk/components/base/input"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"github.com/iota-uz/iota-sdk/pkg/twmerge"
 	"github.com/iota-uz/utils/random"
 )
 

--- a/components/scaffold/filters/filters_templ.go
+++ b/components/scaffold/filters/filters_templ.go
@@ -9,11 +9,11 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
-	"github.com/Oudwins/tailwind-merge-go"
 	icons "github.com/iota-uz/icons/phosphor"
 	"github.com/iota-uz/iota-sdk/components/base"
 	"github.com/iota-uz/iota-sdk/components/base/input"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"github.com/iota-uz/iota-sdk/pkg/twmerge"
 	"github.com/iota-uz/utils/random"
 )
 

--- a/pkg/twmerge/twmerge.go
+++ b/pkg/twmerge/twmerge.go
@@ -1,0 +1,93 @@
+// Package twmerge resolves conflicting Tailwind classes, the way
+// github.com/Oudwins/tailwind-merge-go does — every component in this repo
+// merges a caller-supplied class string against its own defaults on the render
+// path, which means the merge runs on as many goroutines as the server has
+// in-flight requests.
+//
+// The upstream package's ready-made twmerge.Merge is not safe there. Two
+// independent races, both reachable from an ordinary page render:
+//
+//  1. Its default cache (pkg/lru) guards the map and the intrusive list with
+//     two separate mutexes. Set removes a node while holding only cacheMutex,
+//     while an eviction removes a node holding only listMutex; when both touch
+//     the same node the second remove dereferences a nil prev. That is a panic
+//     in the middle of writing a response, not a slow render.
+//
+//  2. CreateTwMerge builds its closures on first call and assigns them —
+//     fnToCall, splitModifiers, getClassGroupId, mergeClassList, cache — with
+//     no synchronisation at all. Concurrent first calls race on the function
+//     value itself.
+//
+// Passing a cache in settles (1): the nil check in upstream's init is the only
+// thing that ever calls lru.Make, so the broken implementation becomes
+// unreachable rather than merely unlikely. Warming the function once, from a
+// single goroutine, during package initialisation settles (2): every call a
+// request can make reads state written before main() began.
+//
+// Import this instead of the upstream package. The call signature is the same,
+// so a call site changes its import and nothing else.
+package twmerge
+
+import (
+	"sync"
+
+	twm "github.com/Oudwins/tailwind-merge-go/pkg/twmerge"
+)
+
+// safeCache is upstream's cache.ICache under one mutex.
+//
+// It is deliberately not an LRU. The keys are class strings written in source,
+// so the live set is bounded by the component tree rather than by traffic, and
+// a keyless flush costs a handful of re-merges. An LRU costs a linked list that
+// has to stay correct under concurrency — which is the thing upstream got
+// wrong, and there is no reason to write it a second time.
+type safeCache struct {
+	mu       sync.RWMutex
+	capacity int
+	entries  map[string]string
+}
+
+func newSafeCache(capacity int) *safeCache {
+	if capacity < 1 {
+		capacity = 1
+	}
+	return &safeCache{
+		capacity: capacity,
+		entries:  make(map[string]string, capacity),
+	}
+}
+
+func (c *safeCache) Get(key string) string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.entries[key]
+}
+
+func (c *safeCache) Set(key, value string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if len(c.entries) >= c.capacity {
+		c.entries = make(map[string]string, c.capacity)
+	}
+	c.entries[key] = value
+}
+
+// merge is initialised, and called once, before main() — see the package doc.
+// The warm call is load-bearing: without it the first two concurrent renders
+// race inside upstream's lazy init.
+var merge = func() twm.TwMergeFn {
+	config := twm.MakeDefaultConfig()
+	fn := twm.CreateTwMerge(config, newSafeCache(config.MaxCacheSize))
+	fn("p-0")
+	return fn
+}()
+
+// Merge joins the given class strings and drops every class a later one
+// overrides. The survivors come back in upstream's class-group order, which is
+// not the order they were written in.
+//
+// It is a function rather than a variable so that no importer can reassign the
+// merge behaviour of every component in the repo from an init somewhere.
+func Merge(classes ...string) string {
+	return merge(classes...)
+}

--- a/pkg/twmerge/twmerge_test.go
+++ b/pkg/twmerge/twmerge_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/iota-uz/iota-sdk/pkg/twmerge"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // classes compares what a merge produced as a set. Upstream groups the
@@ -28,19 +30,11 @@ func classes(merged string) []string {
 func TestMergeResolvesConflicts(t *testing.T) {
 	t.Parallel()
 
-	if got := twmerge.Merge("p-1 p-2"); got != "p-2" {
-		t.Fatalf("Merge(%q) = %q, want %q", "p-1 p-2", got, "p-2")
-	}
-	if got := twmerge.Merge("px-2 py-1", "p-4"); got != "p-4" {
-		t.Fatalf("Merge(%q, %q) = %q, want %q", "px-2 py-1", "p-4", got, "p-4")
-	}
-	if got, want := classes(twmerge.Merge("text-sm font-medium", "text-lg")),
-		[]string{"font-medium", "text-lg"}; !equal(got, want) {
-		t.Fatalf(`Merge("text-sm font-medium", "text-lg") = %v, want %v`, got, want)
-	}
-	if got := twmerge.Merge(""); got != "" {
-		t.Fatalf("Merge(%q) = %q, want empty", "", got)
-	}
+	assert.Equal(t, "p-2", twmerge.Merge("p-1 p-2"))
+	assert.Equal(t, "p-4", twmerge.Merge("px-2 py-1", "p-4"))
+	assert.Equal(t, []string{"font-medium", "text-lg"},
+		classes(twmerge.Merge("text-sm font-medium", "text-lg")))
+	assert.Empty(t, twmerge.Merge(""))
 }
 
 // TestMergeIsGoroutineSafe is the reason this package exists. Every component
@@ -74,9 +68,8 @@ func TestMergeIsGoroutineSafe(t *testing.T) {
 				// Unique per (goroutine, iteration), and a genuine conflict:
 				// the second padding class must win.
 				margin := fmt.Sprintf("m-%d-%d", g, i)
-				got := classes(twmerge.Merge("p-1 "+margin, "p-4"))
-				if want := classes(margin + " p-4"); !equal(got, want) {
-					t.Errorf("Merge(%q, %q) = %v, want %v", "p-1 "+margin, "p-4", got, want)
+				if !assert.Equal(t, classes(margin+" p-4"),
+					classes(twmerge.Merge("p-1 "+margin, "p-4"))) {
 					return
 				}
 			}
@@ -98,28 +91,12 @@ func TestMergeStaysCorrectPastCacheCapacity(t *testing.T) {
 
 	for i := range keys {
 		in := fmt.Sprintf("gap-1 w-%d", i)
-		if got, want := classes(twmerge.Merge(in)), classes(in); !equal(got, want) {
-			t.Fatalf("first pass: Merge(%q) = %v, want %v", in, got, want)
-		}
+		require.Equal(t, classes(in), classes(twmerge.Merge(in)), "first pass: %s", in)
 	}
 	// Second pass over the same keys: the early ones were flushed by now, so
 	// these answers are recomputed rather than read back.
 	for i := range keys {
 		in := fmt.Sprintf("gap-1 w-%d", i)
-		if got, want := classes(twmerge.Merge(in)), classes(in); !equal(got, want) {
-			t.Fatalf("after eviction: Merge(%q) = %v, want %v", in, got, want)
-		}
+		require.Equal(t, classes(in), classes(twmerge.Merge(in)), "after eviction: %s", in)
 	}
-}
-
-func equal(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }

--- a/pkg/twmerge/twmerge_test.go
+++ b/pkg/twmerge/twmerge_test.go
@@ -1,0 +1,125 @@
+package twmerge_test
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/iota-uz/iota-sdk/pkg/twmerge"
+)
+
+// classes compares what a merge produced as a set. Upstream groups the
+// survivors by class group and walks a map to do it, so "gap-1 w-0" comes back
+// as "gap-1 w-0" from one call and "w-0 gap-1" from the next — within a single
+// process, on the same input. Which classes survive is the contract; the order
+// they are printed in is not, and asserting on it makes a test that fails a few
+// runs in ten. (Harmless in HTML: a class attribute is a set.)
+func classes(merged string) []string {
+	fields := strings.Fields(merged)
+	sort.Strings(fields)
+	return fields
+}
+
+// TestMergeResolvesConflicts is the sanity floor: this package must merge the
+// way the upstream one does, or the swap of a dozen component imports changed
+// what those components render.
+func TestMergeResolvesConflicts(t *testing.T) {
+	t.Parallel()
+
+	if got := twmerge.Merge("p-1 p-2"); got != "p-2" {
+		t.Fatalf("Merge(%q) = %q, want %q", "p-1 p-2", got, "p-2")
+	}
+	if got := twmerge.Merge("px-2 py-1", "p-4"); got != "p-4" {
+		t.Fatalf("Merge(%q, %q) = %q, want %q", "px-2 py-1", "p-4", got, "p-4")
+	}
+	if got, want := classes(twmerge.Merge("text-sm font-medium", "text-lg")),
+		[]string{"font-medium", "text-lg"}; !equal(got, want) {
+		t.Fatalf(`Merge("text-sm font-medium", "text-lg") = %v, want %v`, got, want)
+	}
+	if got := twmerge.Merge(""); got != "" {
+		t.Fatalf("Merge(%q) = %q, want empty", "", got)
+	}
+}
+
+// TestMergeIsGoroutineSafe is the reason this package exists. Every component
+// merges classes while rendering, so this is exactly the concurrency an ordinary
+// page under load produces.
+//
+// Two properties are being exercised, and both need the distinct class strings:
+//
+//   - every call misses the cache and therefore writes to it, which is where
+//     upstream's two-mutex LRU corrupts its list and panics on a nil prev;
+//   - the writes far exceed the cache capacity, so evictions run throughout
+//     rather than only at the end.
+//
+// What would make this falsely green: reusing one class string across the
+// goroutines. The first call would fill the cache and every later one would
+// return from Get, so nothing would ever race on a write. Under -race the same
+// body pointed at upstream's twmerge.Merge reports the data race; the panic mode
+// it also catches shows up with or without the flag.
+func TestMergeIsGoroutineSafe(t *testing.T) {
+	t.Parallel()
+
+	const goroutines = 32
+	const perGoroutine = 250 // 8000 distinct keys against a 1000-entry cache
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := range goroutines {
+		go func() {
+			defer wg.Done()
+			for i := range perGoroutine {
+				// Unique per (goroutine, iteration), and a genuine conflict:
+				// the second padding class must win.
+				margin := fmt.Sprintf("m-%d-%d", g, i)
+				got := classes(twmerge.Merge("p-1 "+margin, "p-4"))
+				if want := classes(margin + " p-4"); !equal(got, want) {
+					t.Errorf("Merge(%q, %q) = %v, want %v", "p-1 "+margin, "p-4", got, want)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestMergeStaysCorrectPastCacheCapacity pins the one behaviour the flush-when-
+// full cache could plausibly get wrong: a key evicted by the flush must still
+// merge to the same answer when it comes back, not to a stale or empty one.
+//
+// What would make this falsely green: asserting fewer keys than the cache holds,
+// which never triggers a flush at all.
+func TestMergeStaysCorrectPastCacheCapacity(t *testing.T) {
+	t.Parallel()
+
+	const keys = 2500 // more than the 1000-entry default capacity
+
+	for i := range keys {
+		in := fmt.Sprintf("gap-1 w-%d", i)
+		if got, want := classes(twmerge.Merge(in)), classes(in); !equal(got, want) {
+			t.Fatalf("first pass: Merge(%q) = %v, want %v", in, got, want)
+		}
+	}
+	// Second pass over the same keys: the early ones were flushed by now, so
+	// these answers are recomputed rather than read back.
+	for i := range keys {
+		in := fmt.Sprintf("gap-1 w-%d", i)
+		if got, want := classes(twmerge.Merge(in)), classes(in); !equal(got, want) {
+			t.Fatalf("after eviction: Merge(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Fixes #1016.

## The problem

Every component here merges a caller-supplied class string against its own defaults on the render path, so the merge runs on as many goroutines as the server has in-flight requests. `tailwind-merge-go@v0.2.1`'s ready-made `twmerge.Merge` is not safe there — two independent races:

1. **The default LRU cache** (`pkg/lru`) guards the map and the intrusive list with two separate mutexes. `Set` calls `remove` holding only `cacheMutex` (lru.go:46) while an eviction calls it holding only `listMutex`; when both reach the same node, the second `remove` dereferences a nil `prev` (lru.go:76). That is a panic partway through writing a response, not a slow render.
2. **The lazy init.** `CreateTwMerge` builds its closures on the first call and assigns `fnToCall`, `splitModifiers`, `getClassGroupId`, `mergeClassList` and `cache` with no synchronisation, so concurrent first calls race on the function value itself.

## The fix

A new `pkg/twmerge` wraps `CreateTwMerge` with a cache of our own and warms it once, single-goroutine, at package init.

- Passing a cache in settles (1): the `cache == nil` check in upstream's init is the only thing that ever calls `lru.Make`, so the broken code becomes unreachable rather than merely unlikely.
- The warm call settles (2): every call a request can make reads state written before `main()` began.
- `Merge` is a function, not a `var`, so no importer can reassign the merge behaviour of every component from an init somewhere.

The cache is deliberately **not** an LRU: its keys are class strings written in source, so the live set is bounded by the component tree rather than by traffic, and a flush-when-full costs a handful of re-merges. An LRU costs a linked list that has to stay correct under concurrency — the thing upstream got wrong.

## Blast radius

The fourteen components that imported upstream now import this package. Package name and call signature are unchanged, so **no call site changed** and the generated markup is the same; the `_templ.go` diff is the import line only (regenerated with the pinned templ v0.3.857).

## Verification

- `go test -race -count=5 ./pkg/twmerge/` — green.
- **Red-proof:** the same 32-goroutine body pointed at upstream's `twmerge.Merge` under `-race` reports `WARNING: DATA RACE … create-tailwind-merge.go:36` / `:46`. That variant is not committed.
- `go build ./...`, `go vet`, `gofmt -l`, `golangci-lint run` — clean.
- `templ generate` — 14 files changed, no drift elsewhere.

One incidental finding, pinned in a test comment: upstream groups the survivors by walking a map, so `"gap-1 w-0"` comes back as `"gap-1 w-0"` from one call and `"w-0 gap-1"` from the next — same process, same input. The surviving set is the contract, the print order is not; harmless in HTML, where a class attribute is a set. The tests therefore compare sets.

If CI does not run `-race`, the new test still catches the panic mode; the pure data race needs the flag.

https://claude.ai/code/session_01VBroGVdpqzaENFGzXpKgto

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789282061&installation_model_id=2042&pr_number=1017&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1017&signature=40ab7cc07eb030c99135d02560f90984f19a25b89a4bf490e21a708606514745"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency and reliability when combining utility classes across avatars, cards, inputs, tables, dialogs, loaders, filters, and other UI components.
  - Preserved existing rendering and styling behavior while reducing conflicts between utility classes.

- **Performance**
  - Improved responsiveness and stability during repeated or concurrent style updates.

- **Tests**
  - Added coverage for class conflict resolution, empty inputs, concurrent usage, and correctness across large numbers of style combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->