### PR TITLE
fix(itf): closing a settled shared harness no longer panics

### DIFF
--- a/pkg/itf/harness.go
+++ b/pkg/itf/harness.go
@@ -433,6 +433,16 @@ func (m *harnessManager) close(key string, cleanup CleanupMode) error {
 		entry.cond.Wait()
 	}
 
+	// Waiting released the lock, so the entry this call is holding may have been
+	// settled meanwhile - by another closer, or by a failed getOrCreate, which
+	// drops the entry from the map and leaves its state nil. Either way there is
+	// no state left to release, and dereferencing it below is a nil panic in the
+	// harness teardown of whatever test happened to be last.
+	if entry.state == nil || m.entries[key] != entry {
+		m.mu.Unlock()
+		return nil
+	}
+
 	entry.refs--
 	if entry.refs > 0 {
 		m.mu.Unlock()

--- a/pkg/itf/harness_internal_test.go
+++ b/pkg/itf/harness_internal_test.go
@@ -237,4 +237,3 @@ func TestSharedHarnessManagerCloseSurvivesASettledEntry(t *testing.T) {
 	require.NoError(t, manager.close(key, CleanupKeep))
 	require.Equal(t, 1, manager.entries[key].refs, "a settled entry is left untouched, not counted down")
 }
-

--- a/pkg/itf/harness_internal_test.go
+++ b/pkg/itf/harness_internal_test.go
@@ -215,3 +215,26 @@ func TestTenantIDHelper(t *testing.T) {
 	require.Equal(t, uid.String(), tenantID(&uid))
 	require.Empty(t, tenantID(nil))
 }
+
+// A closer that waits out `closing` can wake up holding an entry that has
+// already been settled: another closer removed it from the map and nilled its
+// state, or a failed getOrCreate dropped it before ever building one. Releasing
+// that entry used to dereference the nil state and panic in the harness cleanup
+// of whichever test ran last, far from the failure that actually caused it.
+func TestSharedHarnessManagerCloseSurvivesASettledEntry(t *testing.T) {
+	t.Parallel()
+
+	manager := &harnessManager{
+		entries: map[string]*managedHarnessState{},
+	}
+
+	const key = "itf-settled-entry-test"
+	manager.entries[key] = &managedHarnessState{
+		refs: 1,
+		cond: sync.NewCond(&manager.mu),
+	}
+
+	require.NoError(t, manager.close(key, CleanupKeep))
+	require.Equal(t, 1, manager.entries[key].refs, "a settled entry is left untouched, not counted down")
+}
+


### PR DESCRIPTION
A shared-harness closer that waits out `closing` releases the manager lock. By the time it wakes, the entry it is holding may already be settled — another closer nilled its state and removed it from the map, or a `getOrCreate` that failed to build a state dropped the entry before one existed. Releasing it then dereferenced the nil state:

```
panic: runtime error: invalid memory address or nil pointer dereference
  pkg/itf.(*harnessState).close(...)      harness.go:459
  pkg/itf.(*harnessManager).close(...)    harness.go:445
  pkg/itf.(*harnessImpl).Close(...)       harness.go:367
  pkg/itf.NewHarness.func2()              harness.go:279
```

The stack names neither the test that failed nor the creation failure behind it — it lands in the cleanup of whichever test happened to run last. Seen in EAI CI on `TestOnePersonInSeveralRolesIsWrittenOnceAndKeepsWhatTheOperatorTyped`, which itself passes.

`getOrCreate` already re-checks the entry after waiting (`entry.state == nil` → drop and retry); `close` now does the same and additionally ignores an entry whose key has been rebound to a newer one.

Regression test `TestSharedHarnessManagerCloseSurvivesASettledEntry` panics without the guard and passes with it.

https://claude.ai/code/session_01K3LdeEZC4mbJGdscMkXBc9

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789478575&installation_model_id=2042&pr_number=1027&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1027&signature=3e6db3fd7de6a71a3e385c3966a82d8a1297a574cd92e02479391da146365ff2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved harness cleanup reliability when entries are removed or invalidated during shutdown.
  - Prevented teardown crashes caused by missing or outdated state.
  - Ensured invalid entries are not incorrectly released or reference-counted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->