### PR TITLE
fix(billing): cancelling a transaction that already ended is refused, not rewritten

### DIFF
--- a/modules/billing/services/billing_service.go
+++ b/modules/billing/services/billing_service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/iota-uz/iota-sdk/modules/billing/domain/aggregates/details"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
 	"github.com/iota-uz/iota-sdk/pkg/eventbus"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
 )
 
 type CreateTransactionCommand struct {
@@ -194,20 +195,22 @@ var ErrTransactionNotCancellable = errors.New("transaction is not active; only a
 // to reach this method with a dead transaction is a caller that believes the
 // transaction is alive, and that caller is better told than humoured.
 func (s *BillingService) Cancel(ctx context.Context, cmd *CancelTransactionCommand) (billing.Transaction, error) {
+	const op serrors.Op = "BillingService.Cancel"
+
 	entity, err := s.repo.GetByID(ctx, cmd.TransactionID)
 	if err != nil {
-		return nil, err
+		return nil, serrors.E(op, err)
 	}
 
 	if !entity.Status().IsActive() {
-		return nil, fmt.Errorf("%w: status %q", ErrTransactionNotCancellable, entity.Status())
+		return nil, serrors.E(op, fmt.Errorf("%w: status %q", ErrTransactionNotCancellable, entity.Status()))
 	}
 
 	provider := s.providers[entity.Gateway()]
 
 	updatedEvent, err := billing.NewUpdatedEvent(ctx, entity)
 	if err != nil {
-		return nil, err
+		return nil, serrors.E(op, err)
 	}
 
 	var updatedTransaction billing.Transaction
@@ -228,7 +231,7 @@ func (s *BillingService) Cancel(ctx context.Context, cmd *CancelTransactionComma
 		return err
 	})
 	if err != nil {
-		return nil, err
+		return nil, serrors.E(op, err)
 	}
 
 	updatedEvent.Result = updatedTransaction

--- a/modules/billing/services/billing_service.go
+++ b/modules/billing/services/billing_service.go
@@ -3,6 +3,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -161,10 +162,45 @@ func (s *BillingService) Save(ctx context.Context, entity billing.Transaction) (
 	return savedTransaction, nil
 }
 
+// ErrTransactionNotCancellable is returned when a cancellation is asked for a
+// transaction that has already left the active set: refunded, partially
+// refunded, expired, failed, completed, or cancelled once already.
+//
+// Cancelling one of those describes nothing that can still happen to the money.
+// The record would be rewritten to say the payment was never taken, and for a
+// refunded transaction that is worse than wrong — the refund disappears from
+// the history, leaving money that went back to the customer recorded as money
+// that never arrived.
+//
+// The gateway providers each refuse a *completed* transaction in their own
+// protocol's terms (ErrPaymeCancelAfterCompletion, ErrOctoCancelAfterCapture,
+// ErrClickCancelAfterPayment). This refuses every other terminal state, and
+// refuses it for every gateway — including Cash and Integrator, which have no
+// provider at all and whose cancellation is a bare status write with nothing
+// standing in front of it.
+var ErrTransactionNotCancellable = errors.New("transaction is not active; only a created or pending transaction can be cancelled")
+
+// Cancel voids an unpaid transaction.
+//
+// A transaction that is no longer active is refused (ErrTransactionNotCancellable)
+// before the provider is called and before the updated event is built: a
+// cancellation that must not happen should neither reach the gateway nor
+// announce a status change that did not occur.
+//
+// The refusal is an error rather than a silent no-op, including for a
+// transaction that is already cancelled. Nothing in this SDK cancels twice — a
+// gateway-initiated cancellation (Payme's CancelTransaction) is handled by
+// PaymeController.cancel through Save and never arrives here — so the only way
+// to reach this method with a dead transaction is a caller that believes the
+// transaction is alive, and that caller is better told than humoured.
 func (s *BillingService) Cancel(ctx context.Context, cmd *CancelTransactionCommand) (billing.Transaction, error) {
 	entity, err := s.repo.GetByID(ctx, cmd.TransactionID)
 	if err != nil {
 		return nil, err
+	}
+
+	if !entity.Status().IsActive() {
+		return nil, fmt.Errorf("%w: status %q", ErrTransactionNotCancellable, entity.Status())
 	}
 
 	provider := s.providers[entity.Gateway()]

--- a/modules/billing/services/billing_service_test.go
+++ b/modules/billing/services/billing_service_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/iota-uz/iota-sdk/modules/billing/services"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -211,6 +212,10 @@ func TestBillingService_Cancel_RefusesTerminalStatus(t *testing.T) {
 				TransactionID: terminal.ID(),
 			})
 			require.ErrorIs(t, err, services.ErrTransactionNotCancellable)
+
+			var wrapped *serrors.Error
+			require.ErrorAs(t, err, &wrapped, "the refusal carries its operation")
+			assert.Equal(t, serrors.Op("BillingService.Cancel"), wrapped.Op)
 
 			stored, err := billingService.GetByID(f.Ctx, terminal.ID())
 			require.NoError(t, err)

--- a/modules/billing/services/billing_service_test.go
+++ b/modules/billing/services/billing_service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -167,6 +168,110 @@ func TestBillingService_CreateTransaction_Payme(t *testing.T) {
 //	assert.NotEqual(t, uuid.Nil, result.ID(), "Expected non-nil transaction ID")
 //	assert.WithinDuration(t, time.Now(), result.CreatedAt(), time.Second*2)
 //}
+
+// TestBillingService_Cancel_RefusesTerminalStatus asserts that a transaction
+// which already left the active set is refused instead of being rewritten to
+// "cancelled" — for Refunded that rewrite erases a refund that really happened.
+//
+// This test is falsely green if Cancel starts failing for an unrelated reason
+// (a missing transaction, a provider outage) and the assertion only checked
+// that an error came back: it pins the sentinel with ErrorIs and re-reads the
+// row to prove the stored status survived, so a refusal that still wrote to the
+// database would fail here.
+func TestBillingService_Cancel_RefusesTerminalStatus(t *testing.T) {
+	t.Parallel()
+	f := setupTest(t)
+	billingService := getBillingService(f)
+
+	tenant, err := composables.UseTenantID(f.Ctx)
+	require.NoError(t, err)
+
+	for _, status := range []billing.Status{
+		billing.Refunded,
+		billing.PartiallyRefunded,
+		billing.Expired,
+		billing.Failed,
+		billing.Completed,
+	} {
+		t.Run(string(status), func(t *testing.T) {
+			created, err := billingService.Create(f.Ctx, &services.CreateTransactionCommand{
+				TenantID: tenant,
+				Quantity: 1000,
+				Currency: billing.UZS,
+				Gateway:  billing.Click,
+				Details:  details.NewClickDetails(fmt.Sprintf("terminal_%s", status)),
+			})
+			require.NoError(t, err, "Create should succeed")
+
+			terminal, err := billingService.Save(f.Ctx, created.SetStatus(status))
+			require.NoError(t, err, "Save should persist the terminal status")
+			require.Equal(t, status, terminal.Status())
+
+			_, err = billingService.Cancel(f.Ctx, &services.CancelTransactionCommand{
+				TransactionID: terminal.ID(),
+			})
+			require.ErrorIs(t, err, services.ErrTransactionNotCancellable)
+
+			stored, err := billingService.GetByID(f.Ctx, terminal.ID())
+			require.NoError(t, err)
+			assert.Equal(t, status, stored.Status(), "a refused cancellation must leave the stored status untouched")
+		})
+	}
+}
+
+// TestBillingService_Cancel_RefusesRepeatCancellation asserts that cancelling a
+// transaction twice is refused rather than treated as a no-op, and that the
+// refusal publishes no event — the second call has no status change to announce.
+//
+// This test is falsely green if the event assertion counts events from another
+// test sharing the bus; it filters by transaction id, so only events about this
+// transaction can satisfy or break it.
+func TestBillingService_Cancel_RefusesRepeatCancellation(t *testing.T) {
+	t.Parallel()
+	f := setupTest(t)
+	billingService := getBillingService(f)
+
+	tenant, err := composables.UseTenantID(f.Ctx)
+	require.NoError(t, err)
+
+	created, err := billingService.Create(f.Ctx, &services.CreateTransactionCommand{
+		TenantID: tenant,
+		Quantity: 1000,
+		Currency: billing.UZS,
+		Gateway:  billing.Click,
+		Details:  details.NewClickDetails("repeat_cancel"),
+	})
+	require.NoError(t, err, "Create should succeed")
+
+	canceled, err := billingService.Cancel(f.Ctx, &services.CancelTransactionCommand{
+		TransactionID: created.ID(),
+	})
+	require.NoError(t, err, "the first cancellation of an active transaction should succeed")
+	require.Equal(t, billing.Canceled, canceled.Status())
+
+	var (
+		mu       sync.Mutex
+		observed int
+	)
+	unsubscribe := f.App.EventPublisher().Subscribe(func(event *billing.UpdatedEvent) {
+		if event.Result == nil || event.Result.ID() != created.ID() {
+			return
+		}
+		mu.Lock()
+		observed++
+		mu.Unlock()
+	})
+	defer unsubscribe()
+
+	_, err = billingService.Cancel(f.Ctx, &services.CancelTransactionCommand{
+		TransactionID: created.ID(),
+	})
+	require.ErrorIs(t, err, services.ErrTransactionNotCancellable)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Zero(t, observed, "a refused cancellation must not publish an update event")
+}
 
 func TestBillingService_RegisterCallback(t *testing.T) {
 	t.Helper()


### PR DESCRIPTION
Pays the debt promised in [#1022 (comment)](https://github.com/iota-uz/iota-sdk/pull/1022#issuecomment-5303218634), answering CodeRabbit's ["Reject every terminal billing status"](https://github.com/iota-uz/iota-sdk/pull/1022#discussion_r3789742157). I refused to widen the guard inside `octoProvider.Cancel` there, because doing it in one provider out of three would give the same cancellation three different meanings; I said the guard's place is `BillingService.Cancel`, for every gateway at once. This is that PR.

## The hole

`BillingService.Cancel` loaded a transaction and cancelled it whatever state it was in. The only guards live in the providers, and each covers exactly one case — a payment the gateway had already captured:

- `paymeProvider.Cancel` — `state == completed || Status() == Completed`
- `octoProvider.Cancel` — `succeeded || Status() == Completed`
- `clickProvider.Cancel` — `payment_id != 0 || Status() == Completed`

Everything else went through. `Refunded`, `PartiallyRefunded`, `Expired`, `Failed`, and a transaction that had been cancelled once already were all rewritten to `Canceled`, and the service published an `UpdatedEvent` (plus the aggregate's own `StatusChangedEvent`) for a change that should never have happened. For `Cash` and `Integrator` there is no provider at all: the cancellation was a bare `SetStatus(billing.Canceled)` with nothing standing in front of it.

`Refunded` is the case that costs money to get wrong. The row stops saying "we took this money and sent it back" and starts saying "we never took it" — a refund that really happened vanishes from the history, and the reconciliation that would have caught it is told nothing changed.

## Why the service, not a third provider

The rule is "a transaction that has left the active set cannot be cancelled". That is not a protocol fact about any one gateway — Payme, Octo and Click each have their own reason to refuse a *captured* payment, and those reasons are correctly theirs, but "you cannot cancel a refund" is the same sentence at every gateway, including the two that have no provider object to put it in.

So the guard goes in one place, above all of them, and the domain already has the predicate: `billing.Status.IsActive()` — `Created || Pending` — the same one `PaymeController.activePaymeTransaction` uses to decide which transaction a customer is still allowed to pay. No second predicate was invented.

The provider guards stay exactly as they are. They are the second line, and they carry protocol specifics the service has no business knowing (Payme writes `state` and `cancel_time` on the way out).

## The idempotency question, decided on callers rather than taste

A repeat cancellation is **an error, not a no-op**. The argument for a no-op was that Payme's own `CancelTransaction` could arrive after we had already cancelled locally, and blowing up on that would be wrong. It does not apply here:

1. That callback never reaches this method. `PaymeController.cancel` resolves the transaction itself, sets `state`/`status` and goes through `BillingService.Save` — `BillingService.Cancel` is not on the gateway-inbound path at all. Same for Octo's notification handler.
2. Nothing in this repository calls `Cancel` twice; no test does either. The one real caller I know of downstream (EAI's `salesPaymentIntentAdapter.CancelPaymentIntent`) pre-filters to `Created`/`Pending` and no-ops for everything else, so it is unaffected — and naturally retry-safe, because a retry re-reads the record, sees `Canceled` and stops before the service.
3. A no-op would have to return a transaction whose status is *not* `Canceled` while reporting success. A caller that then reads `result.Status()` is misled either way; a sentinel it can match with `errors.Is` is the only version it can act on.

So: `ErrTransactionNotCancellable`, wrapped with the offending status for the log (`fmt.Errorf("%w: status %q", ...)`), returned **before** the provider call and **before** `NewUpdatedEvent` — refusing to publish the phantom event is half the fix.

### One behaviour change worth naming

Cancelling a `Completed` transaction now returns the service sentinel instead of the provider's (`ErrPaymeCancelAfterCompletion` / `ErrOctoCancelAfterCapture` / `ErrClickCancelAfterPayment`). That is deliberate — the service refuses first, uniformly — and the provider sentinels are unchanged and still returned when a provider is called directly, which is how their own tests exercise them.

## Tests

`modules/billing/services/billing_service_test.go`, on the package's existing `itf.Setup` harness against real Postgres, because the defect is a *stored* status being overwritten and a mock repository would not have shown it.

- `TestBillingService_Cancel_RefusesTerminalStatus` — `Refunded`, `PartiallyRefunded`, `Expired`, `Failed`, `Completed`; each asserts the sentinel **and** re-reads the row to prove the stored status survived
- `TestBillingService_Cancel_RefusesRepeatCancellation` — cancels once (succeeds), cancels again (refused), and subscribes to the event bus to assert no `UpdatedEvent` was published for that transaction id

**Red before the fix** (guard absent, sentinel declared so the package compiles):

```
=== RUN   TestBillingService_Cancel_RefusesTerminalStatus/refunded
    billing_service_test.go:213:
        	Error:      	Expected error with "transaction is not active; only a created or pending transaction can be cancelled" in chain but got nil.
        	Test:       	TestBillingService_Cancel_RefusesTerminalStatus/refunded
=== RUN   TestBillingService_Cancel_RefusesTerminalStatus/completed
    billing_service_test.go:213:
        	Error:      	Target error should be in err chain:
        	            	expected: "transaction is not active; only a created or pending transaction can be cancelled"
        	            	in chain: "click payment is captured; cancelling it would be a reversal"
--- FAIL: TestBillingService_Cancel_RefusesTerminalStatus (102.83s)
    --- FAIL: TestBillingService_Cancel_RefusesTerminalStatus/refunded (0.01s)
    --- FAIL: TestBillingService_Cancel_RefusesTerminalStatus/partially-refunded (0.00s)
    --- FAIL: TestBillingService_Cancel_RefusesTerminalStatus/expired (0.00s)
    --- FAIL: TestBillingService_Cancel_RefusesTerminalStatus/failed (0.00s)
    --- FAIL: TestBillingService_Cancel_RefusesTerminalStatus/completed (0.00s)
--- FAIL: TestBillingService_Cancel_RefusesRepeatCancellation (104.33s)
FAIL	github.com/iota-uz/iota-sdk/modules/billing/services	104.394s
```

Green after:

```
--- PASS: TestBillingService_Cancel_RefusesTerminalStatus (34.75s)
    --- PASS: .../refunded  .../partially-refunded  .../expired  .../failed  .../completed
--- PASS: TestBillingService_Cancel_RefusesRepeatCancellation (41.74s)
ok  	github.com/iota-uz/iota-sdk/modules/billing/services	41.810s
```

`go test ./modules/billing/...` all green (providers, persistence, controllers included), `go vet ./...` clean, `golangci-lint run ./modules/billing/...` — 0 issues.

## Out of scope

- **`BillingService.Refund` has the same hole** — refunding an already-`Canceled` or already-`Refunded` transaction is not checked either. It is a different rule (a refund is legitimate exactly when money was captured, so the predicate is not `IsActive`), and it deserves its own reasoning and its own tests rather than being smuggled in behind this one.
- `GetByID` still reads outside the transaction, so two concurrent cancellations can both pass the guard. That shape predates this change and is shared by `Refund` and `Delete`; narrowing it means moving the read into `InTx` with row locking across all three, which is a separate change.

https://claude.ai/code/session_01VBroGVdpqzaENFGzXpKgto

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1023"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789416548&installation_model_id=2042&pr_number=1023&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1023&signature=f5ca21af85e4e76ccaecaa9c5b6a2eb9b11f25e8f09ae43a93fd18c0b1a6d4a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cancellation of transactions that are already in a terminal state.
  * Repeated cancellation attempts now return a clear error without changing transaction status.
  * Prevented unnecessary provider calls and update events for invalid cancellation attempts.
  * Improved cancellation errors with clearer operation context.

* **Tests**
  * Added coverage for terminal transactions and repeated cancellation requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->