### PR TITLE
test(oidc): seed callback identity explicitly

### DIFF
--- a/modules/oidc/presentation/controllers/oidc_controller.go
+++ b/modules/oidc/presentation/controllers/oidc_controller.go
@@ -184,8 +184,8 @@ func (c *OIDCController) handleCallback(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	// Redirect back to the OIDC authorize endpoint to complete the flow
-	// The zitadel library will handle generating the authorization code and redirecting to client
-	redirectURL := fmt.Sprintf("/oidc/authorize?id=%s", query.ID)
-	http.Redirect(w, r, redirectURL, http.StatusFound)
+	// Resume the stored authorization request through the provider callback.
+	// The public authorize endpoint expects the original OIDC parameters and
+	// cannot resume an existing request from its internal ID.
+	op.AuthorizeCallback(w, r, c.provider)
 }

--- a/modules/oidc/presentation/controllers/oidc_controller_test.go
+++ b/modules/oidc/presentation/controllers/oidc_controller_test.go
@@ -1,0 +1,91 @@
+package controllers_test
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iota-uz/iota-sdk/modules"
+	"github.com/iota-uz/iota-sdk/modules/oidc/domain/entities/authrequest"
+	"github.com/iota-uz/iota-sdk/modules/oidc/domain/entities/client"
+	oidcstorage "github.com/iota-uz/iota-sdk/modules/oidc/infrastructure/oidc"
+	"github.com/iota-uz/iota-sdk/modules/oidc/infrastructure/persistence"
+	"github.com/iota-uz/iota-sdk/modules/oidc/presentation/controllers"
+	"github.com/iota-uz/iota-sdk/modules/oidc/services"
+	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig"
+	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig/cookies"
+	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/oidcconfig"
+	"github.com/iota-uz/iota-sdk/pkg/itf"
+)
+
+func TestMain(m *testing.M) {
+	if err := os.Chdir("../../../.."); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}
+
+func TestOIDCCallbackCompletesStoredAuthorizationRequest(t *testing.T) {
+	t.Parallel()
+
+	env := itf.Setup(t, itf.WithComponents(modules.Components()...))
+	clientRepo := persistence.NewClientRepository()
+	authRequestRepo := persistence.NewAuthRequestRepository()
+	callbackURL := "https://client.example.test/callback"
+	testClient := client.New("callback-client", "Callback client", "web", []string{callbackURL})
+	_, err := clientRepo.Create(env.Ctx, testClient)
+	require.NoError(t, err)
+
+	request := authrequest.New(
+		testClient.ClientID(),
+		callbackURL,
+		[]string{"openid"},
+		"code",
+		authrequest.WithState("state-123"),
+	).CompleteAuthentication(int(env.User.ID()), env.TenantID())
+	require.NoError(t, authRequestRepo.Create(env.Ctx, request))
+
+	cryptoKey := base64.StdEncoding.EncodeToString(make([]byte, 32))
+	storage := oidcstorage.NewStorage(
+		clientRepo,
+		authRequestRepo,
+		persistence.NewTokenRepository(),
+		nil,
+		env.Pool,
+		cryptoKey,
+		"https://issuer.example.test/oidc",
+		0,
+		0,
+	)
+	controller := controllers.NewOIDCController(
+		storage,
+		&oidcconfig.Config{IssuerURL: "https://issuer.example.test/oidc", CryptoKey: cryptoKey},
+		services.NewOIDCService(clientRepo, authRequestRepo),
+		nil,
+		&httpconfig.Config{},
+		&cookies.Config{SID: "sid"},
+	)
+	router := mux.NewRouter()
+	controller.Register(router)
+
+	recorder := httptest.NewRecorder()
+	httpRequest := httptest.NewRequest(
+		http.MethodGet,
+		"/oidc/authorize/callback?id="+url.QueryEscape(request.ID().String()),
+		nil,
+	).WithContext(env.Ctx)
+	router.ServeHTTP(recorder, httpRequest)
+
+	require.Equal(t, http.StatusFound, recorder.Code)
+	location, err := url.Parse(recorder.Header().Get("Location"))
+	require.NoError(t, err)
+	require.Equal(t, callbackURL, location.Scheme+"://"+location.Host+location.Path)
+	require.NotEmpty(t, location.Query().Get("code"))
+	require.Equal(t, "state-123", location.Query().Get("state"))
+}

--- a/modules/oidc/presentation/controllers/oidc_controller_test.go
+++ b/modules/oidc/presentation/controllers/oidc_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 
@@ -41,6 +42,19 @@ func TestOIDCCallbackCompletesStoredAuthorizationRequest(t *testing.T) {
 	testClient := client.New("callback-client", "Callback client", "web", []string{callbackURL})
 	_, err := clientRepo.Create(env.Ctx, testClient)
 	require.NoError(t, err)
+	tenantID := uuid.New()
+	_, err = env.Tx.Exec(env.Ctx, `INSERT INTO tenants (id, name) VALUES ($1, $2)`, tenantID, "OIDC callback tenant")
+	require.NoError(t, err)
+	var userID int
+	err = env.Tx.QueryRow(
+		env.Ctx,
+		`INSERT INTO users (tenant_id, type, first_name, last_name, email, ui_language)
+		 VALUES ($1, 'user', 'OIDC', 'Callback', $2, 'en')
+		 RETURNING id`,
+		tenantID,
+		"oidc-callback-"+uuid.NewString()+"@example.test",
+	).Scan(&userID)
+	require.NoError(t, err)
 
 	request := authrequest.New(
 		testClient.ClientID(),
@@ -48,7 +62,7 @@ func TestOIDCCallbackCompletesStoredAuthorizationRequest(t *testing.T) {
 		[]string{"openid"},
 		"code",
 		authrequest.WithState("state-123"),
-	).CompleteAuthentication(int(env.User.ID()), env.TenantID())
+	).CompleteAuthentication(userID, tenantID)
 	require.NoError(t, authRequestRepo.Create(env.Ctx, request))
 
 	cryptoKey := base64.StdEncoding.EncodeToString(make([]byte, 32))


### PR DESCRIPTION
## Summary
- seed the tenant and user required by the OIDC callback integration test
- keep the callback regression test independent from optional default test identities

## Context
Follow-up to #1037, which auto-merged before its final integration job completed. Runtime behavior from #1037 is unchanged.

## Verification
- `git diff --check`
- tests intentionally delegated to CI

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790850797&installation_model_id=2042&pr_number=1038&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1038&signature=c5b05137bdf126a2ce3a07229a7c775cc5df6e3ac5ac04ae5c5c724224e6502e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OIDC authorization callbacks now complete the stored authorization request directly.
  * Clients are redirected to their configured callback URL with the authorization code and original state.
  * Improved callback handling for completed authorization flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->