### PR TITLE
fix: Date fields are missing value

### DIFF
--- a/components/scaffold/form/fields.go
+++ b/components/scaffold/form/fields.go
@@ -313,8 +313,8 @@ func (f *dateField) Component() templ.Component {
 		"name": f.key,
 		"type": string(FieldTypeDate),
 	}
-	if !f.defaultVal.IsZero() {
-		attrs["value"] = f.defaultVal.Format(time.DateOnly)
+	if val := mapping.Or(f.value, f.defaultVal); !val.IsZero() {
+		attrs["value"] = val.Format(time.DateOnly)
 	}
 	for k, v := range f.attrs {
 		attrs[k] = v

--- a/components/scaffold/form/fields.go
+++ b/components/scaffold/form/fields.go
@@ -34,6 +34,8 @@ const (
 	FieldTypeSelect        FieldType = "select"
 )
 
+const dateTimeLocalLayout = "2006-01-02T15:04"
+
 // Option for SelectField and RadioField choices
 type Option struct {
 	Value string
@@ -353,8 +355,10 @@ type dateTimeLocalField struct {
 
 func (f *dateTimeLocalField) Component() templ.Component {
 	attrs := templ.Attributes{
-		"name":  f.key,
-		"value": mapping.Or(f.value, f.defaultVal),
+		"name": f.key,
+	}
+	if val := mapping.Or(f.value, f.defaultVal); !val.IsZero() {
+		attrs["value"] = val.Format(dateTimeLocalLayout)
 	}
 	for k, v := range f.attrs {
 		attrs[k] = v

--- a/components/scaffold/form/fields_test.go
+++ b/components/scaffold/form/fields_test.go
@@ -1,0 +1,43 @@
+package form
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func renderField(t *testing.T, field Field) string {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, field.Component().Render(context.Background(), &buf))
+	return buf.String()
+}
+
+func TestDateField_Component_RendersValue(t *testing.T) {
+	t.Parallel()
+
+	field := Date("birth_date", "Birth date").
+		Default(time.Date(2025, 7, 3, 16, 15, 48, 0, time.UTC)).
+		Build()
+
+	require.Contains(t, renderField(t, field), `value="2025-07-03"`)
+}
+
+func TestDateTimeLocalField_Component_RendersValue(t *testing.T) {
+	t.Parallel()
+
+	field := DateTime("started_at", "Started at").
+		Default(time.Date(2025, 7, 3, 16, 15, 48, 0, time.UTC)).
+		Build()
+
+	require.Contains(t, renderField(t, field), `value="2025-07-03T16:15"`)
+}
+
+func TestDateTimeLocalField_Component_OmitsZeroValue(t *testing.T) {
+	t.Parallel()
+
+	require.NotContains(t, renderField(t, DateTime("started_at", "Started at").Build()), "value=")
+}

--- a/components/scaffold/form/fields_test.go
+++ b/components/scaffold/form/fields_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,28 +17,96 @@ func renderField(t *testing.T, field Field) string {
 	return buf.String()
 }
 
-func TestDateField_Component_RendersValue(t *testing.T) {
+func TestDateField_Component_Value(t *testing.T) {
 	t.Parallel()
 
-	field := Date("birth_date", "Birth date").
-		Default(time.Date(2025, 7, 3, 16, 15, 48, 0, time.UTC)).
-		Build()
+	defaultVal := time.Date(2025, 7, 3, 16, 15, 48, 0, time.UTC)
+	storedVal := time.Date(2024, 11, 27, 9, 30, 0, 0, time.UTC)
 
-	require.Contains(t, renderField(t, field), `value="2025-07-03"`)
+	tests := []struct {
+		name  string
+		field Field
+		want  string
+	}{
+		{
+			name:  "DefaultRendered",
+			field: Date("birth_date", "Birth date").Default(defaultVal).Build(),
+			want:  `value="2025-07-03"`,
+		},
+		{
+			name:  "StoredValueRendered",
+			field: Date("birth_date", "Birth date").Build().WithValue(storedVal),
+			want:  `value="2024-11-27"`,
+		},
+		{
+			name:  "StoredValueOverridesDefault",
+			field: Date("birth_date", "Birth date").Default(defaultVal).Build().WithValue(storedVal),
+			want:  `value="2024-11-27"`,
+		},
+		{
+			name:  "ZeroValueOmitted",
+			field: Date("birth_date", "Birth date").Build(),
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rendered := renderField(t, tt.field)
+			if tt.want == "" {
+				assert.NotContains(t, rendered, "value=")
+				return
+			}
+			assert.Contains(t, rendered, tt.want)
+		})
+	}
 }
 
-func TestDateTimeLocalField_Component_RendersValue(t *testing.T) {
+func TestDateTimeLocalField_Component_Value(t *testing.T) {
 	t.Parallel()
 
-	field := DateTime("started_at", "Started at").
-		Default(time.Date(2025, 7, 3, 16, 15, 48, 0, time.UTC)).
-		Build()
+	defaultVal := time.Date(2025, 7, 3, 16, 15, 48, 0, time.UTC)
+	storedVal := time.Date(2024, 11, 27, 9, 30, 0, 0, time.UTC)
 
-	require.Contains(t, renderField(t, field), `value="2025-07-03T16:15"`)
-}
+	tests := []struct {
+		name  string
+		field Field
+		want  string
+	}{
+		{
+			name:  "DefaultRendered",
+			field: DateTime("started_at", "Started at").Default(defaultVal).Build(),
+			want:  `value="2025-07-03T16:15"`,
+		},
+		{
+			name:  "StoredValueRendered",
+			field: DateTime("started_at", "Started at").Build().WithValue(storedVal),
+			want:  `value="2024-11-27T09:30"`,
+		},
+		{
+			name:  "StoredValueOverridesDefault",
+			field: DateTime("started_at", "Started at").Default(defaultVal).Build().WithValue(storedVal),
+			want:  `value="2024-11-27T09:30"`,
+		},
+		{
+			name:  "ZeroValueOmitted",
+			field: DateTime("started_at", "Started at").Build(),
+			want:  "",
+		},
+	}
 
-func TestDateTimeLocalField_Component_OmitsZeroValue(t *testing.T) {
-	t.Parallel()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	require.NotContains(t, renderField(t, DateTime("started_at", "Started at").Build()), "value=")
+			rendered := renderField(t, tt.field)
+			if tt.want == "" {
+				assert.NotContains(t, rendered, "value=")
+				return
+			}
+			assert.Contains(t, rendered, tt.want)
+		})
+	}
 }


### PR DESCRIPTION
Fixes #340

## Root cause

datetime-local form field passes a raw time.Time as an HTML attribute value, which templ silently drops

## Changes

- Format the datetime-local field value with the 2006-01-02T15:04 layout expected by <input type="datetime-local"> (and by the controller's submit-side parser), and omit the attribute entirely when the value is zero. Added a regression test asserting the rendered value attribute for date and datetime-local fields.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1031"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789925149&installation_model_id=2042&pr_number=1031&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1031&signature=edae2bc299066ba2cb68641640686586c7d612f6775e479addf38aa2579a7f42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved date and local date-time form fields to display values in the expected format.
  - Stored values now take precedence over defaults when rendering fields.
  - Empty date and local date-time fields omit unnecessary value attributes.

- **Tests**
  - Added coverage for default values, stored values, precedence rules, formatting, and empty fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->