### PR TITLE
chore(release): prepare v0.5.6

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -12,7 +12,7 @@ This repo ships one public NPM package alongside the Go module:
 Install it with React peers:
 
 ```bash
-pnpm add @iota-uz/sdk@0.5.5 react react-dom
+pnpm add @iota-uz/sdk@0.5.6 react react-dom
 ```
 
 ```ts

--- a/docs/content/getting-started/npm-package.mdx
+++ b/docs/content/getting-started/npm-package.mdx
@@ -13,7 +13,7 @@ Tailwind, or asset surfaces.
 ## Install
 
 ```bash
-pnpm add @iota-uz/sdk@0.5.5 react react-dom
+pnpm add @iota-uz/sdk@0.5.6 react react-dom
 ```
 
 Production consumers should pin an exact SDK version matching their Go module.

--- a/pkg/clienthost/host_test.go
+++ b/pkg/clienthost/host_test.go
@@ -45,7 +45,7 @@ func TestController_ServesCanonicalBootstrapAndDescriptor(t *testing.T) {
 	require.Contains(t, body, `data-sdk-commit="0123456789abcdef0123456789abcdef01234567"`)
 	require.Contains(t, body, `integrity="sha384-example"`)
 	require.Contains(t, body, `"protocolVersion":"1.0.0"`)
-	require.Contains(t, body, `"sdkReleaseVersion":"0.5.5"`)
+	require.Contains(t, body, `"sdkReleaseVersion":"0.5.6"`)
 	require.Contains(t, body, `"sdkCommit":"0123456789abcdef0123456789abcdef01234567"`)
 	require.Contains(t, body, `"theme":"dark"`)
 	require.Contains(t, body, `"csrf":"token"`)

--- a/pkg/sdkidentity/identity.go
+++ b/pkg/sdkidentity/identity.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	ReleaseVersion  = "0.5.5"
+	ReleaseVersion  = "0.5.6"
 	ProtocolVersion = "1.0.0"
 )
 

--- a/web/client-host/src/identity.ts
+++ b/web/client-host/src/identity.ts
@@ -1,6 +1,6 @@
 import { CLIENT_HOST_PROTOCOL_VERSION } from './protocol'
 
-export const SDK_RELEASE_VERSION = '0.5.5'
+export const SDK_RELEASE_VERSION = '0.5.6'
 export const SDK_SOURCE_COMMIT = '__IOTA_SDK_SOURCE_COMMIT__'
 export const SDK_PROTOCOL_VERSION = CLIENT_HOST_PROTOCOL_VERSION
 export const SDK_IDENTITY = Object.freeze({

--- a/web/sdk/package.json
+++ b/web/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@iota-uz/sdk",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Canonical JavaScript distribution for iota-sdk.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- bump the canonical Go and npm SDK identity to 0.5.6
- publish the merged tab-local Lens filter placement from #1029
- keep documentation and client-host identity aligned

## Root cause
Granite pinned the Go module at #1029 while its browser bundle remained on @iota-uz/sdk@0.5.5. The server emitted filter placement metadata that the older browser runtime ignored.

## Verification
- pnpm build
- go test ./pkg/clienthost ./pkg/sdkidentity
- git diff --check

Required to fix EAI-UZ/granite#4324.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789896210&installation_model_id=2042&pr_number=1030&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1030&signature=5019fbcca3c980a8da3dbb88e03959ad4a8ad487be8567a6e2cad6a8c92f8235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to reference SDK version 0.5.6.
* **Release**
  * Updated the SDK and client-host version identifiers to 0.5.6.
* **Tests**
  * Updated version expectations to reflect the 0.5.6 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->