### PR TITLE
feat(oidc): add least-privilege permission scopes

### DIFF
--- a/modules/oidc/README.md
+++ b/modules/oidc/README.md
@@ -251,6 +251,9 @@ The OIDC module fully supports IOTA SDK's multi-tenant architecture:
 - Auth requests are scoped to tenant after user authentication
 - Refresh tokens are scoped to user + tenant + client combination
 - Token claims include `tenant_id`
+- Clients can request least-privilege `permission:<name>` scopes; the resulting
+  `permissions` claim contains only requested permissions effectively granted
+  to the user (directly, through roles, or through group roles)
 - User info returns data for authenticated tenant only
 
 ## Configuration

--- a/modules/oidc/infrastructure/oidc/permission_claims_test.go
+++ b/modules/oidc/infrastructure/oidc/permission_claims_test.go
@@ -1,0 +1,72 @@
+package oidc
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/role"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/user"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/permission"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/value_objects/internet"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPermissionClaimsReturnsOnlyRequestedEffectivePermissions(t *testing.T) {
+	t.Parallel()
+
+	direct := testPermission("Ali.Config")
+	viaRole := testPermission("Ali.Eval")
+	viaGroup := testPermission("Ali.Logs")
+	email, err := internet.NewEmail("oidc-permissions@example.com")
+	require.NoError(t, err)
+	entity := user.New(
+		"OIDC",
+		"User",
+		email,
+		user.UILanguageEN,
+		user.WithPermissions([]permission.Permission{direct}),
+		user.WithRoles([]role.Role{role.New("evaluator", role.WithPermissions([]permission.Permission{viaRole}))}),
+		user.WithGroupPermissions([]permission.Permission{viaGroup}),
+	)
+
+	claims, requested := permissionClaims(entity, []string{
+		"openid",
+		"permission:Ali.Logs",
+		"permission:Ali.Config",
+		"permission:Ali.Missing",
+	})
+
+	require.True(t, requested)
+	require.Equal(t, []string{"Ali.Config", "Ali.Logs"}, claims)
+	// Falsely green if the helper returns every effective grant or ignores
+	// group-inherited permissions instead of intersecting requested scopes.
+	require.NotContains(t, claims, viaRole.Name())
+}
+
+func TestPermissionClaimsDistinguishesUnrequestedFromDenied(t *testing.T) {
+	t.Parallel()
+
+	email, err := internet.NewEmail("oidc-no-permissions@example.com")
+	require.NoError(t, err)
+	entity := user.New("OIDC", "User", email, user.UILanguageEN)
+
+	claims, requested := permissionClaims(entity, []string{"openid"})
+	require.False(t, requested)
+	require.Nil(t, claims)
+
+	claims, requested = permissionClaims(entity, []string{"openid", "permission:Ali.Config"})
+	require.True(t, requested)
+	require.Empty(t, claims)
+	// Falsely green if an empty permission claim is omitted even when the client
+	// explicitly requested a permission scope the user does not have.
+}
+
+func testPermission(name string) permission.Permission {
+	return permission.New(
+		permission.WithID(uuid.New()),
+		permission.WithName(name),
+		permission.WithResource(permission.Resource(name)),
+		permission.WithAction(permission.ActionRead),
+		permission.WithModifier(permission.ModifierAll),
+	)
+}

--- a/modules/oidc/infrastructure/oidc/storage.go
+++ b/modules/oidc/infrastructure/oidc/storage.go
@@ -6,6 +6,8 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/go-jose/go-jose/v4"
@@ -640,6 +642,9 @@ func (s *Storage) SetUserinfoFromScopes(
 			userinfo.AppendClaims("roles", roleNames)
 		}
 	}
+	if permissions, requested := permissionClaims(u, scopes); requested {
+		userinfo.AppendClaims("permissions", permissions)
+	}
 
 	return nil
 }
@@ -749,8 +754,34 @@ func (s *Storage) GetPrivateClaimsFromScopes(
 			claims["roles"] = roleNames
 		}
 	}
+	if permissions, requested := permissionClaims(u, scopes); requested {
+		claims["permissions"] = permissions
+	}
 
 	return claims, nil
+}
+
+const permissionScopePrefix = "permission:"
+
+func permissionClaims(u user.User, scopes []string) ([]string, bool) {
+	requested := make(map[string]struct{})
+	for _, scope := range scopes {
+		if name := strings.TrimPrefix(scope, permissionScopePrefix); name != scope && name != "" {
+			requested[name] = struct{}{}
+		}
+	}
+	if len(requested) == 0 {
+		return nil, false
+	}
+
+	granted := make([]string, 0, len(requested))
+	for _, permission := range user.EffectivePermissions(u) {
+		if _, ok := requested[permission.Name()]; ok {
+			granted = append(granted, permission.Name())
+		}
+	}
+	sort.Strings(granted)
+	return granted, true
 }
 
 // GetKeyByIDAndClientID retrieves a specific key for a client


### PR DESCRIPTION
## Outcome
- accepts `permission:<name>` OIDC scopes
- emits a `permissions` claim containing only the requested permissions effectively granted to the user
- includes direct, role, and group-role grants while preserving least privilege
- documents the extension and covers requested, denied, and unrequested cases

## Verification
- `go test ./modules/oidc/infrastructure/oidc`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790832236&installation_model_id=2042&pr_number=1036&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1036&signature=cc8e7f4fd0a4fe09f0d5399aed0d8e1c9b55749a4f95e6ba6b407ff019fc043d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OIDC clients can request specific least-privilege `permission:<name>` scopes.
  * Granted permissions are included in the `permissions` claim across user information and private claims.
  * Claims include only requested permissions effectively granted to the user.

* **Documentation**
  * Added guidance for requesting permission scopes and interpreting the resulting claims.

* **Tests**
  * Added coverage for direct, role-based, group-inherited, unrequested, and denied permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->