### PR TITLE
fix(itf): evict template stragglers and stop the clone lock convoy

### DIFF
--- a/pkg/itf/README.md
+++ b/pkg/itf/README.md
@@ -107,7 +107,7 @@ instead, at catalog speed:
 # once, before the suite (CI does this in a setup step)
 createdb itf_template
 DB_NAME=itf_template go run cmd/command/main.go migrate up
-psql -d postgres -c "UPDATE pg_database SET datistemplate = true WHERE datname = 'itf_template'"
+psql -d postgres -c "UPDATE pg_database SET datistemplate = true, datallowconn = false WHERE datname = 'itf_template'"
 
 # then
 ITF_TEMPLATE_DB=itf_template go test ./...
@@ -135,9 +135,14 @@ Notes:
   attached to them, live outside the database — so build the template against
   the same cluster the tests run on, and do not expect a migration that only
   ran into the template to have created the role its RLS policies reference.
-- **Nothing may be connected to the template.** Postgres refuses to clone a
-  database with open connections; the harness never opens a pool against it, and
-  serializes concurrent clones on an advisory lock.
+- **Nothing may be connected to the template — `datallowconn = false` is how
+  you guarantee it.** Postgres refuses to clone a database that any backend is
+  connected to, and the backend you forget about is autovacuum: it visits every
+  database on its own schedule, and at a few hundred clones per run it will
+  eventually land on the template. Marking the template the way `template0`
+  marks itself makes the collision impossible rather than rare. The harness also
+  evicts stragglers with `pg_terminate_backend` before each clone and retries
+  the residual race, but that is the safety net, not the design.
 - Per-suite override: `itf.WithTemplateDatabase("other_template")`, or
   `HarnessConfig.Migration.TemplateDB`.
 

--- a/pkg/itf/harness.go
+++ b/pkg/itf/harness.go
@@ -79,6 +79,11 @@ const (
 // and grants attached to them. Migrations that create them (the ai_readonly
 // ROLE behind the RLS policies, for one) therefore have to be run against the
 // same cluster the tests use, not just into the template.
+//
+// Set datallowconn = false on the template once it is built, the way template0
+// protects itself. CREATE DATABASE ... TEMPLATE fails outright while any
+// backend is connected to the source, and the backend nobody remembers is
+// autovacuum.
 const TemplateDBEnv = "ITF_TEMPLATE_DB"
 
 // migrationAdvisoryLockKey serializes migration application across processes.

--- a/pkg/itf/template_test.go
+++ b/pkg/itf/template_test.go
@@ -111,6 +111,37 @@ func TestCreateDBFromTemplate_ConcurrentClones(t *testing.T) {
 	}
 }
 
