### PR TITLE
fix(billing): cancelling an Octo checkout stops the link instead of panicking

### DIFF
--- a/modules/billing/infrastructure/providers/octo_provider.go
+++ b/modules/billing/infrastructure/providers/octo_provider.go
@@ -3,6 +3,7 @@ package providers
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -103,9 +104,38 @@ func (o *octoProvider) Create(ctx context.Context, t billing.Transaction) (billi
 	return t, nil
 }
 
-func (o *octoProvider) Cancel(ctx context.Context, t billing.Transaction) (billing.Transaction, error) {
-	//TODO implement me
-	panic("implement me")
+// ErrOctoCancelAfterCapture is returned when a merchant asks to cancel a
+// payment Octo has already captured. Sending that money back is a refund — the
+// TransactionManagement API's RefundPost — not a cancellation.
+var ErrOctoCancelAfterCapture = errors.New("octo payment is captured; cancelling it would be a refund")
+
+// Cancel abandons a payment the merchant no longer intends to take, and does so
+// without calling Octo.
+//
+// Octo has no cancel endpoint: PreparePayment opens the payment, CheckStatus
+// reads it, RefundPost sends captured money back, and SetAccept answers a hold.
+// The status written here is what the merchant withdraws, and under manual
+// capture (auto_capture=false, which is how a hold arises at all) it also
+// releases the customer's money: Octo asks for the verdict on its notification,
+// and OctoController.determineFinalAcceptStatus answers `cancel` for exactly
+// the statuses below. So a customer who pays a link the merchant has abandoned
+// has their authorisation released rather than captured — the hold is not
+// stranded by writing this locally, it is resolved by it.
+//
+// A captured payment is refused rather than voided (ErrOctoCancelAfterCapture):
+// its money exists, and recording it as never taken is how a refund gets
+// skipped.
+func (o *octoProvider) Cancel(_ context.Context, t billing.Transaction) (billing.Transaction, error) {
+	octoDetails, err := toOctoDetails(t.Details())
+	if err != nil {
+		return nil, err
+	}
+
+	if octoDetails.Status() == octoapi.SucceededStatus || t.Status() == billing.Completed {
+		return nil, ErrOctoCancelAfterCapture
+	}
+
+	return t.SetStatus(billing.Canceled), nil
 }
 
 func (o *octoProvider) Refund(ctx context.Context, t billing.Transaction, quantity float64) (billing.Transaction, error) {

--- a/modules/billing/infrastructure/providers/octo_provider_test.go
+++ b/modules/billing/infrastructure/providers/octo_provider_test.go
@@ -1,0 +1,85 @@
+package providers_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/iota-uz/iota-sdk/modules/billing/domain/aggregates/billing"
+	"github.com/iota-uz/iota-sdk/modules/billing/domain/aggregates/details"
+	"github.com/iota-uz/iota-sdk/modules/billing/infrastructure/providers"
+	"github.com/iota-uz/iota-sdk/pkg/middleware"
+	octoapi "github.com/iota-uz/octo"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+)
+
+// octoProvider is built with a nil-safe log transport and a config that names
+// no host: every test here asserts that Cancel reaches no network at all, so a
+// call would fail rather than hit a stub, which is the stronger statement.
+func octoProvider(t *testing.T) billing.Provider {
+	t.Helper()
+
+	return providers.NewOctoProvider(
+		providers.OctoConfig{OctoShopID: 1, OctoSecret: "secret"},
+		middleware.NewLogTransport(logrus.New(), nil, false, false, "octo-test"),
+	)
+}
+
+func octoTransaction(status string, opts ...billing.Option) billing.Transaction {
+	return billing.New(
+		1920.0, billing.UZS, billing.Octo,
+		details.NewOctoDetails("sale-1",
+			details.OctoWithAutoCapture(false),
+			details.OctoWithStatus(status),
+		),
+		opts...,
+	)
+}
+
+// Cancelling a payment nobody has captured is the merchant withdrawing its
+// willingness to take the money. Octo has no endpoint for that, and none is
+// needed: the status is what the callback reads when it answers Octo's request
+// for a verdict.
+//
+// What would make this falsely green: asserting only that Cancel returns no
+// error. The status is the whole mechanism — without it the link stays live.
+func TestOctoCancelAbandonsAPaymentThatWasNeverCaptured(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []string{
+		octoapi.CreatedStatus,
+		octoapi.WaitUserActionStatus,
+		octoapi.WaitingForCaptureStatus,
+	} {
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+
+			cancelled, err := octoProvider(t).Cancel(context.Background(), octoTransaction(status))
+			require.NoError(t, err)
+			require.Equal(t, billing.Canceled, cancelled.Status())
+			require.False(t, cancelled.Status().IsActive())
+		})
+	}
+}
+
+// `succeeded` means Octo took the money. Marking that transaction cancelled
+// would leave captured funds recorded as never taken, and the refund that
+// should have been asked for never happens.
+func TestOctoCancelRefusesACapturedPayment(t *testing.T) {
+	t.Parallel()
+
+	_, err := octoProvider(t).Cancel(context.Background(), octoTransaction(octoapi.SucceededStatus))
+	require.ErrorIs(t, err, providers.ErrOctoCancelAfterCapture)
+}
+
+// The billing status is consulted as well as Octo's own, because a transaction
+// can be marked Completed by the status check that runs after the callback
+// while its stored octo status is still the one the notification carried.
+func TestOctoCancelRefusesATransactionAlreadyCompletedOnOurSide(t *testing.T) {
+	t.Parallel()
+
+	completed := octoTransaction(octoapi.WaitingForCaptureStatus, billing.WithStatus(billing.Completed))
+
+	_, err := octoProvider(t).Cancel(context.Background(), completed)
+	require.ErrorIs(t, err, providers.ErrOctoCancelAfterCapture)
+}


