### PR TITLE
fix(billing): cancelling a checkout stops the link instead of panicking

### DIFF
--- a/modules/billing/infrastructure/providers/click_provider.go
+++ b/modules/billing/infrastructure/providers/click_provider.go
@@ -114,9 +114,34 @@ func (p *clickProvider) Create(_ context.Context, t billing.Transaction) (billin
 	return t, nil
 }
 
-func (p *clickProvider) Cancel(ctx context.Context, t billing.Transaction) (billing.Transaction, error) {
-	//TODO implement me
-	panic("implement me")
+// ErrClickCancelAfterPayment is returned when a merchant asks to cancel an
+// invoice Click has already paid. Click identifies a captured payment by its
+// payment id, and sending that money back is a reversal — Refund below — not a
+// cancellation.
+var ErrClickCancelAfterPayment = errors.New("click payment is captured; cancelling it would be a reversal")
+
+// Cancel abandons an invoice the customer has not paid, and does so without
+// calling Click.
+//
+// Click has no endpoint for it: the merchant API covers preparing, confirming
+// and reversing a *payment*, and an invoice nobody paid is not yet a payment —
+// it is a link carrying a service id and a merchant transaction id. The only
+// thing a merchant can withdraw is its own willingness to accept the callback,
+// which is what this status does.
+//
+// A captured payment is refused rather than voided (ErrClickCancelAfterPayment):
+// its money exists, and pretending otherwise is how a reversal gets skipped.
+func (p *clickProvider) Cancel(_ context.Context, t billing.Transaction) (billing.Transaction, error) {
+	clickDetails, err := toClickDetails(t.Details())
+	if err != nil {
+		return nil, err
+	}
+
+	if clickDetails.PaymentID() != 0 || t.Status() == billing.Completed {
+		return nil, ErrClickCancelAfterPayment
+	}
+
+	return t.SetStatus(billing.Canceled), nil
 }
 
 // Refund reverses a completed Click payment through the Merchant API.

--- a/modules/billing/infrastructure/providers/click_provider_test.go
+++ b/modules/billing/infrastructure/providers/click_provider_test.go
@@ -187,3 +187,40 @@ func TestClickRefundTreatsANonJSONErrorPageAsAFailure(t *testing.T) {
 	// A transport failure is not a gateway refusal.
 	require.NotErrorAs(t, err, &providers.ClickReversalError{})
 }
+
+// Cancelling an unpaid invoice is the merchant withdrawing a link, and Click
+// has no endpoint for it — the merchant API only prepares, confirms and
+// reverses a payment. What the caller needs is the status, because that is what
+// stops the invoice being honoured.
+func TestClickCancelAbandonsAnUnpaidInvoice(t *testing.T) {
+	t.Parallel()
+
+	unpaid := billing.New(1920.0, billing.UZS, billing.Click,
+		details.NewClickDetails("sale-1",
+			details.ClickWithServiceID(testServiceID),
+			details.ClickWithMerchantUserID(testMerchantUserID),
+		))
+
+	provider, _ := clickProvider(t, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("cancelling an unpaid invoice must not call Click")
+	})
+
+	cancelled, err := provider.Cancel(context.Background(), unpaid)
+	require.NoError(t, err)
+	require.Equal(t, billing.Canceled, cancelled.Status())
+	require.False(t, cancelled.Status().IsActive())
+}
+
+// A payment id means Click took the money. Marking that transaction cancelled
+// would leave captured funds recorded as never taken, and the reversal that
+// should have been asked for never happens.
+func TestClickCancelRefusesACapturedPayment(t *testing.T) {
+	t.Parallel()
+
+	provider, _ := clickProvider(t, func(http.ResponseWriter, *http.Request) {
+		t.Fatal("a refused cancellation must not call Click")
+	})
+
+	_, err := provider.Cancel(context.Background(), clickTransaction(t, 1920.0))
+	require.ErrorIs(t, err, providers.ErrClickCancelAfterPayment)
+}

