### PR TITLE
fix(htmx): Location and account toasts escape non-ASCII/quotes as JSON

### DIFF
--- a/modules/core/presentation/controllers/account_controller.go
+++ b/modules/core/presentation/controllers/account_controller.go
@@ -2,6 +2,7 @@
 package controllers
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 
@@ -293,7 +294,14 @@ func (c *AccountController) RevokeSession(w http.ResponseWriter, r *http.Request
 	// Prevent revoking current session
 	if sessionToRevoke == currentToken {
 		logger.Error("cannot revoke current session")
-		htmx.SetTrigger(w, "error", fmt.Sprintf(`{"message": "%s"}`, pageCtx.T("Account.Sessions.CannotRevokeCurrent")))
+		errorPayload, err := json.Marshal(map[string]string{
+			"message": pageCtx.T("Account.Sessions.CannotRevokeCurrent"),
+		})
+		if err != nil {
+			logger.WithError(err).Error("failed to marshal session revoke toast")
+		} else {
+			htmx.SetTrigger(w, "error", string(errorPayload))
+		}
 		http.Error(w, pageCtx.T("Account.Sessions.CannotRevokeCurrent"), http.StatusForbidden)
 		return
 	}
@@ -306,7 +314,15 @@ func (c *AccountController) RevokeSession(w http.ResponseWriter, r *http.Request
 	}
 
 	// Return success with HTMX trigger
-	htmx.SetTrigger(w, "success", fmt.Sprintf(`{"message": "%s"}`, pageCtx.T("Account.Sessions.RevokeSuccess")))
+	successPayload, err := json.Marshal(map[string]string{
+		"message": pageCtx.T("Account.Sessions.RevokeSuccess"),
+	})
+	if err != nil {
+		logger.WithError(err).Error("failed to marshal session revoke toast")
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	htmx.SetTrigger(w, "success", string(successPayload))
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -341,7 +357,12 @@ func (c *AccountController) RevokeOtherSessions(w http.ResponseWriter, r *http.R
 
 	// Return success with count and refresh page
 	successMsg := fmt.Sprintf(pageCtx.T("Account.Sessions.RevokeAllSuccess"), count)
-	successMsg = fmt.Sprintf(`{"message": "%s"}`, successMsg)
-	htmx.SetTrigger(w, "success", successMsg)
+	successPayload, err := json.Marshal(map[string]string{"message": successMsg})
+	if err != nil {
+		logger.WithError(err).Error("failed to marshal session revoke toast")
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	htmx.SetTrigger(w, "success", string(successPayload))
 	htmx.Refresh(w)
 }

--- a/pkg/htmx/htmx.go
+++ b/pkg/htmx/htmx.go
@@ -31,9 +31,19 @@ func Reselect(w http.ResponseWriter, selector string) {
 func Location(w http.ResponseWriter, path, target string) {
 	if target == "" {
 		w.Header().Add("Hx-Location", path)
-	} else {
-		w.Header().Add("Hx-Location", `{"path":"`+path+`", "target":"`+target+`"}`)
+		return
 	}
+	pathJSON, err := json.Marshal(path)
+	if err != nil {
+		w.Header().Add("Hx-Location", path)
+		return
+	}
+	targetJSON, err := json.Marshal(target)
+	if err != nil {
+		w.Header().Add("Hx-Location", path)
+		return
+	}
+	w.Header().Add("Hx-Location", escapeNonASCII(`{"path":`+string(pathJSON)+`,"target":`+string(targetJSON)+`}`))
 }
 
 // PushURL sets the HX-Push-Url header to push a new URL into the browser history stack.

--- a/pkg/htmx/htmx_test.go
+++ b/pkg/htmx/htmx_test.go
@@ -282,3 +282,54 @@ func TestEscapeNonASCII_SurrogatePairs(t *testing.T) {
 		})
 	}
 }
+
+// TestLocation_SpecialCharactersStayValidJSON covers the same defect
+// SetTrigger already had: Location assembled the two-field form with `+`
+// concatenation, so a quote or backslash in path/target produced JSON htmx
+// failed to parse, and non-ASCII reached the browser as raw UTF-8 mojibake.
+func TestLocation_SpecialCharactersStayValidJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		path   string
+		target string
+	}{
+		{name: "ascii", path: "/policies/1", target: "#content"},
+		{name: "quote in path", path: `/search?q="AB 1234567"`, target: "#content"},
+		{name: "backslash", path: `/files/C:\policies\2026`, target: "#content"},
+		{name: "cyrillic target", path: "/policies/1", target: `[data-панель="сводка"]`},
+		{name: "non-BMP rune", path: "/готово 😀", target: "#content"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			Location(rec, tt.path, tt.target)
+
+			value := headerOnWire(t, rec, "Hx-Location")
+			requireASCII(t, value)
+
+			var payload struct {
+				Path   string `json:"path"`
+				Target string `json:"target"`
+			}
+			require.NoErrorf(t, json.Unmarshal([]byte(value), &payload), "header is not valid JSON: %q", value)
+			assert.Equal(t, tt.path, payload.Path)
+			assert.Equal(t, tt.target, payload.Target)
+		})
+	}
+}
+
+// TestLocation_EmptyTargetUnchanged pins the bare-path form: an empty target
+// must keep sending the path as-is, not JSON-wrap it.
+func TestLocation_EmptyTargetUnchanged(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	Location(rec, "/policies/1", "")
+
+	assert.Equal(t, "/policies/1", headerOnWire(t, rec, "Hx-Location"))
+}


### PR DESCRIPTION
## Summary

Two callers built an `Hx-Location`/`Hx-Trigger` header value by string
concatenation or `fmt.Sprintf` instead of `json.Marshal` — the same class of
bug `SetTrigger` had before #1013/#1017 (merged `50b5e55be`):

- `pkg/htmx/htmx.go` `Location()` — path/target JSON-wrapped with raw `+`
  concatenation.
- `modules/core/presentation/controllers/account_controller.go` (3 call
  sites) — `fmt.Sprintf(`{"message": "%s"}`, ...)` around a translated
  string.

A quote or backslash in the value broke the JSON htmx parses; non-ASCII
reached the browser as raw-UTF-8 mojibake, since browsers decode header
bytes as ISO-8859-1. `account_controller.go` already had the correct
`json.Marshal(map[string]string{...})` pattern next door in
`user_session_handlers.go` — the three fixed call sites now match it.

## Test plan
- [x] `TestLocation_SpecialCharactersStayValidJSON` / `TestLocation_EmptyTargetUnchanged` added, confirmed red on pre-fix `Location()` (stashed the fix, reran — failed on quote/backslash/non-ASCII), green after.
- [x] `GOWORK=off go test ./pkg/htmx/...` — pass
- [x] `GOWORK=off go test ./modules/core/presentation/controllers/... -run Account` — pass
- [x] `GOWORK=off go vet ./pkg/htmx/... ./modules/core/presentation/controllers/...` — clean

Companion EAI-side chore: EAI-UZ/granite#4187

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789480044&installation_model_id=2042&pr_number=1028&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1028&signature=fb4f4a6477fab89344f6f374517aca4dc03235f785fe46f8f00936906e0b9077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->