+// This is the failure that took down all four CI shards of the suite this
+// feature was built for: CREATE DATABASE ... TEMPLATE refuses to run while ANY
+// backend is connected to the source, and at a few hundred clones per run the
+// backend nobody remembers - autovacuum - eventually is that one. A clone must
+// evict stragglers instead of failing.
+//
+// The durable fix is datallowconn = false on the template; this covers the
+// templates that do not have it.
+func TestCreateDBFromTemplate_EvictsAStragglerOnTheTemplate(t *testing.T) {
+	conn, db := adminConn(t)
+	template := buildTemplate(t, conn, db)
+
+	straggler, err := sql.Open("postgres", DBOpts(template, db))
+	require.NoError(t, err)
+	require.NoError(t, straggler.PingContext(context.Background()))
+	t.Cleanup(func() { _ = straggler.Close() })
+
+	clone := sanitizeDBName("itf_evict_" + uuid.New().String()[:8])
+	require.NoError(t, CreateDBFromTemplateE(clone, template, db))
+	t.Cleanup(func() { require.NoError(t, DropDB(clone, db)) })
+
+	cloneConn, err := sql.Open("postgres", DBOpts(clone, db))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, cloneConn.Close()) })
+
+	var id int
+	require.NoError(t, cloneConn.QueryRowContext(context.Background(),
+		"SELECT id FROM template_marker").Scan(&id))
+	assert.Equal(t, 42, id)
+}
+
 func TestCreateDBFromTemplate_MissingTemplateIsLoud(t *testing.T) {
 	_, db := adminConn(t)
 

--- a/pkg/itf/utils.go
+++ b/pkg/itf/utils.go
@@ -268,8 +268,9 @@ func CreateDBFromTemplate(name, template string, db dbconfig.Config) {
 	}()
 
 	create := fmt.Sprintf(`CREATE DATABASE "%s"`, sanitizedName)
+	var sanitizedTemplate string
 	if template != "" {
-		sanitizedTemplate := sanitizeDBName(template)
+		sanitizedTemplate = sanitizeDBName(template)
 		if err := assertTemplateExists(conn, sanitizedTemplate); err != nil {
 			panic(err)
 		}
@@ -282,11 +283,32 @@ func CreateDBFromTemplate(name, template string, db dbconfig.Config) {
 	// `duplicate key value violates unique constraint "pg_database_datname_index"`.
 	// The lock is held for a single catalog operation (milliseconds), unlike
 	// the migration lock, which spans a whole migration run.
-	err = withAdvisoryLock(db, createDatabaseAdvisoryLockKey, "create database", lockRequired, func() error {
-		if _, err := conn.ExecContext(context.Background(), fmt.Sprintf(`DROP DATABASE IF EXISTS "%s"`, sanitizedName)); err != nil {
+	//
+	// The retry wraps the lock rather than sitting inside it. Sleeping while
+	// holding a cluster-wide lock turns one straggler into a convoy: every
+	// sibling harness queues behind the sleeper, and with `go test -p 8` across
+	// four CI shards the waits ran past the acquisition budget and came back as
+	// "canceling statement due to user request" - a lock bottleneck wearing the
+	// costume of a timeout.
+	err = retryWhileTemplateBusy(func() error {
+		return withAdvisoryLock(db, createDatabaseAdvisoryLockKey, "create database", lockRequired, func() error {
+			if sanitizedTemplate != "" {
+				// Postgres refuses to clone a database that anything is
+				// connected to, and "anything" includes an autovacuum worker
+				// that picked this moment to visit the template. Evicting them
+				// is what makes the clone deterministic; the retry below is
+				// only for the backend that connects between this statement
+				// and the next.
+				if err := terminateConnections(conn, sanitizedTemplate); err != nil {
+					return err
+				}
+			}
+			if _, err := conn.ExecContext(context.Background(), fmt.Sprintf(`DROP DATABASE IF EXISTS "%s"`, sanitizedName)); err != nil {
+				return err
+			}
+			_, err := conn.ExecContext(context.Background(), create)
 			return err
-		}
-		return execWithTemplateRetry(conn, create)
+		})
 	})
 	if err != nil {
 		panic(err)
@@ -339,21 +361,41 @@ func assertTemplateExists(conn *sql.DB, template string) error {
 	return nil
 }
 
-// execWithTemplateRetry retries the transient "source database is being
-// accessed by other users" that Postgres raises when a clone starts while
-// another backend still holds a connection to the template. The advisory lock
-// removes the common case (a sibling clone); this covers stragglers such as a
-// connection that has not finished tearing down yet.
-func execWithTemplateRetry(conn *sql.DB, stmt string) error {
-	const attempts = 5
+// retryWhileTemplateBusy retries "source database is being accessed by other
+// users", which Postgres raises when a clone starts while any backend still
+// holds a connection to the template.
+//
+// Terminating the template's backends removes the cause; this covers the one
+// case termination cannot, a backend that connects in the window between the
+// eviction and the CREATE. fn must take and release the lock itself, so the
+// backoff below is served without holding it.
+//
+// The durable fix belongs to whoever builds the template: `datallowconn =
+// false`, the way template0 does it, makes the race impossible instead of rare.
+func retryWhileTemplateBusy(fn func() error) error {
+	const attempts = 8
 	var err error
 	for attempt := range attempts {
-		_, err = conn.ExecContext(context.Background(), stmt)
+		err = fn()
 		if err == nil || !isSourceDatabaseBusy(err) {
 			return err
 		}
 		time.Sleep(time.Duration(attempt+1) * 100 * time.Millisecond)
 	}
+	return err
+}
+
+// terminateConnections evicts every backend connected to dbName except this
+// one. Errors are returned rather than swallowed: a clone that proceeds against
+// a still-occupied template fails anyway, and it fails less legibly.
+func terminateConnections(conn *sql.DB, dbName string) error {
+	const terminateSQL = `
+		SELECT pg_terminate_backend(pg_stat_activity.pid)
+		FROM pg_stat_activity
+		WHERE pg_stat_activity.datname = $1
+		AND pid <> pg_backend_pid()
+	`
+	_, err := conn.ExecContext(context.Background(), terminateSQL, dbName)
 	return err
 }
 


### PR DESCRIPTION
Догоняет #1019. Клонирование включили в реальном CI впервые — и оно уронило **все четыре шарда** прогона [EAI-UZ/granite 31881766415](https://github.com/EAI-UZ/granite/actions/runs/31881766415).

## Что было

132 падения вида

```
pq: source database "eai_itf_template" is being accessed by other users
```

и второе, более тихое семейство:

```
create database advisory lock: acquire failed: pq: canceling statement due to user request
```

Оба — из одной ошибки проектирования.

## Первопричина

`CREATE DATABASE ... TEMPLATE` отказывается работать, пока к источнику подключён **хоть один** бэкенд. Advisory lock разводил сиблинг-**клоны**, то есть ровно ту коллизию, под которую он и писался. Но бэкенд, о котором не помнят, — **autovacuum**: он обходит все базы по своему расписанию, и при паре сотен клонов на шард регулярно попадает в шаблон.

Ретрай при этом делал хуже, а не лучше: он спал **внутри** лока. Один припозднившийся бэкенд превращался в конвой — каждый сиблинг-харнесс вставал в очередь за спящим, ожидание перешагивало 5-минутный бюджет на взятие лока, и бутылочное горлышко возвращалось в костюме таймаута.

## Что меняется

- Перед копированием клон выселяет чужие бэкенды `pg_terminate_backend`.
- Ретрай теперь **оборачивает** лок, а не сидит внутри: backoff обслуживается, ничего не удерживая.
- Документировано, что настоящая защита — `datallowconn = false` на шаблоне, как это делает `template0`: коллизия становится невозможной, а не редкой. Выселение и ретрай — страховка для шаблонов, где этого нет.

## Проверка

`TestCreateDBFromTemplate_EvictsAStragglerOnTheTemplate` — клон, снятый при удерживаемом соединении к шаблону, обязан пройти. Без выселения тест падает: ретраи тут не помогают, соединение живёт всё это время.

Потребитель — [EAI-UZ/granite#4114](https://github.com/EAI-UZ/granite/pull/4114), там же выставляется `datallowconn = false` при сборке шаблона.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789385954&installation_model_id=2042&pr_number=1021&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1021&signature=a7b0b7725ff7aeb4f97d3f6815be2fe3c4d26dc69e6ec905dd737e2a399c23ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->