### PR TITLE
fix(oidc): complete authorization callback flow

### DIFF
--- a/migrations/changes-1788259834.sql
+++ b/migrations/changes-1788259834.sql
@@ -1,0 +1,8 @@
+-- Allow encrypted authorization codes produced by the OIDC provider.
+-- +migrate Up
+ALTER TABLE oidc.auth_requests
+    ALTER COLUMN code TYPE TEXT;
+
+-- +migrate Down
+ALTER TABLE oidc.auth_requests
+    ALTER COLUMN code TYPE VARCHAR(64);

--- a/modules/oidc/presentation/controllers/oidc_controller_test.go
+++ b/modules/oidc/presentation/controllers/oidc_controller_test.go
@@ -1,6 +1,7 @@
 package controllers_test
 
 import (
+	"context"
 	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
 	"github.com/iota-uz/iota-sdk/modules"
@@ -22,6 +24,7 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig"
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig/cookies"
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/oidcconfig"
+	"github.com/iota-uz/iota-sdk/pkg/constants"
 	"github.com/iota-uz/iota-sdk/pkg/itf"
 )
 
@@ -89,11 +92,12 @@ func TestOIDCCallbackCompletesStoredAuthorizationRequest(t *testing.T) {
 	controller.Register(router)
 
 	recorder := httptest.NewRecorder()
+	requestContext := context.WithValue(env.Ctx, constants.LoggerKey, logrus.New().WithField("test", true))
 	httpRequest := httptest.NewRequest(
 		http.MethodGet,
 		"/oidc/authorize/callback?id="+url.QueryEscape(request.ID().String()),
 		nil,
-	).WithContext(env.Ctx)
+	).WithContext(requestContext)
 	router.ServeHTTP(recorder, httpRequest)
 
 	require.Equal(t, http.StatusFound, recorder.Code)

--- a/modules/oidc/presentation/controllers/oidc_controller_test.go
+++ b/modules/oidc/presentation/controllers/oidc_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 
@@ -41,6 +42,19 @@ func TestOIDCCallbackCompletesStoredAuthorizationRequest(t *testing.T) {
 	testClient := client.New("callback-client", "Callback client", "web", []string{callbackURL})
 	_, err := clientRepo.Create(env.Ctx, testClient)
 	require.NoError(t, err)
+	tenantID := uuid.New()
+	_, err = env.Tx.Exec(env.Ctx, `INSERT INTO tenants (id, name) VALUES ($1, $2)`, tenantID, "OIDC callback tenant")
+	require.NoError(t, err)
+	var userID int
+	err = env.Tx.QueryRow(
+		env.Ctx,
+		`INSERT INTO users (tenant_id, type, first_name, last_name, email, ui_language)
+		 VALUES ($1, 'user', 'OIDC', 'Callback', $2, 'en')
+		 RETURNING id`,
+		tenantID,
+		"oidc-callback-"+uuid.NewString()+"@example.test",
+	).Scan(&userID)
+	require.NoError(t, err)
 
 	request := authrequest.New(
 		testClient.ClientID(),
@@ -48,7 +62,7 @@ func TestOIDCCallbackCompletesStoredAuthorizationRequest(t *testing.T) {
 		[]string{"openid"},
 		"code",
 		authrequest.WithState("state-123"),
-	).CompleteAuthentication(int(env.User.ID()), env.TenantID())
+	).CompleteAuthentication(userID, tenantID)
 	require.NoError(t, authRequestRepo.Create(env.Ctx, request))
 
 	cryptoKey := base64.StdEncoding.EncodeToString(make([]byte, 32))


### PR DESCRIPTION
## Summary
- widen OIDC authorization-code storage for the encrypted code emitted by the provider
- seed the tenant and user required by the end-to-end callback integration test
- provide the same request logger context as production middleware

## Context
Follow-up to #1037, which corrected the callback dispatch but auto-merged before its final integration job completed. The completed integration test exposed the incompatible `varchar(64)` authorization-code column before production rollout.

## Verification
- `git diff --check`
- full test suite delegated to CI