### PR TITLE
feat(itf): clone test databases from a pre-migrated template

### DIFF
--- a/pkg/itf/README.md
+++ b/pkg/itf/README.md
@@ -93,6 +93,47 @@ suite.POST("/submit").
 ### Database Name Truncation Fix
 Automatic database name handling for long test names.
 
+### Template Database Cloning
+Every harness provisions its own database. By default that database starts empty
+and the migration set is replayed into it — roughly a second per harness, taken
+under a cluster-wide advisory lock so that parallel harnesses do not race on the
+cluster-global objects migrations create.
+
+Point `ITF_TEMPLATE_DB` at a pre-migrated database and the harness clones it
+instead, at catalog speed:
+
+```bash
+# once, before the suite (CI does this in a setup step)
+createdb itf_template
+DB_NAME=itf_template go run cmd/command/main.go migrate up
+psql -d postgres -c "UPDATE pg_database SET datistemplate = true WHERE datname = 'itf_template'"
+
+# then
+ITF_TEMPLATE_DB=itf_template go test ./...
+```
+
+Measured on `modules/{core,finance,warehouse}` (5 packages, `-p 8`):
+**29.7s → 7.4s**.
+
+Notes:
+
+- **Unset is the default.** A clean checkout still runs `go test ./...` with no
+  extra preparation.
+- **Cloning is orthogonal to the migration policy.** With the default
+  `MigrationApplyOnce` the migrator still runs over the clone, plans zero
+  migrations, and therefore costs almost nothing — while repairing a template
+  built before the newest migration landed. `MigrationSkip` drops even that
+  probe, trusting the template to be current.
+- **The template carries schema only.** `CREATE DATABASE ... TEMPLATE` does not
+  copy cluster-global objects — roles, their settings and grants — so build the
+  template against the same cluster the tests run on. Extensions and RLS
+  policies are database-local and do come across.
+- **Nothing may be connected to the template.** Postgres refuses to clone a
+  database with open connections; the harness never opens a pool against it, and
+  serializes concurrent clones on an advisory lock.
+- Per-suite override: `itf.WithTemplateDatabase("other_template")`, or
+  `HarnessConfig.Migration.TemplateDB`.
+
 ## Quick Start
 
 ### Basic Setup

--- a/pkg/itf/README.md
+++ b/pkg/itf/README.md
@@ -94,6 +94,7 @@ suite.POST("/submit").
 Automatic database name handling for long test names.
 
 ### Template Database Cloning
+
 Every harness provisions its own database. By default that database starts empty
 and the migration set is replayed into it — roughly a second per harness, taken
 under a cluster-wide advisory lock so that parallel harnesses do not race on the
@@ -121,13 +122,19 @@ Notes:
   extra preparation.
 - **Cloning is orthogonal to the migration policy.** With the default
   `MigrationApplyOnce` the migrator still runs over the clone, plans zero
-  migrations, and therefore costs almost nothing — while repairing a template
-  built before the newest migration landed. `MigrationSkip` drops even that
-  probe, trusting the template to be current.
-- **The template carries schema only.** `CREATE DATABASE ... TEMPLATE` does not
-  copy cluster-global objects — roles, their settings and grants — so build the
-  template against the same cluster the tests run on. Extensions and RLS
-  policies are database-local and do come across.
+  migrations, and therefore costs almost nothing — while bringing *that clone*
+  current if the template was built before the newest migration landed. It does
+  not repair the template: a stale template stays stale and every clone keeps
+  paying for the missing migrations until you rebuild it. `MigrationSkip` drops
+  even that probe, trusting the template to be current.
+- **The clone gets the template's rows, too.** `CREATE DATABASE ... TEMPLATE`
+  copies everything database-local — schema, extensions, RLS policies and table
+  contents. Build the template from migrations alone; a template made from a
+  seeded or restored database hands that data to every test.
+- **Cluster-global objects are not copied.** Roles, and the settings and grants
+  attached to them, live outside the database — so build the template against
+  the same cluster the tests run on, and do not expect a migration that only
+  ran into the template to have created the role its RLS policies reference.
 - **Nothing may be connected to the template.** Postgres refuses to clone a
   database with open connections; the harness never opens a pool against it, and
   serializes concurrent clones on an advisory lock.

--- a/pkg/itf/context.go
+++ b/pkg/itf/context.go
@@ -30,6 +30,7 @@ type TestContext struct {
 	components   []composition.Component
 	capabilities []composition.Capability
 	dbName       string
+	templateDB   string        // optional; clone the database from this template
 	source       config.Source // optional; enables ProvideConfig[T] in component Build
 }
 
