### PR TITLE
test(core): cover limited administrator P0 flows

### DIFF
--- a/e2e/tests/rbac/limited-administrator.spec.ts
+++ b/e2e/tests/rbac/limited-administrator.spec.ts
@@ -1,0 +1,340 @@
+import { expect, test, type Page } from '@playwright/test';
+import { login, logout, populateTestData, resetTestDatabase, seedScenario, waitForAlpine } from '../../fixtures';
+
+const limitedAdmin = {
+	email: 'limited-administrator@test.com',
+	password: 'LimitedAdminPass123!',
+};
+
+const permissions = {
+	userRead: '13f011c8-1107-4957-ad19-70cfc167a775',
+	groupRead: '8f9a0b1c-2d3e-4f5a-6b7c-8d9e0f1a2b3c',
+};
+
+const limitedAdminPermissionNames = [
+	'User.Create',
+	'User.Read',
+	'User.Update',
+	'User.Delete',
+	'User.UpdateBlockStatus',
+	'Role.Create',
+	'Role.Read',
+	'Role.Update',
+	'Role.Delete',
+	'Group.Create',
+	'Group.Read',
+	'Group.Update',
+	'Group.Delete',
+];
+
+async function expectNotAdmin(page: Page): Promise<void> {
+	const response = await page.request.get('/departments', { failOnStatusCode: false });
+	expect(response.status(), 'the limited administrator must not inherit Admin').toBe(403);
+}
+
+async function selectOptionsByLabel(page: Page, selector: string, labels: string[]): Promise<void> {
+	await page.locator(selector).evaluate((element, selectedLabels) => {
+		if (!(element instanceof HTMLSelectElement)) throw new Error('expected a select element');
+
+		const wanted = new Set(selectedLabels);
+		let matched = 0;
+		for (const option of Array.from(element.options)) {
+			option.selected = wanted.has(option.text.trim());
+			if (option.selected) matched++;
+		}
+		if (matched !== wanted.size) {
+			throw new Error(`expected ${wanted.size} options, matched ${matched}`);
+		}
+		element.dispatchEvent(new Event('input', { bubbles: true }));
+		element.dispatchEvent(new Event('change', { bubbles: true }));
+	}, labels);
+}
+
+async function setCheckboxState(page: Page, selector: string, checked: boolean): Promise<void> {
+	await page.locator(selector).first().evaluate((element, nextChecked) => {
+		if (!(element instanceof HTMLInputElement)) throw new Error('expected a checkbox input');
+		element.checked = nextChecked;
+		element.dispatchEvent(new Event('change', { bubbles: true }));
+	}, checked);
+}
+
+async function createRole(page: Page, name: string, permissionIDs: string[]): Promise<string> {
+	await page.goto('/roles/new');
+	await expect(page).toHaveURL(/\/roles\/new$/);
+	await waitForAlpine(page);
+	await page.locator('[data-test-id="role-name-input"]').fill(name);
+	await page.locator('[data-test-id="role-description-input"]').fill(`${name} description`);
+
+	for (const permissionID of permissionIDs) {
+		const input = page.locator(`input[name="Permissions[${permissionID}]"]`).first();
+		await expect(input).toBeAttached();
+		await setCheckboxState(page, `input[name="Permissions[${permissionID}]"]`, true);
+	}
+
+	await page.locator('[data-test-id="save-role-btn"]').click();
+	await page.waitForURL(/\/roles$/);
+
+	const row = page.locator('tbody tr').filter({ hasText: name });
+	await expect(row).toBeVisible();
+	const href = await row.locator('a[href^="/roles/"]').first().getAttribute('href');
+	const match = href?.match(/\/roles\/(\d+)$/);
+	if (!match) throw new Error(`role edit URL was not rendered for ${name}`);
+	return match[1];
+}
+
+async function createUser(
+	page: Page,
+	data: {
+		firstName: string;
+		lastName: string;
+		email: string;
+		phone: string;
+		password: string;
+		roleNames?: string[];
+		groupNames?: string[];
+	},
+): Promise<string> {
+	await page.goto('/users/new');
+	await expect(page).toHaveURL(/\/users\/new$/);
+	await page.locator('[name=FirstName]').fill(data.firstName);
+	await page.locator('[name=LastName]').fill(data.lastName);
+	await page.locator('[name=Email]').fill(data.email);
+	await page.locator('[name=Phone]').fill(data.phone);
+	await page.locator('[name=Password]').fill(data.password);
+	await page.locator('[name=Language]').selectOption('en');
+
+	if (data.roleNames) await selectOptionsByLabel(page, 'select[name="RoleIDs"]', data.roleNames);
+	if (data.groupNames) await selectOptionsByLabel(page, 'select[name="GroupIDs"]', data.groupNames);
+
+	await page.locator('#save-btn').click();
+	await page.waitForURL(/\/users$/);
+
+	const row = page.locator('tbody tr').filter({ hasText: `${data.firstName} ${data.lastName}` });
+	await expect(row).toBeVisible();
+	const href = await row.locator('a[href$="/edit"]').first().getAttribute('href');
+	const match = href?.match(/\/users\/(\d+)\/edit$/);
+	if (!match) throw new Error(`user edit URL was not rendered for ${data.email}`);
+	return match[1];
+}
+
+async function submitDeleteFormViaHTMX(page: Page): Promise<void> {
+	const result = await page.evaluate(async () => {
+		const form = document.getElementById('delete-form');
+		if (!(form instanceof HTMLFormElement)) throw new Error('delete form was not rendered');
+		const endpoint = form.getAttribute('hx-delete');
+		if (!endpoint) throw new Error('delete endpoint was not rendered');
+
+		const params = new URLSearchParams();
+		for (const [key, value] of new FormData(form).entries()) params.append(key, String(value));
+
+		const response = await fetch(endpoint, {
+			method: 'DELETE',
+			credentials: 'same-origin',
+			headers: {
+				'HX-Request': 'true',
+				'X-Requested-With': 'XMLHttpRequest',
+				'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+			},
+			body: params.toString(),
+		});
+		return {
+			status: response.status,
+			redirect: response.headers.get('HX-Redirect') ?? response.headers.get('Location'),
+		};
+	});
+
+	expect(result.status).toBeLessThan(400);
+	if (result.redirect) await page.goto(result.redirect);
+}
+
+test.describe('limited administrator P0 management flows', () => {
+	test.describe.configure({ mode: 'serial' });
+
+	test.beforeAll(async ({ request }) => {
+		await resetTestDatabase(request, { reseedMinimal: false });
+		await seedScenario(request, 'comprehensive');
+		await populateTestData(request, {
+			version: '1.0',
+			tenant: {
+				id: '00000000-0000-0000-0000-000000000001',
+				name: 'Default Test Tenant',
+				domain: 'test.localhost',
+			},
+			data: {
+				users: [{
+					email: limitedAdmin.email,
+					password: limitedAdmin.password,
+					firstName: 'Limited',
+					lastName: 'Administrator',
+					language: 'en',
+					permissions: limitedAdminPermissionNames,
+				}],
+			},
+			options: { clearExisting: false, returnIds: true, stopOnError: true },
+		});
+	});
+
+	test.beforeEach(async ({ page }) => {
+		await login(page, limitedAdmin.email, limitedAdmin.password);
+		await expectNotAdmin(page);
+	});
+
+	test.afterEach(async ({ page }) => {
+		await logout(page);
+	});
+
+	test('creates, updates, and deletes a role inside the grant ceiling', async ({ page }) => {
+		const originalName = 'P0 Limited Role';
+		const updatedName = 'P0 Limited Role Updated';
+		const roleID = await createRole(page, originalName, [permissions.userRead]);
+
+		await page.goto(`/roles/${roleID}`);
+		await page.locator('[data-test-id="role-name-input"]').fill(updatedName);
+		await page.locator('[data-test-id="role-description-input"]').fill('Updated inside the actor ceiling');
+		await setCheckboxState(page, `input[name="Permissions[${permissions.groupRead}]"]`, true);
+		await page.locator('[data-test-id="save-role-btn"]').click();
+		await page.waitForURL(/\/roles$/);
+
+		const updatedRow = page.locator('tbody tr').filter({ hasText: updatedName });
+		await expect(updatedRow).toBeVisible();
+		await page.goto(`/roles/${roleID}`);
+		await expect(page.locator(`input[name="Permissions[${permissions.userRead}]"]`).first()).toBeChecked();
+		await expect(page.locator(`input[name="Permissions[${permissions.groupRead}]"]`).first()).toBeChecked();
+
+		await page.locator('[data-test-id="delete-role-btn"]').click();
+		await submitDeleteFormViaHTMX(page);
+		await expect(page).toHaveURL(/\/roles$/);
+		await expect(page.locator('tbody tr').filter({ hasText: updatedName })).toHaveCount(0);
+
+		// Falsely green if the actor is Admin: expectNotAdmin proves the same
+		// session cannot access an unrelated resource before exercising CRUD.
+	});
+
+	test('manages the full lifecycle of a weaker user', async ({ page }) => {
+		const roleName = 'P0 Managed User Reader';
+		const roleID = await createRole(page, roleName, [permissions.userRead]);
+		const userID = await createUser(page, {
+			firstName: 'P0Managed',
+			lastName: 'User',
+			email: 'p0-managed-user@test.com',
+			phone: '+998901112201',
+			password: 'ManagedUserPass123!',
+			roleNames: [roleName],
+		});
+
+		await page.goto(`/users/${userID}/edit`);
+		await page.locator('[name=FirstName]').fill('P0Updated');
+		await page.locator('#save-btn').click();
+		await page.waitForURL(/\/users$/);
+		await expect(page.locator('tbody tr').filter({ hasText: 'P0Updated User' })).toBeVisible();
+
+		await page.goto(`/users/${userID}/edit`);
+		await page.getByRole('button', { name: 'Block User', exact: true }).click();
+		const blockDrawer = page.locator(`#block-user-drawer-${userID}`);
+		await expect(blockDrawer.locator('[name=BlockReason]')).toBeVisible();
+		await blockDrawer.locator('[name=BlockReason]').fill('P0 lifecycle verification');
+		await blockDrawer.getByRole('button', { name: 'Block User', exact: true }).click();
+		await expect(page.getByText('Blocked', { exact: true })).toBeVisible();
+
+		await expect(page.getByRole('button', { name: 'Unblock User', exact: true })).toBeVisible();
+		const unblockResponse = await page.request.post(`/users/${userID}/unblock`, {
+			headers: { 'HX-Request': 'true' },
+			failOnStatusCode: false,
+		});
+		expect(unblockResponse.status()).toBe(200);
+		await page.reload();
+		await expect(page.getByRole('button', { name: 'Block User', exact: true })).toBeVisible();
+
+		await page.locator('#delete-user-btn').click();
+		await submitDeleteFormViaHTMX(page);
+		await expect(page).toHaveURL(/\/users$/);
+		await expect(page.locator('tbody tr').filter({ hasText: 'P0Updated User' })).toHaveCount(0);
+
+		await page.goto(`/roles/${roleID}`);
+		await page.locator('[data-test-id="delete-role-btn"]').click();
+		await submitDeleteFormViaHTMX(page);
+
+		// Falsely green if only creation works: the same persisted target is
+		// updated, blocked, unblocked, and deleted through its real UI routes.
+	});
+
+	test('propagates and revokes access through a group role', async ({ page }) => {
+		const roleName = 'P0 Group User Reader';
+		const groupName = 'P0 Permission Group';
+		const updatedGroupName = 'P0 Permission Group Updated';
+		const targetEmail = 'p0-group-user@test.com';
+		const targetPassword = 'GroupUserPass123!';
+		const roleID = await createRole(page, roleName, [permissions.userRead]);
+
+		await page.goto('/groups');
+		await page.locator('button:visible').filter({ hasText: 'New group' }).click();
+		const newDrawer = page.locator('#new-group-drawer');
+		await expect(newDrawer.locator('form[hx-post="/groups"]')).toBeVisible();
+		await newDrawer.locator('[name=Name]').fill(groupName);
+		await setCheckboxState(page, `#new-group-drawer input[name=RoleIDs][value="${roleID}"]`, true);
+		await newDrawer.locator('#save-btn').click();
+		await page.waitForURL(/\/groups$/);
+
+		let groupRow = page.locator('#groups-table-body tr').filter({ hasText: groupName });
+		await expect(groupRow).toBeVisible();
+		const rowID = await groupRow.getAttribute('id');
+		const groupID = rowID?.replace(/^group-/, '');
+		if (!groupID) throw new Error('created group ID was not rendered');
+
+		await groupRow.click();
+		const editDrawer = page.locator('#edit-group-drawer');
+		await expect(editDrawer.locator('[name=Name]')).toBeVisible();
+		await editDrawer.locator('[name=Name]').fill(updatedGroupName);
+		await editDrawer.locator('#save-btn').click();
+		await page.waitForURL(/\/groups$/);
+		groupRow = page.locator('#groups-table-body tr').filter({ hasText: updatedGroupName });
+		await expect(groupRow).toBeVisible();
+
+		const userID = await createUser(page, {
+			firstName: 'P0Group',
+			lastName: 'User',
+			email: targetEmail,
+			phone: '+998901112202',
+			password: targetPassword,
+			groupNames: [updatedGroupName],
+		});
+
+		await logout(page);
+		await login(page, targetEmail, targetPassword);
+		const inheritedAccess = await page.goto('/users');
+		expect(inheritedAccess?.status()).toBe(200);
+		await expect(page.locator('table')).toBeVisible();
+
+		await logout(page);
+		await login(page, limitedAdmin.email, limitedAdmin.password);
+		await page.goto(`/users/${userID}/edit`);
+		await selectOptionsByLabel(page, 'select[name="GroupIDs"]', []);
+		await page.locator('#save-btn').click();
+		await page.waitForURL(/\/users$/);
+
+		await logout(page);
+		await login(page, targetEmail, targetPassword);
+		const revokedAccess = await page.request.get('/users', { failOnStatusCode: false });
+		expect(revokedAccess.status()).toBe(403);
+
+		await logout(page);
+		await login(page, limitedAdmin.email, limitedAdmin.password);
+		await page.goto(`/users/${userID}/edit`);
+		await page.locator('#delete-user-btn').click();
+		await submitDeleteFormViaHTMX(page);
+
+		await page.goto('/groups');
+		groupRow = page.locator('#groups-table-body tr').filter({ hasText: updatedGroupName });
+		await groupRow.click();
+		await page.locator('#edit-group-drawer #delete-group-btn').click();
+		await page.waitForURL(/\/groups$/);
+		await expect(page.locator('#groups-table-body tr').filter({ hasText: updatedGroupName })).toHaveCount(0);
+
+		await page.goto(`/roles/${roleID}`);
+		await page.locator('[data-test-id="delete-role-btn"]').click();
+		await submitDeleteFormViaHTMX(page);
+
+		// Falsely green if the target receives User.Read directly or through a
+		// role: removing its only group must turn the same /users request to 403.
+	});
+});

--- a/modules/testkit/services/populate_service.go
+++ b/modules/testkit/services/populate_service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/composables"
 	"github.com/iota-uz/iota-sdk/pkg/defaults"
 	"github.com/iota-uz/iota-sdk/pkg/repo"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
 	pkgtwofactor "github.com/iota-uz/iota-sdk/pkg/twofactor"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -177,6 +178,8 @@ func (s *PopulateService) populateData(ctx context.Context, data *schemas.DataSp
 }
 
 func (s *PopulateService) createUsers(ctx context.Context, users []schemas.UserSpec) error {
+	const op = serrors.Op("PopulateService.createUsers")
+
 	logger := composables.UseLogger(ctx)
 
 	// Get tenant ID from context
@@ -253,7 +256,7 @@ func (s *PopulateService) createUsers(ctx context.Context, users []schemas.UserS
 		if len(userSpec.Permissions) > 0 {
 			requestedPermissions, err := resolvePermissions(ctx, permissionRepo, userSpec.Permissions)
 			if err != nil {
-				return fmt.Errorf("failed to resolve permissions for user %s: %w", userSpec.Email, err)
+				return serrors.E(op, err, fmt.Sprintf("failed to resolve permissions for user %s", userSpec.Email))
 			}
 			userOptions = append(userOptions, user.WithPermissions(requestedPermissions))
 		}
@@ -352,9 +355,11 @@ func resolvePermissions(
 	repository permission.Repository,
 	names []string,
 ) ([]permission.Permission, error) {
+	const op = serrors.Op("PopulateService.resolvePermissions")
+
 	available, err := repository.GetAll(ctx)
 	if err != nil {
-		return nil, err
+		return nil, serrors.E(op, err)
 	}
 
 	byName := make(map[string]permission.Permission, len(available))
@@ -370,7 +375,7 @@ func resolvePermissions(
 		}
 		candidate, ok := byName[name]
 		if !ok {
-			return nil, fmt.Errorf("permission %q not found", name)
+			return nil, serrors.E(op, serrors.NotFound, fmt.Sprintf("permission %q not found", name))
 		}
 		seen[name] = struct{}{}
 		requested = append(requested, candidate)

--- a/modules/testkit/services/populate_service.go
+++ b/modules/testkit/services/populate_service.go
@@ -250,6 +250,13 @@ func (s *PopulateService) createUsers(ctx context.Context, users []schemas.UserS
 			user.WithTenantID(tenantID),
 			user.WithType(user.TypeUser),
 		}
+		if len(userSpec.Permissions) > 0 {
+			requestedPermissions, err := resolvePermissions(ctx, permissionRepo, userSpec.Permissions)
+			if err != nil {
+				return fmt.Errorf("failed to resolve permissions for user %s: %w", userSpec.Email, err)
+			}
+			userOptions = append(userOptions, user.WithPermissions(requestedPermissions))
+		}
 
 		if userSpec.TwoFactorMethod != "" {
 			method, err := parseTwoFactorMethod(userSpec.TwoFactorMethod)
@@ -338,6 +345,37 @@ func (s *PopulateService) createUsers(ctx context.Context, users []schemas.UserS
 	}
 
 	return nil
+}
+
+func resolvePermissions(
+	ctx context.Context,
+	repository permission.Repository,
+	names []string,
+) ([]permission.Permission, error) {
+	available, err := repository.GetAll(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	byName := make(map[string]permission.Permission, len(available))
+	for _, candidate := range available {
+		byName[candidate.Name()] = candidate
+	}
+
+	requested := make([]permission.Permission, 0, len(names))
+	seen := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		if _, duplicate := seen[name]; duplicate {
+			continue
+		}
+		candidate, ok := byName[name]
+		if !ok {
+			return nil, fmt.Errorf("permission %q not found", name)
+		}
+		seen[name] = struct{}{}
+		requested = append(requested, candidate)
+	}
+	return requested, nil
 }
 
 func parseTwoFactorMethod(raw string) (pkgtwofactor.Method, error) {

--- a/modules/testkit/services/populate_service_test.go
+++ b/modules/testkit/services/populate_service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/iota-uz/iota-sdk/modules"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/role"
 	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence"
+	corepermissions "github.com/iota-uz/iota-sdk/modules/core/permissions"
 	"github.com/iota-uz/iota-sdk/modules/testkit/domain/schemas"
 	"github.com/iota-uz/iota-sdk/modules/testkit/services"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
@@ -19,6 +20,50 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPopulateService_AssignsRequestedUserPermissionsWithoutAdminRole(t *testing.T) {
+	t.Parallel()
+
+	f := setupTest(t)
+	tenantID := uuid.New()
+	ctx := context.WithValue(
+		composables.WithTenantID(f.Ctx, tenantID),
+		constants.LoggerKey,
+		logrus.NewEntry(logrus.New()),
+	)
+	populateService := services.NewPopulateService(f.Pool)
+
+	_, err := populateService.Execute(ctx, &schemas.PopulateRequest{
+		Version: "1.0",
+		Tenant: &schemas.TenantSpec{
+			ID:   tenantID.String(),
+			Name: "Limited administrator fixture",
+		},
+		Data: &schemas.DataSpec{Users: []schemas.UserSpec{{
+			Email:       "limited-admin-fixture@example.com",
+			Password:    "TestPass123!",
+			FirstName:   "Limited",
+			LastName:    "Administrator",
+			Permissions: []string{corepermissions.UserRead.Name(), corepermissions.RoleRead.Name()},
+		}}},
+	})
+	require.NoError(t, err)
+
+	created, err := persistence.NewUserRepository(persistence.NewUploadRepository()).GetByEmail(
+		ctx,
+		"limited-admin-fixture@example.com",
+	)
+	require.NoError(t, err)
+	assert.Empty(t, created.Roles())
+	require.Len(t, created.Permissions(), 2)
+	assert.ElementsMatch(t, []string{corepermissions.UserRead.Name(), corepermissions.RoleRead.Name()}, []string{
+		created.Permissions()[0].Name(),
+		created.Permissions()[1].Name(),
+	})
+
+	// Falsely green if the fixture silently assigns Admin: exact direct grants
+	// and an empty role set are both part of the test identity contract.
+}
 
 // setupTest creates all necessary dependencies for tests
 func setupTest(t *testing.T) *itf.TestEnvironment {

--- a/modules/testkit/services/populate_service_test.go
+++ b/modules/testkit/services/populate_service_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/composables"
 	"github.com/iota-uz/iota-sdk/pkg/constants"
 	"github.com/iota-uz/iota-sdk/pkg/itf"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
 	pkgtwofactor "github.com/iota-uz/iota-sdk/pkg/twofactor"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -22,47 +23,83 @@ import (
 )
 
 func TestPopulateService_AssignsRequestedUserPermissionsWithoutAdminRole(t *testing.T) {
-	t.Parallel()
-
-	f := setupTest(t)
-	tenantID := uuid.New()
-	ctx := context.WithValue(
-		composables.WithTenantID(f.Ctx, tenantID),
-		constants.LoggerKey,
-		logrus.NewEntry(logrus.New()),
-	)
-	populateService := services.NewPopulateService(f.Pool)
-
-	_, err := populateService.Execute(ctx, &schemas.PopulateRequest{
-		Version: "1.0",
-		Tenant: &schemas.TenantSpec{
-			ID:   tenantID.String(),
-			Name: "Limited administrator fixture",
+	tests := []struct {
+		name            string
+		email           string
+		permissions     []string
+		wantPermissions []string
+		wantErrorKind   string
+	}{
+		{
+			name:            "assigns exact direct grants",
+			email:           "limited-admin-fixture@example.com",
+			permissions:     []string{corepermissions.UserRead.Name(), corepermissions.RoleRead.Name()},
+			wantPermissions: []string{corepermissions.UserRead.Name(), corepermissions.RoleRead.Name()},
 		},
-		Data: &schemas.DataSpec{Users: []schemas.UserSpec{{
-			Email:       "limited-admin-fixture@example.com",
-			Password:    "TestPass123!",
-			FirstName:   "Limited",
-			LastName:    "Administrator",
-			Permissions: []string{corepermissions.UserRead.Name(), corepermissions.RoleRead.Name()},
-		}}},
-	})
-	require.NoError(t, err)
+		{
+			name:            "deduplicates permission names",
+			email:           "duplicate-permissions-fixture@example.com",
+			permissions:     []string{corepermissions.UserRead.Name(), corepermissions.UserRead.Name()},
+			wantPermissions: []string{corepermissions.UserRead.Name()},
+		},
+		{
+			name:          "rejects unavailable permission names",
+			email:         "unavailable-permission-fixture@example.com",
+			permissions:   []string{"Missing.Read"},
+			wantErrorKind: "not_found",
+		},
+	}
 
-	created, err := persistence.NewUserRepository(persistence.NewUploadRepository()).GetByEmail(
-		ctx,
-		"limited-admin-fixture@example.com",
-	)
-	require.NoError(t, err)
-	assert.Empty(t, created.Roles())
-	require.Len(t, created.Permissions(), 2)
-	assert.ElementsMatch(t, []string{corepermissions.UserRead.Name(), corepermissions.RoleRead.Name()}, []string{
-		created.Permissions()[0].Name(),
-		created.Permissions()[1].Name(),
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := setupTest(t)
+			tenantID := uuid.New()
+			ctx := context.WithValue(
+				composables.WithTenantID(f.Ctx, tenantID),
+				constants.LoggerKey,
+				logrus.NewEntry(logrus.New()),
+			)
+			populateService := services.NewPopulateService(f.Pool)
 
-	// Falsely green if the fixture silently assigns Admin: exact direct grants
-	// and an empty role set are both part of the test identity contract.
+			_, err := populateService.Execute(ctx, &schemas.PopulateRequest{
+				Version: "1.0",
+				Tenant: &schemas.TenantSpec{
+					ID:   tenantID.String(),
+					Name: "Limited administrator fixture",
+				},
+				Data: &schemas.DataSpec{Users: []schemas.UserSpec{{
+					Email:       tt.email,
+					Password:    "TestPass123!",
+					FirstName:   "Limited",
+					LastName:    "Administrator",
+					Permissions: tt.permissions,
+				}}},
+			})
+
+			if tt.wantErrorKind != "" {
+				require.Error(t, err)
+				var structuredErr *serrors.Error
+				require.ErrorAs(t, err, &structuredErr)
+				assert.Equal(t, serrors.Op("PopulateService.createUsers"), structuredErr.Op)
+				assert.Equal(t, tt.wantErrorKind, structuredErr.ErrorKind())
+				// Falsely green if unavailable names are silently ignored instead of rejecting the fixture.
+				return
+			}
+			require.NoError(t, err)
+
+			created, err := persistence.NewUserRepository(persistence.NewUploadRepository()).GetByEmail(ctx, tt.email)
+			require.NoError(t, err)
+			assert.Empty(t, created.Roles())
+			permissionNames := make([]string, 0, len(created.Permissions()))
+			for _, directPermission := range created.Permissions() {
+				permissionNames = append(permissionNames, directPermission.Name())
+			}
+			assert.ElementsMatch(t, tt.wantPermissions, permissionNames)
+
+			// Falsely green if direct grants are ignored or replaced with Admin: exact
+			// deduplicated grants and an empty role set define the test identity.
+		})
+	}
 }
 
 // setupTest creates all necessary dependencies for tests


### PR DESCRIPTION
## Summary

- make testkit user fixtures assign the exact requested direct permissions without implicitly granting Admin
- cover limited-administrator role create/update/delete within the actor permission ceiling
- cover the complete weaker-user lifecycle: create, update, block, unblock, and delete
- cover effective access propagation and revocation through group → role → user

## Regression proof

Applied the test-only diff to the parent of #1034 (`255299e60`):

- role CRUD: passed
- weaker-user lifecycle: passed
- group-role propagation: failed at the expected authorization boundary (`GET /users` returned 403 instead of 200)

All three pass on current `main`. This proves the third scenario catches the pre-#1033 runtime regression while the first two preserve previously allowed behavior.

## Verification

- `BASE_URL=http://localhost:3201 pnpm exec playwright test tests/rbac/limited-administrator.spec.ts --workers=1 --repeat-each=3 --reporter=list` — 9 passed
- relevant existing + new E2E selection — 11 passed, 1 existing skipped
- `GOWORK=off go test ./modules/testkit/services -count=1`
- `GOWORK=off go vet ./modules/testkit/services`
- `pnpm exec tsc --noEmit` (from `e2e`)
- `git diff --check`

Refs iota-uz/eai#1033

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1035"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790266602&installation_model_id=2042&pr_number=1035&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1035&signature=469aa2b58b0051bd6a84499ad8a9704a32e6918834f6bdcf64878748800bb5b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for assigning specific permissions directly to newly created users without granting administrator access.
  * Duplicate permissions are handled automatically, while unknown permissions are rejected.
  * Limited administrators can manage authorized roles and users, including creation, updates, blocking, unblocking, and deletion.
  * Group-based access is verified throughout its lifecycle, including removal when membership changes.

* **Bug Fixes**
  * Restricted administrators remain blocked from areas requiring broader administrative access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->