### PR DESCRIPTION
Finishes what #1020 started. That PR implemented `Cancel` for Payme and Click; `octoProvider.Cancel` was left as `panic("implement me")`, and Octo is the gateway the payment screen preselects — so abandoning an Octo link to hand the customer another one is the *common* path through the code, not the rare one.

The panic kills the request mid-flight: no status, no body, nothing for htmx to swap. The operator sees a button that goes silent and a tab that looks frozen. EAI hit exactly this in production (EAI-UZ/granite#4126, reported independently of #1020).

## What Octo needs, and why it is not a network call

Octo's merchant API has no cancel operation at all: `PreparePayment` opens the payment, `CheckStatus` reads it, `RefundPost` sends captured money back, and `SetAccept` answers a hold.

Under manual capture — `auto_capture=false`, which is the only way a hold arises — Octo asks the merchant for its verdict *on the notification*, and `OctoController.determineFinalAcceptStatus` already answers `cancel` for `Failed` and `Canceled`. So writing the status locally is not a merchant quietly walking away from money it is holding on a customer's card: it is the value that release reads. A customer who pays an abandoned link has their authorisation released rather than captured.

A captured payment (`succeeded`, or `Completed` on our side) is refused with `ErrOctoCancelAfterCapture` rather than voided. Its money exists, and recording it as never taken is how a refund gets skipped.

## Tests

`modules/billing/infrastructure/providers/octo_provider_test.go`, no network by construction — the provider is built against a config that names no host, so a call would fail rather than reach a stub.

- `TestOctoCancelAbandonsAPaymentThatWasNeverCaptured` over `created`, `wait_user_action` and `waiting_for_capture`
- `TestOctoCancelRefusesACapturedPayment`
- `TestOctoCancelRefusesATransactionAlreadyCompletedOnOurSide` — the billing status is consulted as well as Octo's own, because the post-callback status check can mark a transaction `Completed` while its stored octo status still carries what the notification said

**Red before the fix:**

```
--- FAIL: TestOctoCancelAbandonsAPaymentThatWasNeverCaptured (0.00s)
    --- FAIL: TestOctoCancelAbandonsAPaymentThatWasNeverCaptured/created
    --- FAIL: TestOctoCancelAbandonsAPaymentThatWasNeverCaptured/wait_user_action
panic: implement me
```

`go vet`, `gofmt` clean.

## Out of scope

`octoProvider.Refund` still panics. Nothing calls it today, and a refund is a real network call to `RefundPost` — a separate change with its own reasoning, not something to smuggle in here.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789402516&installation_model_id=2042&pr_number=1022&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1022&signature=9b5275bb6d91e89fcbe8d39b5f7fbc7bf810d40099c37832b151751ffcc04b86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for canceling eligible Octo payments without contacting the payment provider.

* **Bug Fixes**
  * Prevented cancellation of captured or completed payments.
  * Added clear error handling when a payment cannot be canceled.
  * Added coverage for cancellation scenarios, including offline processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->