### PR TITLE
fix: Editing client — "Save" button stays active and reverts changes on sec...

### DIFF
--- a/modules/crm/presentation/controllers/client_controller.go
+++ b/modules/crm/presentation/controllers/client_controller.go
@@ -974,9 +974,9 @@ func (c *ClientController) UpdatePersonal(
 
 	clientVM := mappers.ClientToViewModel(entity)
 	htmx.Retarget(w, "#personal-info-card")
+	htmx.Reswap(w, "outerHTML")
 	templ.Handler(clients.PersonalInfoCard(clientVM), templ.WithStreaming()).ServeHTTP(w, r)
 }
-
 func (c *ClientController) UpdatePassport(
 	r *http.Request,
 	w http.ResponseWriter,
@@ -1050,9 +1050,9 @@ func (c *ClientController) UpdatePassport(
 
 	clientVM := mappers.ClientToViewModel(entity)
 	htmx.Retarget(w, "#passport-info-card")
+	htmx.Reswap(w, "outerHTML")
 	templ.Handler(clients.PassportInfoCard(clientVM), templ.WithStreaming()).ServeHTTP(w, r)
 }
-
 func (c *ClientController) UpdateTax(
 	r *http.Request,
 	w http.ResponseWriter,
@@ -1126,9 +1126,9 @@ func (c *ClientController) UpdateTax(
 
 	clientVM := mappers.ClientToViewModel(entity)
 	htmx.Retarget(w, "#tax-info-card")
+	htmx.Reswap(w, "outerHTML")
 	templ.Handler(clients.TaxInfoCard(clientVM), templ.WithStreaming()).ServeHTTP(w, r)
 }
-
 func (c *ClientController) UpdateNotes(
 	r *http.Request,
 	w http.ResponseWriter,
@@ -1163,15 +1163,14 @@ func (c *ClientController) UpdateNotes(
 		}
 
 		clientVM := mappers.ClientToViewModel(entity)
-		props := &clients.TaxInfoEditProps{
+		props := &clients.NotesInfoEditProps{
 			Client: clientVM,
 			Errors: errorsMap,
 			Form:   "notes-info-edit-form",
 		}
-		templ.Handler(clients.TaxInfoEditForm(props), templ.WithStreaming()).ServeHTTP(w, r)
+		templ.Handler(clients.NotesInfoEditForm(props), templ.WithStreaming()).ServeHTTP(w, r)
 		return
 	}
-
 	entity, err := clientService.GetByID(r.Context(), id)
 	if err != nil {
 		logger.Errorf("Error retrieving client: %v", err)
@@ -1201,9 +1200,9 @@ func (c *ClientController) UpdateNotes(
 
 	clientVM := mappers.ClientToViewModel(entity)
 	htmx.Retarget(w, "#notes-info-card")
+	htmx.Reswap(w, "outerHTML")
 	templ.Handler(clients.NotesInfoCard(clientVM), templ.WithStreaming()).ServeHTTP(w, r)
 }
-
 func (c *ClientController) Delete(
 	r *http.Request,
 	w http.ResponseWriter,

--- a/modules/crm/presentation/controllers/client_controller.go
+++ b/modules/crm/presentation/controllers/client_controller.go
@@ -1163,6 +1163,7 @@ func (c *ClientController) UpdateNotes(
 		}
 
 		clientVM := mappers.ClientToViewModel(entity)
+		clientVM.Comments = dto.Comments
 		props := &clients.NotesInfoEditProps{
 			Client: clientVM,
 			Errors: errorsMap,


### PR DESCRIPTION
Fixes #274

## Root cause

Client card update responses swap the card into itself (innerHTML), leaving a live Save form with no inputs

## Changes

- Send Hx-Reswap: outerHTML together with the existing Hx-Retarget in all four ClientController update handlers so the card element is replaced instead of nested, which removes the stale Save form/inputs and restores the fresh read-mode card. Also fixed UpdateNotes rendering TaxInfoEditForm/TaxInfoEditProps on validation failure, which injected tax fields bound to the notes form and would blank Comments on the next save.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789925194&installation_model_id=2042&pr_number=1032&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1032&signature=cf99b9b44a2014400761220db8b06e6ff1ddec54e7e298c54b7b4f5436954203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated client detail interactions to refresh the relevant cards correctly.
  * Fixed notes validation errors so submitted comments are preserved and the notes editing form is displayed instead of the tax form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->