@@ -83,7 +84,8 @@ func (tc *TestContext) Build(tb testing.TB) *TestEnvironment {
 			Cleanup:      CleanupDropOnExit,
 		},
 		Migration: MigrationConfig{
-			Policy: MigrationApplyOnce,
+			Policy:     MigrationApplyOnce,
+			TemplateDB: tc.templateDB,
 		},
 		Isolation: IsolationConfig{
 			Mode: IsolationRollback,

--- a/pkg/itf/harness.go
+++ b/pkg/itf/harness.go
@@ -69,11 +69,16 @@ const (
 // replay into a ~10ms catalog copy. Unset (the default) keeps the historical
 // behaviour, so a developer's `go test ./...` needs no extra preparation.
 //
-// The template holds schema only. Cluster-global objects that migrations create
-// - roles, and the role-level settings and grants attached to them - are NOT
-// copied by CREATE DATABASE ... TEMPLATE, so whoever builds the template must
-// run the migrations against the same cluster the tests use. Extensions and RLS
-// policies are database-local and do come across.
+// CREATE DATABASE ... TEMPLATE copies everything database-local: schema,
+// extensions, RLS policies - and ROWS. Whatever sits in the template's tables
+// lands in every clone, so a template must be built from migrations alone and
+// never from a seeded or restored database, unless every test is meant to see
+// that data.
+//
+// What it does NOT copy is cluster-global: roles, and the role-level settings
+// and grants attached to them. Migrations that create them (the ai_readonly
+// ROLE behind the RLS policies, for one) therefore have to be run against the
+// same cluster the tests use, not just into the template.
 const TemplateDBEnv = "ITF_TEMPLATE_DB"
 
 // migrationAdvisoryLockKey serializes migration application across processes.
@@ -137,9 +142,11 @@ type MigrationConfig struct {
 	//
 	// Cloning is orthogonal to Policy. With the default MigrationApplyOnce the
 	// harness still runs the migrator over the clone, which plans zero
-	// migrations and therefore costs almost nothing - and repairs a template
-	// that was built before the newest migration landed. MigrationSkip drops
-	// even that, at the price of trusting the template to be current.
+	// migrations and therefore costs almost nothing - and brings THIS CLONE
+	// current when the template was built before the newest migration landed.
+	// It does not touch the template: a stale template stays stale, and every
+	// clone keeps paying for the missing migrations until it is rebuilt.
+	// MigrationSkip drops even that, at the price of trusting the template.
 	TemplateDB string
 }
 

--- a/pkg/itf/harness.go
+++ b/pkg/itf/harness.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -62,11 +63,24 @@ const (
 	MigrationSkip      MigrationPolicy = "skip"
 )
 
+// TemplateDBEnv names a pre-migrated template database. When it is set and
+// [MigrationConfig.TemplateDB] is empty, every harness clones its database from
+// that template instead of creating an empty one, turning a ~1s migration
+// replay into a ~10ms catalog copy. Unset (the default) keeps the historical
+// behaviour, so a developer's `go test ./...` needs no extra preparation.
+//
+// The template holds schema only. Cluster-global objects that migrations create
+// - roles, and the role-level settings and grants attached to them - are NOT
+// copied by CREATE DATABASE ... TEMPLATE, so whoever builds the template must
+// run the migrations against the same cluster the tests use. Extensions and RLS
+// policies are database-local and do come across.
+const TemplateDBEnv = "ITF_TEMPLATE_DB"
+
 // migrationAdvisoryLockKey serializes migration application across processes.
 // Parallel harnesses (separate test binaries, and t.Parallel within one) each
 // provision their OWN per-test database but share one Postgres server;
 // migrations that touch cluster-global catalog objects (e.g. the ai_readonly
-// ROLE + RLS in changes-1997500070.sql) otherwise race with
+// ROLE + RLS in changes-1997500670.sql) otherwise race with
 // "tuple concurrently updated (SQLSTATE XX000)".
 //
 // NOTE: Postgres advisory locks are DATABASE-LOCAL (the lock tag includes the
@@ -79,6 +93,13 @@ const (
 // The value is an arbitrary stable constant, distinct from other advisory-lock
 // keys in the codebase.
 const migrationAdvisoryLockKey int64 = 6_073_120_419_784_512_301
+
+// createDatabaseAdvisoryLockKey serializes DROP + CREATE DATABASE across
+// processes. Two hazards share it: shared-per-package harnesses in sibling test
+// binaries derive the same database name and collide on
+// pg_database_datname_index, and concurrent clones of one template collide on
+// the template itself. Held for a single catalog statement, not a migration run.
+const createDatabaseAdvisoryLockKey int64 = 6_073_120_419_784_512_302
 
 type IsolationMode string
 
@@ -110,6 +131,16 @@ type DatabaseConfig struct {
 
 type MigrationConfig struct {
 	Policy MigrationPolicy
+	// TemplateDB names a pre-migrated database to clone instead of creating an
+	// empty one. Empty falls back to the [TemplateDBEnv] environment variable,
+	// and then to creating an empty database.
+	//
+	// Cloning is orthogonal to Policy. With the default MigrationApplyOnce the
+	// harness still runs the migrator over the clone, which plans zero
+	// migrations and therefore costs almost nothing - and repairs a template
+	// that was built before the newest migration landed. MigrationSkip drops
+	// even that, at the price of trusting the template to be current.
+	TemplateDB string
 }
 
 type TxConfig struct {
@@ -444,7 +475,7 @@ func createHarnessState(key string, cfg HarnessConfig, isPerTest bool) (*harness
 	db := LoadDBConfigFromEnv()
 
 	dbName := buildDBName(cfg.Name, key, isPerTest)
-	if err := CreateDBE(dbName, db); err != nil {
+	if err := CreateDBFromTemplateE(dbName, cfg.Migration.TemplateDB, db); err != nil {
 		return nil, serrors.E(opCreateDB, err, "create database")
 	}
 
@@ -554,6 +585,9 @@ func normalizeHarnessConfig(tb testing.TB, cfg HarnessConfig) HarnessConfig {
 	if cfg.Migration.Policy == "" {
 		cfg.Migration.Policy = MigrationApplyOnce
 	}
+	if cfg.Migration.TemplateDB == "" {
+		cfg.Migration.TemplateDB = os.Getenv(TemplateDBEnv)
+	}
 	if cfg.Isolation.Mode == "" {
 		cfg.Isolation.Mode = IsolationRollback
 	}
@@ -590,11 +624,12 @@ func buildHarnessKey(cfg HarnessConfig) string {
 	}
 
 	return fmt.Sprintf(
-		"name=%s|components=%v|prov=%s|migrate=%s|iso=%s|cleanup=%s|seed=%s|pool=%d/%d/%s/%s|tx=%s/%s/%s|tenant=%s|locales=%v",
+		"name=%s|components=%v|prov=%s|migrate=%s|template=%s|iso=%s|cleanup=%s|seed=%s|pool=%d/%d/%s/%s|tx=%s/%s/%s|tenant=%s|locales=%v",
 		cfg.Name,
 		componentTypes,
 		cfg.Database.Provisioning,
 		cfg.Migration.Policy,
+		cfg.Migration.TemplateDB,
 		cfg.Isolation.Mode,
 		cfg.Database.Cleanup,
 		cfg.Seed.Policy,

--- a/pkg/itf/itf.go
+++ b/pkg/itf/itf.go
@@ -86,6 +86,17 @@ func WithDatabase(name string) Option {
 	}
 }
 
+// WithTemplateDatabase clones the test database from a pre-migrated template
+// instead of creating an empty one and replaying migrations. Overrides the
+// [TemplateDBEnv] environment variable, which is the usual way to switch a
+// whole CI run over; reach for this option when one suite needs a different
+// template from the rest.
+func WithTemplateDatabase(name string) Option {
+	return func(tc *TestContext) {
+		tc.templateDB = name
+	}
+}
+
 // WithUser sets the default user for the test context
 func WithUser(u user.User) Option {
 	return func(tc *TestContext) {

--- a/pkg/itf/template_test.go
+++ b/pkg/itf/template_test.go
@@ -1,0 +1,145 @@
+package itf
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/dbconfig"
+	"github.com/stretchr/testify/require"
+)
+
+// adminConn opens the maintenance connection the template helpers use, or skips
+// the test when no cluster is reachable so a clean checkout still runs
+// `go test ./...` without Postgres.
+func adminConn(t *testing.T) (*sql.DB, dbconfig.Config) {
+	t.Helper()
+
+	db := LoadDBConfigFromEnv()
+	conn, err := sql.Open("postgres", adminConnString(db))
+	if err != nil {
+		t.Skipf("no admin connection: %v", err)
+	}
+	if err := conn.PingContext(context.Background()); err != nil {
+		_ = conn.Close()
+		t.Skipf("no Postgres at %s:%s: %v", db.Host, db.Port, err)
+	}
+	t.Cleanup(func() {
+		require.NoError(t, conn.Close())
+	})
+	return conn, db
+}
+
+// buildTemplate creates a database carrying one marker table and marks it as a
+// template, mirroring what CI does with the real migration set.
+func buildTemplate(t *testing.T, conn *sql.DB, db dbconfig.Config) string {
+	t.Helper()
+
+	name := sanitizeDBName("itf_tpl_" + uuid.New().String()[:8])
+	CreateDB(name, db)
+	t.Cleanup(func() {
+		_, _ = conn.ExecContext(context.Background(),
+			"UPDATE pg_database SET datistemplate = false WHERE datname = $1", name)
+		require.NoError(t, DropDB(name, db))
+	})
+
+	seed, err := sql.Open("postgres", DBOpts(name, db))
+	require.NoError(t, err)
+	_, err = seed.ExecContext(context.Background(), "CREATE TABLE template_marker (id int primary key)")
+	require.NoError(t, err)
+	_, err = seed.ExecContext(context.Background(), "INSERT INTO template_marker (id) VALUES (42)")
+	require.NoError(t, err)
+	// Postgres refuses to clone a database that still has connections open.
+	require.NoError(t, seed.Close())
+
+	_, err = conn.ExecContext(context.Background(),
+		"UPDATE pg_database SET datistemplate = true WHERE datname = $1", name)
+	require.NoError(t, err)
+
+	return name
+}
+
+func TestCreateDBFromTemplate_CopiesSchema(t *testing.T) {
+	conn, db := adminConn(t)
+	template := buildTemplate(t, conn, db)
+
+	clone := sanitizeDBName("itf_clone_" + uuid.New().String()[:8])
+	require.NoError(t, CreateDBFromTemplateE(clone, template, db))
+	t.Cleanup(func() { require.NoError(t, DropDB(clone, db)) })
+
+	cloneConn, err := sql.Open("postgres", DBOpts(clone, db))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, cloneConn.Close()) }()
+
+	var id int
+	require.NoError(t, cloneConn.QueryRowContext(context.Background(),
+		"SELECT id FROM template_marker").Scan(&id))
+	require.Equal(t, 42, id)
+}
+
+// Concurrent clones of one template are the normal case under `go test -p 8`:
+// Postgres locks the source out for the duration of each copy, so without the
+// advisory lock and the busy retry they fail with "source database is being
+// accessed by other users".
+func TestCreateDBFromTemplate_ConcurrentClones(t *testing.T) {
+	conn, db := adminConn(t)
+	template := buildTemplate(t, conn, db)
+
+	const clones = 6
+	errs := make([]error, clones)
+	names := make([]string, clones)
+
+	var wg sync.WaitGroup
+	for i := range clones {
+		names[i] = sanitizeDBName(fmt.Sprintf("itf_par_%s_%d", uuid.New().String()[:8], i))
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs[i] = CreateDBFromTemplateE(names[i], template, db)
+		}()
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "clone %d", i)
+		require.NoError(t, DropDB(names[i], db))
+	}
+}
+
+func TestCreateDBFromTemplate_MissingTemplateIsLoud(t *testing.T) {
+	_, db := adminConn(t)
+
+	err := CreateDBFromTemplateE(
+		sanitizeDBName("itf_missing_"+uuid.New().String()[:8]),
+		"itf_template_that_does_not_exist",
+		db,
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not exist")
+	require.Contains(t, err.Error(), TemplateDBEnv)
+}
+
+func TestNormalizeHarnessConfig_TemplateFromEnv(t *testing.T) {
+	t.Setenv(TemplateDBEnv, "some_template")
+
+	cfg := normalizeHarnessConfig(t, HarnessConfig{Name: "x"})
+	require.Equal(t, "some_template", cfg.Migration.TemplateDB)
+
+	explicit := normalizeHarnessConfig(t, HarnessConfig{
+		Name:      "x",
+		Migration: MigrationConfig{TemplateDB: "explicit"},
+	})
+	require.Equal(t, "explicit", explicit.Migration.TemplateDB)
+}
+
+func TestBuildHarnessKey_SeparatesTemplates(t *testing.T) {
+	t.Parallel()
+
+	base := HarnessConfig{Name: "x"}
+	withTemplate := HarnessConfig{Name: "x", Migration: MigrationConfig{TemplateDB: "tpl"}}
+
+	require.NotEqual(t, buildHarnessKey(base), buildHarnessKey(withTemplate))
+}

--- a/pkg/itf/template_test.go
+++ b/pkg/itf/template_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/dbconfig"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -122,17 +124,119 @@ func TestCreateDBFromTemplate_MissingTemplateIsLoud(t *testing.T) {
 	require.Contains(t, err.Error(), TemplateDBEnv)
 }
 
-func TestNormalizeHarnessConfig_TemplateFromEnv(t *testing.T) {
-	t.Setenv(TemplateDBEnv, "some_template")
+func TestNormalizeHarnessConfig_TemplatePrecedence(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		env   string
+		given MigrationConfig
+		want  string
+	}{
+		{
+			name:  "environment supplies the template when the config is silent",
+			env:   "some_template",
+			given: MigrationConfig{},
+			want:  "some_template",
+		},
+		{
+			name:  "an explicit template wins over the environment",
+			env:   "some_template",
+			given: MigrationConfig{TemplateDB: "explicit"},
+			want:  "explicit",
+		},
+		{
+			name:  "no environment and no config means no cloning",
+			env:   "",
+			given: MigrationConfig{},
+			want:  "",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(TemplateDBEnv, tt.env)
 
-	cfg := normalizeHarnessConfig(t, HarnessConfig{Name: "x"})
-	require.Equal(t, "some_template", cfg.Migration.TemplateDB)
+			cfg := normalizeHarnessConfig(t, HarnessConfig{Name: "x", Migration: tt.given})
 
-	explicit := normalizeHarnessConfig(t, HarnessConfig{
-		Name:      "x",
-		Migration: MigrationConfig{TemplateDB: "explicit"},
-	})
-	require.Equal(t, "explicit", explicit.Migration.TemplateDB)
+			assert.Equal(t, tt.want, cfg.Migration.TemplateDB)
+		})
+	}
+}
+
+// MigrationSkip only became reachable with cloning: before it, every harness
+// started from an empty database and the readiness probe could not pass. These
+// two cases are the contract - a clone of a migrated template satisfies the
+// policy, a clone of one without migration bookkeeping is refused loudly rather
+// than handing the suite a half-built schema.
+func TestMigrationSkip_AcceptsAClonedTemplate(t *testing.T) {
+	conn, db := adminConn(t)
+
+	for _, tt := range []struct {
+		name      string
+		migrated  bool
+		assertErr func(t *testing.T, err error)
+	}{
+		{
+			name:     "a template carrying gorp_migrations is ready",
+			migrated: true,
+			assertErr: func(t *testing.T, err error) {
+				t.Helper()
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name:     "a template without gorp_migrations is refused",
+			migrated: false,
+			assertErr: func(t *testing.T, err error) {
+				t.Helper()
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "gorp_migrations")
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			template := buildTemplate(t, conn, db)
+			if tt.migrated {
+				markTemplateMigrated(t, conn, db, template)
+			}
+
+			clone := sanitizeDBName("itf_skip_" + uuid.New().String()[:8])
+			require.NoError(t, CreateDBFromTemplateE(clone, template, db))
+			t.Cleanup(func() { require.NoError(t, DropDB(clone, db)) })
+
+			ctx := context.Background()
+			pool, err := pgxpool.New(ctx, DBOpts(clone, db))
+			require.NoError(t, err)
+			t.Cleanup(pool.Close)
+
+			err = runMigrationPolicy(ctx, pool, nil, MigrationConfig{
+				Policy:     MigrationSkip,
+				TemplateDB: template,
+			})
+
+			tt.assertErr(t, err)
+		})
+	}
+}
+
+// markTemplateMigrated gives a template the bookkeeping table the readiness
+// probe looks for. It has to unmark and re-mark the template: Postgres refuses
+// connections to a database while datistemplate is set.
+func markTemplateMigrated(t *testing.T, conn *sql.DB, db dbconfig.Config, template string) {
+	t.Helper()
+
+	ctx := context.Background()
+	_, err := conn.ExecContext(ctx,
+		"UPDATE pg_database SET datistemplate = false WHERE datname = $1", template)
+	require.NoError(t, err)
+
+	seed, err := sql.Open("postgres", DBOpts(template, db))
+	require.NoError(t, err)
+	_, err = seed.ExecContext(ctx,
+		"CREATE TABLE gorp_migrations (id text primary key, applied_at timestamptz)")
+	require.NoError(t, err)
+	require.NoError(t, seed.Close())
+
+	_, err = conn.ExecContext(ctx,
+		"UPDATE pg_database SET datistemplate = true WHERE datname = $1", template)
+	require.NoError(t, err)
 }
 
 func TestBuildHarnessKey_SeparatesTemplates(t *testing.T) {

--- a/pkg/itf/utils.go
+++ b/pkg/itf/utils.go
@@ -282,7 +282,7 @@ func CreateDBFromTemplate(name, template string, db dbconfig.Config) {
 	// `duplicate key value violates unique constraint "pg_database_datname_index"`.
 	// The lock is held for a single catalog operation (milliseconds), unlike
 	// the migration lock, which spans a whole migration run.
-	err = withAdvisoryLock(db, createDatabaseAdvisoryLockKey, "create database", func() error {
+	err = withAdvisoryLock(db, createDatabaseAdvisoryLockKey, "create database", lockRequired, func() error {
 		if _, err := conn.ExecContext(context.Background(), fmt.Sprintf(`DROP DATABASE IF EXISTS "%s"`, sanitizedName)); err != nil {
 			return err
 		}
@@ -408,19 +408,52 @@ func dropDB(name string, db dbconfig.Config) error {
 // effort) so a transient lock hiccup degrades to prior behavior rather than
 // failing the whole test run.
 func withMigrationAdvisoryLock(db dbconfig.Config, fn func() error) error {
-	return withAdvisoryLock(db, migrationAdvisoryLockKey, "migration", fn)
+	return withAdvisoryLock(db, migrationAdvisoryLockKey, "migration", lockBestEffort, fn)
 }
+
+// Whether a caller can survive running fn without the lock. Migrations are
+// idempotent under the migrator's own bookkeeping, so an unlocked run degrades
+// to the pre-lock behaviour - noisy, occasionally racy, but not destructive.
+// DROP DATABASE + CREATE DATABASE is neither: two harnesses interleaving there
+// replace each other's database out from under a running test. Anything that
+// rewrites the catalog must fail rather than proceed unserialized.
+const (
+	lockBestEffort = false
+	lockRequired   = true
+)
+
+// advisoryLockAcquireTimeout bounds only the WAIT for the lock, never the work
+// done under it. Without it a lock leaked by a crashed sibling turns into a
+// test binary that hangs until the go test timeout kills it with no
+// explanation. The bound is generous because the migration path legitimately
+// holds the lock for a full migration replay per waiting harness.
+const advisoryLockAcquireTimeout = 5 * time.Minute
 
 // withAdvisoryLock runs fn while holding a session-level Postgres advisory lock
 // with the given key. label appears in the warnings emitted on the degraded
 // paths. See [withMigrationAdvisoryLock] for why the lock is taken on the
 // shared admin database rather than the caller's own.
-func withAdvisoryLock(db dbconfig.Config, key int64, label string, fn func() error) error {
+//
+// required decides what happens when the lock cannot be taken: with
+// lockBestEffort fn runs unlocked and the failure is only logged; with
+// lockRequired the error is returned and fn never runs.
+func withAdvisoryLock(db dbconfig.Config, key int64, label string, required bool, fn func() error) error {
 	ctx := context.Background()
+
+	degrade := func(stage string, cause error) error {
+		if required {
+			return serrors.E(
+				serrors.Op("itf.withAdvisoryLock"),
+				fmt.Errorf("%s advisory lock: %s: %w", label, stage, cause),
+			)
+		}
+		log.Printf("[WARNING] %s advisory lock: %s, running unlocked: %v", label, stage, cause)
+		return fn()
+	}
+
 	sqlDB, err := sql.Open("postgres", adminConnString(db))
 	if err != nil {
-		log.Printf("[WARNING] %s advisory lock: open admin connection failed, running unlocked: %v", label, err)
-		return fn()
+		return degrade("open admin connection failed", err)
 	}
 	defer func() {
 		if cerr := sqlDB.Close(); cerr != nil {
@@ -432,8 +465,7 @@ func withAdvisoryLock(db dbconfig.Config, key int64, label string, fn func() err
 	// released on the SAME connection, which a pool would not guarantee.
 	conn, err := sqlDB.Conn(ctx)
 	if err != nil {
-		log.Printf("[WARNING] %s advisory lock: pin connection failed, running unlocked: %v", label, err)
-		return fn()
+		return degrade("pin connection failed", err)
 	}
 	defer func() {
 		if cerr := conn.Close(); cerr != nil {
@@ -441,9 +473,10 @@ func withAdvisoryLock(db dbconfig.Config, key int64, label string, fn func() err
 		}
 	}()
 
-	if _, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", key); err != nil {
-		log.Printf("[WARNING] %s advisory lock: acquire failed, running unlocked: %v", label, err)
-		return fn()
+	acquireCtx, cancel := context.WithTimeout(ctx, advisoryLockAcquireTimeout)
+	defer cancel()
+	if _, err := conn.ExecContext(acquireCtx, "SELECT pg_advisory_lock($1)", key); err != nil {
+		return degrade("acquire failed", err)
 	}
 	defer func() {
 		if _, uerr := conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", key); uerr != nil {

--- a/pkg/itf/utils.go
+++ b/pkg/itf/utils.go
@@ -241,11 +241,22 @@ func intelligentTruncate(name string, maxLength int) string {
 
 // CreateDB creates a test database using an explicit dbconfig.Config for the admin connection.
 func CreateDB(name string, db dbconfig.Config) {
+	CreateDBFromTemplate(name, "", db)
+}
+
+// CreateDBFromTemplate creates a test database, cloning it from template when
+// template is non-empty. Cloning replaces a migration replay (~1s) with a
+// catalog-level copy (~10ms); see [MigrationConfig.TemplateDB] for how the
+// harness picks the template up.
+//
+// The template database must exist and must have no open connections: Postgres
+// refuses CREATE DATABASE ... TEMPLATE while anything is connected to the
+// source. The harness never opens a pool against the template, so the only
+// realistic contender is another clone in flight, which the advisory lock below
+// serializes.
+func CreateDBFromTemplate(name, template string, db dbconfig.Config) {
 	sanitizedName := sanitizeDBName(name)
-	adminConnStr := fmt.Sprintf(
-		"host=%s port=%s user=%s dbname=postgres password=%s sslmode=disable",
-		db.Host, db.Port, db.User, db.Password,
-	)
+	adminConnStr := adminConnString(db)
 	conn, err := sql.Open("postgres", adminConnStr)
 	if err != nil {
 		panic(err)
@@ -255,25 +266,99 @@ func CreateDB(name string, db dbconfig.Config) {
 			log.Printf("[WARNING] Error closing CreateDB connection: %v", err)
 		}
 	}()
-	_, err = conn.ExecContext(context.Background(), fmt.Sprintf(`DROP DATABASE IF EXISTS "%s"`, sanitizedName))
-	if err != nil {
-		panic(err)
+
+	create := fmt.Sprintf(`CREATE DATABASE "%s"`, sanitizedName)
+	if template != "" {
+		sanitizedTemplate := sanitizeDBName(template)
+		if err := assertTemplateExists(conn, sanitizedTemplate); err != nil {
+			panic(err)
+		}
+		create = fmt.Sprintf(`CREATE DATABASE "%s" TEMPLATE "%s"`, sanitizedName, sanitizedTemplate)
 	}
-	_, err = conn.ExecContext(context.Background(), fmt.Sprintf(`CREATE DATABASE "%s"`, sanitizedName))
+
+	// DROP + CREATE is not atomic, and shared-per-package harnesses in sibling
+	// test binaries derive the SAME database name from the same config. Without
+	// this lock they interleave into
+	// `duplicate key value violates unique constraint "pg_database_datname_index"`.
+	// The lock is held for a single catalog operation (milliseconds), unlike
+	// the migration lock, which spans a whole migration run.
+	err = withAdvisoryLock(db, createDatabaseAdvisoryLockKey, "create database", func() error {
+		if _, err := conn.ExecContext(context.Background(), fmt.Sprintf(`DROP DATABASE IF EXISTS "%s"`, sanitizedName)); err != nil {
+			return err
+		}
+		return execWithTemplateRetry(conn, create)
+	})
 	if err != nil {
 		panic(err)
 	}
 }
 
 // CreateDBE creates a test database and returns an error instead of panicking.
-func CreateDBE(name string, db dbconfig.Config) (err error) {
+func CreateDBE(name string, db dbconfig.Config) error {
+	return CreateDBFromTemplateE(name, "", db)
+}
+
+// CreateDBFromTemplateE is [CreateDBFromTemplate] returning an error instead of
+// panicking.
+func CreateDBFromTemplateE(name, template string, db dbconfig.Config) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			err = serrors.E(opCreateDBE, fmt.Errorf("failed to create test database %q: %v", sanitizeDBName(name), r))
 		}
 	}()
-	CreateDB(name, db)
+	CreateDBFromTemplate(name, template, db)
 	return nil
+}
+
+func adminConnString(db dbconfig.Config) string {
+	return fmt.Sprintf(
+		"host=%s port=%s user=%s dbname=postgres password=%s sslmode=disable",
+		db.Host, db.Port, db.User, db.Password,
+	)
+}
+
+// assertTemplateExists fails loudly rather than silently producing an empty
+// database: a misspelled or not-yet-built template would otherwise surface much
+// later as "schema not ready", or as hundreds of "relation does not exist".
+func assertTemplateExists(conn *sql.DB, template string) error {
+	var exists bool
+	err := conn.QueryRowContext(
+		context.Background(),
+		"SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)",
+		template,
+	).Scan(&exists)
+	if err != nil {
+		return fmt.Errorf("probe template database %q: %w", template, err)
+	}
+	if !exists {
+		return fmt.Errorf(
+			"template database %q does not exist; build it before running tests or unset %s",
+			template, TemplateDBEnv,
+		)
+	}
+	return nil
+}
+
+// execWithTemplateRetry retries the transient "source database is being
+// accessed by other users" that Postgres raises when a clone starts while
+// another backend still holds a connection to the template. The advisory lock
+// removes the common case (a sibling clone); this covers stragglers such as a
+// connection that has not finished tearing down yet.
+func execWithTemplateRetry(conn *sql.DB, stmt string) error {
+	const attempts = 5
+	var err error
+	for attempt := range attempts {
+		_, err = conn.ExecContext(context.Background(), stmt)
+		if err == nil || !isSourceDatabaseBusy(err) {
+			return err
+		}
+		time.Sleep(time.Duration(attempt+1) * 100 * time.Millisecond)
+	}
+	return err
+}
+
+func isSourceDatabaseBusy(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "is being accessed by other users")
 }
 
 // DropDB drops a test database. Used for cleanup after tests to free disk space.
@@ -323,20 +408,23 @@ func dropDB(name string, db dbconfig.Config) error {
 // effort) so a transient lock hiccup degrades to prior behavior rather than
 // failing the whole test run.
 func withMigrationAdvisoryLock(db dbconfig.Config, fn func() error) error {
-	ctx := context.Background()
-	adminConnStr := fmt.Sprintf(
-		"host=%s port=%s user=%s dbname=postgres password=%s sslmode=disable",
-		db.Host, db.Port, db.User, db.Password,
-	)
+	return withAdvisoryLock(db, migrationAdvisoryLockKey, "migration", fn)
+}
 
-	sqlDB, err := sql.Open("postgres", adminConnStr)
+// withAdvisoryLock runs fn while holding a session-level Postgres advisory lock
+// with the given key. label appears in the warnings emitted on the degraded
+// paths. See [withMigrationAdvisoryLock] for why the lock is taken on the
+// shared admin database rather than the caller's own.
+func withAdvisoryLock(db dbconfig.Config, key int64, label string, fn func() error) error {
+	ctx := context.Background()
+	sqlDB, err := sql.Open("postgres", adminConnString(db))
 	if err != nil {
-		log.Printf("[WARNING] migration advisory lock: open admin connection failed, running unlocked: %v", err)
+		log.Printf("[WARNING] %s advisory lock: open admin connection failed, running unlocked: %v", label, err)
 		return fn()
 	}
 	defer func() {
 		if cerr := sqlDB.Close(); cerr != nil {
-			log.Printf("[WARNING] migration advisory lock: closing admin pool: %v", cerr)
+			log.Printf("[WARNING] %s advisory lock: closing admin pool: %v", label, cerr)
 		}
 	}()
 
@@ -344,22 +432,22 @@ func withMigrationAdvisoryLock(db dbconfig.Config, fn func() error) error {
 	// released on the SAME connection, which a pool would not guarantee.
 	conn, err := sqlDB.Conn(ctx)
 	if err != nil {
-		log.Printf("[WARNING] migration advisory lock: pin connection failed, running unlocked: %v", err)
+		log.Printf("[WARNING] %s advisory lock: pin connection failed, running unlocked: %v", label, err)
 		return fn()
 	}
 	defer func() {
 		if cerr := conn.Close(); cerr != nil {
-			log.Printf("[WARNING] migration advisory lock: closing pinned connection: %v", cerr)
+			log.Printf("[WARNING] %s advisory lock: closing pinned connection: %v", label, cerr)
 		}
 	}()
 
-	if _, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", migrationAdvisoryLockKey); err != nil {
-		log.Printf("[WARNING] migration advisory lock: acquire failed, running unlocked: %v", err)
+	if _, err := conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", key); err != nil {
+		log.Printf("[WARNING] %s advisory lock: acquire failed, running unlocked: %v", label, err)
 		return fn()
 	}
 	defer func() {
-		if _, uerr := conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", migrationAdvisoryLockKey); uerr != nil {
-			log.Printf("[WARNING] migration advisory lock: release failed: %v", uerr)
+		if _, uerr := conn.ExecContext(ctx, "SELECT pg_advisory_unlock($1)", key); uerr != nil {
+			log.Printf("[WARNING] %s advisory lock: release failed: %v", label, uerr)
 		}
 	}()
 


### PR DESCRIPTION
## Problem

Every ITF harness provisions its own database, and that database starts empty:
`app.Migrations().Run()` replays the whole migration set into it. Because
migrations touch cluster-global catalog objects (roles, and the settings and
grants hung off them), the run is wrapped in a session advisory lock on the
shared `postgres` database — held for the *entire* run. So the cost is not just
~1s per harness, it is ~1s per harness *serialized across every parallel test
binary*.

`MigrationSkip` was written as the escape hatch and has never been reachable:
`createHarnessState` always creates an empty database, so the
`public.gorp_migrations` probe behind `MigrationSkip` cannot pass. It was
designed against a second half that was never written.

## Change

`ITF_TEMPLATE_DB` names a pre-migrated database. When it is set, the harness
clones it — `CREATE DATABASE … TEMPLATE …` — instead of creating an empty one.

```bash
createdb itf_template
DB_NAME=itf_template go run cmd/command/main.go migrate up
psql -d postgres -c "UPDATE pg_database SET datistemplate = true WHERE datname = 'itf_template'"

ITF_TEMPLATE_DB=itf_template go test ./...
```

Per-suite override: `itf.WithTemplateDatabase("other")`, or
`HarnessConfig.Migration.TemplateDB`.

## Measurement

`modules/{core/infrastructure/persistence, core/infrastructure/query,
core/services, finance/infrastructure/persistence,
warehouse/infrastructure/persistence}`, `-p 8`, local PG 17, all green both ways:

| | wall-clock |
| --- | --- |
| without template | **29.7s** |
| with template | **7.4s** |

Single package (`core/infrastructure/persistence`): 4.76s → 0.92s.

## Design notes

**Cloning is orthogonal to the migration policy.** With the default
`MigrationApplyOnce` the migrator still runs over the clone — it plans zero
migrations, so it costs almost nothing, and it *repairs* a template built before
the newest migration landed. `MigrationSkip` drops even that probe, trusting the
template to be current. This is why no caller has to change anything: setting one
env var in CI is the whole adoption story, and staleness is self-healing rather
than a footgun.

**A second, short advisory lock** now guards `DROP` + `CREATE DATABASE`. Two
distinct hazards share it:

- Postgres refuses to clone a database that has any open connection, so
  concurrent clones of one template collide.
- Shared-per-package harnesses in sibling test binaries derive the *same*
  database name from the same config and collided on
  `pg_database_datname_index`. That race predates this PR — it is visible today
  as sporadic `duplicate key value violates unique constraint
  "pg_database_datname_index"` — and this lock closes it.

It is held for a single catalog statement (milliseconds), unlike the migration
lock which spans a whole run. Stragglers that still slip past are retried on
`source database is being accessed by other users`.

**A missing template fails loudly** at creation, naming the env var, rather than
surfacing later as "schema not ready" or a wall of "relation does not exist".

**The template carries schema only.** `CREATE DATABASE … TEMPLATE` does not copy
cluster-global objects — roles, their settings, their grants — so the template
must be built against the same cluster the tests run on. Extensions and RLS
policies are database-local and do come across. This is now documented in
`pkg/itf/README.md`; there was no warning about it anywhere before.

**Unset is the default**, so a clean checkout still runs `go test ./...` with no
preparation.

## Tests

`pkg/itf/template_test.go` — schema is copied, six concurrent clones of one
template all succeed, a missing template errors clearly, env fallback and
harness-key separation. The DB-backed cases skip when no cluster is reachable.

Not in this PR: flipping the SDK's own CI suite over to cloning. The capability
and its coverage land here; switching the whole suite is a behavioural change
that deserves its own before/after run.

Drive-by: the advisory-lock comment cited `changes-1997500070.sql`, which does
not exist — the `ai_readonly` role is created in `changes-1997500670.sql`.

Closes #1018

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789378517&installation_model_id=2042&pr_number=1019&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1019&signature=d95971e5f8ca69550246f67de4a91a41d5805e91511eb814c2906e8000129931"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for cloning test databases from a pre-migrated PostgreSQL template.
  * Added configuration through `ITF_TEMPLATE_DB` and per-test template database selection.
  * Preserved existing migration policies while improving harness provisioning performance.
  * Added safeguards for concurrent database creation and clearer errors for unavailable templates.

* **Documentation**
  * Added setup guidance, configuration options, performance details, and template database requirements.

* **Tests**
  * Added coverage for cloning, schema copying, concurrency, invalid templates, and configuration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->