### PR TITLE
fix(money): a numeric currency code answers with the same currency every time

### DIFF
--- a/pkg/money/currency.go
+++ b/pkg/money/currency.go
@@ -18,15 +18,60 @@ type Currency struct {
 
 type Currencies map[string]*Currency
 
-// CurrencyByNumericCode returns the currency given the numeric code defined in ISO-4271.
+// CurrencyByNumericCode returns the currency given the numeric code defined in
+// ISO-4217.
+//
+// A numeric code is not unique in this collection. "840" is declared by both
+// USD and USDSPACE, where USDSPACE is a thousands-separator variant rather than
+// a currency of its own, and "532" by both ANG and XCG, which is a genuine
+// succession in the standard. Ranging over the map and returning the first hit
+// answers with whichever entry Go's randomised iteration happened to visit
+// first, so the same numeric code yields a different currency between runs of
+// the same binary - and callers persist Currency.Code, so that reaches storage.
+//
+// The winner is therefore chosen rather than stumbled upon: an entry whose Code
+// is a three-letter ISO alphabetic code beats one that is not, and among those
+// the lexicographically smallest Code wins. The answer never varies.
 func (c Currencies) CurrencyByNumericCode(code string) *Currency {
+	var best *Currency
 	for _, sc := range c {
-		if sc.NumericCode == code {
-			return sc
+		if sc.NumericCode != code {
+			continue
+		}
+		if best == nil || preferredCurrency(sc, best) {
+			best = sc
 		}
 	}
 
-	return nil
+	return best
+}
+
+// preferredCurrency reports whether candidate should displace incumbent as the
+// answer for a numeric code both of them declare.
+func preferredCurrency(candidate, incumbent *Currency) bool {
+	candidateISO, incumbentISO := isISOAlphabeticCode(candidate.Code), isISOAlphabeticCode(incumbent.Code)
+	if candidateISO != incumbentISO {
+		return candidateISO
+	}
+
+	return candidate.Code < incumbent.Code
+}
+
+// isISOAlphabeticCode reports whether code has the shape ISO-4217 gives an
+// alphabetic currency code: exactly three capital letters. Formatting variants
+// carried in this collection - USDSPACE and anything a caller adds like it -
+// do not, which is what keeps them from answering a numeric-code lookup.
+func isISOAlphabeticCode(code string) bool {
+	if len(code) != 3 {
+		return false
+	}
+	for i := 0; i < len(code); i++ {
+		if code[i] < 'A' || code[i] > 'Z' {
+			return false
+		}
+	}
+
+	return true
 }
 
 // CurrencyByCode returns the currency given the currency code defined as a constant.

--- a/pkg/money/currency_test.go
+++ b/pkg/money/currency_test.go
@@ -154,3 +154,46 @@ func TestCurrency_GetCurrencyByNumericCodeNonExistingCurrency(t *testing.T) {
 		t.Errorf("Unexpected currency returned %+v", currency)
 	}
 }
+
+// "840" is declared by USD and by the USDSPACE formatting variant. The lookup
+// used to return whichever the map's randomised iteration reached first, so a
+// dollar receipt was rendered - and stored - as "USDSPACE" on some runs.
+func TestCurrency_GetCurrencyByNumericCodePrefersTheISOCodeOverAVariant(t *testing.T) {
+	for i := 0; i < 200; i++ {
+		got := GetCurrencyByNumericCode("840")
+		if got == nil || got.Code != USD {
+			t.Fatalf("iteration %d: expected USD for 840, got %+v", i, got)
+		}
+	}
+}
+
+// "532" is a genuine collision in the standard rather than a variant: XCG
+// succeeded ANG and inherited its numeric code. Neither answer is wrong, but
+// the lookup must give the same one every time.
+func TestCurrency_GetCurrencyByNumericCodeIsStableOnACollision(t *testing.T) {
+	first := GetCurrencyByNumericCode("532")
+	if first == nil {
+		t.Fatal("expected a currency for 532")
+	}
+	for i := 0; i < 200; i++ {
+		got := GetCurrencyByNumericCode("532")
+		if got == nil || got.Code != first.Code {
+			t.Fatalf("iteration %d: 532 answered %+v after %+v", i, got, first)
+		}
+	}
+}
+
+// The rule holds for currencies a caller adds, not only for the built-in table.
+func TestCurrencies_CurrencyByNumericCodePrefersTheISOCodeAmongAdded(t *testing.T) {
+	const numericCode = "999"
+	iso := &Currency{Code: "ZZZ", NumericCode: numericCode, Fraction: 2, Grapheme: "z", Template: "$1", Decimal: ".", Thousand: ","}
+	variant := &Currency{Code: "AAASPACE", NumericCode: numericCode, Fraction: 2, Grapheme: "z", Template: "$1", Decimal: ".", Thousand: " "}
+
+	cs := Currencies{}.Add(variant).Add(iso)
+	for i := 0; i < 200; i++ {
+		got := cs.CurrencyByNumericCode(numericCode)
+		if got == nil || got.Code != iso.Code {
+			t.Fatalf("iteration %d: expected the ISO code %s, got %+v", i, iso.Code, got)
+		}
+	}
+}

--- a/pkg/money/currency_test.go
+++ b/pkg/money/currency_test.go
@@ -168,17 +168,13 @@ func TestCurrency_GetCurrencyByNumericCodePrefersTheISOCodeOverAVariant(t *testi
 }
 
 // "532" is a genuine collision in the standard rather than a variant: XCG
-// succeeded ANG and inherited its numeric code. Neither answer is wrong, but
-// the lookup must give the same one every time.
+// succeeded ANG and inherited its numeric code. Both are ISO-shaped, so the
+// tie-break is the smaller code, and it must answer that one every time.
 func TestCurrency_GetCurrencyByNumericCodeIsStableOnACollision(t *testing.T) {
-	first := GetCurrencyByNumericCode("532")
-	if first == nil {
-		t.Fatal("expected a currency for 532")
-	}
 	for i := 0; i < 200; i++ {
 		got := GetCurrencyByNumericCode("532")
-		if got == nil || got.Code != first.Code {
-			t.Fatalf("iteration %d: 532 answered %+v after %+v", i, got, first)
+		if got == nil || got.Code != ANG {
+			t.Fatalf("iteration %d: expected %s for 532, got %+v", i, ANG, got)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #1025.

## The defect

`Currencies.CurrencyByNumericCode` ranged over the currency map and returned the first entry whose `NumericCode` matched. Go randomises map iteration, so a numeric code carried by more than one entry resolved differently between runs of the same binary.

Two codes are shared in the built-in table:

| Numeric | Entries | Nature |
| --- | --- | --- |
| `840` | `USD`, `USDSPACE` | `USDSPACE` is a thousands-separator variant, not a currency |
| `532` | `ANG`, `XCG` | a genuine succession in the standard |

`Currency.Code` is not only a formatting hint — consumers persist it. In EAI this reaches storage through `NappCurrencyToCode` (reinsurance contracts and offers) and through the 1C admissions drawer and its Excel export, so a dollar receipt could be written as `USDSPACE`. It also turned a downstream test red at random, which under EAI's release model blocks a release with no way to tell a flake from a break.

## The fix

The winner is chosen instead of stumbled upon: an entry whose `Code` is a three-letter ISO alphabetic code beats one that is not, and among those the lexicographically smallest `Code` wins. `840` therefore answers `USD`, and `532` answers `ANG` — the same on every call.

The rule applies to currencies a caller adds through `Add`, not only to the built-in table, so a downstream formatting variant cannot capture a numeric code either.

No signature changes, no behaviour change for the ~170 numeric codes that only one entry declares.

## Tests

Three added in `pkg/money/currency_test.go`: `840` resolves to `USD` across 200 lookups; `532` gives one stable answer across 200 lookups; and a `Currencies` built from a caller's own variant plus an ISO entry answers with the ISO one.

`GOWORK=off go test ./pkg/money/` is green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789470450&installation_model_id=2042&pr_number=1026&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1026&signature=4aed7f3a4a7202d323e49a61034c5000b28a09bf112f60344c4527bb5cb6a35e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Currency lookups by numeric code now return consistent results when multiple currencies share the same code.
  * Standard three-letter currency codes are prioritized over formatting variants.
  * Runtime-added currencies follow the same deterministic selection rules.

* **Tests**
  * Added coverage for duplicate-code handling, stable results, and runtime-added currencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->