--- a/modules/billing/infrastructure/providers/payme_provider.go
+++ b/modules/billing/infrastructure/providers/payme_provider.go
@@ -90,12 +90,14 @@ var ErrPaymeCancelAfterCompletion = errors.New("payme transaction is completed; 
 // being allowed to pay something the sale has moved on from.
 //
 // A transaction Payme already created and performed is deliberately refused
-// rather than voided — see ErrPaymeCancelAfterCompletion. What this does not
-// promise is that money cannot still arrive: a customer who created the
-// transaction before the cancellation can still perform it, because
-// PerformTransaction resolves by transaction id and does not consult the
-// status. Handling that captured payment belongs to the caller, and refusing
-// it is not an option — it is how "the customer paid and got nothing" happens.
+// rather than voided — see ErrPaymeCancelAfterCompletion.
+//
+// The customer who opened their transaction *before* the cancellation is the
+// case this leaves to PaymeController.perform: a perform resolves by
+// transaction id, so nothing here can stop the call arriving. What the state
+// written below does is give that handler something to refuse on, and it
+// refuses — an unconfirmed perform is money Payme returns, whereas accepting it
+// is money taken for an order that has moved on.
 func (p *paymeProvider) Cancel(_ context.Context, t billing.Transaction) (billing.Transaction, error) {
 	paymeDetails, err := toPaymeDetails(t.Details())
 	if err != nil {

--- a/modules/billing/infrastructure/providers/payme_provider.go
+++ b/modules/billing/infrastructure/providers/payme_provider.go
@@ -4,8 +4,10 @@ package providers
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/iota-uz/iota-sdk/modules/billing/domain/aggregates/billing"
 	"github.com/iota-uz/iota-sdk/modules/billing/domain/aggregates/details"
@@ -69,9 +71,52 @@ func (p *paymeProvider) Create(_ context.Context, t billing.Transaction) (billin
 	return t, nil
 }
 
+// ErrPaymeCancelAfterCompletion is returned when a merchant asks to cancel a
+// transaction Payme has already completed. Sending that money back is a
+// refund, and Payme models it as its own operation with its own reason code —
+// treating it as a cancellation here would mark captured money as never taken.
+var ErrPaymeCancelAfterCompletion = errors.New("payme transaction is completed; cancelling it would be a refund")
+
+// Cancel voids a checkout the customer has not paid, and does so without
+// calling Payme.
+//
+// That is not a shortcut: Payme's merchant protocol has no cancel a merchant
+// can send. Every transaction operation is Payme calling us —
+// CreateTransaction, PerformTransaction, CancelTransaction — so the only thing
+// a merchant can do about a link nobody used is stop honouring it. Which is
+// exactly what this does: the transaction leaves the active set, and
+// PaymeController.create resolves an account through activePaymeTransaction, so
+// a customer opening the old link is answered with InvalidAccount instead of
+// being allowed to pay something the sale has moved on from.
+//
+// A transaction Payme already created and performed is deliberately refused
+// rather than voided — see ErrPaymeCancelAfterCompletion. What this does not
+// promise is that money cannot still arrive: a customer who created the
+// transaction before the cancellation can still perform it, because
+// PerformTransaction resolves by transaction id and does not consult the
+// status. Handling that captured payment belongs to the caller, and refusing
+// it is not an option — it is how "the customer paid and got nothing" happens.
 func (p *paymeProvider) Cancel(_ context.Context, t billing.Transaction) (billing.Transaction, error) {
-	//TODO implement me
-	panic("implement me")
+	paymeDetails, err := toPaymeDetails(t.Details())
+	if err != nil {
+		return nil, err
+	}
+
+	if paymeDetails.State() == paymeapi.TransactionStateCompleted || t.Status() == billing.Completed {
+		return nil, ErrPaymeCancelAfterCompletion
+	}
+
+	if paymeDetails.CancelTime() == 0 {
+		paymeDetails = paymeDetails.SetCancelTime(time.Now().UnixMilli())
+	}
+
+	// Reason is left as Payme set it. Its vocabulary describes why *Payme*
+	// cancelled a transaction (recipient not found, debit error, timeout); a
+	// merchant abandoning its own checkout is none of those, and picking the
+	// nearest code would put a fact into the record that Payme never stated.
+	return t.
+		SetStatus(billing.Canceled).
+		SetDetails(paymeDetails.SetState(paymeapi.TransactionStateCancelledBeforeCompletion)), nil
 }
 
 func (p *paymeProvider) Refund(_ context.Context, t billing.Transaction, quantity float64) (billing.Transaction, error) {

--- a/modules/billing/infrastructure/providers/payme_provider_test.go
+++ b/modules/billing/infrastructure/providers/payme_provider_test.go
@@ -1,0 +1,73 @@
+package providers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/iota-uz/iota-sdk/modules/billing/domain/aggregates/billing"
+	"github.com/iota-uz/iota-sdk/modules/billing/domain/aggregates/details"
+	"github.com/iota-uz/iota-sdk/modules/billing/infrastructure/providers"
+	paymeapi "github.com/iota-uz/payme"
+)
+
+func paymeProvider() billing.Provider {
+	return providers.NewPaymeProvider(providers.PaymeConfig{
+		URL:        "https://checkout.test.paycom.uz",
+		MerchantID: "merchant-1",
+		User:       "Paycom",
+		SecretKey:  "secret",
+	})
+}
+
+func paymeTransaction(t *testing.T, opts ...details.PaymeOption) billing.Transaction {
+	t.Helper()
+
+	opts = append([]details.PaymeOption{
+		details.PaymeWithAccount(map[string]any{"order_id": "policy:1"}),
+	}, opts...)
+
+	return billing.New(1920.0, billing.UZS, billing.Payme, details.NewPaymeDetails("policy:1", opts...))
+}
+
+// Cancelling a minted checkout is what a merchant does when the customer moves
+// to another gateway, and the whole point of it is the state the transaction
+// leaves behind: PaymeController.create picks an account's transaction through
+// activePaymeTransaction, so only a status outside the active set makes the old
+// link stop being payable. Asserting the details' state alone would pass while
+// the transaction stayed active and the customer kept two live links.
+func TestPaymeCancelTakesTheTransactionOutOfTheActiveSet(t *testing.T) {
+	t.Parallel()
+
+	created, err := paymeProvider().Create(context.Background(), paymeTransaction(t))
+	require.NoError(t, err)
+	require.Equal(t, int32(paymeapi.TransactionStateCreated), created.Details().(details.PaymeDetails).State())
+
+	cancelled, err := paymeProvider().Cancel(context.Background(), created)
+	require.NoError(t, err)
+
+	require.Equal(t, billing.Canceled, cancelled.Status())
+	require.False(t, cancelled.Status().IsActive())
+
+	cancelledDetails := cancelled.Details().(details.PaymeDetails)
+	require.Equal(t, int32(paymeapi.TransactionStateCancelledBeforeCompletion), cancelledDetails.State())
+	require.NotZero(t, cancelledDetails.CancelTime())
+	// Payme's reason codes say why Payme cancelled something. A merchant
+	// abandoning its own checkout is not one of them, and inventing the nearest
+	// code would record a Payme decision that was never made.
+	require.Zero(t, cancelledDetails.Reason())
+}
+
+// A cancellation that arrives after the customer paid must not be answered by
+// marking captured money as never taken: that is a refund, and Payme gives it
+// its own operation and its own reason code.
+func TestPaymeCancelRefusesACompletedTransaction(t *testing.T) {
+	t.Parallel()
+
+	completed := paymeTransaction(t, details.PaymeWithState(paymeapi.TransactionStateCompleted)).
+		SetStatus(billing.Completed)
+
+	_, err := paymeProvider().Cancel(context.Background(), completed)
+	require.ErrorIs(t, err, providers.ErrPaymeCancelAfterCompletion)
+}

--- a/modules/billing/presentation/controllers/payme_controller.go
+++ b/modules/billing/presentation/controllers/payme_controller.go
@@ -549,6 +549,35 @@ func (c *PaymeController) perform(ctx context.Context, r *paymeapi.PerformTransa
 		return nil, &errRPC
 	}
 
+	// A perform resolves by transaction id alone, so nothing on Payme's side
+	// stops a customer paying a checkout the merchant has already stopped
+	// honouring — refusing it is the merchant's job, and the protocol says so:
+	// only states created and completed may be performed, everything else is
+	// terminal and answers -31008. Completed stays allowed because a repeated
+	// perform must be idempotent, not an error.
+	//
+	// Without this the transaction rides straight into InvokeCallback, whose
+	// host may well answer nil for a status it does not consider relevant, and
+	// a cancelled transaction is then stamped Completed: money accepted, with
+	// no order left to apply it to. Answering Payme with an error instead
+	// leaves the payment unconfirmed and Payme returns the funds.
+	//
+	// The refusal changes nothing on the transaction. It is already in the
+	// state it was cancelled into, and rewriting it here would overwrite the
+	// reason it carries.
+	switch {
+	case paymeDetails.State() != paymeapi.TransactionStateCreated &&
+		paymeDetails.State() != paymeapi.TransactionStateCompleted,
+		entity.Status() == billing.Canceled:
+		logger.WithFields(logrus.Fields{
+			"transaction_id": r.Id,
+			"state":          paymeDetails.State(),
+			"status":         entity.Status(),
+		}).Error("Transaction is no longer payable in PerformTransaction")
+		errRPC := paymeapi.PerformTransactionOperationNotAllowedError()
+		return nil, &errRPC
+	}
+
 	// Invoke callback to validate transaction
 	if err := c.billingService.InvokeCallback(ctx, entity); err != nil {
 		logger.WithError(err).WithField("transaction_id", r.Id).Error("Callback error in PerformTransaction")

--- a/modules/billing/presentation/controllers/payme_controller_test.go
+++ b/modules/billing/presentation/controllers/payme_controller_test.go
@@ -156,6 +156,104 @@ func TestPaymeController_CheckPerform_RejectsDuplicateActiveTransactions(t *test
 	assert.Equal(t, paymeapi.CheckPerformTransactionInvalidAccountError().Code, errRPC.Code)
 }
 
+// A customer can hold a checkout open across a cancellation: they opened their
+// transaction while the link was live and only pressed pay afterwards. Payme
+// resolves a perform by transaction id and never consults its state, so the
+// call arrives regardless — refusing it is the merchant's job, and answering
+// anything but an error means money accepted for an order that has moved on.
+func TestPaymeController_Perform_RefusesACancelledTransaction(t *testing.T) {
+	t.Parallel()
+
+	cancelled := newPaymeControllerTestTransaction(
+		billing.Canceled,
+		"cancelled-row",
+		details.PaymeWithID("payme-tx-1"),
+		details.PaymeWithState(paymeapi.TransactionStateCancelledBeforeCompletion),
+		details.PaymeWithReason(paymeapi.CancelReasonDebitError),
+	)
+	controller := newTestPaymePerformController(t, "payme-tx-1", cancelled, func(context.Context, billing.Transaction) error {
+		t.Fatal("a cancelled transaction must never reach the host callback")
+		return nil
+	}, func(billing.Transaction) {
+		t.Fatal("refusing a perform must not rewrite the transaction")
+	})
+
+	ctx := context.WithValue(context.Background(), constants.TxKey, struct{}{})
+	resp, errRPC := controller.perform(ctx, &paymeapi.PerformTransactionRequest{
+		Id: "payme-tx-1",
+	}, logrus.New().WithField("test", true))
+
+	require.Nil(t, resp)
+	require.NotNil(t, errRPC)
+	assert.Equal(t, paymeapi.PerformTransactionOperationNotAllowedError().Code, errRPC.Code)
+}
+
+// The other half of the same rule: a perform Payme repeats — because our answer
+// was lost, not because anything changed — must still be honoured, or Payme
+// keeps retrying a payment it has already taken.
+func TestPaymeController_Perform_StaysIdempotentOnACompletedTransaction(t *testing.T) {
+	t.Parallel()
+
+	completed := newPaymeControllerTestTransaction(
+		billing.Completed,
+		"completed-row",
+		details.PaymeWithID("payme-tx-1"),
+		details.PaymeWithState(paymeapi.TransactionStateCompleted),
+		details.PaymeWithPerformTime(1710000002000),
+	)
+	var invoked bool
+	controller := newTestPaymePerformController(t, "payme-tx-1", completed, func(context.Context, billing.Transaction) error {
+		invoked = true
+		return nil
+	}, nil)
+
+	ctx := context.WithValue(context.Background(), constants.TxKey, struct{}{})
+	resp, errRPC := controller.perform(ctx, &paymeapi.PerformTransactionRequest{
+		Id: "payme-tx-1",
+	}, logrus.New().WithField("test", true))
+
+	require.Nil(t, errRPC)
+	require.NotNil(t, resp)
+	assert.True(t, invoked)
+	assert.Equal(t, "completed-row", resp.Transaction)
+	assert.EqualValues(t, paymeapi.TransactionStateCompleted, resp.State)
+	assert.Equal(t, int64(1710000002000), resp.PerformTime)
+}
+
+func newTestPaymePerformController(
+	t *testing.T,
+	transactionID string,
+	transaction billing.Transaction,
+	callback billing.TransactionCallback,
+	onSave func(billing.Transaction),
+) *PaymeController {
+	t.Helper()
+
+	repo := &testBillingRepo{
+		getByDetailsFields: func(_ context.Context, gateway billing.Gateway, filters []billing.DetailsFieldFilter) ([]billing.Transaction, error) {
+			require.Equal(t, billing.Payme, gateway)
+			require.Equal(t, []billing.DetailsFieldFilter{{
+				Path:     []string{"id"},
+				Operator: billing.OpEqual,
+				Value:    transactionID,
+			}}, filters)
+
+			return []billing.Transaction{transaction}, nil
+		},
+		save: func(_ context.Context, tx billing.Transaction) (billing.Transaction, error) {
+			if onSave != nil {
+				onSave(tx)
+			}
+			return tx, nil
+		},
+	}
+
+	billingService := services.NewBillingService(repo, nil, noopEventBus{})
+	billingService.RegisterCallback(callback)
+
+	return &PaymeController{billingService: billingService}
+}
+
 func newTestPaymeController(
 	t *testing.T,
 	account map[string]any,


### PR DESCRIPTION
## What

`BillingService.Cancel` delegates to the gateway's provider whenever one is registered, and `paymeProvider.Cancel` / `clickProvider.Cancel` were both `panic("implement me")`. Every caller that supersedes an unpaid checkout — the common case being an operator handing the customer a link on a different gateway after the first one failed them — takes the request down with it.

Downstream this is a live P0: EAI's sales saga cancels the superseded intent inside the claim transaction, so switching the payment gateway on a sale answers the operator with a 500 (EAI-UZ/granite#4112).

## Why local, and not an API call

Neither gateway exposes a cancel a merchant can send.

- **Payme.** The whole transaction protocol is Payme calling us — `CreateTransaction`, `PerformTransaction`, `CancelTransaction`. A merchant cannot cancel; it can only stop honouring the link. Which is exactly what the status does: `PaymeController.create` resolves an account through `activePaymeTransaction`, so a cancelled transaction is no longer selectable and a customer opening the old link is answered `InvalidAccount`.
- **Click.** The merchant API prepares, confirms and reverses a *payment*. An invoice nobody paid is not a payment yet — it is a link carrying a service id and a merchant transaction id.

So cancellation is a local fact, and the transaction leaving the active set is the whole mechanism.

## What it refuses

A transaction whose money already arrived is refused, not voided (`ErrPaymeCancelAfterCompletion`, `ErrClickCancelAfterPayment`). That money exists; sending it back is a reversal, and recording it as never taken is how the reversal gets skipped.

Payme's `reason` is left untouched. Its vocabulary states why *Payme* cancelled something (recipient not found, debit error, timeout); a merchant abandoning its own checkout is none of those, and picking the nearest code would put a decision into the record that Payme never made.

## The other half: perform refuses too

Stopping the link being *started* is not the same as stopping it being *paid*. A customer who opened their transaction before the cancellation still holds a checkout, and `PerformTransaction` resolves by transaction id alone — it consulted neither the state nor the status, so the call went through, the transaction was stamped `Completed`, and the host was handed a status it does not consider relevant. That is money accepted for an order that has moved on, which is the failure the cancellation exists to prevent.

Payme's protocol makes refusing it the merchant's job: only states created and completed may be performed. `PaymeController.perform` now answers `-31008` for anything else, before the callback runs, and leaves the transaction exactly as the cancellation left it — reason included. An unconfirmed perform is money Payme returns. A repeated perform on a *completed* transaction stays idempotent, because Payme retries a call whose answer it lost.

One residual, not reachable in the wild: a perform on a transaction still in status `Created` — one where `CheckPerformTransaction` never ran — rides the same "status the host ignores" path. Real Payme always calls `CheckPerformTransaction` first.

## Not in scope

`octoProvider.Cancel` and `stripeProvider.Cancel` still panic. Octo exposes a real cancel endpoint, so a local-only status there would be a lie, and neither is reachable from the path this fixes.

## Tests

`payme_provider_test.go` (new) and two cases in `click_provider_test.go`: cancelling a minted checkout takes the transaction out of the active set with the right Payme state and a cancel time, and a captured payment is refused. The Click cases fail the test if the provider touches the network.

`payme_controller_test.go`: a perform on a cancelled transaction answers `-31008`, never reaches the host callback and never writes the transaction; a perform on a completed one still answers with its perform time. Both fail the test if the controller does otherwise.

End to end, through EAI's browser suite: sell a policy, take a Payme checkout, open the transaction, switch the sale to Click, then perform the old transaction (EAI-UZ/granite#4121). Before this commit that spec was green in the worst way — the perform succeeded and the money vanished.

`go test ./modules/billing/...` green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789382217&installation_model_id=2042&pr_number=1020&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1020&signature=6eeef0bfc4936307e13485f7829145b002d497be33209b0d0be686fa6779a223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added transaction cancellation support for Click and Payme payments.
  - Unpaid or incomplete transactions can now be canceled without contacting the payment provider.
  - Cancellations record the appropriate status, timestamp, and provider state.

- **Bug Fixes**
  - Prevented cancellation of completed or captured payments with clear errors.
  - Rejected invalid cancellation requests and disallowed operations on canceled transactions.
  - Preserved idempotent handling for completed transactions.

- **Tests**
  - Added coverage for successful cancellations and rejected cancellation or perform requests across both providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
