### PR TITLE
feat(auth): add multi-account sessions and OIDC account picker

### DIFF
--- a/components/base/dropdown.templ
+++ b/components/base/dropdown.templ
@@ -51,8 +51,9 @@ templ DropdownFormItem(props DropdownFormItemProps) {
 }
 
 type DetailsDropdownProps struct {
-	Summary templ.Component
-	Classes templ.CSSClasses
+	Summary     templ.Component
+	Classes     templ.CSSClasses
+	MenuClasses templ.CSSClasses
 }
 
 func newDetailsDropdown(props *DetailsDropdownProps) *DetailsDropdownProps {
@@ -68,7 +69,7 @@ templ (p *DetailsDropdownProps) render() {
 			if p.Summary != nil {
 				@p.Summary
 			}
-			<ul class="flex flex-col gap-1 mt-1 absolute bg-surface-300 right-0 text-sm rounded-md w-44 overflow-hidden shadow-sm border border-secondary p-1">
+			<ul class={ "flex flex-col gap-1 mt-1 absolute bg-surface-300 right-0 text-sm rounded-md w-44 overflow-hidden shadow-sm border border-secondary p-1", p.MenuClasses }>
 				{ children... }
 			</ul>
 		</details>

--- a/components/base/dropdown.templ
+++ b/components/base/dropdown.templ
@@ -26,6 +26,7 @@ templ DropdownItem(props DropdownItemProps) {
 type DropdownFormItemProps struct {
 	Action string
 	Method string
+	Fields map[string]string
 }
 
 func normalizeDropdownFormMethod(method string) string {
@@ -39,6 +40,9 @@ templ DropdownFormItem(props DropdownFormItemProps) {
 	<li>
 		<form action={ templ.SafeURL(props.Action) } method={ normalizeDropdownFormMethod(props.Method) }>
 			@composables.CSRFTokenField()
+			for name, value := range props.Fields {
+				<input type="hidden" name={ name } value={ value }/>
+			}
 			<button type="submit" class="block w-full p-2 text-left duration-200 hover:bg-surface-400 rounded-md">
 				{ children... }
 			</button>

--- a/components/base/dropdown_templ.go
+++ b/components/base/dropdown_templ.go
@@ -196,8 +196,9 @@ func DropdownFormItem(props DropdownFormItemProps) templ.Component {
 }
 
 type DetailsDropdownProps struct {
-	Summary templ.Component
-	Classes templ.CSSClasses
+	Summary     templ.Component
+	Classes     templ.CSSClasses
+	MenuClasses templ.CSSClasses
 }
 
 func newDetailsDropdown(props *DetailsDropdownProps) *DetailsDropdownProps {
@@ -256,7 +257,25 @@ func (p *DetailsDropdownProps) render() templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<ul class=\"flex flex-col gap-1 mt-1 absolute bg-surface-300 right-0 text-sm rounded-md w-44 overflow-hidden shadow-sm border border-secondary p-1\">")
+		var templ_7745c5c3_Var11 = []any{"flex flex-col gap-1 mt-1 absolute bg-surface-300 right-0 text-sm rounded-md w-44 overflow-hidden shadow-sm border border-secondary p-1", p.MenuClasses}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var11...)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<ul class=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var12 string
+		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var11).String())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/dropdown.templ`, Line: 1, Col: 0}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -264,7 +283,7 @@ func (p *DetailsDropdownProps) render() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</ul></details><details class=\"hidden peer-open:block\" name=\"details-dropdown\"><summary class=\"fixed w-full h-full left-0 top-0\"></summary></details></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</ul></details><details class=\"hidden peer-open:block\" name=\"details-dropdown\"><summary class=\"fixed w-full h-full left-0 top-0\"></summary></details></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -288,12 +307,12 @@ func DetailsDropdown(props *DetailsDropdownProps) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var11 == nil {
-			templ_7745c5c3_Var11 = templ.NopComponent
+		templ_7745c5c3_Var13 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var13 == nil {
+			templ_7745c5c3_Var13 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Var12 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var14 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -305,13 +324,13 @@ func DetailsDropdown(props *DetailsDropdownProps) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templ_7745c5c3_Var11.Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = templ_7745c5c3_Var13.Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = newDetailsDropdown(props).render().Render(templ.WithChildren(ctx, templ_7745c5c3_Var12), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = newDetailsDropdown(props).render().Render(templ.WithChildren(ctx, templ_7745c5c3_Var14), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/components/base/dropdown_templ.go
+++ b/components/base/dropdown_templ.go
@@ -86,6 +86,7 @@ func DropdownItem(props DropdownItemProps) templ.Component {
 type DropdownFormItemProps struct {
 	Action string
 	Method string
+	Fields map[string]string
 }
 
 func normalizeDropdownFormMethod(method string) string {
@@ -132,7 +133,7 @@ func DropdownFormItem(props DropdownFormItemProps) templ.Component {
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(normalizeDropdownFormMethod(props.Method))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/dropdown.templ`, Line: 40, Col: 97}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/dropdown.templ`, Line: 41, Col: 97}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
@@ -146,7 +147,39 @@ func DropdownFormItem(props DropdownFormItemProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<button type=\"submit\" class=\"block w-full p-2 text-left duration-200 hover:bg-surface-400 rounded-md\">")
+		for name, value := range props.Fields {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<input type=\"hidden\" name=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var6 string
+			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(name)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/dropdown.templ`, Line: 44, Col: 36}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\" value=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var7 string
+			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(value)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/dropdown.templ`, Line: 44, Col: 52}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "\"> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<button type=\"submit\" class=\"block w-full p-2 text-left duration-200 hover:bg-surface-400 rounded-md\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -154,7 +187,7 @@ func DropdownFormItem(props DropdownFormItemProps) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</button></form></li>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</button></form></li>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -190,30 +223,30 @@ func (p *DetailsDropdownProps) render() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var6 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var6 == nil {
-			templ_7745c5c3_Var6 = templ.NopComponent
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		var templ_7745c5c3_Var7 = []any{templ.Classes("relative", p.Classes)}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var7...)
+		var templ_7745c5c3_Var9 = []any{templ.Classes("relative", p.Classes)}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var9...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<div class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var8 string
-		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var7).String())
+		var templ_7745c5c3_Var10 string
+		templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var9).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `components/base/dropdown.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "\"><details class=\"relative z-10 peer\" name=\"details-dropdown\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\"><details class=\"relative z-10 peer\" name=\"details-dropdown\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -223,15 +256,15 @@ func (p *DetailsDropdownProps) render() templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<ul class=\"flex flex-col gap-1 mt-1 absolute bg-surface-300 right-0 text-sm rounded-md w-44 overflow-hidden shadow-sm border border-secondary p-1\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<ul class=\"flex flex-col gap-1 mt-1 absolute bg-surface-300 right-0 text-sm rounded-md w-44 overflow-hidden shadow-sm border border-secondary p-1\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templ_7745c5c3_Var6.Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = templ_7745c5c3_Var8.Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</ul></details><details class=\"hidden peer-open:block\" name=\"details-dropdown\"><summary class=\"fixed w-full h-full left-0 top-0\"></summary></details></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</ul></details><details class=\"hidden peer-open:block\" name=\"details-dropdown\"><summary class=\"fixed w-full h-full left-0 top-0\"></summary></details></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -255,12 +288,12 @@ func DetailsDropdown(props *DetailsDropdownProps) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var9 == nil {
-			templ_7745c5c3_Var9 = templ.NopComponent
+		templ_7745c5c3_Var11 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var11 == nil {
+			templ_7745c5c3_Var11 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Var10 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var12 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -272,13 +305,13 @@ func DetailsDropdown(props *DetailsDropdownProps) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templ_7745c5c3_Var9.Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = templ_7745c5c3_Var11.Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = newDetailsDropdown(props).render().Render(templ.WithChildren(ctx, templ_7745c5c3_Var10), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = newDetailsDropdown(props).render().Render(templ.WithChildren(ctx, templ_7745c5c3_Var12), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/e2e/tests/core/account-switching.spec.ts
+++ b/e2e/tests/core/account-switching.spec.ts
@@ -2,7 +2,6 @@ import { createHash, randomBytes } from 'node:crypto';
 import { expect, test, type Page } from '@playwright/test';
 import { populateTestData, resetTestDatabase } from '../../fixtures/test-data';
 
-const baseURL = process.env.BASE_URL ?? 'http://localhost:3201';
 const password = 'TestPass123!';
 
 async function credentialLogin(page: Page, email: string) {
@@ -82,84 +81,86 @@ test.describe.serial('browser account switching', () => {
 		await expect(page.getByTestId('account-card')).toHaveCount(5);
 		await expect(page.getByTestId('account-card').filter({ hasText: 'picker-1@example.test' })).toHaveCount(0);
 	});
-});
 
-test('OIDC uses the shared picker and preserves state, nonce, and PKCE', async ({ page, request }) => {
-	const redirectURI = `${baseURL}/__test__/oidc-callback`;
-	await resetTestDatabase(request, { reseedMinimal: true });
-	await populateTestData(request, {
-		version: '1.0',
-		tenant: {
-			id: '00000000-0000-0000-0000-000000000001',
-			name: 'OIDC Picker Tenant',
-			domain: 'localhost',
-		},
-		data: {
-			users: [
-				{ email: 'oidc-one@example.test', password, firstName: 'OIDC One', lastName: 'Account', language: 'en' },
-				{ email: 'oidc-two@example.test', password, firstName: 'OIDC Two', lastName: 'Account', language: 'en' },
-			],
-			oidcClients: [{
-				clientId: 'account-picker-e2e',
-				name: 'Account Picker E2E',
-				redirectUris: [redirectURI],
-				scopes: ['openid', 'profile', 'email', 'tenant_id'],
-			}],
-		},
-	});
-	await credentialLogin(page, 'oidc-one@example.test');
-	await credentialLogin(page, 'oidc-two@example.test');
+	test('OIDC uses the shared picker and preserves state, nonce, and PKCE', async ({ page, request, baseURL }) => {
+		expect(baseURL).toBeTruthy();
+		const applicationURL = baseURL!;
+		const redirectURI = `${applicationURL}/__test__/oidc-callback`;
+		await resetTestDatabase(request, { reseedMinimal: true });
+		await populateTestData(request, {
+			version: '1.0',
+			tenant: {
+				id: '00000000-0000-0000-0000-000000000001',
+				name: 'OIDC Picker Tenant',
+				domain: 'localhost',
+			},
+			data: {
+				users: [
+					{ email: 'oidc-one@example.test', password, firstName: 'OIDC One', lastName: 'Account', language: 'en' },
+					{ email: 'oidc-two@example.test', password, firstName: 'OIDC Two', lastName: 'Account', language: 'en' },
+				],
+				oidcClients: [{
+					clientId: 'account-picker-e2e',
+					name: 'Account Picker E2E',
+					redirectUris: [redirectURI],
+					scopes: ['openid', 'profile', 'email', 'tenant_id'],
+				}],
+			},
+		});
+		await credentialLogin(page, 'oidc-one@example.test');
+		await credentialLogin(page, 'oidc-two@example.test');
 
-	const verifier = randomBytes(32).toString('base64url');
-	const challenge = createHash('sha256').update(verifier).digest('base64url');
-	const state = `state-${randomBytes(8).toString('hex')}`;
-	const nonce = `nonce-${randomBytes(8).toString('hex')}`;
-	const authorize = new URL('/oidc/authorize', baseURL);
-	authorize.search = new URLSearchParams({
-		client_id: 'account-picker-e2e',
-		redirect_uri: redirectURI,
-		response_type: 'code',
-		scope: 'openid profile email tenant_id',
-		state,
-		nonce,
-		code_challenge: challenge,
-		code_challenge_method: 'S256',
-	}).toString();
-
-	await page.goto(authorize.toString());
-	await expect(page).toHaveURL(/\/login\?auth_request=/);
-	await expect(page.getByTestId('account-card')).toHaveCount(2);
-	await Promise.all([
-		page.waitForURL((url) => url.pathname === '/__test__/oidc-callback'),
-		page.getByTestId('account-card').filter({ hasText: 'oidc-one@example.test' }).click(),
-	]);
-
-	const callback = new URL(page.url());
-	expect(callback.searchParams.get('state')).toBe(state);
-	const code = callback.searchParams.get('code');
-	expect(code).toBeTruthy();
-
-	const tokenResponse = await request.post('/oidc/oauth/token', {
-		form: {
-			grant_type: 'authorization_code',
+		const verifier = randomBytes(32).toString('base64url');
+		const challenge = createHash('sha256').update(verifier).digest('base64url');
+		const state = `state-${randomBytes(8).toString('hex')}`;
+		const nonce = `nonce-${randomBytes(8).toString('hex')}`;
+		const authorize = new URL('/oidc/authorize', applicationURL);
+		authorize.search = new URLSearchParams({
 			client_id: 'account-picker-e2e',
 			redirect_uri: redirectURI,
-			code: code!,
-			code_verifier: verifier,
-		},
-		failOnStatusCode: false,
-	});
-	expect(tokenResponse.ok(), await tokenResponse.text()).toBeTruthy();
-	const tokens = await tokenResponse.json();
-	const claims = JSON.parse(Buffer.from(tokens.id_token.split('.')[1], 'base64url').toString('utf8'));
-	expect(claims.nonce).toBe(nonce);
-	expect(claims.tenant_id).toBe('00000000-0000-0000-0000-000000000001');
+			response_type: 'code',
+			scope: 'openid profile email tenant_id',
+			state,
+			nonce,
+			code_challenge: challenge,
+			code_challenge_method: 'S256',
+		}).toString();
 
-	const userInfoResponse = await request.get('/oidc/userinfo', {
-		headers: { Authorization: `Bearer ${tokens.access_token}` },
-		failOnStatusCode: false,
+		await page.goto(authorize.toString());
+		await expect(page).toHaveURL(/\/login\?auth_request=/);
+		await expect(page.getByTestId('account-card')).toHaveCount(2);
+		await Promise.all([
+			page.waitForURL((url) => url.pathname === '/__test__/oidc-callback'),
+			page.getByTestId('account-card').filter({ hasText: 'oidc-one@example.test' }).click(),
+		]);
+
+		const callback = new URL(page.url());
+		expect(callback.searchParams.get('state')).toBe(state);
+		const code = callback.searchParams.get('code');
+		expect(code).toBeTruthy();
+
+		const tokenResponse = await request.post('/oidc/oauth/token', {
+			form: {
+				grant_type: 'authorization_code',
+				client_id: 'account-picker-e2e',
+				redirect_uri: redirectURI,
+				code: code!,
+				code_verifier: verifier,
+			},
+			failOnStatusCode: false,
+		});
+		expect(tokenResponse.ok(), await tokenResponse.text()).toBeTruthy();
+		const tokens = await tokenResponse.json();
+		const claims = JSON.parse(Buffer.from(tokens.id_token.split('.')[1], 'base64url').toString('utf8'));
+		expect(claims.nonce).toBe(nonce);
+		expect(claims.tenant_id).toBe('00000000-0000-0000-0000-000000000001');
+
+		const userInfoResponse = await request.get('/oidc/userinfo', {
+			headers: { Authorization: `Bearer ${tokens.access_token}` },
+			failOnStatusCode: false,
+		});
+		expect(userInfoResponse.ok(), await userInfoResponse.text()).toBeTruthy();
+		const userInfo = await userInfoResponse.json();
+		expect(userInfo.email).toBe('oidc-one@example.test');
 	});
-	expect(userInfoResponse.ok(), await userInfoResponse.text()).toBeTruthy();
-	const userInfo = await userInfoResponse.json();
-	expect(userInfo.email).toBe('oidc-one@example.test');
 });

--- a/e2e/tests/core/account-switching.spec.ts
+++ b/e2e/tests/core/account-switching.spec.ts
@@ -153,6 +153,7 @@ test('OIDC uses the shared picker and preserves state, nonce, and PKCE', async (
 	const tokens = await tokenResponse.json();
 	const claims = JSON.parse(Buffer.from(tokens.id_token.split('.')[1], 'base64url').toString('utf8'));
 	expect(claims.nonce).toBe(nonce);
+	expect(claims.tenant_id).toBe('00000000-0000-0000-0000-000000000001');
 
 	const userInfoResponse = await request.get('/oidc/userinfo', {
 		headers: { Authorization: `Bearer ${tokens.access_token}` },
@@ -161,5 +162,4 @@ test('OIDC uses the shared picker and preserves state, nonce, and PKCE', async (
 	expect(userInfoResponse.ok(), await userInfoResponse.text()).toBeTruthy();
 	const userInfo = await userInfoResponse.json();
 	expect(userInfo.email).toBe('oidc-one@example.test');
-	expect(userInfo.tenant_id).toBe('00000000-0000-0000-0000-000000000001');
 });

--- a/e2e/tests/core/account-switching.spec.ts
+++ b/e2e/tests/core/account-switching.spec.ts
@@ -1,0 +1,158 @@
+import { createHash, randomBytes } from 'node:crypto';
+import { expect, test, type Page } from '@playwright/test';
+import { populateTestData, resetTestDatabase } from '../../fixtures/test-data';
+
+const baseURL = process.env.BASE_URL ?? 'http://localhost:3201';
+const password = 'TestPass123!';
+
+async function credentialLogin(page: Page, email: string) {
+	await page.goto('/login#login-methods');
+	await page.locator('form#login-methods [type=email]').fill(email);
+	await page.locator('form#login-methods [type=password]').fill(password);
+	await Promise.all([
+		page.waitForURL((url) => url.pathname !== '/login'),
+		page.locator('form#login-methods button[type=submit]').click(),
+	]);
+}
+
+async function seedAccounts(request: Parameters<typeof resetTestDatabase>[0], count = 6) {
+	await resetTestDatabase(request, { reseedMinimal: true });
+	await populateTestData(request, {
+		version: '1.0',
+		tenant: {
+			id: '00000000-0000-0000-0000-000000000001',
+			name: 'Account Picker Tenant',
+			domain: 'localhost',
+		},
+		data: {
+			users: Array.from({ length: count }, (_, index) => ({
+				email: `picker-${index + 1}@example.test`,
+				password,
+				firstName: `Picker ${index + 1}`,
+				lastName: 'Account',
+				language: 'en',
+			})),
+		},
+	});
+}
+
+test.describe.serial('browser account switching', () => {
+	test('keeps accounts, switches without credentials, and scopes logout', async ({ page, request }) => {
+		await seedAccounts(request, 2);
+		await credentialLogin(page, 'picker-1@example.test');
+		await credentialLogin(page, 'picker-2@example.test');
+
+		await page.goto('/login');
+		await expect(page.getByTestId('account-card')).toHaveCount(2);
+		await expect(page.getByTestId('use-another-account')).toBeVisible();
+
+		await Promise.all([
+			page.waitForURL((url) => url.pathname === '/'),
+			page.getByTestId('account-card').filter({ hasText: 'picker-1@example.test' }).click(),
+		]);
+
+		await page.goto('/login');
+		await expect(page.getByTestId('account-card').filter({ hasText: 'picker-1@example.test' })).toContainText('Active');
+		await page.goto('/');
+		await page.locator('details[name="details-dropdown"] > summary').first().click();
+		await Promise.all([
+			page.waitForURL((url) => url.pathname === '/'),
+			page.locator('form[action="/logout"] button').click(),
+		]);
+
+		await page.goto('/login');
+		await expect(page.getByTestId('account-card')).toHaveCount(1);
+		await expect(page.getByTestId('account-card')).toContainText('picker-2@example.test');
+
+		await page.goto('/');
+		await page.locator('details[name="details-dropdown"] > summary').first().click();
+		await Promise.all([
+			page.waitForURL((url) => url.pathname === '/login'),
+			page.locator('form[action="/logout/all"] button').click(),
+		]);
+		await expect(page.getByTestId('account-picker')).toHaveCount(0);
+	});
+
+	test('evicts the least-recently-active account when a sixth account is added', async ({ page, request }) => {
+		await seedAccounts(request);
+		for (let index = 1; index <= 6; index += 1) {
+			await credentialLogin(page, `picker-${index}@example.test`);
+		}
+		await page.goto('/login');
+		await expect(page.getByTestId('account-card')).toHaveCount(5);
+		await expect(page.getByTestId('account-card').filter({ hasText: 'picker-1@example.test' })).toHaveCount(0);
+	});
+});
+
+test('OIDC uses the shared picker and preserves state, nonce, and PKCE', async ({ page, request }) => {
+	const redirectURI = `${baseURL}/__test__/oidc-callback`;
+	await resetTestDatabase(request, { reseedMinimal: true });
+	await populateTestData(request, {
+		version: '1.0',
+		tenant: {
+			id: '00000000-0000-0000-0000-000000000001',
+			name: 'OIDC Picker Tenant',
+			domain: 'localhost',
+		},
+		data: {
+			users: [
+				{ email: 'oidc-one@example.test', password, firstName: 'OIDC One', lastName: 'Account', language: 'en' },
+				{ email: 'oidc-two@example.test', password, firstName: 'OIDC Two', lastName: 'Account', language: 'en' },
+			],
+			oidcClients: [{
+				clientId: 'account-picker-e2e',
+				name: 'Account Picker E2E',
+				redirectUris: [redirectURI],
+				scopes: ['openid', 'profile', 'email', 'tenant_id'],
+			}],
+		},
+	});
+	await credentialLogin(page, 'oidc-one@example.test');
+	await credentialLogin(page, 'oidc-two@example.test');
+
+	const verifier = randomBytes(32).toString('base64url');
+	const challenge = createHash('sha256').update(verifier).digest('base64url');
+	const state = `state-${randomBytes(8).toString('hex')}`;
+	const nonce = `nonce-${randomBytes(8).toString('hex')}`;
+	const authorize = new URL('/oidc/authorize', baseURL);
+	authorize.search = new URLSearchParams({
+		client_id: 'account-picker-e2e',
+		redirect_uri: redirectURI,
+		response_type: 'code',
+		scope: 'openid profile email tenant_id',
+		state,
+		nonce,
+		code_challenge: challenge,
+		code_challenge_method: 'S256',
+	}).toString();
+
+	await page.goto(authorize.toString());
+	await expect(page).toHaveURL(/\/login\?auth_request=/);
+	await expect(page.getByTestId('account-card')).toHaveCount(2);
+	await Promise.all([
+		page.waitForURL((url) => url.pathname === '/__test__/oidc-callback'),
+		page.getByTestId('account-card').filter({ hasText: 'oidc-one@example.test' }).click(),
+	]);
+
+	const callback = new URL(page.url());
+	expect(callback.searchParams.get('state')).toBe(state);
+	const code = callback.searchParams.get('code');
+	expect(code).toBeTruthy();
+
+	const tokenResponse = await request.post('/oidc/oauth/token', {
+		form: {
+			grant_type: 'authorization_code',
+			client_id: 'account-picker-e2e',
+			redirect_uri: redirectURI,
+			code: code!,
+			code_verifier: verifier,
+		},
+		failOnStatusCode: false,
+	});
+	expect(tokenResponse.ok(), await tokenResponse.text()).toBeTruthy();
+	const tokens = await tokenResponse.json();
+	const claims = JSON.parse(Buffer.from(tokens.id_token.split('.')[1], 'base64url').toString('utf8'));
+	expect(claims.nonce).toBe(nonce);
+	expect(claims.email).toBe('oidc-one@example.test');
+	expect(claims.tenant_id).toBe('00000000-0000-0000-0000-000000000001');
+});

--- a/e2e/tests/core/account-switching.spec.ts
+++ b/e2e/tests/core/account-switching.spec.ts
@@ -153,6 +153,13 @@ test('OIDC uses the shared picker and preserves state, nonce, and PKCE', async (
 	const tokens = await tokenResponse.json();
 	const claims = JSON.parse(Buffer.from(tokens.id_token.split('.')[1], 'base64url').toString('utf8'));
 	expect(claims.nonce).toBe(nonce);
-	expect(claims.email).toBe('oidc-one@example.test');
-	expect(claims.tenant_id).toBe('00000000-0000-0000-0000-000000000001');
+
+	const userInfoResponse = await request.get('/oidc/userinfo', {
+		headers: { Authorization: `Bearer ${tokens.access_token}` },
+		failOnStatusCode: false,
+	});
+	expect(userInfoResponse.ok(), await userInfoResponse.text()).toBeTruthy();
+	const userInfo = await userInfoResponse.json();
+	expect(userInfo.email).toBe('oidc-one@example.test');
+	expect(userInfo.tenant_id).toBe('00000000-0000-0000-0000-000000000001');
 });

--- a/modules/core/component.go
+++ b/modules/core/component.go
@@ -139,12 +139,13 @@ func (c *component) Build(builder *composition.Builder) error {
 	composition.ProvideFunc(builder, services.NewUploadService)
 	composition.ProvideFunc(builder, services.NewSessionService)
 	composition.ProvideFunc(builder, newCoreUserService)
+	composition.ProvideFunc(builder, services.NewBrowserSessionService)
 	composition.ProvideFunc(builder, services.NewUserQueryService)
 	composition.ProvideFunc(builder, services.NewGroupQueryService)
 	composition.ProvideFunc(builder, services.NewRoleQueryService)
 	composition.ProvideFunc(builder, services.NewExcelExportService)
 	composition.ProvideFunc(builder, newCoreAuthService)
-	composition.ProvideFunc(builder, services.NewAuthFlowService)
+	composition.ProvideFunc(builder, services.NewAuthFlowServiceWithBrowserSessions)
 	composition.ProvideFunc(builder, services.NewCurrencyService)
 	composition.ProvideFunc(builder, services.NewRoleService)
 	composition.ProvideFunc(builder, services.NewPermissionService)
@@ -204,6 +205,10 @@ func (c *component) Build(builder *composition.Builder) error {
 		if err != nil {
 			return nil, err
 		}
+		browserSessions, err := composition.Resolve[*services.BrowserSessionService](container)
+		if err != nil {
+			return nil, err
+		}
 		httpCfg, err := composition.Resolve[*httpconfig.Config](container)
 		if err != nil {
 			return nil, err
@@ -219,7 +224,7 @@ func (c *component) Build(builder *composition.Builder) error {
 		return []application.GraphSchema{
 			{
 				Value: graph.NewExecutableSchema(graph.Config{
-					Resolvers: graph.NewResolver(app, userSvc, uploadSvc, authSvc, httpCfg, cookiesCfg, appCfg),
+					Resolvers: graph.NewResolver(app, userSvc, uploadSvc, authSvc, browserSessions, httpCfg, cookiesCfg, appCfg),
 				}),
 				BasePath: "/",
 			},
@@ -266,6 +271,7 @@ func (c *component) Build(builder *composition.Builder) error {
 			userService *services.UserService,
 			authService *services.AuthService,
 			authFlowService *services.AuthFlowService,
+			browserSessions *services.BrowserSessionService,
 			tenantService *services.TenantService,
 			groupService *services.GroupService,
 			roleService *services.RoleService,
@@ -292,11 +298,11 @@ func (c *component) Build(builder *composition.Builder) error {
 			// Auth and infrastructure controllers — always registered.
 			ctrls := []application.Controller{
 				controllers.NewHealthController(app),
-				controllers.NewLoginController(authService, authFlowService, httpCfg, cookiesCfg, headersCfg, googleCfg, opts.LoginControllerOptions),
-				controllers.NewTwoFactorSetupController(twoFactorService, sessionService, userService, httpCfg, cookiesCfg, sessionCfg, appCfg),
-				controllers.NewTwoFactorVerifyController(twoFactorService, sessionService, userService, httpCfg, cookiesCfg, sessionCfg, appCfg),
+				controllers.NewLoginControllerWithBrowserSessions(authService, authFlowService, browserSessions, httpCfg, cookiesCfg, headersCfg, googleCfg, opts.LoginControllerOptions),
+				controllers.NewTwoFactorSetupController(twoFactorService, sessionService, userService, httpCfg, sessionCfg, browserSessions),
+				controllers.NewTwoFactorVerifyController(twoFactorService, sessionService, userService, httpCfg, sessionCfg, browserSessions),
 				controllers.NewAccountController(app, userService, tenantService, uploadService, sessionService, cookiesCfg),
-				controllers.NewLogoutController(httpCfg, cookiesCfg, appCfg),
+				controllers.NewLogoutController(httpCfg, browserSessions),
 				controllers.NewUploadController(uploadService, uploadsCfg),
 			}
 			if opts.UploadsAuthorizer != nil || opts.DefaultTenantID != uuid.Nil {

--- a/modules/core/component.go
+++ b/modules/core/component.go
@@ -207,7 +207,7 @@ func (c *component) Build(builder *composition.Builder) error {
 		}
 		browserSessions, err := composition.Resolve[*services.BrowserSessionService](container)
 		if err != nil {
-			return nil, err
+			return nil, serrors.E(op, err)
 		}
 		httpCfg, err := composition.Resolve[*httpconfig.Config](container)
 		if err != nil {

--- a/modules/core/domain/entities/session/session_repository.go
+++ b/modules/core/domain/entities/session/session_repository.go
@@ -31,6 +31,7 @@ type Repository interface {
 	GetAll(ctx context.Context) ([]Session, error)
 	GetPaginated(ctx context.Context, params *FindParams) ([]Session, error)
 	GetByToken(ctx context.Context, token string) (Session, error)
+	GetByTokenAnyTenant(ctx context.Context, token string) (Session, error)
 	GetByTokenAndAudience(ctx context.Context, token string, audience SessionAudience) (Session, error)
 	GetByUserID(ctx context.Context, userID uint) ([]Session, error)
 	Create(ctx context.Context, user Session) error

--- a/modules/core/infrastructure/persistence/session_repository.go
+++ b/modules/core/infrastructure/persistence/session_repository.go
@@ -195,6 +195,17 @@ func (g *SessionRepository) GetByToken(ctx context.Context, token string) (sessi
 	return sessions[0], nil
 }
 
+func (g *SessionRepository) GetByTokenAnyTenant(ctx context.Context, token string) (session.Session, error) {
+	sessions, err := g.querySessions(ctx, repo.Join(selectSessionQuery, "WHERE token = $1"), token)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get browser session by token")
+	}
+	if len(sessions) == 0 {
+		return nil, ErrSessionNotFound
+	}
+	return sessions[0], nil
+}
+
 func (g *SessionRepository) GetByTokenAndAudience(ctx context.Context, token string, audience session.SessionAudience) (session.Session, error) {
 	// First try with tenant from context
 	tenantID, err := composables.UseTenantID(ctx)

--- a/modules/core/infrastructure/persistence/session_repository.go
+++ b/modules/core/infrastructure/persistence/session_repository.go
@@ -195,6 +195,9 @@ func (g *SessionRepository) GetByToken(ctx context.Context, token string) (sessi
 	return sessions[0], nil
 }
 
+// GetByTokenAnyTenant intentionally bypasses tenant filtering for opaque browser-cookie resolution.
+// Callers must re-scope subsequent tenant access with the returned session's TenantID.
+// Use GetByToken for ordinary tenant-scoped lookups.
 func (g *SessionRepository) GetByTokenAnyTenant(ctx context.Context, token string) (session.Session, error) {
 	sessions, err := g.querySessions(ctx, repo.Join(selectSessionQuery, "WHERE token = $1"), token)
 	if err != nil {

--- a/modules/core/interfaces/graph/auth.resolvers.go
+++ b/modules/core/interfaces/graph/auth.resolvers.go
@@ -12,10 +12,13 @@ import (
 	model "github.com/iota-uz/iota-sdk/modules/core/interfaces/graph/gqlmodels"
 	"github.com/iota-uz/iota-sdk/modules/core/interfaces/graph/mappers"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
 )
 
 // Authenticate is the resolver for the authenticate field.
 func (r *mutationResolver) Authenticate(ctx context.Context, email string, password string) (*model.Session, error) {
+	const op serrors.Op = "core.graph.Authenticate"
+
 	writer, ok := composables.UseWriter(ctx)
 	if !ok {
 		return nil, fmt.Errorf("request params not found")
@@ -32,7 +35,7 @@ func (r *mutationResolver) Authenticate(ctx context.Context, email string, passw
 	}
 	cookie, err := r.browserSessions.AddFromRequest(ctx, request, sess)
 	if err != nil {
-		return nil, err
+		return nil, serrors.E(op, err)
 	}
 	http.SetCookie(writer, cookie)
 	return mappers.SessionToGraphModel(sess), nil

--- a/modules/core/interfaces/graph/auth.resolvers.go
+++ b/modules/core/interfaces/graph/auth.resolvers.go
@@ -26,28 +26,13 @@ func (r *mutationResolver) Authenticate(ctx context.Context, email string, passw
 		return nil, err
 	}
 
-	sidKey := "sid"
-	domain := ""
-	secure := false
-	if r.cookiesCfg != nil && r.cookiesCfg.SID != "" {
-		sidKey = r.cookiesCfg.SID
+	request, ok := composables.UseRequest(ctx)
+	if !ok {
+		return nil, fmt.Errorf("request not found")
 	}
-	if r.cookiesCfg != nil {
-		domain = r.cookiesCfg.Domain
-	}
-	if r.appCfg != nil {
-		secure = r.appCfg.IsProduction()
-	}
-
-	cookie := &http.Cookie{
-		Name:     sidKey,
-		Value:    sess.Token(),
-		Expires:  sess.ExpiresAt(),
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-		Secure:   secure,
-		Domain:   domain,
-		Path:     "/",
+	cookie, err := r.browserSessions.AddFromRequest(ctx, request, sess)
+	if err != nil {
+		return nil, err
 	}
 	http.SetCookie(writer, cookie)
 	return mappers.SessionToGraphModel(sess), nil

--- a/modules/core/interfaces/graph/resolver.go
+++ b/modules/core/interfaces/graph/resolver.go
@@ -20,6 +20,7 @@ type Resolver struct {
 	userService       *services.UserService
 	uploadService     *services.UploadService
 	authService       *services.AuthService
+	browserSessions   *services.BrowserSessionService
 	uploadsAuthorizer types.UploadsAuthorizer
 	usersAuthorizer   types.UsersAuthorizer
 	httpCfg           *httpconfig.Config
@@ -67,6 +68,7 @@ func NewResolver(
 	userService *services.UserService,
 	uploadService *services.UploadService,
 	authService *services.AuthService,
+	browserSessions *services.BrowserSessionService,
 	httpCfg *httpconfig.Config,
 	cookiesCfg *cookies.Config,
 	appCfg *appconfig.Config,
@@ -77,6 +79,7 @@ func NewResolver(
 		userService:       userService,
 		uploadService:     uploadService,
 		authService:       authService,
+		browserSessions:   browserSessions,
 		uploadsAuthorizer: authorizers.NewDefaultUploadsAuthorizer(),
 		usersAuthorizer:   authorizers.NewDefaultUsersAuthorizer(userService),
 		httpCfg:           httpCfg,

--- a/modules/core/presentation/controllers/account_controller.go
+++ b/modules/core/presentation/controllers/account_controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/htmx"
 	"github.com/iota-uz/iota-sdk/pkg/intl"
 	"github.com/iota-uz/iota-sdk/pkg/middleware"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
 )
 
 type AccountController struct {
@@ -366,12 +367,18 @@ func (c *AccountController) RevokeOtherSessions(w http.ResponseWriter, r *http.R
 }
 
 func (c *AccountController) currentSession(r *http.Request) (session.Session, error) {
+	const op serrors.Op = "accountController.currentSession"
+
 	cookieName := "sid"
 	if c.cfg != nil && c.cfg.SID != "" {
 		cookieName = c.cfg.SID
 	}
 	if _, err := r.Cookie(cookieName); err != nil {
-		return nil, err
+		return nil, serrors.E(op, err)
 	}
-	return composables.UseSession(r.Context())
+	sess, err := composables.UseSession(r.Context())
+	if err != nil {
+		return nil, serrors.E(op, err)
+	}
+	return sess, nil
 }

--- a/modules/core/presentation/controllers/account_controller.go
+++ b/modules/core/presentation/controllers/account_controller.go
@@ -9,6 +9,7 @@ import (
 	"github.com/a-h/templ"
 	"github.com/gorilla/mux"
 
+	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/session"
 	"github.com/iota-uz/iota-sdk/modules/core/permissions"
 	"github.com/iota-uz/iota-sdk/modules/core/presentation/controllers/dtos"
 	"github.com/iota-uz/iota-sdk/modules/core/presentation/mappers"
@@ -209,7 +210,7 @@ func (c *AccountController) GetSessions(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	currentSession, err := composables.UseSession(r.Context())
+	currentSession, err := c.currentSession(r)
 	if err != nil {
 		logger.WithError(err).Error("failed to get current session")
 		http.Error(w, "Session not found", http.StatusUnauthorized)
@@ -249,7 +250,7 @@ func (c *AccountController) RevokeSession(w http.ResponseWriter, r *http.Request
 	vars := mux.Vars(r)
 	tokenHash := vars["token"]
 
-	currentSession, err := composables.UseSession(r.Context())
+	currentSession, err := c.currentSession(r)
 	if err != nil {
 		logger.WithError(err).Error("failed to get current session")
 		http.Error(w, "Session not found", http.StatusUnauthorized)
@@ -336,7 +337,7 @@ func (c *AccountController) RevokeOtherSessions(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	currentSession, err := composables.UseSession(r.Context())
+	currentSession, err := c.currentSession(r)
 	if err != nil {
 		logger.WithError(err).Error("failed to get current session")
 		http.Error(w, "Session not found", http.StatusUnauthorized)
@@ -362,4 +363,15 @@ func (c *AccountController) RevokeOtherSessions(w http.ResponseWriter, r *http.R
 	}
 	htmx.SetTrigger(w, "success", string(successPayload))
 	htmx.Refresh(w)
+}
+
+func (c *AccountController) currentSession(r *http.Request) (session.Session, error) {
+	cookieName := "sid"
+	if c.cfg != nil && c.cfg.SID != "" {
+		cookieName = c.cfg.SID
+	}
+	if _, err := r.Cookie(cookieName); err != nil {
+		return nil, err
+	}
+	return composables.UseSession(r.Context())
 }

--- a/modules/core/presentation/controllers/account_controller.go
+++ b/modules/core/presentation/controllers/account_controller.go
@@ -209,14 +209,13 @@ func (c *AccountController) GetSessions(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// Get current session token from cookie
-	cookie, err := r.Cookie(c.cfg.SID)
+	currentSession, err := composables.UseSession(r.Context())
 	if err != nil {
-		logger.WithError(err).Error("failed to get session cookie")
+		logger.WithError(err).Error("failed to get current session")
 		http.Error(w, "Session not found", http.StatusUnauthorized)
 		return
 	}
-	currentToken := cookie.Value
+	currentToken := currentSession.Token()
 
 	// Fetch all sessions for the user
 	sessions, err := c.sessionService.GetByUserID(r.Context(), user.ID())
@@ -250,14 +249,13 @@ func (c *AccountController) RevokeSession(w http.ResponseWriter, r *http.Request
 	vars := mux.Vars(r)
 	tokenHash := vars["token"]
 
-	// Get current session token from cookie
-	cookie, err := r.Cookie(c.cfg.SID)
+	currentSession, err := composables.UseSession(r.Context())
 	if err != nil {
-		logger.WithError(err).Error("failed to get session cookie")
+		logger.WithError(err).Error("failed to get current session")
 		http.Error(w, "Session not found", http.StatusUnauthorized)
 		return
 	}
-	currentToken := cookie.Value
+	currentToken := currentSession.Token()
 
 	// Get current user
 	user, err := composables.UseUser(r.Context())
@@ -338,14 +336,13 @@ func (c *AccountController) RevokeOtherSessions(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	// Get current session token from cookie
-	cookie, err := r.Cookie(c.cfg.SID)
+	currentSession, err := composables.UseSession(r.Context())
 	if err != nil {
-		logger.WithError(err).Error("failed to get session cookie")
+		logger.WithError(err).Error("failed to get current session")
 		http.Error(w, "Session not found", http.StatusUnauthorized)
 		return
 	}
-	currentToken := cookie.Value
+	currentToken := currentSession.Token()
 
 	// Terminate all other sessions
 	count, err := c.sessionService.TerminateOtherSessions(r.Context(), user.ID(), currentToken)

--- a/modules/core/presentation/controllers/graphql_controller.go
+++ b/modules/core/presentation/controllers/graphql_controller.go
@@ -30,6 +30,7 @@ type GraphQLController struct {
 	userService     *services.UserService
 	uploadService   *services.UploadService
 	authService     *services.AuthService
+	browserSessions *services.BrowserSessionService
 	httpCfg         *httpconfig.Config
 	cookiesCfg      *cookies.Config
 	appCfg          *appconfig.Config
@@ -54,7 +55,7 @@ func (g *GraphQLController) Descriptor() application.ControllerDescriptor {
 func (g *GraphQLController) Register(r *mux.Router) {
 	schema := graph.NewExecutableSchema(
 		graph.Config{
-			Resolvers: graph.NewResolver(g.app, g.userService, g.uploadService, g.authService, g.httpCfg, g.cookiesCfg, g.appCfg, g.resolverOptions...),
+			Resolvers: graph.NewResolver(g.app, g.userService, g.uploadService, g.authService, g.browserSessions, g.httpCfg, g.cookiesCfg, g.appCfg, g.resolverOptions...),
 		},
 	)
 	srv := graphql.NewBaseServer(schema, g.uploadsCfg)
@@ -106,6 +107,7 @@ func NewGraphQLController(
 	userService *services.UserService,
 	uploadService *services.UploadService,
 	authService *services.AuthService,
+	browserSessions *services.BrowserSessionService,
 	httpCfg *httpconfig.Config,
 	cookiesCfg *cookies.Config,
 	appCfg *appconfig.Config,
@@ -113,14 +115,15 @@ func NewGraphQLController(
 	opts ...GraphQLControllerOption,
 ) application.Controller {
 	c := &GraphQLController{
-		app:           app,
-		userService:   userService,
-		uploadService: uploadService,
-		authService:   authService,
-		httpCfg:       httpCfg,
-		cookiesCfg:    cookiesCfg,
-		appCfg:        appCfg,
-		uploadsCfg:    uploadsCfg,
+		app:             app,
+		userService:     userService,
+		uploadService:   uploadService,
+		authService:     authService,
+		browserSessions: browserSessions,
+		httpCfg:         httpCfg,
+		cookiesCfg:      cookiesCfg,
+		appCfg:          appCfg,
+		uploadsCfg:      uploadsCfg,
 	}
 	for _, opt := range opts {
 		opt(c)

--- a/modules/core/presentation/controllers/login_account_controller_test.go
+++ b/modules/core/presentation/controllers/login_account_controller_test.go
@@ -79,7 +79,7 @@ func TestLoginController_CustomRendererReceivesAccountPickerContext(t *testing.T
 
 	suite.POST("/login/session?next=/users").
 		Cookie(cookiesCfg.SID, browserCookie.Value).
-		FormString("session_ref", captured.Accounts[0].SessionReference).
+		FormString("SessionRef", captured.Accounts[0].SessionReference).
 		Expect(t).
 		Status(http.StatusSeeOther).
 		RedirectTo("/users")

--- a/modules/core/presentation/controllers/login_account_controller_test.go
+++ b/modules/core/presentation/controllers/login_account_controller_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/a-h/templ"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/iota-uz/iota-sdk/modules/core"
@@ -23,64 +24,75 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/itf"
 )
 
-func TestLoginController_CustomRendererReceivesAccountPickerContext(t *testing.T) {
+func TestLoginController_CustomRendererReceivesAccountPickerContext_Scenarios(t *testing.T) {
 	t.Parallel()
-	suite := itf.NewSuiteBuilder(t).WithComponents(core.NewComponent(&core.ModuleOptions{
-		PermissionSchema: defaults.PermissionSchema(),
-	})).AsUser().Build()
-	persistTestUser(t, suite.Env())
-
-	sessionService := itf.GetService[services.SessionService](suite.Env())
-	browserSessions := itf.GetService[services.BrowserSessionService](suite.Env())
-	token := "login-renderer-" + uuid.NewString()
-	require.NoError(t, sessionService.Create(suite.Env().Ctx, &session.CreateDTO{
-		Token: token, UserID: suite.Env().User.ID(), TenantID: suite.Env().Tenant.ID,
-		IP: "127.0.0.1", UserAgent: "login-renderer-test",
-	}))
-	sess, err := sessionService.GetBrowserSessionByToken(suite.Env().Ctx, token)
-	require.NoError(t, err)
-	browserCookie, err := browserSessions.Add(suite.Env().Ctx, "", sess)
-	require.NoError(t, err)
-
-	var captured controllers.LoginPageViewModel
-	options := &controllers.LoginControllerOptions{
-		Renderer: func(_ context.Context, vm controllers.LoginPageViewModel) templ.Component {
-			captured = vm
-			return templ.ComponentFunc(func(_ context.Context, w io.Writer) error {
-				_, err := fmt.Fprintf(w, "accounts=%d next=%s ref=%s", len(vm.Accounts), vm.NextURL, vm.Accounts[0].SessionReference)
-				return err
-			})
-		},
+	tests := []struct {
+		name    string
+		nextURL string
+	}{
+		{name: "renders and activates a stored account", nextURL: "/users"},
 	}
-	controller := controllers.NewLoginControllerWithBrowserSessions(
-		itf.GetService[services.AuthService](suite.Env()),
-		itf.GetService[services.AuthFlowService](suite.Env()),
-		browserSessions,
-		itf.GetService[httpconfig.Config](suite.Env()),
-		itf.GetService[cookies.Config](suite.Env()),
-		itf.GetService[headers.Config](suite.Env()),
-		itf.GetService[googleoauthconfig.Config](suite.Env()),
-		options,
-	)
-	suite.Register(controller)
 
-	cookiesCfg := itf.GetService[cookies.Config](suite.Env())
-	response := suite.GET("/login?next=/users").
-		Cookie(cookiesCfg.SID, browserCookie.Value).
-		Expect(t).
-		Status(http.StatusOK)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			suite := itf.NewSuiteBuilder(t).WithComponents(core.NewComponent(&core.ModuleOptions{
+				PermissionSchema: defaults.PermissionSchema(),
+			})).AsUser().Build()
+			persistTestUser(t, suite.Env())
 
-	require.Len(t, captured.Accounts, 1)
-	require.Equal(t, "/users", captured.NextURL)
-	require.Equal(t, suite.Env().User.ID(), captured.Accounts[0].UserID)
-	require.Equal(t, suite.Env().Tenant.ID.String(), captured.Accounts[0].TenantID)
-	require.NotEqual(t, token, captured.Accounts[0].SessionReference)
-	require.Contains(t, response.Body(), "accounts=1 next=/users")
+			sessionService := itf.GetService[services.SessionService](suite.Env())
+			browserSessions := itf.GetService[services.BrowserSessionService](suite.Env())
+			token := "login-renderer-" + uuid.NewString()
+			require.NoError(t, sessionService.Create(suite.Env().Ctx, &session.CreateDTO{
+				Token: token, UserID: suite.Env().User.ID(), TenantID: suite.Env().Tenant.ID,
+				IP: "127.0.0.1", UserAgent: "login-renderer-test",
+			}))
+			sess, err := sessionService.GetBrowserSessionByToken(suite.Env().Ctx, token)
+			require.NoError(t, err)
+			browserCookie, err := browserSessions.Add(suite.Env().Ctx, "", sess)
+			require.NoError(t, err)
 
-	suite.POST("/login/session?next=/users").
-		Cookie(cookiesCfg.SID, browserCookie.Value).
-		FormString("SessionReference", captured.Accounts[0].SessionReference).
-		Expect(t).
-		Status(http.StatusSeeOther).
-		RedirectTo("/users")
+			var captured controllers.LoginPageViewModel
+			options := &controllers.LoginControllerOptions{
+				Renderer: func(_ context.Context, vm controllers.LoginPageViewModel) templ.Component {
+					captured = vm
+					return templ.ComponentFunc(func(_ context.Context, w io.Writer) error {
+						_, err := fmt.Fprintf(w, "accounts=%d next=%s ref=%s", len(vm.Accounts), vm.NextURL, vm.Accounts[0].SessionReference)
+						return err
+					})
+				},
+			}
+			controller := controllers.NewLoginControllerWithBrowserSessions(
+				itf.GetService[services.AuthService](suite.Env()),
+				itf.GetService[services.AuthFlowService](suite.Env()),
+				browserSessions,
+				itf.GetService[httpconfig.Config](suite.Env()),
+				itf.GetService[cookies.Config](suite.Env()),
+				itf.GetService[headers.Config](suite.Env()),
+				itf.GetService[googleoauthconfig.Config](suite.Env()),
+				options,
+			)
+			suite.Register(controller)
+
+			cookiesCfg := itf.GetService[cookies.Config](suite.Env())
+			response := suite.GET("/login?next="+tt.nextURL).
+				Cookie(cookiesCfg.SID, browserCookie.Value).
+				Expect(t).
+				Status(http.StatusOK)
+
+			require.Len(t, captured.Accounts, 1)
+			assert.Equal(t, tt.nextURL, captured.NextURL)
+			assert.Equal(t, suite.Env().User.ID(), captured.Accounts[0].UserID)
+			assert.Equal(t, suite.Env().Tenant.ID.String(), captured.Accounts[0].TenantID)
+			assert.NotEqual(t, token, captured.Accounts[0].SessionReference)
+			assert.Contains(t, response.Body(), "accounts=1 next="+tt.nextURL)
+
+			suite.POST("/login/session?next="+tt.nextURL).
+				Cookie(cookiesCfg.SID, browserCookie.Value).
+				FormString("SessionReference", captured.Accounts[0].SessionReference).
+				Expect(t).
+				Status(http.StatusSeeOther).
+				RedirectTo(tt.nextURL)
+		})
+	}
 }

--- a/modules/core/presentation/controllers/login_account_controller_test.go
+++ b/modules/core/presentation/controllers/login_account_controller_test.go
@@ -1,0 +1,86 @@
+package controllers_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/a-h/templ"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iota-uz/iota-sdk/modules/core"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/session"
+	"github.com/iota-uz/iota-sdk/modules/core/presentation/controllers"
+	"github.com/iota-uz/iota-sdk/modules/core/services"
+	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/googleoauthconfig"
+	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig"
+	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig/cookies"
+	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig/headers"
+	"github.com/iota-uz/iota-sdk/pkg/defaults"
+	"github.com/iota-uz/iota-sdk/pkg/itf"
+)
+
+func TestLoginController_CustomRendererReceivesAccountPickerContext(t *testing.T) {
+	t.Parallel()
+	suite := itf.NewSuiteBuilder(t).WithComponents(core.NewComponent(&core.ModuleOptions{
+		PermissionSchema: defaults.PermissionSchema(),
+	})).AsUser().Build()
+	persistTestUser(t, suite.Env())
+
+	sessionService := itf.GetService[services.SessionService](suite.Env())
+	browserSessions := itf.GetService[services.BrowserSessionService](suite.Env())
+	token := "login-renderer-" + uuid.NewString()
+	require.NoError(t, sessionService.Create(suite.Env().Ctx, &session.CreateDTO{
+		Token: token, UserID: suite.Env().User.ID(), TenantID: suite.Env().Tenant.ID,
+		IP: "127.0.0.1", UserAgent: "login-renderer-test",
+	}))
+	sess, err := sessionService.GetBrowserSessionByToken(suite.Env().Ctx, token)
+	require.NoError(t, err)
+	browserCookie, err := browserSessions.Add(suite.Env().Ctx, "", sess)
+	require.NoError(t, err)
+
+	var captured controllers.LoginPageViewModel
+	options := &controllers.LoginControllerOptions{
+		Renderer: func(_ context.Context, vm controllers.LoginPageViewModel) templ.Component {
+			captured = vm
+			return templ.ComponentFunc(func(_ context.Context, w io.Writer) error {
+				_, err := fmt.Fprintf(w, "accounts=%d next=%s ref=%s", len(vm.Accounts), vm.NextURL, vm.Accounts[0].SessionReference)
+				return err
+			})
+		},
+	}
+	controller := controllers.NewLoginControllerWithBrowserSessions(
+		itf.GetService[services.AuthService](suite.Env()),
+		itf.GetService[services.AuthFlowService](suite.Env()),
+		browserSessions,
+		itf.GetService[httpconfig.Config](suite.Env()),
+		itf.GetService[cookies.Config](suite.Env()),
+		itf.GetService[headers.Config](suite.Env()),
+		itf.GetService[googleoauthconfig.Config](suite.Env()),
+		options,
+	)
+	suite.Register(controller)
+
+	cookiesCfg := itf.GetService[cookies.Config](suite.Env())
+	response := suite.GET("/login?next=/users").
+		Cookie(cookiesCfg.SID, browserCookie.Value).
+		Expect(t).
+		Status(http.StatusOK)
+
+	require.Len(t, captured.Accounts, 1)
+	require.Equal(t, "/users", captured.NextURL)
+	require.Equal(t, suite.Env().User.ID(), captured.Accounts[0].UserID)
+	require.Equal(t, suite.Env().Tenant.ID.String(), captured.Accounts[0].TenantID)
+	require.NotEqual(t, token, captured.Accounts[0].SessionReference)
+	require.Contains(t, response.Body(), "accounts=1 next=/users")
+
+	suite.POST("/login/session?next=/users").
+		Cookie(cookiesCfg.SID, browserCookie.Value).
+		FormString("session_ref", captured.Accounts[0].SessionReference).
+		Expect(t).
+		Status(http.StatusSeeOther).
+		RedirectTo("/users")
+}

--- a/modules/core/presentation/controllers/login_account_controller_test.go
+++ b/modules/core/presentation/controllers/login_account_controller_test.go
@@ -79,7 +79,7 @@ func TestLoginController_CustomRendererReceivesAccountPickerContext(t *testing.T
 
 	suite.POST("/login/session?next=/users").
 		Cookie(cookiesCfg.SID, browserCookie.Value).
-		FormString("SessionRef", captured.Accounts[0].SessionReference).
+		FormString("SessionReference", captured.Accounts[0].SessionReference).
 		Expect(t).
 		Status(http.StatusSeeOther).
 		RedirectTo("/users")

--- a/modules/core/presentation/controllers/login_controller.go
+++ b/modules/core/presentation/controllers/login_controller.go
@@ -619,7 +619,7 @@ func (c *LoginController) SelectSession(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	nextURL := security.GetValidatedRedirect(r.URL.Query().Get("next"))
-	if _, err := c.browserSessions.Activate(w, r, r.FormValue("SessionRef")); err != nil {
+	if _, err := c.browserSessions.Activate(w, r, r.FormValue("SessionReference")); err != nil {
 		shared.SetFlash(w, "error", []byte(intl.MustT(r.Context(), "Login.Errors.SessionExpired")))
 		http.Redirect(w, r, fmt.Sprintf("/login?next=%s", url.QueryEscape(nextURL)), http.StatusSeeOther)
 		return

--- a/modules/core/presentation/controllers/login_controller.go
+++ b/modules/core/presentation/controllers/login_controller.go
@@ -619,7 +619,7 @@ func (c *LoginController) SelectSession(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 	nextURL := security.GetValidatedRedirect(r.URL.Query().Get("next"))
-	if _, err := c.browserSessions.Activate(w, r, r.FormValue("session_ref")); err != nil {
+	if _, err := c.browserSessions.Activate(w, r, r.FormValue("SessionRef")); err != nil {
 		shared.SetFlash(w, "error", []byte(intl.MustT(r.Context(), "Login.Errors.SessionExpired")))
 		http.Redirect(w, r, fmt.Sprintf("/login?next=%s", url.QueryEscape(nextURL)), http.StatusSeeOther)
 		return

--- a/modules/core/presentation/controllers/login_controller.go
+++ b/modules/core/presentation/controllers/login_controller.go
@@ -267,7 +267,7 @@ func (c *LoginController) GoogleCallback(w http.ResponseWriter, r *http.Request)
 	loginRedirectURL := fmt.Sprintf("/login?%s", queryParams.Encode())
 	finalizeResult, err := c.authFlowService.FinalizeAuthentication(r.Context(), authResult, services.FinalizeAuthenticationOptions{
 		NextURL:            nextURL,
-		SessionCookieValue: sessionCookieValue(r, c.cookiesCfg.SID),
+		SessionCookieValue: sessionCookieValue(r, c.sidCookieName()),
 		AccessCheck:        c.runLoginAccessCheck,
 	})
 	if err != nil {
@@ -557,7 +557,7 @@ func (c *LoginController) Post(w http.ResponseWriter, r *http.Request) {
 	loginRedirectURL := buildLoginRedirectURL(dto.Email, nextURL, authRequestID)
 	finalizeResult, err := c.authFlowService.FinalizeAuthentication(r.Context(), authResult, services.FinalizeAuthenticationOptions{
 		NextURL:            postLoginRedirectURL,
-		SessionCookieValue: sessionCookieValue(r, c.cookiesCfg.SID),
+		SessionCookieValue: sessionCookieValue(r, c.sidCookieName()),
 		AccessCheck:        c.runLoginAccessCheck,
 	})
 	if err != nil {
@@ -598,7 +598,7 @@ func (c *LoginController) FinalizeAuthentication(
 
 	finalizeResult, err := c.authFlowService.FinalizeAuthentication(r.Context(), authResult, services.FinalizeAuthenticationOptions{
 		NextURL:            validatedNextURL,
-		SessionCookieValue: sessionCookieValue(r, c.cookiesCfg.SID),
+		SessionCookieValue: sessionCookieValue(r, c.sidCookieName()),
 		AccessCheck:        c.runLoginAccessCheck,
 	})
 	if err != nil {
@@ -632,6 +632,13 @@ func sessionCookieValue(r *http.Request, name string) string {
 		return cookie.Value
 	}
 	return ""
+}
+
+func (c *LoginController) sidCookieName() string {
+	if c.cookiesCfg != nil && c.cookiesCfg.SID != "" {
+		return c.cookiesCfg.SID
+	}
+	return "sid"
 }
 
 func buildLoginRedirectURL(email, nextURL, authRequestID string) string {

--- a/modules/core/presentation/controllers/login_controller.go
+++ b/modules/core/presentation/controllers/login_controller.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/gorilla/mux"
+	"github.com/iota-uz/iota-sdk/modules/core/presentation/mappers"
 	"github.com/iota-uz/iota-sdk/modules/core/presentation/templates/pages/login"
 )
 
@@ -96,6 +97,21 @@ func NewLoginController(
 	googleCfg *googleoauthconfig.Config,
 	opts ...*LoginControllerOptions,
 ) application.Controller {
+	return NewLoginControllerWithBrowserSessions(
+		authService, authFlowService, nil, httpCfg, cookiesCfg, headersCfg, googleCfg, opts...,
+	)
+}
+
+func NewLoginControllerWithBrowserSessions(
+	authService *services.AuthService,
+	authFlowService *services.AuthFlowService,
+	browserSessions *services.BrowserSessionService,
+	httpCfg *httpconfig.Config,
+	cookiesCfg *cookies.Config,
+	headersCfg *headers.Config,
+	googleCfg *googleoauthconfig.Config,
+	opts ...*LoginControllerOptions,
+) application.Controller {
 	options := &LoginControllerOptions{}
 	if len(opts) > 0 && opts[0] != nil {
 		options = opts[0]
@@ -103,6 +119,7 @@ func NewLoginController(
 	return &LoginController{
 		authService:     authService,
 		authFlowService: authFlowService,
+		browserSessions: browserSessions,
 		httpCfg:         httpCfg,
 		cookiesCfg:      cookiesCfg,
 		headersCfg:      headersCfg,
@@ -124,6 +141,7 @@ func (c *LoginController) SetTwoFactorService(service *twofactor.TwoFactorServic
 type LoginController struct {
 	authService      *services.AuthService
 	authFlowService  *services.AuthFlowService
+	browserSessions  *services.BrowserSessionService
 	twoFactorService *twofactor.TwoFactorService
 	httpCfg          *httpconfig.Config
 	cookiesCfg       *cookies.Config
@@ -145,6 +163,7 @@ func (c *LoginController) Register(r *mux.Router) {
 	postRouter := r.PathPrefix("/login").Subrouter()
 	postRouter.Use(c.PostMiddlewares()...)
 	postRouter.HandleFunc("", c.Post).Methods(http.MethodPost)
+	postRouter.HandleFunc("/session", c.SelectSession).Methods(http.MethodPost)
 
 	for _, provider := range c.optionsOrDefault().MethodProviders {
 		if provider == nil {
@@ -197,8 +216,18 @@ func (c *LoginController) runLoginAccessCheck(ctx context.Context, u coreuser.Us
 func (c *LoginController) GoogleCallback(w http.ResponseWriter, r *http.Request) {
 	// Validate and sanitize the redirect URL to prevent open redirect attacks
 	nextURL := security.GetValidatedRedirect(r.URL.Query().Get("next"))
+	savedNextURL, authRequestID := c.authService.OAuthContinuation(r)
+	if savedNextURL != "" {
+		nextURL = security.GetValidatedRedirect(savedNextURL)
+	}
+	if authRequestID != "" {
+		nextURL = fmt.Sprintf("/oidc/authorize/callback?id=%s", url.QueryEscape(authRequestID))
+	}
 	queryParams := url.Values{
 		"next": []string{nextURL},
+	}
+	if authRequestID != "" {
+		queryParams.Set("auth_request", authRequestID)
 	}
 	code := r.URL.Query().Get("code")
 	if code == "" {
@@ -237,8 +266,9 @@ func (c *LoginController) GoogleCallback(w http.ResponseWriter, r *http.Request)
 
 	loginRedirectURL := fmt.Sprintf("/login?%s", queryParams.Encode())
 	finalizeResult, err := c.authFlowService.FinalizeAuthentication(r.Context(), authResult, services.FinalizeAuthenticationOptions{
-		NextURL:     nextURL,
-		AccessCheck: c.runLoginAccessCheck,
+		NextURL:            nextURL,
+		SessionCookieValue: sessionCookieValue(r, c.cookiesCfg.SID),
+		AccessCheck:        c.runLoginAccessCheck,
 	})
 	if err != nil {
 		c.handleFinalizeError(w, r, loginRedirectURL, err)
@@ -268,13 +298,34 @@ func (c *LoginController) Get(w http.ResponseWriter, r *http.Request) {
 	}
 
 	logoComponent, _ := composables.UseLogo(r.Context())
+	nextURL := security.GetValidatedRedirect(r.URL.Query().Get("next"))
+	authRequestID := r.URL.Query().Get("auth_request")
+	authRequestInvalid := false
+	if authRequestID != "" && (c.browserSessions == nil || c.browserSessions.ValidateAuthorizationRequest(r.Context(), authRequestID) != nil) {
+		authRequestInvalid = true
+		errorMessage = []byte(intl.MustT(r.Context(), "Login.Errors.AuthorizationRequestInvalid"))
+	}
+	accounts, err := c.loginAccounts(w, r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	selectionURL := fmt.Sprintf("/login/session?next=%s", url.QueryEscape(nextURL))
+	if authRequestID != "" {
+		selectionURL = fmt.Sprintf("/oidc/authorize/select?auth_request=%s", url.QueryEscape(authRequestID))
+	}
 
 	viewModel := LoginPageViewModel{
-		ErrorsMap:    errorsMap,
-		Email:        email,
-		ErrorMessage: string(errorMessage),
-		Methods:      methods,
-		Logo:         logoComponent,
+		ErrorsMap:                   errorsMap,
+		Email:                       email,
+		ErrorMessage:                string(errorMessage),
+		Methods:                     methods,
+		Logo:                        logoComponent,
+		Accounts:                    accounts,
+		NextURL:                     nextURL,
+		AuthRequestID:               authRequestID,
+		SelectionURL:                selectionURL,
+		AuthorizationRequestInvalid: authRequestInvalid,
 	}
 
 	if renderer := c.optionsOrDefault().Renderer; renderer != nil {
@@ -295,12 +346,64 @@ func (c *LoginController) Get(w http.ResponseWriter, r *http.Request) {
 
 func (c *LoginController) renderDefaultLogin(w http.ResponseWriter, r *http.Request, vm LoginPageViewModel) error {
 	return c.renderLoginComponent(w, r, login.Index(&login.LoginProps{
-		ErrorsMap:    vm.ErrorsMap,
-		Email:        vm.Email,
-		ErrorMessage: vm.ErrorMessage,
-		Methods:      toTemplateLoginMethods(vm.Methods),
-		Logo:         vm.Logo,
+		ErrorsMap:                   vm.ErrorsMap,
+		Email:                       vm.Email,
+		ErrorMessage:                vm.ErrorMessage,
+		Methods:                     toTemplateLoginMethods(vm.Methods),
+		Logo:                        vm.Logo,
+		Accounts:                    toTemplateLoginAccounts(vm.Accounts),
+		NextURL:                     vm.NextURL,
+		AuthRequestID:               vm.AuthRequestID,
+		SelectionURL:                vm.SelectionURL,
+		AuthorizationRequestInvalid: vm.AuthorizationRequestInvalid,
 	}))
+}
+
+func (c *LoginController) loginAccounts(w http.ResponseWriter, r *http.Request) ([]LoginAccount, error) {
+	if c.browserSessions == nil {
+		return nil, nil
+	}
+	resolved, err := c.browserSessions.Resolve(w, r)
+	if err != nil {
+		return nil, err
+	}
+	accounts := make([]LoginAccount, 0, len(resolved))
+	for _, browserSession := range resolved {
+		if !browserSession.Session.IsActive() {
+			continue
+		}
+		u := mappers.UserToViewModel(browserSession.User)
+		avatarURL := ""
+		if u.Avatar != nil {
+			avatarURL = u.Avatar.URL
+		}
+		accounts = append(accounts, LoginAccount{
+			SessionReference: browserSession.Reference(),
+			UserID:           browserSession.Session.UserID(),
+			TenantID:         browserSession.Session.TenantID().String(),
+			FullName:         u.Title(),
+			Email:            u.Email,
+			AvatarURL:        avatarURL,
+			Initials:         shared.GetInitials(u.FirstName, u.LastName),
+			Active:           browserSession.Active,
+		})
+	}
+	return accounts, nil
+}
+
+func toTemplateLoginAccounts(accounts []LoginAccount) []login.Account {
+	mapped := make([]login.Account, 0, len(accounts))
+	for _, account := range accounts {
+		mapped = append(mapped, login.Account{
+			SessionReference: account.SessionReference,
+			FullName:         account.FullName,
+			Email:            account.Email,
+			AvatarURL:        account.AvatarURL,
+			Initials:         account.Initials,
+			Active:           account.Active,
+		})
+	}
+	return mapped
 }
 
 func (c *LoginController) renderLoginComponent(w http.ResponseWriter, r *http.Request, component interface {
@@ -340,7 +443,11 @@ func (c *LoginController) buildLoginMethods(w http.ResponseWriter, r *http.Reque
 	}
 
 	if c.includeGoogleMethod() && c.googleCfg.IsConfigured() {
-		codeURL, err := c.authService.GoogleAuthenticate(w)
+		codeURL, err := c.authService.GoogleAuthenticateFor(
+			w,
+			security.GetValidatedRedirect(r.URL.Query().Get("next")),
+			r.URL.Query().Get("auth_request"),
+		)
 		if err != nil {
 			composables.UseLogger(r.Context()).Error("failed to build google login method", "error", err)
 		} else {
@@ -429,7 +536,7 @@ func (c *LoginController) Post(w http.ResponseWriter, r *http.Request) {
 	}
 	if errorsMap, ok := dto.Ok(r.Context()); !ok {
 		shared.SetFlashMap(w, "errorsMap", errorsMap)
-		http.Redirect(w, r, fmt.Sprintf("/login?email=%s&next=%s", url.QueryEscape(dto.Email), url.QueryEscape(nextURL)), http.StatusFound)
+		http.Redirect(w, r, buildLoginRedirectURL(dto.Email, nextURL, authRequestID), http.StatusFound)
 		return
 	}
 
@@ -443,14 +550,15 @@ func (c *LoginController) Post(w http.ResponseWriter, r *http.Request) {
 		} else {
 			shared.SetFlash(w, "error", []byte(intl.MustT(r.Context(), "Errors.Internal")))
 		}
-		http.Redirect(w, r, fmt.Sprintf("/login?email=%s&next=%s", url.QueryEscape(dto.Email), url.QueryEscape(nextURL)), http.StatusFound)
+		http.Redirect(w, r, buildLoginRedirectURL(dto.Email, nextURL, authRequestID), http.StatusFound)
 		return
 	}
 
-	loginRedirectURL := fmt.Sprintf("/login?email=%s&next=%s", url.QueryEscape(dto.Email), url.QueryEscape(nextURL))
+	loginRedirectURL := buildLoginRedirectURL(dto.Email, nextURL, authRequestID)
 	finalizeResult, err := c.authFlowService.FinalizeAuthentication(r.Context(), authResult, services.FinalizeAuthenticationOptions{
-		NextURL:     postLoginRedirectURL,
-		AccessCheck: c.runLoginAccessCheck,
+		NextURL:            postLoginRedirectURL,
+		SessionCookieValue: sessionCookieValue(r, c.cookiesCfg.SID),
+		AccessCheck:        c.runLoginAccessCheck,
 	})
 	if err != nil {
 		c.handleFinalizeError(w, r, loginRedirectURL, err)
@@ -489,8 +597,9 @@ func (c *LoginController) FinalizeAuthentication(
 	loginRedirectURL := fmt.Sprintf("/login?next=%s", url.QueryEscape(validatedNextURL))
 
 	finalizeResult, err := c.authFlowService.FinalizeAuthentication(r.Context(), authResult, services.FinalizeAuthenticationOptions{
-		NextURL:     validatedNextURL,
-		AccessCheck: c.runLoginAccessCheck,
+		NextURL:            validatedNextURL,
+		SessionCookieValue: sessionCookieValue(r, c.cookiesCfg.SID),
+		AccessCheck:        c.runLoginAccessCheck,
 	})
 	if err != nil {
 		c.handleFinalizeError(w, r, loginRedirectURL, err)
@@ -498,6 +607,42 @@ func (c *LoginController) FinalizeAuthentication(
 	}
 
 	c.applyFinalizeResult(w, r, finalizeResult)
+}
+
+func (c *LoginController) SelectSession(w http.ResponseWriter, r *http.Request) {
+	if c.browserSessions == nil {
+		http.Error(w, "account switching unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	nextURL := security.GetValidatedRedirect(r.URL.Query().Get("next"))
+	if _, err := c.browserSessions.Activate(w, r, r.FormValue("session_ref")); err != nil {
+		shared.SetFlash(w, "error", []byte(intl.MustT(r.Context(), "Login.Errors.SessionExpired")))
+		http.Redirect(w, r, fmt.Sprintf("/login?next=%s", url.QueryEscape(nextURL)), http.StatusSeeOther)
+		return
+	}
+	http.Redirect(w, r, nextURL, http.StatusSeeOther)
+}
+
+func sessionCookieValue(r *http.Request, name string) string {
+	if cookie, err := r.Cookie(name); err == nil {
+		return cookie.Value
+	}
+	return ""
+}
+
+func buildLoginRedirectURL(email, nextURL, authRequestID string) string {
+	query := url.Values{"next": []string{security.GetValidatedRedirect(nextURL)}}
+	if email != "" {
+		query.Set("email", email)
+	}
+	if authRequestID != "" {
+		query.Set("auth_request", authRequestID)
+	}
+	return "/login?" + query.Encode()
 }
 
 func (c *LoginController) handleFinalizeError(

--- a/modules/core/presentation/controllers/login_extensibility.go
+++ b/modules/core/presentation/controllers/login_extensibility.go
@@ -50,11 +50,27 @@ type LoginMethod struct {
 	Attributes templ.Attributes
 }
 
+type LoginAccount struct {
+	SessionReference string
+	UserID           uint
+	TenantID         string
+	FullName         string
+	Email            string
+	AvatarURL        string
+	Initials         string
+	Active           bool
+}
+
 // LoginPageViewModel contains data required to render a login page.
 type LoginPageViewModel struct {
-	ErrorsMap    map[string]string
-	ErrorMessage string
-	Email        string
-	Methods      []LoginMethod
-	Logo         templ.Component
+	ErrorsMap                   map[string]string
+	ErrorMessage                string
+	Email                       string
+	Methods                     []LoginMethod
+	Logo                        templ.Component
+	Accounts                    []LoginAccount
+	NextURL                     string
+	AuthRequestID               string
+	SelectionURL                string
+	AuthorizationRequestInvalid bool
 }

--- a/modules/core/presentation/controllers/logout_controller.go
+++ b/modules/core/presentation/controllers/logout_controller.go
@@ -2,30 +2,24 @@
 package controllers
 
 import (
-	"errors"
 	"net/http"
-	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 
-	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence"
 	"github.com/iota-uz/iota-sdk/modules/core/services"
 	"github.com/iota-uz/iota-sdk/pkg/application"
-	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/appconfig"
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig"
-	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig/cookies"
 	"github.com/iota-uz/iota-sdk/pkg/di"
 )
 
 type LogoutController struct {
-	cfg        *httpconfig.Config
-	cookiesCfg *cookies.Config
-	appCfg     *appconfig.Config
+	cfg             *httpconfig.Config
+	browserSessions *services.BrowserSessionService
 }
 
-func NewLogoutController(cfg *httpconfig.Config, cookiesCfg *cookies.Config, appCfg *appconfig.Config) application.Controller {
-	return &LogoutController{cfg: cfg, cookiesCfg: cookiesCfg, appCfg: appCfg}
+func NewLogoutController(cfg *httpconfig.Config, browserSessions *services.BrowserSessionService) application.Controller {
+	return &LogoutController{cfg: cfg, browserSessions: browserSessions}
 }
 
 func (c *LogoutController) Descriptor() application.ControllerDescriptor {
@@ -34,6 +28,7 @@ func (c *LogoutController) Descriptor() application.ControllerDescriptor {
 
 func (c *LogoutController) Register(r *mux.Router) {
 	r.HandleFunc("/logout", di.H(c.Logout)).Methods(http.MethodPost)
+	r.HandleFunc("/logout/all", di.H(c.LogoutAll)).Methods(http.MethodPost)
 	r.HandleFunc("/logout", c.MethodNotAllowed).Methods(http.MethodGet)
 }
 
@@ -45,33 +40,32 @@ func (c *LogoutController) MethodNotAllowed(w http.ResponseWriter, _ *http.Reque
 func (c *LogoutController) Logout(
 	w http.ResponseWriter,
 	r *http.Request,
-	sessionService *services.SessionService,
 	logger *logrus.Entry,
 ) {
-	if cookie, err := r.Cookie(c.cookiesCfg.SID); err == nil && cookie.Value != "" {
-		if err := sessionService.Delete(r.Context(), cookie.Value); err != nil && !errors.Is(err, persistence.ErrSessionNotFound) {
-			logger.WithError(err).Warn("failed to delete session on logout")
-		}
+	sessions, err := c.browserSessions.RemoveCurrent(w, r)
+	if err != nil {
+		logger.WithError(err).Warn("failed to delete current session on logout")
 	}
 
-	http.SetCookie(
-		w, &http.Cookie{
-			Name:     c.cookiesCfg.SID,
-			Value:    "",
-			Domain:   c.cookiesCfg.Domain,
-			Path:     "/",
-			MaxAge:   -1,
-			Expires:  time.Unix(0, 0),
-			HttpOnly: true,
-			SameSite: http.SameSiteLaxMode,
-			Secure:   c.appCfg.IsProduction(),
-		},
-	)
+	setLogoutHeaders(w)
+	redirectURL := "/login"
+	if len(sessions) > 0 {
+		redirectURL = "/"
+	}
+	http.Redirect(w, r, redirectURL, http.StatusSeeOther)
+}
 
+func (c *LogoutController) LogoutAll(w http.ResponseWriter, r *http.Request, logger *logrus.Entry) {
+	if err := c.browserSessions.RemoveAll(w, r); err != nil {
+		logger.WithError(err).Warn("failed to delete all sessions on logout")
+	}
+	setLogoutHeaders(w)
+	w.Header().Set("Clear-Site-Data", `"cache", "cookies", "storage"`)
+	http.Redirect(w, r, "/login", http.StatusSeeOther)
+}
+
+func setLogoutHeaders(w http.ResponseWriter) {
 	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, private")
 	w.Header().Set("Pragma", "no-cache")
 	w.Header().Set("Expires", "0")
-	w.Header().Set("Clear-Site-Data", `"cache", "cookies", "storage"`)
-
-	http.Redirect(w, r, "/login", http.StatusSeeOther)
 }

--- a/modules/core/presentation/controllers/logout_controller.go
+++ b/modules/core/presentation/controllers/logout_controller.go
@@ -45,6 +45,7 @@ func (c *LogoutController) Logout(
 	sessions, err := c.browserSessions.RemoveCurrent(w, r)
 	if err != nil {
 		logger.WithError(err).Warn("failed to delete current session on logout")
+		c.browserSessions.Clear(w)
 	}
 
 	setLogoutHeaders(w)
@@ -58,6 +59,7 @@ func (c *LogoutController) Logout(
 func (c *LogoutController) LogoutAll(w http.ResponseWriter, r *http.Request, logger *logrus.Entry) {
 	if err := c.browserSessions.RemoveAll(w, r); err != nil {
 		logger.WithError(err).Warn("failed to delete all sessions on logout")
+		c.browserSessions.Clear(w)
 	}
 	setLogoutHeaders(w)
 	w.Header().Set("Clear-Site-Data", `"cache", "cookies", "storage"`)

--- a/modules/core/presentation/controllers/logout_controller_test.go
+++ b/modules/core/presentation/controllers/logout_controller_test.go
@@ -29,11 +29,11 @@ func TestLogoutController_Scenarios(t *testing.T) {
 
 	testCases := []struct {
 		name string
-		run  func(t *testing.T, suite *itf.Suite, cfg cfgBundle, sessionService *services.SessionService)
+		run  func(t *testing.T, suite *itf.Suite, cfg cfgBundle, sessionService *services.SessionService, browserSessions *services.BrowserSessionService)
 	}{
 		{
 			name: "post deletes session and clears browser state",
-			run: func(t *testing.T, suite *itf.Suite, cfg cfgBundle, sessionService *services.SessionService) {
+			run: func(t *testing.T, suite *itf.Suite, cfg cfgBundle, sessionService *services.SessionService, _ *services.BrowserSessionService) {
 				t.Helper()
 
 				token := "logout-test-session-token"
@@ -56,7 +56,7 @@ func TestLogoutController_Scenarios(t *testing.T) {
 				require.Equal(t, "no-store, no-cache, must-revalidate, private", response.Header("Cache-Control"))
 				require.Equal(t, "no-cache", response.Header("Pragma"))
 				require.Equal(t, "0", response.Header("Expires"))
-				require.Equal(t, `"cache", "cookies", "storage"`, response.Header("Clear-Site-Data"))
+				require.Empty(t, response.Header("Clear-Site-Data"))
 
 				respCookies := response.Cookies()
 				require.NotEmpty(t, respCookies, "expected at least one Set-Cookie header")
@@ -85,8 +85,61 @@ func TestLogoutController_Scenarios(t *testing.T) {
 			},
 		},
 		{
+			name: "post removes only current account and activates remaining account",
+			run: func(t *testing.T, suite *itf.Suite, cfg cfgBundle, sessionService *services.SessionService, browserSessions *services.BrowserSessionService) {
+				t.Helper()
+				firstToken := "logout-first-session-token"
+				secondToken := "logout-second-session-token"
+				for _, token := range []string{firstToken, secondToken} {
+					require.NoError(t, sessionService.Create(suite.Env().Ctx, &session.CreateDTO{
+						UserID: suite.Env().User.ID(), TenantID: suite.Env().Tenant.ID,
+						IP: "127.0.0.1", UserAgent: "logout-test-agent", Token: token,
+					}))
+				}
+				first, err := sessionService.GetBrowserSessionByToken(suite.Env().Ctx, firstToken)
+				require.NoError(t, err)
+				second, err := sessionService.GetBrowserSessionByToken(suite.Env().Ctx, secondToken)
+				require.NoError(t, err)
+				cookie, err := browserSessions.Add(suite.Env().Ctx, "", first)
+				require.NoError(t, err)
+				cookie, err = browserSessions.Add(suite.Env().Ctx, cookie.Value, second)
+				require.NoError(t, err)
+
+				response := suite.POST("/logout").
+					Cookie(cfg.cookiesCfg.SID, cookie.Value).
+					Expect(t).
+					Status(http.StatusSeeOther).
+					RedirectTo("/")
+
+				updatedCookie := findResponseCookie(t, response, cfg.cookiesCfg.SID)
+				require.NotEmpty(t, updatedCookie.Value)
+				_, err = sessionService.GetBrowserSessionByToken(suite.Env().Ctx, secondToken)
+				require.ErrorIs(t, err, persistence.ErrSessionNotFound)
+				_, err = sessionService.GetBrowserSessionByToken(suite.Env().Ctx, firstToken)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "logout all clears browser state",
+			run: func(t *testing.T, suite *itf.Suite, cfg cfgBundle, sessionService *services.SessionService, _ *services.BrowserSessionService) {
+				t.Helper()
+				token := "logout-all-session-token"
+				require.NoError(t, sessionService.Create(suite.Env().Ctx, &session.CreateDTO{
+					UserID: suite.Env().User.ID(), TenantID: suite.Env().Tenant.ID,
+					IP: "127.0.0.1", UserAgent: "logout-test-agent", Token: token,
+				}))
+				response := suite.POST("/logout/all").
+					Cookie(cfg.cookiesCfg.SID, token).
+					Expect(t).
+					Status(http.StatusSeeOther).
+					RedirectTo("/login")
+				require.Equal(t, `"cache", "cookies", "storage"`, response.Header("Clear-Site-Data"))
+				require.Empty(t, findResponseCookie(t, response, cfg.cookiesCfg.SID).Value)
+			},
+		},
+		{
 			name: "get returns method not allowed",
-			run: func(t *testing.T, suite *itf.Suite, _ cfgBundle, _ *services.SessionService) {
+			run: func(t *testing.T, suite *itf.Suite, _ cfgBundle, _ *services.SessionService, _ *services.BrowserSessionService) {
 				t.Helper()
 
 				response := suite.GET("/logout").
@@ -112,12 +165,24 @@ func TestLogoutController_Scenarios(t *testing.T) {
 			cookiesCfg := itf.GetService[cookies.Config](suite.Env())
 			appCfg := itf.GetService[appconfig.Config](suite.Env())
 			cfg := cfgBundle{httpCfg: httpCfg, cookiesCfg: cookiesCfg, appCfg: appCfg}
-			controller := controllers.NewLogoutController(httpCfg, cookiesCfg, appCfg)
+			browserSessions := itf.GetService[services.BrowserSessionService](suite.Env())
+			controller := controllers.NewLogoutController(httpCfg, browserSessions)
 			suite.Register(controller)
 
 			sessionService := itf.GetService[services.SessionService](suite.Env())
 
-			tc.run(t, suite, cfg, sessionService)
+			tc.run(t, suite, cfg, sessionService, browserSessions)
 		})
 	}
+}
+
+func findResponseCookie(t *testing.T, response *itf.Response, name string) *http.Cookie {
+	t.Helper()
+	for _, cookie := range response.Cookies() {
+		if cookie.Name == name {
+			return cookie
+		}
+	}
+	require.FailNow(t, "response cookie not found", name)
+	return nil
 }

--- a/modules/core/presentation/controllers/session_controller.go
+++ b/modules/core/presentation/controllers/session_controller.go
@@ -100,8 +100,8 @@ func (c *SessionController) List(
 
 	// Get current user's session token for highlighting
 	currentToken := ""
-	if cookie, err := r.Cookie(c.cfg.SID); err == nil {
-		currentToken = cookie.Value
+	if currentSession, err := composables.UseSession(r.Context()); err == nil {
+		currentToken = currentSession.Token()
 	}
 
 	// Build admin session view models with user info

--- a/modules/core/presentation/controllers/twofactor_setup_controller.go
+++ b/modules/core/presentation/controllers/twofactor_setup_controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/intl"
 	"github.com/iota-uz/iota-sdk/pkg/middleware"
 	"github.com/iota-uz/iota-sdk/pkg/security"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
 	"github.com/iota-uz/iota-sdk/pkg/shared"
 	pkgtwofactor "github.com/iota-uz/iota-sdk/pkg/twofactor"
 )
@@ -105,6 +106,7 @@ func requireTwoFactorSetupSession(w http.ResponseWriter, logger *logrus.Entry, r
 }
 
 func (c *TwoFactorSetupController) activateSession(w http.ResponseWriter, r *http.Request, sess session.Session) (session.Session, error) {
+	const op serrors.Op = "TwoFactorSetupController.activateSession"
 	updatedSession := session.New(
 		sess.Token(),
 		sess.UserID(),
@@ -118,11 +120,11 @@ func (c *TwoFactorSetupController) activateSession(w http.ResponseWriter, r *htt
 	)
 
 	if err := c.sessionService.Update(r.Context(), updatedSession); err != nil {
-		return nil, err
+		return nil, serrors.E(op, err)
 	}
 	cookie, err := c.browserSessions.AddFromRequest(r.Context(), r, updatedSession)
 	if err != nil {
-		return nil, err
+		return nil, serrors.E(op, err)
 	}
 	http.SetCookie(w, cookie)
 

--- a/modules/core/presentation/controllers/twofactor_setup_controller.go
+++ b/modules/core/presentation/controllers/twofactor_setup_controller.go
@@ -2,7 +2,6 @@
 package controllers
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -18,9 +17,7 @@ import (
 	"github.com/iota-uz/iota-sdk/modules/core/services/twofactor"
 	"github.com/iota-uz/iota-sdk/pkg/application"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
-	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/appconfig"
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig"
-	httpcookies "github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig/cookies"
 	httpsession "github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig/session"
 	"github.com/iota-uz/iota-sdk/pkg/intl"
 	"github.com/iota-uz/iota-sdk/pkg/middleware"
@@ -43,18 +40,16 @@ func NewTwoFactorSetupController(
 	sessionService *services.SessionService,
 	userService *services.UserService,
 	httpCfg *httpconfig.Config,
-	cookiesCfg *httpcookies.Config,
 	sessionCfg *httpsession.Config,
-	appCfg *appconfig.Config,
+	browserSessions *services.BrowserSessionService,
 ) application.Controller {
 	return &TwoFactorSetupController{
 		twoFactorService: twoFactorService,
 		sessionService:   sessionService,
 		userService:      userService,
 		httpCfg:          httpCfg,
-		cookiesCfg:       cookiesCfg,
 		sessionCfg:       sessionCfg,
-		appCfg:           appCfg,
+		browserSessions:  browserSessions,
 	}
 }
 
@@ -66,9 +61,8 @@ type TwoFactorSetupController struct {
 	sessionService   *services.SessionService
 	userService      *services.UserService
 	httpCfg          *httpconfig.Config
-	cookiesCfg       *httpcookies.Config
 	sessionCfg       *httpsession.Config
-	appCfg           *appconfig.Config
+	browserSessions  *services.BrowserSessionService
 }
 
 type methodChoiceDTO struct {
@@ -110,7 +104,7 @@ func requireTwoFactorSetupSession(w http.ResponseWriter, logger *logrus.Entry, r
 	return sess, true
 }
 
-func (c *TwoFactorSetupController) activateSession(ctx context.Context, w http.ResponseWriter, sess session.Session) (session.Session, error) {
+func (c *TwoFactorSetupController) activateSession(w http.ResponseWriter, r *http.Request, sess session.Session) (session.Session, error) {
 	updatedSession := session.New(
 		sess.Token(),
 		sess.UserID(),
@@ -123,20 +117,14 @@ func (c *TwoFactorSetupController) activateSession(ctx context.Context, w http.R
 		session.WithCreatedAt(sess.CreatedAt()),
 	)
 
-	if err := c.sessionService.Update(ctx, updatedSession); err != nil {
+	if err := c.sessionService.Update(r.Context(), updatedSession); err != nil {
 		return nil, err
 	}
-
-	http.SetCookie(w, &http.Cookie{
-		Name:     c.cookiesCfg.SID,
-		Value:    updatedSession.Token(),
-		Expires:  updatedSession.ExpiresAt(),
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-		Secure:   c.appCfg.IsProduction(),
-		Domain:   c.cookiesCfg.Domain,
-		Path:     "/",
-	})
+	cookie, err := c.browserSessions.AddFromRequest(r.Context(), r, updatedSession)
+	if err != nil {
+		return nil, err
+	}
+	http.SetCookie(w, cookie)
 
 	return updatedSession, nil
 }
@@ -460,7 +448,7 @@ func (c *TwoFactorSetupController) PostTOTPConfirm(w http.ResponseWriter, r *htt
 		return
 	}
 
-	if _, err := c.activateSession(r.Context(), w, sess); err != nil {
+	if _, err := c.activateSession(w, r, sess); err != nil {
 		logger.WithError(err).Error("failed to update session to active")
 		http.Error(w, "failed to activate session", http.StatusInternalServerError)
 		return
@@ -587,7 +575,7 @@ func (c *TwoFactorSetupController) PostOTPConfirm(w http.ResponseWriter, r *http
 		return
 	}
 
-	if _, err := c.activateSession(r.Context(), w, sess); err != nil {
+	if _, err := c.activateSession(w, r, sess); err != nil {
 		logger.WithError(err).Error("failed to update session to active")
 		http.Error(w, "failed to activate session", http.StatusInternalServerError)
 		return

--- a/modules/core/presentation/controllers/twofactor_verify_controller.go
+++ b/modules/core/presentation/controllers/twofactor_verify_controller.go
@@ -15,9 +15,7 @@ import (
 	"github.com/iota-uz/iota-sdk/modules/core/services/twofactor"
 	"github.com/iota-uz/iota-sdk/pkg/application"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
-	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/appconfig"
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig"
-	httpcookies "github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig/cookies"
 	httpsession "github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig/session"
 	"github.com/iota-uz/iota-sdk/pkg/intl"
 	"github.com/iota-uz/iota-sdk/pkg/middleware"
@@ -40,18 +38,16 @@ func NewTwoFactorVerifyController(
 	sessionService *services.SessionService,
 	userService *services.UserService,
 	httpCfg *httpconfig.Config,
-	cookiesCfg *httpcookies.Config,
 	sessionCfg *httpsession.Config,
-	appCfg *appconfig.Config,
+	browserSessions *services.BrowserSessionService,
 ) application.Controller {
 	return &TwoFactorVerifyController{
 		twoFactorService: twoFactorService,
 		sessionService:   sessionService,
 		userService:      userService,
 		httpCfg:          httpCfg,
-		cookiesCfg:       cookiesCfg,
 		sessionCfg:       sessionCfg,
-		appCfg:           appCfg,
+		browserSessions:  browserSessions,
 	}
 }
 
@@ -63,9 +59,8 @@ type TwoFactorVerifyController struct {
 	sessionService   *services.SessionService
 	userService      *services.UserService
 	httpCfg          *httpconfig.Config
-	cookiesCfg       *httpcookies.Config
 	sessionCfg       *httpsession.Config
-	appCfg           *appconfig.Config
+	browserSessions  *services.BrowserSessionService
 }
 
 // Descriptor returns the controller descriptor.
@@ -238,16 +233,11 @@ func (c *TwoFactorVerifyController) PostVerify(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	// Update the session cookie with new expiry to match the extended DB session
-	sessionCookie := &http.Cookie{
-		Name:     c.cookiesCfg.SID,
-		Value:    updatedSession.Token(),
-		Expires:  updatedSession.ExpiresAt(),
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-		Secure:   c.appCfg.IsProduction(),
-		Domain:   c.cookiesCfg.Domain,
-		Path:     "/",
+	sessionCookie, err := c.browserSessions.AddFromRequest(r.Context(), r, updatedSession)
+	if err != nil {
+		logger.Error("failed to update browser session cookie", "error", err)
+		http.Error(w, "failed to activate session", http.StatusInternalServerError)
+		return
 	}
 	http.SetCookie(w, sessionCookie)
 
@@ -366,16 +356,11 @@ func (c *TwoFactorVerifyController) PostRecovery(w http.ResponseWriter, r *http.
 		return
 	}
 
-	// Update the session cookie with new expiry to match the extended DB session
-	sessionCookie := &http.Cookie{
-		Name:     c.cookiesCfg.SID,
-		Value:    updatedSession.Token(),
-		Expires:  updatedSession.ExpiresAt(),
-		HttpOnly: true,
-		SameSite: http.SameSiteLaxMode,
-		Secure:   c.appCfg.IsProduction(),
-		Domain:   c.cookiesCfg.Domain,
-		Path:     "/",
+	sessionCookie, err := c.browserSessions.AddFromRequest(r.Context(), r, updatedSession)
+	if err != nil {
+		logger.Error("failed to update browser session cookie", "error", err)
+		http.Error(w, "failed to activate session", http.StatusInternalServerError)
+		return
 	}
 	http.SetCookie(w, sessionCookie)
 

--- a/modules/core/presentation/locales/en.json
+++ b/modules/core/presentation/locales/en.json
@@ -463,14 +463,19 @@
     "WelcomeBack": "Welcome back",
     "LoginToUse": "Log in to use IOTA ERP",
     "LoginWithGoogle": "Log in with Google",
-    "OrSignInWith": "Or sign in with...",
+		"OrSignInWith": "Or sign in with...",
+		"ChooseAccount": "Choose an account",
+		"UseAnotherAccount": "Use another account",
+		"ActiveAccount": "Active",
     "Errors": {
       "PasswordInvalid": "Email or password is invalid",
       "OauthStateNotFound": "oAuth state not found. Please, try again.",
       "OauthStateInvalid": "Invalid oAuth state. Please, try again.",
       "OauthCodeNotFound": "oAuth code not found. Please, try again.",
       "UserNotFound": "User not found",
-      "AccountBlocked": "Your account has been blocked. Please contact administrator."
+			"AccountBlocked": "Your account has been blocked. Please contact administrator.",
+			"SessionExpired": "That account session expired. Sign in again or choose another account."
+			,"AuthorizationRequestInvalid": "This authorization request is no longer valid. Return to the application and start again."
     }
   },
   "Modules": {
@@ -598,7 +603,11 @@
     "Navbar": {
       "Profile": "Profile",
       "Sessions": "Sessions",
-      "Logout": "Logout",
+			"Logout": "Logout",
+			"CurrentAccount": "Current account",
+			"AddAccount": "Add account",
+			"LogoutCurrent": "Logout current",
+			"LogoutAll": "Logout all accounts",
       "Settings": "Settings"
     },
     "Departments": "Departments"

--- a/modules/core/presentation/locales/pt-BR.json
+++ b/modules/core/presentation/locales/pt-BR.json
@@ -463,14 +463,19 @@
     "WelcomeBack": "Bem-vindo de volta",
     "LoginToUse": "Entre para usar o IOTA ERP",
     "LoginWithGoogle": "Entrar com Google",
-    "OrSignInWith": "Ou entre com...",
+		"OrSignInWith": "Ou entre com...",
+		"ChooseAccount": "Escolha uma conta",
+		"UseAnotherAccount": "Usar outra conta",
+		"ActiveAccount": "Ativa",
     "Errors": {
       "PasswordInvalid": "E-mail ou senha inválidos",
       "OauthStateNotFound": "Estado oAuth não encontrado. Por favor, tente novamente.",
       "OauthStateInvalid": "Estado oAuth inválido. Por favor, tente novamente.",
       "OauthCodeNotFound": "Código oAuth não encontrado. Por favor, tente novamente.",
       "UserNotFound": "Usuário não encontrado",
-      "AccountBlocked": "Sua conta foi bloqueada. Entre em contato com o administrador."
+			"AccountBlocked": "Sua conta foi bloqueada. Entre em contato com o administrador.",
+			"SessionExpired": "A sessão desta conta expirou. Entre novamente ou escolha outra conta."
+			,"AuthorizationRequestInvalid": "Esta solicitação de autorização não é mais válida. Volte ao aplicativo e tente novamente."
     }
   },
   "Modules": {
@@ -597,7 +602,11 @@
     "Navbar": {
       "Profile": "Perfil",
       "Sessions": "Sessões",
-      "Logout": "Sair",
+			"Logout": "Sair",
+			"CurrentAccount": "Conta atual",
+			"AddAccount": "Adicionar conta",
+			"LogoutCurrent": "Sair da conta atual",
+			"LogoutAll": "Sair de todas as contas",
       "Settings": "Configurações"
     },
     "Departments": "Departamentos",

--- a/modules/core/presentation/locales/ru.json
+++ b/modules/core/presentation/locales/ru.json
@@ -463,14 +463,19 @@
     "WelcomeBack": "Добро пожаловать",
     "LoginToUse": "Войдите, чтобы использовать IOTA ERP",
     "LoginWithGoogle": "Войти через Google",
-    "OrSignInWith": "Или войдите через...",
+		"OrSignInWith": "Или войдите через...",
+		"ChooseAccount": "Выберите аккаунт",
+		"UseAnotherAccount": "Использовать другой аккаунт",
+		"ActiveAccount": "Активный",
     "Errors": {
       "PasswordInvalid": "Неверный пароль или электронная почта",
       "OauthStateNotFound": "Состояние oAuth не найдено. Пожалуйста, попробуйте еще раз.",
       "OauthStateInvalid": "Недопустимое состояние oAuth. Пожалуйста, попробуйте еще раз.",
       "OauthCodeNotFound": "Код oAuth не найден. Пожалуйста, попробуйте еще раз.",
       "UserNotFound": "Пользователь не найден",
-      "AccountBlocked": "Ваш аккаунт заблокирован. Обратитесь к администратору."
+			"AccountBlocked": "Ваш аккаунт заблокирован. Обратитесь к администратору.",
+			"SessionExpired": "Сессия этого аккаунта истекла. Войдите снова или выберите другой аккаунт."
+			,"AuthorizationRequestInvalid": "Запрос авторизации больше недействителен. Вернитесь в приложение и начните снова."
     }
   },
   "Modules": {
@@ -598,7 +603,11 @@
     "Navbar": {
       "Profile": "Профиль",
       "Sessions": "Сеансы",
-      "Logout": "Выйти",
+			"Logout": "Выйти",
+			"CurrentAccount": "Текущий аккаунт",
+			"AddAccount": "Добавить аккаунт",
+			"LogoutCurrent": "Выйти из текущего",
+			"LogoutAll": "Выйти из всех аккаунтов",
       "Settings": "Настройки"
     },
     "Departments": "Отделы"

--- a/modules/core/presentation/locales/uz-Cyrl.json
+++ b/modules/core/presentation/locales/uz-Cyrl.json
@@ -463,14 +463,19 @@
     "WelcomeBack": "Xush kelibsiz",
     "LoginToUse": "IOTA ERP dan foydalanish uchun tizimga kiring",
     "LoginWithGoogle": "Google orqali kirish",
-    "OrSignInWith": "Yoki quyidagi orqali kiring",
+		"OrSignInWith": "Yoki quyidagi orqali kiring",
+		"ChooseAccount": "Аккаунтни танланг",
+		"UseAnotherAccount": "Бошқа аккаунтдан фойдаланиш",
+		"ActiveAccount": "Фаол",
     "Errors": {
       "PasswordInvalid": "Email yoki parol noto'g'ri",
       "OauthStateNotFound": "OAuth holati topilmadi. Iltimos, qayta urinib ko'ring.",
       "OauthStateInvalid": "OAuth holati yaroqsiz. Iltimos, qayta urinib ko'ring.",
       "OauthCodeNotFound": "OAuth kodi topilmadi. Iltimos, qayta urinib ko'ring.",
       "UserNotFound": "Foydalanuvchi topilmadi",
-      "AccountBlocked": "Sizning akkauntingiz bloklangan. Administratorga murojaat qiling."
+			"AccountBlocked": "Sizning akkauntingiz bloklangan. Administratorga murojaat qiling.",
+			"SessionExpired": "Бу аккаунт сессияси тугаган. Қайта киринг ёки бошқа аккаунтни танланг."
+			,"AuthorizationRequestInvalid": "Авторизация сўрови энди яроқсиз. Иловага қайтиб, қайта бошланг."
     }
   },
   "Modules": {
@@ -598,7 +603,11 @@
     "Navbar": {
       "Profile": "Profil",
       "Sessions": "Sessiyalar",
-      "Logout": "Chiqish",
+			"Logout": "Chiqish",
+			"CurrentAccount": "Жорий аккаунт",
+			"AddAccount": "Аккаунт қўшиш",
+			"LogoutCurrent": "Жорий аккаунтдан чиқиш",
+			"LogoutAll": "Барча аккаунтлардан чиқиш",
       "Settings": "Созламалар"
     },
     "Departments": "Бўлимлар"

--- a/modules/core/presentation/locales/uz.json
+++ b/modules/core/presentation/locales/uz.json
@@ -463,14 +463,19 @@
     "WelcomeBack": "Xush kelibsiz",
     "LoginToUse": "IOTA ERP dan foydalanish uchun tizimga kiring",
     "LoginWithGoogle": "Google orqali kirish",
-    "OrSignInWith": "Yoki quyidagi orqali kiring",
+		"OrSignInWith": "Yoki quyidagi orqali kiring",
+		"ChooseAccount": "Akkauntni tanlang",
+		"UseAnotherAccount": "Boshqa akkauntdan foydalanish",
+		"ActiveAccount": "Faol",
     "Errors": {
       "PasswordInvalid": "Email yoki parol noto'g'ri",
       "OauthStateNotFound": "OAuth holati topilmadi. Iltimos, qayta urinib ko'ring.",
       "OauthStateInvalid": "OAuth holati yaroqsiz. Iltimos, qayta urinib ko'ring.",
       "OauthCodeNotFound": "OAuth kodi topilmadi. Iltimos, qayta urinib ko'ring.",
       "UserNotFound": "Foydalanuvchi topilmadi",
-      "AccountBlocked": "Sizning akkauntingiz bloklangan. Administratorga murojaat qiling."
+			"AccountBlocked": "Sizning akkauntingiz bloklangan. Administratorga murojaat qiling.",
+			"SessionExpired": "Bu akkaunt sessiyasi tugagan. Qayta kiring yoki boshqa akkauntni tanlang."
+			,"AuthorizationRequestInvalid": "Avtorizatsiya so‘rovi endi yaroqsiz. Ilovaga qaytib, qayta boshlang."
     }
   },
   "Modules": {
@@ -598,7 +603,11 @@
     "Navbar": {
       "Profile": "Profil",
       "Sessions": "Sessiyalar",
-      "Logout": "Chiqish",
+			"Logout": "Chiqish",
+			"CurrentAccount": "Joriy akkaunt",
+			"AddAccount": "Akkaunt qo‘shish",
+			"LogoutCurrent": "Joriy akkauntdan chiqish",
+			"LogoutAll": "Barcha akkauntlardan chiqish",
       "Settings": "Sozlamalar"
     },
     "Departments": "Bo'limlar"

--- a/modules/core/presentation/locales/zh.json
+++ b/modules/core/presentation/locales/zh.json
@@ -463,14 +463,19 @@
     "WelcomeBack": "欢迎回来",
     "LoginToUse": "登录以使用 IOTA ERP",
     "LoginWithGoogle": "使用 Google 登录",
-    "OrSignInWith": "或使用...登录",
+		"OrSignInWith": "或使用...登录",
+		"ChooseAccount": "选择账户",
+		"UseAnotherAccount": "使用其他账户",
+		"ActiveAccount": "当前",
     "Errors": {
       "PasswordInvalid": "电子邮件或密码无效",
       "OauthStateNotFound": "未找到 oAuth 状态。请重试。",
       "OauthStateInvalid": "无效的 oAuth 状态。请重试。",
       "OauthCodeNotFound": "未找到 oAuth 代码。请重试。",
       "UserNotFound": "未找到用户",
-      "AccountBlocked": "您的账户已被封禁。请联系管理员。"
+			"AccountBlocked": "您的账户已被封禁。请联系管理员。",
+			"SessionExpired": "该账户会话已过期。请重新登录或选择其他账户。"
+			,"AuthorizationRequestInvalid": "此授权请求已失效。请返回应用并重新开始。"
     }
   },
   "Modules": {
@@ -602,7 +607,11 @@
     "Navbar": {
       "Profile": "个人资料",
       "Sessions": "会话",
-      "Logout": "退出登录",
+			"Logout": "退出登录",
+			"CurrentAccount": "当前账户",
+			"AddAccount": "添加账户",
+			"LogoutCurrent": "退出当前账户",
+			"LogoutAll": "退出所有账户",
       "Settings": "设置"
     },
     "Departments": "部门"

--- a/modules/core/presentation/templates/layouts/authenticated.templ
+++ b/modules/core/presentation/templates/layouts/authenticated.templ
@@ -9,8 +9,10 @@ import (
 	"github.com/iota-uz/iota-sdk/components/sidebar"
 	"github.com/iota-uz/iota-sdk/components/spotlight"
 	"github.com/iota-uz/iota-sdk/modules/core/presentation/mappers"
+	"github.com/iota-uz/iota-sdk/modules/core/services"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
 	"github.com/iota-uz/iota-sdk/pkg/types"
+	"net/url"
 )
 
 var (
@@ -131,6 +133,13 @@ templ SidebarTrigger(class string) {
 }
 
 templ Navbar(pageCtx types.PageContext, navbarLeft templ.Component) {
+	{{
+		browserSessions := services.UseBrowserSessions(ctx)
+		nextURL := "/"
+		if pageCtx.GetURL() != nil {
+			nextURL = pageCtx.GetURL().RequestURI()
+		}
+	}}
 	<section class="h-16 shadow-b-lg border-b w-full flex items-center px-4 md:px-8 bg-surface-300 border-b-primary">
 		if navbarLeft != nil {
 			@navbarLeft
@@ -153,8 +162,32 @@ templ Navbar(pageCtx types.PageContext, navbarLeft templ.Component) {
 				@base.DropdownItem(base.DropdownItemProps{Href: "/settings"}) {
 					{ pageCtx.T("NavigationLinks.Navbar.Settings") }
 				}
+				if len(browserSessions) > 0 {
+					<li class="border-t border-secondary my-1"></li>
+					for _, browserSession := range browserSessions {
+						if browserSession.Session.IsActive() {
+							{{ account := mappers.UserToViewModel(browserSession.User) }}
+							@base.DropdownFormItem(base.DropdownFormItemProps{
+								Action: "/login/session?next=" + url.QueryEscape(nextURL),
+								Method: "post",
+								Fields: map[string]string{"session_ref": browserSession.Reference()},
+							}) {
+								<span class="block truncate">{ account.Title() }</span>
+								if browserSession.Active {
+									<span class="block text-xs text-200">{ pageCtx.T("NavigationLinks.Navbar.CurrentAccount") }</span>
+								}
+							}
+						}
+					}
+					@base.DropdownItem(base.DropdownItemProps{Href: "/login?next=" + url.QueryEscape(nextURL) + "#login-methods"}) {
+						{ pageCtx.T("NavigationLinks.Navbar.AddAccount") }
+					}
+				}
 				@base.DropdownFormItem(base.DropdownFormItemProps{Action: "/logout", Method: "post"}) {
-					{ pageCtx.T("NavigationLinks.Navbar.Logout") }
+					{ pageCtx.T("NavigationLinks.Navbar.LogoutCurrent") }
+				}
+				@base.DropdownFormItem(base.DropdownFormItemProps{Action: "/logout/all", Method: "post"}) {
+					{ pageCtx.T("NavigationLinks.Navbar.LogoutAll") }
 				}
 			}
 			@SidebarTrigger("lg:hidden")

--- a/modules/core/presentation/templates/layouts/authenticated.templ
+++ b/modules/core/presentation/templates/layouts/authenticated.templ
@@ -27,7 +27,7 @@ templ Avatar() {
 			url = u.Avatar.URL
 		}
 	}}
-	<summary class="flex items-center justify-center cursor-pointer">
+	<summary class="flex items-center justify-center cursor-pointer" aria-label={ u.Title() }>
 		@avatar.Avatar(avatar.Props{
 			ImageURL: url,
 			Initials: u.Initials(),
@@ -150,8 +150,9 @@ templ Navbar(pageCtx types.PageContext, navbarLeft templ.Component) {
 			</div>
 			@ThemeSwitcher()
 			@base.DetailsDropdown(&base.DetailsDropdownProps{
-				Summary: Avatar(),
-				Classes: templ.Classes("z-[80]"),
+				Summary:     Avatar(),
+				Classes:     templ.Classes("z-[80]"),
+				MenuClasses: templ.Classes("w-64"),
 			}) {
 				@base.DropdownItem(base.DropdownItemProps{Href: "/account"}) {
 					{ pageCtx.T("NavigationLinks.Navbar.Profile") }
@@ -166,16 +167,28 @@ templ Navbar(pageCtx types.PageContext, navbarLeft templ.Component) {
 					<li class="border-t border-secondary my-1"></li>
 					for _, browserSession := range browserSessions {
 						if browserSession.Session.IsActive() {
-							{{ account := mappers.UserToViewModel(browserSession.User) }}
+							{{
+								account := mappers.UserToViewModel(browserSession.User)
+								avatarURL := ""
+								if account.Avatar != nil {
+									avatarURL = account.Avatar.URL
+								}
+							}}
 							@base.DropdownFormItem(base.DropdownFormItemProps{
 								Action: "/login/session?next=" + url.QueryEscape(nextURL),
 								Method: "post",
-								Fields: map[string]string{"SessionRef": browserSession.Reference()},
+								Fields: map[string]string{"SessionReference": browserSession.Reference()},
 							}) {
-								<span class="block truncate">{ account.Title() }</span>
-								if browserSession.Active {
-									<span class="block text-xs text-200">{ pageCtx.T("NavigationLinks.Navbar.CurrentAccount") }</span>
-								}
+								<span class="flex items-center gap-3">
+									@avatar.Avatar(avatar.Props{ImageURL: avatarURL, Initials: account.Initials(), Class: templ.Classes("w-8 h-8 text-xs")})
+									<span class="min-w-0 flex-1">
+										<span class="block truncate font-medium">{ account.Title() }</span>
+										<span class="block truncate text-xs text-200">{ account.Email }</span>
+										if browserSession.Active {
+											<span class="block text-xs text-200">{ pageCtx.T("NavigationLinks.Navbar.CurrentAccount") }</span>
+										}
+									</span>
+								</span>
 							}
 						}
 					}

--- a/modules/core/presentation/templates/layouts/authenticated.templ
+++ b/modules/core/presentation/templates/layouts/authenticated.templ
@@ -170,7 +170,7 @@ templ Navbar(pageCtx types.PageContext, navbarLeft templ.Component) {
 							@base.DropdownFormItem(base.DropdownFormItemProps{
 								Action: "/login/session?next=" + url.QueryEscape(nextURL),
 								Method: "post",
-								Fields: map[string]string{"session_ref": browserSession.Reference()},
+								Fields: map[string]string{"SessionRef": browserSession.Reference()},
 							}) {
 								<span class="block truncate">{ account.Title() }</span>
 								if browserSession.Active {

--- a/modules/core/presentation/templates/layouts/authenticated_templ.go
+++ b/modules/core/presentation/templates/layouts/authenticated_templ.go
@@ -437,7 +437,7 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 						templ_7745c5c3_Err = base.DropdownFormItem(base.DropdownFormItemProps{
 							Action: "/login/session?next=" + url.QueryEscape(nextURL),
 							Method: "post",
-							Fields: map[string]string{"session_ref": browserSession.Reference()},
+							Fields: map[string]string{"SessionRef": browserSession.Reference()},
 						}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var15), templ_7745c5c3_Buffer)
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err

--- a/modules/core/presentation/templates/layouts/authenticated_templ.go
+++ b/modules/core/presentation/templates/layouts/authenticated_templ.go
@@ -17,8 +17,10 @@ import (
 	"github.com/iota-uz/iota-sdk/components/sidebar"
 	"github.com/iota-uz/iota-sdk/components/spotlight"
 	"github.com/iota-uz/iota-sdk/modules/core/presentation/mappers"
+	"github.com/iota-uz/iota-sdk/modules/core/services"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
 	"github.com/iota-uz/iota-sdk/pkg/types"
+	"net/url"
 )
 
 var (
@@ -237,6 +239,12 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 			templ_7745c5c3_Var7 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+
+		browserSessions := services.UseBrowserSessions(ctx)
+		nextURL := "/"
+		if pageCtx.GetURL() != nil {
+			nextURL = pageCtx.GetURL().RequestURI()
+		}
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<section class=\"h-16 shadow-b-lg border-b w-full flex items-center px-4 md:px-8 bg-surface-300 border-b-primary\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
@@ -290,7 +298,7 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 				var templ_7745c5c3_Var10 string
 				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.Profile"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 148, Col: 50}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 157, Col: 50}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 				if templ_7745c5c3_Err != nil {
@@ -321,7 +329,7 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 				var templ_7745c5c3_Var12 string
 				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.Sessions"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 151, Col: 51}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 160, Col: 51}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 				if templ_7745c5c3_Err != nil {
@@ -352,7 +360,7 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 				var templ_7745c5c3_Var14 string
 				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.Settings"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 154, Col: 51}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 163, Col: 51}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 				if templ_7745c5c3_Err != nil {
@@ -368,7 +376,111 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Var15 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			if len(browserSessions) > 0 {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<li class=\"border-t border-secondary my-1\"></li>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				for _, browserSession := range browserSessions {
+					if browserSession.Session.IsActive() {
+						account := mappers.UserToViewModel(browserSession.User)
+						templ_7745c5c3_Var15 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+							templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+							templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+							if !templ_7745c5c3_IsBuffer {
+								defer func() {
+									templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+									if templ_7745c5c3_Err == nil {
+										templ_7745c5c3_Err = templ_7745c5c3_BufErr
+									}
+								}()
+							}
+							ctx = templ.InitializeContext(ctx)
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<span class=\"block truncate\">")
+							if templ_7745c5c3_Err != nil {
+								return templ_7745c5c3_Err
+							}
+							var templ_7745c5c3_Var16 string
+							templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(account.Title())
+							if templ_7745c5c3_Err != nil {
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 175, Col: 54}
+							}
+							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
+							if templ_7745c5c3_Err != nil {
+								return templ_7745c5c3_Err
+							}
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</span> ")
+							if templ_7745c5c3_Err != nil {
+								return templ_7745c5c3_Err
+							}
+							if browserSession.Active {
+								templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<span class=\"block text-xs text-200\">")
+								if templ_7745c5c3_Err != nil {
+									return templ_7745c5c3_Err
+								}
+								var templ_7745c5c3_Var17 string
+								templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.CurrentAccount"))
+								if templ_7745c5c3_Err != nil {
+									return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 177, Col: 98}
+								}
+								_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
+								if templ_7745c5c3_Err != nil {
+									return templ_7745c5c3_Err
+								}
+								templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</span>")
+								if templ_7745c5c3_Err != nil {
+									return templ_7745c5c3_Err
+								}
+							}
+							return nil
+						})
+						templ_7745c5c3_Err = base.DropdownFormItem(base.DropdownFormItemProps{
+							Action: "/login/session?next=" + url.QueryEscape(nextURL),
+							Method: "post",
+							Fields: map[string]string{"session_ref": browserSession.Reference()},
+						}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var15), templ_7745c5c3_Buffer)
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, " ")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Var18 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+					templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+					templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+					if !templ_7745c5c3_IsBuffer {
+						defer func() {
+							templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+							if templ_7745c5c3_Err == nil {
+								templ_7745c5c3_Err = templ_7745c5c3_BufErr
+							}
+						}()
+					}
+					ctx = templ.InitializeContext(ctx)
+					var templ_7745c5c3_Var19 string
+					templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.AddAccount"))
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 183, Col: 54}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					return nil
+				})
+				templ_7745c5c3_Err = base.DropdownItem(base.DropdownItemProps{Href: "/login?next=" + url.QueryEscape(nextURL) + "#login-methods"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var18), templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, " ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Var20 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 				if !templ_7745c5c3_IsBuffer {
@@ -380,18 +492,49 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 					}()
 				}
 				ctx = templ.InitializeContext(ctx)
-				var templ_7745c5c3_Var16 string
-				templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.Logout"))
+				var templ_7745c5c3_Var21 string
+				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.LogoutCurrent"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 157, Col: 49}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 187, Col: 56}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				return nil
 			})
-			templ_7745c5c3_Err = base.DropdownFormItem(base.DropdownFormItemProps{Action: "/logout", Method: "post"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var15), templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = base.DropdownFormItem(base.DropdownFormItemProps{Action: "/logout", Method: "post"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var20), templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, " ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Var22 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+				if !templ_7745c5c3_IsBuffer {
+					defer func() {
+						templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+						if templ_7745c5c3_Err == nil {
+							templ_7745c5c3_Err = templ_7745c5c3_BufErr
+						}
+					}()
+				}
+				ctx = templ.InitializeContext(ctx)
+				var templ_7745c5c3_Var23 string
+				templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.LogoutAll"))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 190, Col: 52}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				return nil
+			})
+			templ_7745c5c3_Err = base.DropdownFormItem(base.DropdownFormItemProps{Action: "/logout/all", Method: "post"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var22), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -408,7 +551,7 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</div></section>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</div></section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -432,9 +575,9 @@ func DefaultSidebarFooter() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var17 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var17 == nil {
-			templ_7745c5c3_Var17 = templ.NopComponent
+		templ_7745c5c3_Var24 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var24 == nil {
+			templ_7745c5c3_Var24 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = SidebarFooter().Render(ctx, templ_7745c5c3_Buffer)
@@ -461,12 +604,12 @@ func SidebarFooter() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var18 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var18 == nil {
-			templ_7745c5c3_Var18 = templ.NopComponent
+		templ_7745c5c3_Var25 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var25 == nil {
+			templ_7745c5c3_Var25 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<!-- Toggle button at bottom --><button @click.stop=\"toggle(); $dispatch(&#39;sidebar-toggle&#39;)\" class=\"hidden lg:flex items-center justify-center w-full p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-md transition-colors\"><div x-show=\"!isCollapsed\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<!-- Toggle button at bottom --><button @click.stop=\"toggle(); $dispatch(&#39;sidebar-toggle&#39;)\" class=\"hidden lg:flex items-center justify-center w-full p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-md transition-colors\"><div x-show=\"!isCollapsed\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -474,7 +617,7 @@ func SidebarFooter() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</div><div x-show=\"isCollapsed\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</div><div x-show=\"isCollapsed\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -482,11 +625,11 @@ func SidebarFooter() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</div></button>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</div></button>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templ_7745c5c3_Var18.Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = templ_7745c5c3_Var25.Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -510,12 +653,12 @@ func MobileSidebar(props sidebar.Props) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var19 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var19 == nil {
-			templ_7745c5c3_Var19 = templ.NopComponent
+		templ_7745c5c3_Var26 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var26 == nil {
+			templ_7745c5c3_Var26 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Var20 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var27 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -527,7 +670,7 @@ func MobileSidebar(props sidebar.Props) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<div class=\"w-3/4 sm:w-2/3\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<div class=\"w-3/4 sm:w-2/3\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -535,7 +678,7 @@ func MobileSidebar(props sidebar.Props) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -544,7 +687,7 @@ func MobileSidebar(props sidebar.Props) templ.Component {
 		templ_7745c5c3_Err = dialog.Drawer(dialog.DrawerProps{
 			Direction: dialog.LTR,
 			Action:    "open-sidebar",
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var20), templ_7745c5c3_Buffer)
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var27), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -568,12 +711,12 @@ func DefaultSidebarHeader() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var21 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var21 == nil {
-			templ_7745c5c3_Var21 = templ.NopComponent
+		templ_7745c5c3_Var28 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var28 == nil {
+			templ_7745c5c3_Var28 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<div class=\"flex flex-col items-center justify-center space-y-4\"><a href=\"/\" class=\"flex items-center gap-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<div class=\"flex flex-col items-center justify-center space-y-4\"><a href=\"/\" class=\"flex items-center gap-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -581,7 +724,7 @@ func DefaultSidebarHeader() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</a></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</a></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -610,15 +753,15 @@ func Authenticated(props AuthenticatedProps) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var22 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var22 == nil {
-			templ_7745c5c3_Var22 = templ.NopComponent
+		templ_7745c5c3_Var29 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var29 == nil {
+			templ_7745c5c3_Var29 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 
 		pageCtx := composables.UsePageCtx(ctx)
 		sidebarProps := MustUseSidebarProps(ctx)
-		templ_7745c5c3_Var23 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var30 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -634,7 +777,7 @@ func Authenticated(props AuthenticatedProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -642,20 +785,20 @@ func Authenticated(props AuthenticatedProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, " <div x-data=\"{\n\t\t\t\tsidebarCollapsed: initSidebarCollapsed(),\n\t\t\t\tinit() {\n\t\t\t\t\tthis.$nextTick(() =&gt; {\n\t\t\t\t\t\t// Listen for storage changes from other tabs\n\t\t\t\t\t\twindow.addEventListener(&#39;storage&#39;, (e) =&gt; {\n\t\t\t\t\t\t\tif (e.key === &#39;sidebar-collapsed&#39;) {\n\t\t\t\t\t\t\t\tthis.sidebarCollapsed = e.newValue === &#39;true&#39;;\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t});\n\t\t\t\t\t});\n\t\t\t\t}\n\t\t\t}\" data-sidebar-state=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, " <div x-data=\"{\n\t\t\t\tsidebarCollapsed: initSidebarCollapsed(),\n\t\t\t\tinit() {\n\t\t\t\t\tthis.$nextTick(() =&gt; {\n\t\t\t\t\t\t// Listen for storage changes from other tabs\n\t\t\t\t\t\twindow.addEventListener(&#39;storage&#39;, (e) =&gt; {\n\t\t\t\t\t\t\tif (e.key === &#39;sidebar-collapsed&#39;) {\n\t\t\t\t\t\t\t\tthis.sidebarCollapsed = e.newValue === &#39;true&#39;;\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t});\n\t\t\t\t\t});\n\t\t\t\t}\n\t\t\t}\" data-sidebar-state=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var24 string
-			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(string(sidebarProps.InitialState))
+			var templ_7745c5c3_Var31 string
+			templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(string(sidebarProps.InitialState))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 231, Col: 57}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 264, Col: 57}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "\" @sidebar-toggle=\"sidebarCollapsed = !sidebarCollapsed\" class=\"flex min-h-screen sdk-min-h-dvh w-full\"><div class=\"hidden lg:block flex-shrink-0\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "\" @sidebar-toggle=\"sidebarCollapsed = !sidebarCollapsed\" class=\"flex min-h-screen sdk-min-h-dvh w-full\"><div class=\"hidden lg:block flex-shrink-0\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -663,7 +806,7 @@ func Authenticated(props AuthenticatedProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</div><div class=\"flex-1 flex flex-col h-screen sdk-h-dvh overflow-hidden\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "</div><div class=\"flex-1 flex flex-col h-screen sdk-h-dvh overflow-hidden\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -671,21 +814,21 @@ func Authenticated(props AuthenticatedProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<div class=\"flex-1 overflow-y-auto content\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "<div class=\"flex-1 overflow-y-auto content\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templ_7745c5c3_Var22.Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = templ_7745c5c3_Var29.Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</div></div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</div></div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = Base(&props.BaseProps).Render(templ.WithChildren(ctx, templ_7745c5c3_Var23), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Base(&props.BaseProps).Render(templ.WithChildren(ctx, templ_7745c5c3_Var30), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/modules/core/presentation/templates/layouts/authenticated_templ.go
+++ b/modules/core/presentation/templates/layouts/authenticated_templ.go
@@ -54,7 +54,20 @@ func Avatar() templ.Component {
 		if u.Avatar != nil {
 			url = u.Avatar.URL
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<summary class=\"flex items-center justify-center cursor-pointer\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<summary class=\"flex items-center justify-center cursor-pointer\" aria-label=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var2 string
+		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(u.Title())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 30, Col: 88}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -65,7 +78,7 @@ func Avatar() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "</summary>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "</summary>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -89,12 +102,12 @@ func ThemeSwitcher() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var2 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var2 == nil {
-			templ_7745c5c3_Var2 = templ.NopComponent
+		templ_7745c5c3_Var3 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var3 == nil {
+			templ_7745c5c3_Var3 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, "<div class=\"flex items-center justify-center relative\"><input class=\"peer/system appearance-none absolute\" type=\"radio\" name=\"theme\" value=\"system\" id=\"theme-system\" onchange=\"onThemeChange(this)\" checked> <label for=\"theme-light\" class=\"group/system absolute flex items-center justify-center w-9 h-9 rounded-full bg-gray-200 text-black cursor-pointer invisible peer-checked/system:visible\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "<div class=\"flex items-center justify-center relative\"><input class=\"peer/system appearance-none absolute\" type=\"radio\" name=\"theme\" value=\"system\" id=\"theme-system\" onchange=\"onThemeChange(this)\" checked> <label for=\"theme-light\" class=\"group/system absolute flex items-center justify-center w-9 h-9 rounded-full bg-gray-200 text-black cursor-pointer invisible peer-checked/system:visible\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -105,7 +118,7 @@ func ThemeSwitcher() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 4, "</label> <input class=\"peer/light appearance-none absolute\" type=\"radio\" name=\"theme\" value=\"light\" id=\"theme-light\" onchange=\"onThemeChange(this)\"> <label for=\"theme-dark\" class=\"group/light absolute flex items-center justify-center w-9 h-9 rounded-full bg-gray-200 text-black cursor-pointer invisible peer-checked/light:visible\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</label> <input class=\"peer/light appearance-none absolute\" type=\"radio\" name=\"theme\" value=\"light\" id=\"theme-light\" onchange=\"onThemeChange(this)\"> <label for=\"theme-dark\" class=\"group/light absolute flex items-center justify-center w-9 h-9 rounded-full bg-gray-200 text-black cursor-pointer invisible peer-checked/light:visible\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -117,7 +130,7 @@ func ThemeSwitcher() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</label> <input class=\"peer/dark appearance-none absolute\" type=\"radio\" name=\"theme\" value=\"dark\" id=\"theme-dark\" onchange=\"onThemeChange(this)\"> <label for=\"theme-system\" class=\"group/dark absolute flex items-center justify-center w-9 h-9 rounded-full bg-black-950 text-white cursor-pointer invisible peer-checked/dark:visible\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</label> <input class=\"peer/dark appearance-none absolute\" type=\"radio\" name=\"theme\" value=\"dark\" id=\"theme-dark\" onchange=\"onThemeChange(this)\"> <label for=\"theme-system\" class=\"group/dark absolute flex items-center justify-center w-9 h-9 rounded-full bg-black-950 text-white cursor-pointer invisible peer-checked/dark:visible\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -130,11 +143,11 @@ func ThemeSwitcher() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</label></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</label></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var3 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var4 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -146,13 +159,13 @@ func ThemeSwitcher() templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<script>\n\t\t\tlet THEME_STORAGE_KEY = \"iota-theme\";\n\t\t\tlet savedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);\n\t\t\tlet initialTheme = savedTheme ?? \"system\";\n\t\t\tlet root = document.documentElement;\n\t\t\tlet previousTheme = initialTheme;\n\t\t\tlet radioInput = document.getElementById(`theme-${initialTheme}`);\n\t\t\tfunction changeTheme(theme) {\n\t\t\t\troot.classList.remove(previousTheme);\n\t\t\t\tif (!theme) theme = initialTheme;\n\t\t\t\twindow.localStorage.setItem(THEME_STORAGE_KEY, theme);\n\t\t\t\troot.classList.add(theme)\n\t\t\t\tpreviousTheme = theme;\n\t\t\t}\n\t\t\tfunction onThemeChange(input) {\n\t\t\t\tchangeTheme(input.value);\n\t\t\t}\n\t\t\tif (radioInput) {\n\t\t\t\tradioInput.checked = true;\n\t\t\t\tchangeTheme(initialTheme);\n\t\t\t}\n\t\t</script>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<script>\n\t\t\tlet THEME_STORAGE_KEY = \"iota-theme\";\n\t\t\tlet savedTheme = window.localStorage.getItem(THEME_STORAGE_KEY);\n\t\t\tlet initialTheme = savedTheme ?? \"system\";\n\t\t\tlet root = document.documentElement;\n\t\t\tlet previousTheme = initialTheme;\n\t\t\tlet radioInput = document.getElementById(`theme-${initialTheme}`);\n\t\t\tfunction changeTheme(theme) {\n\t\t\t\troot.classList.remove(previousTheme);\n\t\t\t\tif (!theme) theme = initialTheme;\n\t\t\t\twindow.localStorage.setItem(THEME_STORAGE_KEY, theme);\n\t\t\t\troot.classList.add(theme)\n\t\t\t\tpreviousTheme = theme;\n\t\t\t}\n\t\t\tfunction onThemeChange(input) {\n\t\t\t\tchangeTheme(input.value);\n\t\t\t}\n\t\t\tif (radioInput) {\n\t\t\t\tradioInput.checked = true;\n\t\t\t\tchangeTheme(initialTheme);\n\t\t\t}\n\t\t</script>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = navbarOnce.Once().Render(templ.WithChildren(ctx, templ_7745c5c3_Var3), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = navbarOnce.Once().Render(templ.WithChildren(ctx, templ_7745c5c3_Var4), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -176,33 +189,33 @@ func SidebarTrigger(class string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var4 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var4 == nil {
-			templ_7745c5c3_Var4 = templ.NopComponent
+		templ_7745c5c3_Var5 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var5 == nil {
+			templ_7745c5c3_Var5 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		var templ_7745c5c3_Var5 = []any{
+		var templ_7745c5c3_Var6 = []any{
 			"flex items-center justify-center w-9 h-9 rounded-md bg-surface-400 text-black cursor-pointer",
 			class,
 		}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var5...)
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var6...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<button x-data class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "<button x-data class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var6 string
-		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var5).String())
+		var templ_7745c5c3_Var7 string
+		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var6).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\" @click=\"$dispatch(&#39;open-sidebar&#39;)\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\" @click=\"$dispatch(&#39;open-sidebar&#39;)\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -210,7 +223,7 @@ func SidebarTrigger(class string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "</button>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</button>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -234,9 +247,9 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var7 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var7 == nil {
-			templ_7745c5c3_Var7 = templ.NopComponent
+		templ_7745c5c3_Var8 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var8 == nil {
+			templ_7745c5c3_Var8 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 
@@ -245,7 +258,7 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 		if pageCtx.GetURL() != nil {
 			nextURL = pageCtx.GetURL().RequestURI()
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<section class=\"h-16 shadow-b-lg border-b w-full flex items-center px-4 md:px-8 bg-surface-300 border-b-primary\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<section class=\"h-16 shadow-b-lg border-b w-full flex items-center px-4 md:px-8 bg-surface-300 border-b-primary\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -255,7 +268,7 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<div class=\"ml-auto flex items-center gap-4 md:gap-8\"><div class=\"hidden lg:block\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div class=\"ml-auto flex items-center gap-4 md:gap-8\"><div class=\"hidden lg:block\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -263,7 +276,7 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -271,7 +284,7 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Var8 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var9 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -283,7 +296,7 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Var9 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_Var10 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 				if !templ_7745c5c3_IsBuffer {
@@ -295,49 +308,18 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 					}()
 				}
 				ctx = templ.InitializeContext(ctx)
-				var templ_7745c5c3_Var10 string
-				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.Profile"))
+				var templ_7745c5c3_Var11 string
+				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.Profile"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 157, Col: 50}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 158, Col: 50}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				return nil
-			})
-			templ_7745c5c3_Err = base.DropdownItem(base.DropdownItemProps{Href: "/account"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var9), templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, " ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Var11 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-				if !templ_7745c5c3_IsBuffer {
-					defer func() {
-						templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-						if templ_7745c5c3_Err == nil {
-							templ_7745c5c3_Err = templ_7745c5c3_BufErr
-						}
-					}()
-				}
-				ctx = templ.InitializeContext(ctx)
-				var templ_7745c5c3_Var12 string
-				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.Sessions"))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 160, Col: 51}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				return nil
 			})
-			templ_7745c5c3_Err = base.DropdownItem(base.DropdownItemProps{Href: "/account/sessions"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var11), templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = base.DropdownItem(base.DropdownItemProps{Href: "/account"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var10), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -345,7 +327,7 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Var13 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_Var12 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 				if !templ_7745c5c3_IsBuffer {
@@ -357,18 +339,18 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 					}()
 				}
 				ctx = templ.InitializeContext(ctx)
-				var templ_7745c5c3_Var14 string
-				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.Settings"))
+				var templ_7745c5c3_Var13 string
+				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.Sessions"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 163, Col: 51}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 161, Col: 51}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				return nil
 			})
-			templ_7745c5c3_Err = base.DropdownItem(base.DropdownItemProps{Href: "/settings"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var13), templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = base.DropdownItem(base.DropdownItemProps{Href: "/account/sessions"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var12), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -376,15 +358,51 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
+			templ_7745c5c3_Var14 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+				if !templ_7745c5c3_IsBuffer {
+					defer func() {
+						templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+						if templ_7745c5c3_Err == nil {
+							templ_7745c5c3_Err = templ_7745c5c3_BufErr
+						}
+					}()
+				}
+				ctx = templ.InitializeContext(ctx)
+				var templ_7745c5c3_Var15 string
+				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.Settings"))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 164, Col: 51}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				return nil
+			})
+			templ_7745c5c3_Err = base.DropdownItem(base.DropdownItemProps{Href: "/settings"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var14), templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, " ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 			if len(browserSessions) > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<li class=\"border-t border-secondary my-1\"></li>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<li class=\"border-t border-secondary my-1\"></li>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				for _, browserSession := range browserSessions {
 					if browserSession.Session.IsActive() {
+
 						account := mappers.UserToViewModel(browserSession.User)
-						templ_7745c5c3_Var15 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+						avatarURL := ""
+						if account.Avatar != nil {
+							avatarURL = account.Avatar.URL
+						}
+						templ_7745c5c3_Var16 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 							templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 							templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 							if !templ_7745c5c3_IsBuffer {
@@ -396,59 +414,84 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 								}()
 							}
 							ctx = templ.InitializeContext(ctx)
-							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<span class=\"block truncate\">")
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<span class=\"flex items-center gap-3\">")
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
-							var templ_7745c5c3_Var16 string
-							templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(account.Title())
-							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 175, Col: 54}
-							}
-							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
+							templ_7745c5c3_Err = avatar.Avatar(avatar.Props{ImageURL: avatarURL, Initials: account.Initials(), Class: templ.Classes("w-8 h-8 text-xs")}).Render(ctx, templ_7745c5c3_Buffer)
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
-							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</span> ")
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<span class=\"min-w-0 flex-1\"><span class=\"block truncate font-medium\">")
+							if templ_7745c5c3_Err != nil {
+								return templ_7745c5c3_Err
+							}
+							var templ_7745c5c3_Var17 string
+							templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(account.Title())
+							if templ_7745c5c3_Err != nil {
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 185, Col: 68}
+							}
+							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
+							if templ_7745c5c3_Err != nil {
+								return templ_7745c5c3_Err
+							}
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</span> <span class=\"block truncate text-xs text-200\">")
+							if templ_7745c5c3_Err != nil {
+								return templ_7745c5c3_Err
+							}
+							var templ_7745c5c3_Var18 string
+							templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(account.Email)
+							if templ_7745c5c3_Err != nil {
+								return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 186, Col: 71}
+							}
+							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
+							if templ_7745c5c3_Err != nil {
+								return templ_7745c5c3_Err
+							}
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</span> ")
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
 							if browserSession.Active {
-								templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<span class=\"block text-xs text-200\">")
+								templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<span class=\"block text-xs text-200\">")
 								if templ_7745c5c3_Err != nil {
 									return templ_7745c5c3_Err
 								}
-								var templ_7745c5c3_Var17 string
-								templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.CurrentAccount"))
+								var templ_7745c5c3_Var19 string
+								templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.CurrentAccount"))
 								if templ_7745c5c3_Err != nil {
-									return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 177, Col: 98}
+									return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 188, Col: 100}
 								}
-								_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
-								if templ_7745c5c3_Err != nil {
-									return templ_7745c5c3_Err
-								}
-								templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</span>")
+								_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 								if templ_7745c5c3_Err != nil {
 									return templ_7745c5c3_Err
 								}
+								templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</span>")
+								if templ_7745c5c3_Err != nil {
+									return templ_7745c5c3_Err
+								}
+							}
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</span></span>")
+							if templ_7745c5c3_Err != nil {
+								return templ_7745c5c3_Err
 							}
 							return nil
 						})
 						templ_7745c5c3_Err = base.DropdownFormItem(base.DropdownFormItemProps{
 							Action: "/login/session?next=" + url.QueryEscape(nextURL),
 							Method: "post",
-							Fields: map[string]string{"SessionRef": browserSession.Reference()},
-						}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var15), templ_7745c5c3_Buffer)
+							Fields: map[string]string{"SessionReference": browserSession.Reference()},
+						}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var16), templ_7745c5c3_Buffer)
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, " ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, " ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Var18 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+				templ_7745c5c3_Var20 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 					templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 					templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 					if !templ_7745c5c3_IsBuffer {
@@ -460,54 +503,23 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 						}()
 					}
 					ctx = templ.InitializeContext(ctx)
-					var templ_7745c5c3_Var19 string
-					templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.AddAccount"))
+					var templ_7745c5c3_Var21 string
+					templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.AddAccount"))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 183, Col: 54}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 196, Col: 54}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					return nil
 				})
-				templ_7745c5c3_Err = base.DropdownItem(base.DropdownItemProps{Href: "/login?next=" + url.QueryEscape(nextURL) + "#login-methods"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var18), templ_7745c5c3_Buffer)
+				templ_7745c5c3_Err = base.DropdownItem(base.DropdownItemProps{Href: "/login?next=" + url.QueryEscape(nextURL) + "#login-methods"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var20), templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, " ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Var20 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-				if !templ_7745c5c3_IsBuffer {
-					defer func() {
-						templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-						if templ_7745c5c3_Err == nil {
-							templ_7745c5c3_Err = templ_7745c5c3_BufErr
-						}
-					}()
-				}
-				ctx = templ.InitializeContext(ctx)
-				var templ_7745c5c3_Var21 string
-				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.LogoutCurrent"))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 187, Col: 56}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				return nil
-			})
-			templ_7745c5c3_Err = base.DropdownFormItem(base.DropdownFormItemProps{Action: "/logout", Method: "post"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var20), templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -524,9 +536,9 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 				}
 				ctx = templ.InitializeContext(ctx)
 				var templ_7745c5c3_Var23 string
-				templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.LogoutAll"))
+				templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.LogoutCurrent"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 190, Col: 52}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 200, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 				if templ_7745c5c3_Err != nil {
@@ -534,16 +546,48 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 				}
 				return nil
 			})
-			templ_7745c5c3_Err = base.DropdownFormItem(base.DropdownFormItemProps{Action: "/logout/all", Method: "post"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var22), templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = base.DropdownFormItem(base.DropdownFormItemProps{Action: "/logout", Method: "post"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var22), templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, " ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Var24 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+				templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+				templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+				if !templ_7745c5c3_IsBuffer {
+					defer func() {
+						templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+						if templ_7745c5c3_Err == nil {
+							templ_7745c5c3_Err = templ_7745c5c3_BufErr
+						}
+					}()
+				}
+				ctx = templ.InitializeContext(ctx)
+				var templ_7745c5c3_Var25 string
+				templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Navbar.LogoutAll"))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 203, Col: 52}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				return nil
+			})
+			templ_7745c5c3_Err = base.DropdownFormItem(base.DropdownFormItemProps{Action: "/logout/all", Method: "post"}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var24), templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
 		templ_7745c5c3_Err = base.DetailsDropdown(&base.DetailsDropdownProps{
-			Summary: Avatar(),
-			Classes: templ.Classes("z-[80]"),
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var8), templ_7745c5c3_Buffer)
+			Summary:     Avatar(),
+			Classes:     templ.Classes("z-[80]"),
+			MenuClasses: templ.Classes("w-64"),
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var9), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -551,7 +595,7 @@ func Navbar(pageCtx types.PageContext, navbarLeft templ.Component) templ.Compone
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</div></section>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "</div></section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -575,9 +619,9 @@ func DefaultSidebarFooter() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var24 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var24 == nil {
-			templ_7745c5c3_Var24 = templ.NopComponent
+		templ_7745c5c3_Var26 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var26 == nil {
+			templ_7745c5c3_Var26 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = SidebarFooter().Render(ctx, templ_7745c5c3_Buffer)
@@ -604,12 +648,12 @@ func SidebarFooter() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var25 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var25 == nil {
-			templ_7745c5c3_Var25 = templ.NopComponent
+		templ_7745c5c3_Var27 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var27 == nil {
+			templ_7745c5c3_Var27 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<!-- Toggle button at bottom --><button @click.stop=\"toggle(); $dispatch(&#39;sidebar-toggle&#39;)\" class=\"hidden lg:flex items-center justify-center w-full p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-md transition-colors\"><div x-show=\"!isCollapsed\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<!-- Toggle button at bottom --><button @click.stop=\"toggle(); $dispatch(&#39;sidebar-toggle&#39;)\" class=\"hidden lg:flex items-center justify-center w-full p-2 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-md transition-colors\"><div x-show=\"!isCollapsed\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -617,7 +661,7 @@ func SidebarFooter() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</div><div x-show=\"isCollapsed\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</div><div x-show=\"isCollapsed\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -625,11 +669,11 @@ func SidebarFooter() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</div></button>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</div></button>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templ_7745c5c3_Var25.Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = templ_7745c5c3_Var27.Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -653,12 +697,12 @@ func MobileSidebar(props sidebar.Props) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var26 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var26 == nil {
-			templ_7745c5c3_Var26 = templ.NopComponent
+		templ_7745c5c3_Var28 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var28 == nil {
+			templ_7745c5c3_Var28 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Var27 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var29 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -670,7 +714,7 @@ func MobileSidebar(props sidebar.Props) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<div class=\"w-3/4 sm:w-2/3\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "<div class=\"w-3/4 sm:w-2/3\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -678,7 +722,7 @@ func MobileSidebar(props sidebar.Props) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -687,7 +731,7 @@ func MobileSidebar(props sidebar.Props) templ.Component {
 		templ_7745c5c3_Err = dialog.Drawer(dialog.DrawerProps{
 			Direction: dialog.LTR,
 			Action:    "open-sidebar",
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var27), templ_7745c5c3_Buffer)
+		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var29), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -711,12 +755,12 @@ func DefaultSidebarHeader() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var28 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var28 == nil {
-			templ_7745c5c3_Var28 = templ.NopComponent
+		templ_7745c5c3_Var30 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var30 == nil {
+			templ_7745c5c3_Var30 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<div class=\"flex flex-col items-center justify-center space-y-4\"><a href=\"/\" class=\"flex items-center gap-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "<div class=\"flex flex-col items-center justify-center space-y-4\"><a href=\"/\" class=\"flex items-center gap-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -724,7 +768,7 @@ func DefaultSidebarHeader() templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</a></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "</a></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -753,15 +797,15 @@ func Authenticated(props AuthenticatedProps) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var29 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var29 == nil {
-			templ_7745c5c3_Var29 = templ.NopComponent
+		templ_7745c5c3_Var31 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var31 == nil {
+			templ_7745c5c3_Var31 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 
 		pageCtx := composables.UsePageCtx(ctx)
 		sidebarProps := MustUseSidebarProps(ctx)
-		templ_7745c5c3_Var30 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var32 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -777,7 +821,7 @@ func Authenticated(props AuthenticatedProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, " ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, " ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -785,20 +829,20 @@ func Authenticated(props AuthenticatedProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, " <div x-data=\"{\n\t\t\t\tsidebarCollapsed: initSidebarCollapsed(),\n\t\t\t\tinit() {\n\t\t\t\t\tthis.$nextTick(() =&gt; {\n\t\t\t\t\t\t// Listen for storage changes from other tabs\n\t\t\t\t\t\twindow.addEventListener(&#39;storage&#39;, (e) =&gt; {\n\t\t\t\t\t\t\tif (e.key === &#39;sidebar-collapsed&#39;) {\n\t\t\t\t\t\t\t\tthis.sidebarCollapsed = e.newValue === &#39;true&#39;;\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t});\n\t\t\t\t\t});\n\t\t\t\t}\n\t\t\t}\" data-sidebar-state=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, " <div x-data=\"{\n\t\t\t\tsidebarCollapsed: initSidebarCollapsed(),\n\t\t\t\tinit() {\n\t\t\t\t\tthis.$nextTick(() =&gt; {\n\t\t\t\t\t\t// Listen for storage changes from other tabs\n\t\t\t\t\t\twindow.addEventListener(&#39;storage&#39;, (e) =&gt; {\n\t\t\t\t\t\t\tif (e.key === &#39;sidebar-collapsed&#39;) {\n\t\t\t\t\t\t\t\tthis.sidebarCollapsed = e.newValue === &#39;true&#39;;\n\t\t\t\t\t\t\t}\n\t\t\t\t\t\t});\n\t\t\t\t\t});\n\t\t\t\t}\n\t\t\t}\" data-sidebar-state=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var31 string
-			templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(string(sidebarProps.InitialState))
+			var templ_7745c5c3_Var33 string
+			templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(string(sidebarProps.InitialState))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 264, Col: 57}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/layouts/authenticated.templ`, Line: 277, Col: 57}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "\" @sidebar-toggle=\"sidebarCollapsed = !sidebarCollapsed\" class=\"flex min-h-screen sdk-min-h-dvh w-full\"><div class=\"hidden lg:block flex-shrink-0\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "\" @sidebar-toggle=\"sidebarCollapsed = !sidebarCollapsed\" class=\"flex min-h-screen sdk-min-h-dvh w-full\"><div class=\"hidden lg:block flex-shrink-0\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -806,7 +850,7 @@ func Authenticated(props AuthenticatedProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "</div><div class=\"flex-1 flex flex-col h-screen sdk-h-dvh overflow-hidden\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "</div><div class=\"flex-1 flex flex-col h-screen sdk-h-dvh overflow-hidden\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -814,21 +858,21 @@ func Authenticated(props AuthenticatedProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "<div class=\"flex-1 overflow-y-auto content\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "<div class=\"flex-1 overflow-y-auto content\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templ_7745c5c3_Var29.Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = templ_7745c5c3_Var31.Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</div></div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "</div></div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = Base(&props.BaseProps).Render(templ.WithChildren(ctx, templ_7745c5c3_Var30), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Base(&props.BaseProps).Render(templ.WithChildren(ctx, templ_7745c5c3_Var32), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/modules/core/presentation/templates/pages/login/index.templ
+++ b/modules/core/presentation/templates/pages/login/index.templ
@@ -3,6 +3,7 @@ package login
 import (
 	icons "github.com/iota-uz/icons/phosphor"
 	"github.com/iota-uz/iota-sdk/components/base/alert"
+	"github.com/iota-uz/iota-sdk/components/base/avatar"
 	"github.com/iota-uz/iota-sdk/components/base/button"
 	"github.com/iota-uz/iota-sdk/components/base/input"
 	"github.com/iota-uz/iota-sdk/internal/assets"
@@ -20,11 +21,25 @@ type LoginMethod struct {
 }
 
 type LoginProps struct {
-	ErrorsMap    map[string]string
-	ErrorMessage string
-	Email        string
-	Methods      []LoginMethod
-	Logo         templ.Component
+	ErrorsMap                   map[string]string
+	ErrorMessage                string
+	Email                       string
+	Methods                     []LoginMethod
+	Logo                        templ.Component
+	Accounts                    []Account
+	NextURL                     string
+	AuthRequestID               string
+	SelectionURL                string
+	AuthorizationRequestInvalid bool
+}
+
+type Account struct {
+	SessionReference string
+	FullName         string
+	Email            string
+	AvatarURL        string
+	Initials         string
+	Active           bool
 }
 
 var (
@@ -99,74 +114,104 @@ templ Index(p *LoginProps) {
 		<div class="flex flex-col h-screen overflow-y-auto">
 			@Header(p.Logo)
 			<div class="flex-1 flex items-center justify-center">
-				<form class="mx-4 max-w-md w-full p-6 md:p-11 flex flex-col gap-4 bg-surface-300 rounded-xl shadow-[0_20px_20px_0px_rgba(0,0,0,0.08),0_0_0_7px_rgba(255,255,255,0.5)]" method="post">
-					@composables.CSRFTokenField()
+				<div class="mx-4 max-w-md w-full p-6 md:p-11 flex flex-col gap-4 bg-surface-300 rounded-xl shadow-[0_20px_20px_0px_rgba(0,0,0,0.08),0_0_0_7px_rgba(255,255,255,0.5)]">
 					<div class="text-center">
 						<h1 class="text-2xl text-100">
-							{ pageCtx.T("Login.WelcomeBack") }
+							if len(p.Accounts) > 0 {
+								{ pageCtx.T("Login.ChooseAccount") }
+							} else {
+								{ pageCtx.T("Login.WelcomeBack") }
+							}
 						</h1>
 						<p class="mt-2 text-200">{ pageCtx.T("Login.LoginToUse") }</p>
 					</div>
 					<hr class="border border-primary"/>
-					if hasExternalMethod {
-						for _, method := range p.Methods {
-							if method.ID != "password" {
-								{{ attrs := templ.Attributes{} }}
-								if method.Href == "" {
-									{{ attrs["type"] = "button" }}
-								}
-								for key, value := range method.Attributes {
-									{{ attrs[key] = value }}
-								}
-								@button.Secondary(button.Props{
-									Size:  button.SizeNormal,
-									Class: "justify-center items-center gap-3",
-									Href:  method.Href,
-									Attrs: attrs,
-								}) {
-									if method.Icon != nil {
-										@method.Icon
+					if !p.AuthorizationRequestInvalid && len(p.Accounts) > 0 {
+						<div class="flex flex-col gap-2" data-testid="account-picker">
+							for _, account := range p.Accounts {
+								<form method="post" action={ templ.SafeURL(p.SelectionURL) }>
+									@composables.CSRFTokenField()
+									<input type="hidden" name="session_ref" value={ account.SessionReference }/>
+									<button type="submit" class="w-full flex items-center gap-3 rounded-lg border border-primary p-3 text-left hover:bg-surface-200" data-testid="account-card">
+										@avatar.Avatar(avatar.Props{ImageURL: account.AvatarURL, Initials: account.Initials})
+										<span class="min-w-0 flex-1">
+											<span class="block truncate text-100 font-medium">{ account.FullName }</span>
+											<span class="block truncate text-sm text-200">{ account.Email }</span>
+										</span>
+										if account.Active {
+											<span class="text-xs text-200">{ pageCtx.T("Login.ActiveAccount") }</span>
+										}
+									</button>
+								</form>
+							}
+						</div>
+						<a href="#login-methods" class="text-center text-sm text-primary-600 hover:underline" data-testid="use-another-account">{ pageCtx.T("Login.UseAnotherAccount") }</a>
+						<hr class="border border-primary"/>
+					}
+					if !p.AuthorizationRequestInvalid {
+						<form id="login-methods" class="flex flex-col gap-4" method="post">
+							@composables.CSRFTokenField()
+							if hasExternalMethod {
+								for _, method := range p.Methods {
+									if method.ID != "password" {
+										{{ attrs := templ.Attributes{} }}
+										if method.Href == "" {
+											{{ attrs["type"] = "button" }}
+										}
+										for key, value := range method.Attributes {
+											{{ attrs[key] = value }}
+										}
+										@button.Secondary(button.Props{
+											Size:  button.SizeNormal,
+											Class: "justify-center items-center gap-3",
+											Href:  method.Href,
+											Attrs: attrs,
+										}) {
+											if method.Icon != nil {
+												@method.Icon
+											}
+											{ method.Label }
+										}
 									}
-									{ method.Label }
+								}
+								if hasPasswordMethod {
+									<p class="text-xs text-200 text-center">{ pageCtx.T("Login.OrSignInWith") }</p>
 								}
 							}
-						}
-						if hasPasswordMethod {
-							<p class="text-xs text-200 text-center">{ pageCtx.T("Login.OrSignInWith") }</p>
-						}
+							if len(p.ErrorMessage) > 0 {
+								@alert.Error() {
+									{ p.ErrorMessage }
+								}
+							}
+							if hasPasswordMethod {
+								@input.Email(&input.Props{
+									Label: pageCtx.T("Login.Email"),
+									Attrs: templ.Attributes{
+										"name":  "Email",
+										"value": p.Email,
+									},
+									Error: p.ErrorsMap["Email"],
+								})
+								@input.Password(&input.Props{
+									Label: pageCtx.T("Login.Password"),
+									Attrs: templ.Attributes{
+										"name": "Password",
+									},
+									Error: p.ErrorsMap["Password"],
+								})
+								@button.Primary(button.Props{
+									Size:  button.SizeNormal,
+									Class: "justify-center",
+									Attrs: templ.Attributes{
+										"type": "submit",
+									},
+								}) {
+									{ pageCtx.T("Login.Login") }
+								}
+							}
+						</form>
 					}
-					if len(p.ErrorMessage) > 0 {
-						@alert.Error() {
-							{ p.ErrorMessage }
-						}
-					}
-					if hasPasswordMethod {
-						@input.Email(&input.Props{
-							Label: pageCtx.T("Login.Email"),
-							Attrs: templ.Attributes{
-								"name":  "Email",
-								"value": p.Email,
-							},
-							Error: p.ErrorsMap["Email"],
-						})
-						@input.Password(&input.Props{
-							Label: pageCtx.T("Login.Password"),
-							Attrs: templ.Attributes{
-								"name": "Password",
-							},
-							Error: p.ErrorsMap["Password"],
-						})
-						@button.Primary(button.Props{
-							Size:  button.SizeNormal,
-							Class: "justify-center",
-							Attrs: templ.Attributes{
-								"type": "submit",
-							},
-						}) {
-							{ pageCtx.T("Login.Login") }
-						}
-					}
-				</form>
+				</div>
 			</div>
 		</div>
 	}

--- a/modules/core/presentation/templates/pages/login/index.templ
+++ b/modules/core/presentation/templates/pages/login/index.templ
@@ -117,7 +117,9 @@ templ Index(p *LoginProps) {
 				<div class="mx-4 max-w-md w-full p-6 md:p-11 flex flex-col gap-4 bg-surface-300 rounded-xl shadow-[0_20px_20px_0px_rgba(0,0,0,0.08),0_0_0_7px_rgba(255,255,255,0.5)]">
 					<div class="text-center">
 						<h1 class="text-2xl text-100">
-							if len(p.Accounts) > 0 {
+							if p.AuthorizationRequestInvalid {
+								{ pageCtx.T("Login.Login") }
+							} else if len(p.Accounts) > 0 {
 								{ pageCtx.T("Login.ChooseAccount") }
 							} else {
 								{ pageCtx.T("Login.WelcomeBack") }
@@ -126,12 +128,17 @@ templ Index(p *LoginProps) {
 						<p class="mt-2 text-200">{ pageCtx.T("Login.LoginToUse") }</p>
 					</div>
 					<hr class="border border-primary"/>
-					if !p.AuthorizationRequestInvalid && len(p.Accounts) > 0 {
+					if p.AuthorizationRequestInvalid {
+						<div class="flex flex-col gap-4 text-center" role="alert">
+							<p class="text-red-600">{ p.ErrorMessage }</p>
+							<a href="/login" class="text-primary-600 hover:underline">{ pageCtx.T("Login.Login") }</a>
+						</div>
+					} else if len(p.Accounts) > 0 {
 						<div class="flex flex-col gap-2" data-testid="account-picker">
 							for _, account := range p.Accounts {
-								<form method="post" action={ templ.SafeURL(p.SelectionURL) }>
+								<form method="post" action={ templ.URL(p.SelectionURL) }>
 									@composables.CSRFTokenField()
-									<input type="hidden" name="session_ref" value={ account.SessionReference }/>
+									<input type="hidden" name="SessionRef" value={ account.SessionReference }/>
 									<button type="submit" class="w-full flex items-center gap-3 rounded-lg border border-primary p-3 text-left hover:bg-surface-200" data-testid="account-card">
 										@avatar.Avatar(avatar.Props{ImageURL: account.AvatarURL, Initials: account.Initials})
 										<span class="min-w-0 flex-1">

--- a/modules/core/presentation/templates/pages/login/index.templ
+++ b/modules/core/presentation/templates/pages/login/index.templ
@@ -4,6 +4,7 @@ import (
 	icons "github.com/iota-uz/icons/phosphor"
 	"github.com/iota-uz/iota-sdk/components/base/alert"
 	"github.com/iota-uz/iota-sdk/components/base/avatar"
+	"github.com/iota-uz/iota-sdk/components/base/badge"
 	"github.com/iota-uz/iota-sdk/components/base/button"
 	"github.com/iota-uz/iota-sdk/components/base/input"
 	"github.com/iota-uz/iota-sdk/internal/assets"
@@ -136,19 +137,29 @@ templ Index(p *LoginProps) {
 					} else if len(p.Accounts) > 0 {
 						<div class="flex flex-col gap-2" data-testid="account-picker">
 							for _, account := range p.Accounts {
+								{{ accountAttrs := templ.Attributes{"type": "submit", "data-testid": "account-card"} }}
+								if account.Active {
+									{{ accountAttrs["aria-current"] = "true" }}
+								}
 								<form method="post" action={ templ.URL(p.SelectionURL) }>
 									@composables.CSRFTokenField()
-									<input type="hidden" name="SessionRef" value={ account.SessionReference }/>
-									<button type="submit" class="w-full flex items-center gap-3 rounded-lg border border-primary p-3 text-left hover:bg-surface-200" data-testid="account-card">
+									<input type="hidden" name="SessionReference" value={ account.SessionReference }/>
+									@button.Secondary(button.Props{
+										Size:  button.SizeNormal,
+										Class: "w-full !h-auto min-h-16 justify-start gap-3 p-3 text-left",
+										Attrs: accountAttrs,
+									}) {
 										@avatar.Avatar(avatar.Props{ImageURL: account.AvatarURL, Initials: account.Initials})
 										<span class="min-w-0 flex-1">
 											<span class="block truncate text-100 font-medium">{ account.FullName }</span>
 											<span class="block truncate text-sm text-200">{ account.Email }</span>
 										</span>
 										if account.Active {
-											<span class="text-xs text-200">{ pageCtx.T("Login.ActiveAccount") }</span>
+											@badge.New(badge.Props{Variant: badge.VariantGreen, Class: templ.Classes("!h-6 px-2 text-xs")}) {
+												{ pageCtx.T("Login.ActiveAccount") }
+											}
 										}
-									</button>
+									}
 								</form>
 							}
 						</div>

--- a/modules/core/presentation/templates/pages/login/index_templ.go
+++ b/modules/core/presentation/templates/pages/login/index_templ.go
@@ -213,23 +213,33 @@ func Index(p *LoginProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if len(p.Accounts) > 0 {
+			if p.AuthorizationRequestInvalid {
 				var templ_7745c5c3_Var6 string
-				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.ChooseAccount"))
+				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.Login"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 121, Col: 42}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 121, Col: 34}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-			} else {
+			} else if len(p.Accounts) > 0 {
 				var templ_7745c5c3_Var7 string
-				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.WelcomeBack"))
+				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.ChooseAccount"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 123, Col: 40}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 123, Col: 42}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			} else {
+				var templ_7745c5c3_Var8 string
+				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.WelcomeBack"))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 125, Col: 40}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -238,12 +248,12 @@ func Index(p *LoginProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var8 string
-			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.LoginToUse"))
+			var templ_7745c5c3_Var9 string
+			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.LoginToUse"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 126, Col: 62}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 128, Col: 62}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -251,22 +261,53 @@ func Index(p *LoginProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if !p.AuthorizationRequestInvalid && len(p.Accounts) > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div class=\"flex flex-col gap-2\" data-testid=\"account-picker\">")
+			if p.AuthorizationRequestInvalid {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div class=\"flex flex-col gap-4 text-center\" role=\"alert\"><p class=\"text-red-600\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var10 string
+				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(p.ErrorMessage)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 133, Col: 47}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</p><a href=\"/login\" class=\"text-primary-600 hover:underline\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var11 string
+				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.Login"))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 134, Col: 91}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</a></div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			} else if len(p.Accounts) > 0 {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<div class=\"flex flex-col gap-2\" data-testid=\"account-picker\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				for _, account := range p.Accounts {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<form method=\"post\" action=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<form method=\"post\" action=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var9 templ.SafeURL = templ.SafeURL(p.SelectionURL)
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var9)))
+					var templ_7745c5c3_Var12 templ.SafeURL = templ.URL(p.SelectionURL)
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var12)))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -274,20 +315,20 @@ func Index(p *LoginProps) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<input type=\"hidden\" name=\"session_ref\" value=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<input type=\"hidden\" name=\"SessionRef\" value=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var10 string
-					templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(account.SessionReference)
+					var templ_7745c5c3_Var13 string
+					templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(account.SessionReference)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 134, Col: 81}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 141, Col: 80}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\"> <button type=\"submit\" class=\"w-full flex items-center gap-3 rounded-lg border border-primary p-3 text-left hover:bg-surface-200\" data-testid=\"account-card\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\"> <button type=\"submit\" class=\"w-full flex items-center gap-3 rounded-lg border border-primary p-3 text-left hover:bg-surface-200\" data-testid=\"account-card\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -295,80 +336,80 @@ func Index(p *LoginProps) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<span class=\"min-w-0 flex-1\"><span class=\"block truncate text-100 font-medium\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<span class=\"min-w-0 flex-1\"><span class=\"block truncate text-100 font-medium\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var11 string
-					templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(account.FullName)
+					var templ_7745c5c3_Var14 string
+					templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(account.FullName)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 138, Col: 79}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 145, Col: 79}
 					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</span> <span class=\"block truncate text-sm text-200\">")
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					var templ_7745c5c3_Var12 string
-					templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(account.Email)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 139, Col: 72}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</span> <span class=\"block truncate text-sm text-200\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</span></span> ")
+					var templ_7745c5c3_Var15 string
+					templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(account.Email)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 146, Col: 72}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</span></span> ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					if account.Active {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<span class=\"text-xs text-200\">")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<span class=\"text-xs text-200\">")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						var templ_7745c5c3_Var13 string
-						templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.ActiveAccount"))
+						var templ_7745c5c3_Var16 string
+						templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.ActiveAccount"))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 142, Col: 76}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 149, Col: 76}
 						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</span>")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</span>")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</button></form>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</button></form>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</div><a href=\"#login-methods\" class=\"text-center text-sm text-primary-600 hover:underline\" data-testid=\"use-another-account\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</div><a href=\"#login-methods\" class=\"text-center text-sm text-primary-600 hover:underline\" data-testid=\"use-another-account\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var14 string
-				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.UseAnotherAccount"))
+				var templ_7745c5c3_Var17 string
+				templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.UseAnotherAccount"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 148, Col: 164}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 155, Col: 164}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</a><hr class=\"border border-primary\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</a><hr class=\"border border-primary\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if !p.AuthorizationRequestInvalid {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<form id=\"login-methods\" class=\"flex flex-col gap-4\" method=\"post\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<form id=\"login-methods\" class=\"flex flex-col gap-4\" method=\"post\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -386,11 +427,11 @@ func Index(p *LoginProps) templ.Component {
 							for key, value := range method.Attributes {
 								attrs[key] = value
 							}
-							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, " ")
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, " ")
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
-							templ_7745c5c3_Var15 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+							templ_7745c5c3_Var18 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 								templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 								templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 								if !templ_7745c5c3_IsBuffer {
@@ -408,16 +449,16 @@ func Index(p *LoginProps) templ.Component {
 										return templ_7745c5c3_Err
 									}
 								}
-								templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, " ")
+								templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, " ")
 								if templ_7745c5c3_Err != nil {
 									return templ_7745c5c3_Err
 								}
-								var templ_7745c5c3_Var16 string
-								templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(method.Label)
+								var templ_7745c5c3_Var19 string
+								templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(method.Label)
 								if templ_7745c5c3_Err != nil {
-									return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 173, Col: 25}
+									return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 180, Col: 25}
 								}
-								_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
+								_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 								if templ_7745c5c3_Err != nil {
 									return templ_7745c5c3_Err
 								}
@@ -428,38 +469,38 @@ func Index(p *LoginProps) templ.Component {
 								Class: "justify-center items-center gap-3",
 								Href:  method.Href,
 								Attrs: attrs,
-							}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var15), templ_7745c5c3_Buffer)
+							}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var18), templ_7745c5c3_Buffer)
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
 						}
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, " ")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, " ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					if hasPasswordMethod {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<p class=\"text-xs text-200 text-center\">")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "<p class=\"text-xs text-200 text-center\">")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						var templ_7745c5c3_Var17 string
-						templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.OrSignInWith"))
+						var templ_7745c5c3_Var20 string
+						templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.OrSignInWith"))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 178, Col: 82}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 185, Col: 82}
 						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</p>")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</p>")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 					}
 				}
 				if len(p.ErrorMessage) > 0 {
-					templ_7745c5c3_Var18 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+					templ_7745c5c3_Var21 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 						templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 						templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 						if !templ_7745c5c3_IsBuffer {
@@ -471,18 +512,18 @@ func Index(p *LoginProps) templ.Component {
 							}()
 						}
 						ctx = templ.InitializeContext(ctx)
-						var templ_7745c5c3_Var19 string
-						templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(p.ErrorMessage)
+						var templ_7745c5c3_Var22 string
+						templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(p.ErrorMessage)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 183, Col: 25}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 190, Col: 25}
 						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 						return nil
 					})
-					templ_7745c5c3_Err = alert.Error().Render(templ.WithChildren(ctx, templ_7745c5c3_Var18), templ_7745c5c3_Buffer)
+					templ_7745c5c3_Err = alert.Error().Render(templ.WithChildren(ctx, templ_7745c5c3_Var21), templ_7745c5c3_Buffer)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -499,7 +540,7 @@ func Index(p *LoginProps) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, " ")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, " ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -513,11 +554,11 @@ func Index(p *LoginProps) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, " ")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, " ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Var20 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+					templ_7745c5c3_Var23 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 						templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 						templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 						if !templ_7745c5c3_IsBuffer {
@@ -529,12 +570,12 @@ func Index(p *LoginProps) templ.Component {
 							}()
 						}
 						ctx = templ.InitializeContext(ctx)
-						var templ_7745c5c3_Var21 string
-						templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.Login"))
+						var templ_7745c5c3_Var24 string
+						templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.Login"))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 209, Col: 35}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 216, Col: 35}
 						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
@@ -546,17 +587,17 @@ func Index(p *LoginProps) templ.Component {
 						Attrs: templ.Attributes{
 							"type": "submit",
 						},
-					}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var20), templ_7745c5c3_Buffer)
+					}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var23), templ_7745c5c3_Buffer)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</form>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</form>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</div></div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</div></div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -586,12 +627,12 @@ func GoogleIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var22 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var22 == nil {
-			templ_7745c5c3_Var22 = templ.NopComponent
+		templ_7745c5c3_Var25 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var25 == nil {
+			templ_7745c5c3_Var25 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M23.52 12.2729C23.52 11.422 23.4436 10.6038 23.3018 9.81836H12V14.4602H18.4582C18.18 15.9602 17.3345 17.2311 16.0636 18.082V21.0929H19.9418C22.2109 19.0038 23.52 15.9274 23.52 12.2729Z\" fill=\"#4285F4\"></path> <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M12 23.9993C15.24 23.9993 17.9564 22.9248 19.9418 21.092L16.0636 18.0811C14.9891 18.8011 13.6145 19.2266 12 19.2266C8.87455 19.2266 6.22909 17.1157 5.28546 14.2793H1.27637V17.3884C3.25091 21.3102 7.30909 23.9993 12 23.9993Z\" fill=\"#34A853\"></path> <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M5.28545 14.2804C5.04545 13.5604 4.90909 12.7913 4.90909 12.0004C4.90909 11.2095 5.04545 10.4404 5.28545 9.72042V6.61133H1.27636C0.463636 8.23133 0 10.0641 0 12.0004C0 13.9368 0.463636 15.7695 1.27636 17.3895L5.28545 14.2804Z\" fill=\"#FBBC05\"></path> <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M12 4.77273C13.7618 4.77273 15.3436 5.37818 16.5873 6.56727L20.0291 3.12545C17.9509 1.18909 15.2345 0 12 0C7.30909 0 3.25091 2.68909 1.27637 6.61091L5.28546 9.72C6.22909 6.88364 8.87455 4.77273 12 4.77273Z\" fill=\"#EA4335\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M23.52 12.2729C23.52 11.422 23.4436 10.6038 23.3018 9.81836H12V14.4602H18.4582C18.18 15.9602 17.3345 17.2311 16.0636 18.082V21.0929H19.9418C22.2109 19.0038 23.52 15.9274 23.52 12.2729Z\" fill=\"#4285F4\"></path> <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M12 23.9993C15.24 23.9993 17.9564 22.9248 19.9418 21.092L16.0636 18.0811C14.9891 18.8011 13.6145 19.2266 12 19.2266C8.87455 19.2266 6.22909 17.1157 5.28546 14.2793H1.27637V17.3884C3.25091 21.3102 7.30909 23.9993 12 23.9993Z\" fill=\"#34A853\"></path> <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M5.28545 14.2804C5.04545 13.5604 4.90909 12.7913 4.90909 12.0004C4.90909 11.2095 5.04545 10.4404 5.28545 9.72042V6.61133H1.27636C0.463636 8.23133 0 10.0641 0 12.0004C0 13.9368 0.463636 15.7695 1.27636 17.3895L5.28545 14.2804Z\" fill=\"#FBBC05\"></path> <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M12 4.77273C13.7618 4.77273 15.3436 5.37818 16.5873 6.56727L20.0291 3.12545C17.9509 1.18909 15.2345 0 12 0C7.30909 0 3.25091 2.68909 1.27637 6.61091L5.28546 9.72C6.22909 6.88364 8.87455 4.77273 12 4.77273Z\" fill=\"#EA4335\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/modules/core/presentation/templates/pages/login/index_templ.go
+++ b/modules/core/presentation/templates/pages/login/index_templ.go
@@ -11,6 +11,7 @@ import templruntime "github.com/a-h/templ/runtime"
 import (
 	icons "github.com/iota-uz/icons/phosphor"
 	"github.com/iota-uz/iota-sdk/components/base/alert"
+	"github.com/iota-uz/iota-sdk/components/base/avatar"
 	"github.com/iota-uz/iota-sdk/components/base/button"
 	"github.com/iota-uz/iota-sdk/components/base/input"
 	"github.com/iota-uz/iota-sdk/internal/assets"
@@ -28,11 +29,25 @@ type LoginMethod struct {
 }
 
 type LoginProps struct {
-	ErrorsMap    map[string]string
-	ErrorMessage string
-	Email        string
-	Methods      []LoginMethod
-	Logo         templ.Component
+	ErrorsMap                   map[string]string
+	ErrorMessage                string
+	Email                       string
+	Methods                     []LoginMethod
+	Logo                        templ.Component
+	Accounts                    []Account
+	NextURL                     string
+	AuthRequestID               string
+	SelectionURL                string
+	AuthorizationRequestInvalid bool
+}
+
+type Account struct {
+	SessionReference string
+	FullName         string
+	Email            string
+	AvatarURL        string
+	Initials         string
+	Active           bool
 }
 
 var (
@@ -78,7 +93,7 @@ func Header(logo templ.Component) templ.Component {
 			var templ_7745c5c3_Var2 string
 			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(companyLogo)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 41, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 56, Col: 26}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
@@ -194,220 +209,354 @@ func Index(p *LoginProps) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<div class=\"flex-1 flex items-center justify-center\"><form class=\"mx-4 max-w-md w-full p-6 md:p-11 flex flex-col gap-4 bg-surface-300 rounded-xl shadow-[0_20px_20px_0px_rgba(0,0,0,0.08),0_0_0_7px_rgba(255,255,255,0.5)]\" method=\"post\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<div class=\"flex-1 flex items-center justify-center\"><div class=\"mx-4 max-w-md w-full p-6 md:p-11 flex flex-col gap-4 bg-surface-300 rounded-xl shadow-[0_20px_20px_0px_rgba(0,0,0,0.08),0_0_0_7px_rgba(255,255,255,0.5)]\"><div class=\"text-center\"><h1 class=\"text-2xl text-100\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = composables.CSRFTokenField().Render(ctx, templ_7745c5c3_Buffer)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<div class=\"text-center\"><h1 class=\"text-2xl text-100\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var6 string
-			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.WelcomeBack"))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 106, Col: 39}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</h1><p class=\"mt-2 text-200\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var7 string
-			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.LoginToUse"))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 108, Col: 62}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</p></div><hr class=\"border border-primary\">")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			if hasExternalMethod {
-				for _, method := range p.Methods {
-					if method.ID != "password" {
-						attrs := templ.Attributes{}
-						if method.Href == "" {
-							attrs["type"] = "button"
-						}
-						for key, value := range method.Attributes {
-							attrs[key] = value
-						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, " ")
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-						templ_7745c5c3_Var8 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-							templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-							templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-							if !templ_7745c5c3_IsBuffer {
-								defer func() {
-									templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-									if templ_7745c5c3_Err == nil {
-										templ_7745c5c3_Err = templ_7745c5c3_BufErr
-									}
-								}()
-							}
-							ctx = templ.InitializeContext(ctx)
-							if method.Icon != nil {
-								templ_7745c5c3_Err = method.Icon.Render(ctx, templ_7745c5c3_Buffer)
-								if templ_7745c5c3_Err != nil {
-									return templ_7745c5c3_Err
-								}
-							}
-							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, " ")
-							if templ_7745c5c3_Err != nil {
-								return templ_7745c5c3_Err
-							}
-							var templ_7745c5c3_Var9 string
-							templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(method.Label)
-							if templ_7745c5c3_Err != nil {
-								return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 130, Col: 23}
-							}
-							_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
-							if templ_7745c5c3_Err != nil {
-								return templ_7745c5c3_Err
-							}
-							return nil
-						})
-						templ_7745c5c3_Err = button.Secondary(button.Props{
-							Size:  button.SizeNormal,
-							Class: "justify-center items-center gap-3",
-							Href:  method.Href,
-							Attrs: attrs,
-						}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var8), templ_7745c5c3_Buffer)
-						if templ_7745c5c3_Err != nil {
-							return templ_7745c5c3_Err
-						}
-					}
+			if len(p.Accounts) > 0 {
+				var templ_7745c5c3_Var6 string
+				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.ChooseAccount"))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 121, Col: 42}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, " ")
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				if hasPasswordMethod {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<p class=\"text-xs text-200 text-center\">")
+			} else {
+				var templ_7745c5c3_Var7 string
+				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.WelcomeBack"))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 123, Col: 40}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</h1><p class=\"mt-2 text-200\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var8 string
+			templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.LoginToUse"))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 126, Col: 62}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</p></div><hr class=\"border border-primary\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if !p.AuthorizationRequestInvalid && len(p.Accounts) > 0 {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<div class=\"flex flex-col gap-2\" data-testid=\"account-picker\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				for _, account := range p.Accounts {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<form method=\"post\" action=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var9 templ.SafeURL = templ.SafeURL(p.SelectionURL)
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(string(templ_7745c5c3_Var9)))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = composables.CSRFTokenField().Render(ctx, templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<input type=\"hidden\" name=\"session_ref\" value=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var10 string
-					templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.OrSignInWith"))
+					templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(account.SessionReference)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 135, Col: 80}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 134, Col: 81}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</p>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\"> <button type=\"submit\" class=\"w-full flex items-center gap-3 rounded-lg border border-primary p-3 text-left hover:bg-surface-200\" data-testid=\"account-card\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-				}
-			}
-			if len(p.ErrorMessage) > 0 {
-				templ_7745c5c3_Var11 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-					templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-					templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-					if !templ_7745c5c3_IsBuffer {
-						defer func() {
-							templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-							if templ_7745c5c3_Err == nil {
-								templ_7745c5c3_Err = templ_7745c5c3_BufErr
-							}
-						}()
-					}
-					ctx = templ.InitializeContext(ctx)
-					var templ_7745c5c3_Var12 string
-					templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(p.ErrorMessage)
+					templ_7745c5c3_Err = avatar.Avatar(avatar.Props{ImageURL: account.AvatarURL, Initials: account.Initials}).Render(ctx, templ_7745c5c3_Buffer)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 140, Col: 23}
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<span class=\"min-w-0 flex-1\"><span class=\"block truncate text-100 font-medium\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var11 string
+					templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(account.FullName)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 138, Col: 79}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "</span> <span class=\"block truncate text-sm text-200\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var12 string
+					templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(account.Email)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 139, Col: 72}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					return nil
-				})
-				templ_7745c5c3_Err = alert.Error().Render(templ.WithChildren(ctx, templ_7745c5c3_Var11), templ_7745c5c3_Buffer)
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-			}
-			if hasPasswordMethod {
-				templ_7745c5c3_Err = input.Email(&input.Props{
-					Label: pageCtx.T("Login.Email"),
-					Attrs: templ.Attributes{
-						"name":  "Email",
-						"value": p.Email,
-					},
-					Error: p.ErrorsMap["Email"],
-				}).Render(ctx, templ_7745c5c3_Buffer)
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, " ")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = input.Password(&input.Props{
-					Label: pageCtx.T("Login.Password"),
-					Attrs: templ.Attributes{
-						"name": "Password",
-					},
-					Error: p.ErrorsMap["Password"],
-				}).Render(ctx, templ_7745c5c3_Buffer)
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, " ")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Var13 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
-					templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
-					templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
-					if !templ_7745c5c3_IsBuffer {
-						defer func() {
-							templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
-							if templ_7745c5c3_Err == nil {
-								templ_7745c5c3_Err = templ_7745c5c3_BufErr
-							}
-						}()
-					}
-					ctx = templ.InitializeContext(ctx)
-					var templ_7745c5c3_Var14 string
-					templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.Login"))
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 166, Col: 33}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</span></span> ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					return nil
-				})
-				templ_7745c5c3_Err = button.Primary(button.Props{
-					Size:  button.SizeNormal,
-					Class: "justify-center",
-					Attrs: templ.Attributes{
-						"type": "submit",
-					},
-				}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var13), templ_7745c5c3_Buffer)
+					if account.Active {
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<span class=\"text-xs text-200\">")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						var templ_7745c5c3_Var13 string
+						templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.ActiveAccount"))
+						if templ_7745c5c3_Err != nil {
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 142, Col: 76}
+						}
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</span>")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</button></form>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</div><a href=\"#login-methods\" class=\"text-center text-sm text-primary-600 hover:underline\" data-testid=\"use-another-account\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var14 string
+				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.UseAnotherAccount"))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 148, Col: 164}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</a><hr class=\"border border-primary\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</form></div></div>")
+			if !p.AuthorizationRequestInvalid {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "<form id=\"login-methods\" class=\"flex flex-col gap-4\" method=\"post\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = composables.CSRFTokenField().Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				if hasExternalMethod {
+					for _, method := range p.Methods {
+						if method.ID != "password" {
+							attrs := templ.Attributes{}
+							if method.Href == "" {
+								attrs["type"] = "button"
+							}
+							for key, value := range method.Attributes {
+								attrs[key] = value
+							}
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, " ")
+							if templ_7745c5c3_Err != nil {
+								return templ_7745c5c3_Err
+							}
+							templ_7745c5c3_Var15 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+								templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+								templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+								if !templ_7745c5c3_IsBuffer {
+									defer func() {
+										templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+										if templ_7745c5c3_Err == nil {
+											templ_7745c5c3_Err = templ_7745c5c3_BufErr
+										}
+									}()
+								}
+								ctx = templ.InitializeContext(ctx)
+								if method.Icon != nil {
+									templ_7745c5c3_Err = method.Icon.Render(ctx, templ_7745c5c3_Buffer)
+									if templ_7745c5c3_Err != nil {
+										return templ_7745c5c3_Err
+									}
+								}
+								templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, " ")
+								if templ_7745c5c3_Err != nil {
+									return templ_7745c5c3_Err
+								}
+								var templ_7745c5c3_Var16 string
+								templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(method.Label)
+								if templ_7745c5c3_Err != nil {
+									return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 173, Col: 25}
+								}
+								_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
+								if templ_7745c5c3_Err != nil {
+									return templ_7745c5c3_Err
+								}
+								return nil
+							})
+							templ_7745c5c3_Err = button.Secondary(button.Props{
+								Size:  button.SizeNormal,
+								Class: "justify-center items-center gap-3",
+								Href:  method.Href,
+								Attrs: attrs,
+							}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var15), templ_7745c5c3_Buffer)
+							if templ_7745c5c3_Err != nil {
+								return templ_7745c5c3_Err
+							}
+						}
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, " ")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					if hasPasswordMethod {
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<p class=\"text-xs text-200 text-center\">")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						var templ_7745c5c3_Var17 string
+						templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.OrSignInWith"))
+						if templ_7745c5c3_Err != nil {
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 178, Col: 82}
+						}
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</p>")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+					}
+				}
+				if len(p.ErrorMessage) > 0 {
+					templ_7745c5c3_Var18 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+						templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+						templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+						if !templ_7745c5c3_IsBuffer {
+							defer func() {
+								templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+								if templ_7745c5c3_Err == nil {
+									templ_7745c5c3_Err = templ_7745c5c3_BufErr
+								}
+							}()
+						}
+						ctx = templ.InitializeContext(ctx)
+						var templ_7745c5c3_Var19 string
+						templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(p.ErrorMessage)
+						if templ_7745c5c3_Err != nil {
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 183, Col: 25}
+						}
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						return nil
+					})
+					templ_7745c5c3_Err = alert.Error().Render(templ.WithChildren(ctx, templ_7745c5c3_Var18), templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				if hasPasswordMethod {
+					templ_7745c5c3_Err = input.Email(&input.Props{
+						Label: pageCtx.T("Login.Email"),
+						Attrs: templ.Attributes{
+							"name":  "Email",
+							"value": p.Email,
+						},
+						Error: p.ErrorsMap["Email"],
+					}).Render(ctx, templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, " ")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = input.Password(&input.Props{
+						Label: pageCtx.T("Login.Password"),
+						Attrs: templ.Attributes{
+							"name": "Password",
+						},
+						Error: p.ErrorsMap["Password"],
+					}).Render(ctx, templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, " ")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Var20 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+						templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+						templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+						if !templ_7745c5c3_IsBuffer {
+							defer func() {
+								templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+								if templ_7745c5c3_Err == nil {
+									templ_7745c5c3_Err = templ_7745c5c3_BufErr
+								}
+							}()
+						}
+						ctx = templ.InitializeContext(ctx)
+						var templ_7745c5c3_Var21 string
+						templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.Login"))
+						if templ_7745c5c3_Err != nil {
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 209, Col: 35}
+						}
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						return nil
+					})
+					templ_7745c5c3_Err = button.Primary(button.Props{
+						Size:  button.SizeNormal,
+						Class: "justify-center",
+						Attrs: templ.Attributes{
+							"type": "submit",
+						},
+					}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var20), templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</form>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</div></div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -437,12 +586,12 @@ func GoogleIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var15 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var15 == nil {
-			templ_7745c5c3_Var15 = templ.NopComponent
+		templ_7745c5c3_Var22 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var22 == nil {
+			templ_7745c5c3_Var22 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "<svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M23.52 12.2729C23.52 11.422 23.4436 10.6038 23.3018 9.81836H12V14.4602H18.4582C18.18 15.9602 17.3345 17.2311 16.0636 18.082V21.0929H19.9418C22.2109 19.0038 23.52 15.9274 23.52 12.2729Z\" fill=\"#4285F4\"></path> <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M12 23.9993C15.24 23.9993 17.9564 22.9248 19.9418 21.092L16.0636 18.0811C14.9891 18.8011 13.6145 19.2266 12 19.2266C8.87455 19.2266 6.22909 17.1157 5.28546 14.2793H1.27637V17.3884C3.25091 21.3102 7.30909 23.9993 12 23.9993Z\" fill=\"#34A853\"></path> <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M5.28545 14.2804C5.04545 13.5604 4.90909 12.7913 4.90909 12.0004C4.90909 11.2095 5.04545 10.4404 5.28545 9.72042V6.61133H1.27636C0.463636 8.23133 0 10.0641 0 12.0004C0 13.9368 0.463636 15.7695 1.27636 17.3895L5.28545 14.2804Z\" fill=\"#FBBC05\"></path> <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M12 4.77273C13.7618 4.77273 15.3436 5.37818 16.5873 6.56727L20.0291 3.12545C17.9509 1.18909 15.2345 0 12 0C7.30909 0 3.25091 2.68909 1.27637 6.61091L5.28546 9.72C6.22909 6.88364 8.87455 4.77273 12 4.77273Z\" fill=\"#EA4335\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M23.52 12.2729C23.52 11.422 23.4436 10.6038 23.3018 9.81836H12V14.4602H18.4582C18.18 15.9602 17.3345 17.2311 16.0636 18.082V21.0929H19.9418C22.2109 19.0038 23.52 15.9274 23.52 12.2729Z\" fill=\"#4285F4\"></path> <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M12 23.9993C15.24 23.9993 17.9564 22.9248 19.9418 21.092L16.0636 18.0811C14.9891 18.8011 13.6145 19.2266 12 19.2266C8.87455 19.2266 6.22909 17.1157 5.28546 14.2793H1.27637V17.3884C3.25091 21.3102 7.30909 23.9993 12 23.9993Z\" fill=\"#34A853\"></path> <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M5.28545 14.2804C5.04545 13.5604 4.90909 12.7913 4.90909 12.0004C4.90909 11.2095 5.04545 10.4404 5.28545 9.72042V6.61133H1.27636C0.463636 8.23133 0 10.0641 0 12.0004C0 13.9368 0.463636 15.7695 1.27636 17.3895L5.28545 14.2804Z\" fill=\"#FBBC05\"></path> <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M12 4.77273C13.7618 4.77273 15.3436 5.37818 16.5873 6.56727L20.0291 3.12545C17.9509 1.18909 15.2345 0 12 0C7.30909 0 3.25091 2.68909 1.27637 6.61091L5.28546 9.72C6.22909 6.88364 8.87455 4.77273 12 4.77273Z\" fill=\"#EA4335\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/modules/core/presentation/templates/pages/login/index_templ.go
+++ b/modules/core/presentation/templates/pages/login/index_templ.go
@@ -12,6 +12,7 @@ import (
 	icons "github.com/iota-uz/icons/phosphor"
 	"github.com/iota-uz/iota-sdk/components/base/alert"
 	"github.com/iota-uz/iota-sdk/components/base/avatar"
+	"github.com/iota-uz/iota-sdk/components/base/badge"
 	"github.com/iota-uz/iota-sdk/components/base/button"
 	"github.com/iota-uz/iota-sdk/components/base/input"
 	"github.com/iota-uz/iota-sdk/internal/assets"
@@ -93,7 +94,7 @@ func Header(logo templ.Component) templ.Component {
 			var templ_7745c5c3_Var2 string
 			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(companyLogo)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 56, Col: 26}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 57, Col: 26}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
@@ -217,7 +218,7 @@ func Index(p *LoginProps) templ.Component {
 				var templ_7745c5c3_Var6 string
 				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.Login"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 121, Col: 34}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 122, Col: 34}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 				if templ_7745c5c3_Err != nil {
@@ -227,7 +228,7 @@ func Index(p *LoginProps) templ.Component {
 				var templ_7745c5c3_Var7 string
 				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.ChooseAccount"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 123, Col: 42}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 124, Col: 42}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 				if templ_7745c5c3_Err != nil {
@@ -237,7 +238,7 @@ func Index(p *LoginProps) templ.Component {
 				var templ_7745c5c3_Var8 string
 				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.WelcomeBack"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 125, Col: 40}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 126, Col: 40}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 				if templ_7745c5c3_Err != nil {
@@ -251,7 +252,7 @@ func Index(p *LoginProps) templ.Component {
 			var templ_7745c5c3_Var9 string
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.LoginToUse"))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 128, Col: 62}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 129, Col: 62}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {
@@ -269,7 +270,7 @@ func Index(p *LoginProps) templ.Component {
 				var templ_7745c5c3_Var10 string
 				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(p.ErrorMessage)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 133, Col: 47}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 134, Col: 47}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 				if templ_7745c5c3_Err != nil {
@@ -282,7 +283,7 @@ func Index(p *LoginProps) templ.Component {
 				var templ_7745c5c3_Var11 string
 				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.Login"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 134, Col: 91}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 135, Col: 91}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 				if templ_7745c5c3_Err != nil {
@@ -298,7 +299,11 @@ func Index(p *LoginProps) templ.Component {
 					return templ_7745c5c3_Err
 				}
 				for _, account := range p.Accounts {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<form method=\"post\" action=\"")
+					accountAttrs := templ.Attributes{"type": "submit", "data-testid": "account-card"}
+					if account.Active {
+						accountAttrs["aria-current"] = "true"
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, " <form method=\"post\" action=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -315,101 +320,133 @@ func Index(p *LoginProps) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<input type=\"hidden\" name=\"SessionRef\" value=\"")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<input type=\"hidden\" name=\"SessionReference\" value=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var13 string
 					templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(account.SessionReference)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 141, Col: 80}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 146, Col: 86}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\"> <button type=\"submit\" class=\"w-full flex items-center gap-3 rounded-lg border border-primary p-3 text-left hover:bg-surface-200\" data-testid=\"account-card\">")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = avatar.Avatar(avatar.Props{ImageURL: account.AvatarURL, Initials: account.Initials}).Render(ctx, templ_7745c5c3_Buffer)
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<span class=\"min-w-0 flex-1\"><span class=\"block truncate text-100 font-medium\">")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var14 string
-					templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(account.FullName)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 145, Col: 79}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</span> <span class=\"block truncate text-sm text-200\">")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					var templ_7745c5c3_Var15 string
-					templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(account.Email)
-					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 146, Col: 72}
-					}
-					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</span></span> ")
-					if templ_7745c5c3_Err != nil {
-						return templ_7745c5c3_Err
-					}
-					if account.Active {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<span class=\"text-xs text-200\">")
+					templ_7745c5c3_Var14 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+						templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+						templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+						if !templ_7745c5c3_IsBuffer {
+							defer func() {
+								templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+								if templ_7745c5c3_Err == nil {
+									templ_7745c5c3_Err = templ_7745c5c3_BufErr
+								}
+							}()
+						}
+						ctx = templ.InitializeContext(ctx)
+						templ_7745c5c3_Err = avatar.Avatar(avatar.Props{ImageURL: account.AvatarURL, Initials: account.Initials}).Render(ctx, templ_7745c5c3_Buffer)
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, " <span class=\"min-w-0 flex-1\"><span class=\"block truncate text-100 font-medium\">")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						var templ_7745c5c3_Var15 string
+						templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(account.FullName)
+						if templ_7745c5c3_Err != nil {
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 154, Col: 79}
+						}
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</span> <span class=\"block truncate text-sm text-200\">")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 						var templ_7745c5c3_Var16 string
-						templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.ActiveAccount"))
+						templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(account.Email)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 149, Col: 76}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 155, Col: 72}
 						}
 						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</span>")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</span></span> ")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
+						if account.Active {
+							templ_7745c5c3_Var17 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+								templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+								templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+								if !templ_7745c5c3_IsBuffer {
+									defer func() {
+										templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+										if templ_7745c5c3_Err == nil {
+											templ_7745c5c3_Err = templ_7745c5c3_BufErr
+										}
+									}()
+								}
+								ctx = templ.InitializeContext(ctx)
+								var templ_7745c5c3_Var18 string
+								templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.ActiveAccount"))
+								if templ_7745c5c3_Err != nil {
+									return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 159, Col: 46}
+								}
+								_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
+								if templ_7745c5c3_Err != nil {
+									return templ_7745c5c3_Err
+								}
+								return nil
+							})
+							templ_7745c5c3_Err = badge.New(badge.Props{Variant: badge.VariantGreen, Class: templ.Classes("!h-6 px-2 text-xs")}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var17), templ_7745c5c3_Buffer)
+							if templ_7745c5c3_Err != nil {
+								return templ_7745c5c3_Err
+							}
+						}
+						return nil
+					})
+					templ_7745c5c3_Err = button.Secondary(button.Props{
+						Size:  button.SizeNormal,
+						Class: "w-full !h-auto min-h-16 justify-start gap-3 p-3 text-left",
+						Attrs: accountAttrs,
+					}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var14), templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</button></form>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</form>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "</div><a href=\"#login-methods\" class=\"text-center text-sm text-primary-600 hover:underline\" data-testid=\"use-another-account\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "</div><a href=\"#login-methods\" class=\"text-center text-sm text-primary-600 hover:underline\" data-testid=\"use-another-account\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var17 string
-				templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.UseAnotherAccount"))
+				var templ_7745c5c3_Var19 string
+				templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.UseAnotherAccount"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 155, Col: 164}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 166, Col: 164}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</a><hr class=\"border border-primary\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</a><hr class=\"border border-primary\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if !p.AuthorizationRequestInvalid {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "<form id=\"login-methods\" class=\"flex flex-col gap-4\" method=\"post\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<form id=\"login-methods\" class=\"flex flex-col gap-4\" method=\"post\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -427,11 +464,11 @@ func Index(p *LoginProps) templ.Component {
 							for key, value := range method.Attributes {
 								attrs[key] = value
 							}
-							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, " ")
+							templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, " ")
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
-							templ_7745c5c3_Var18 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+							templ_7745c5c3_Var20 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 								templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 								templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 								if !templ_7745c5c3_IsBuffer {
@@ -449,16 +486,16 @@ func Index(p *LoginProps) templ.Component {
 										return templ_7745c5c3_Err
 									}
 								}
-								templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, " ")
+								templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, " ")
 								if templ_7745c5c3_Err != nil {
 									return templ_7745c5c3_Err
 								}
-								var templ_7745c5c3_Var19 string
-								templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(method.Label)
+								var templ_7745c5c3_Var21 string
+								templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(method.Label)
 								if templ_7745c5c3_Err != nil {
-									return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 180, Col: 25}
+									return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 191, Col: 25}
 								}
-								_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
+								_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 								if templ_7745c5c3_Err != nil {
 									return templ_7745c5c3_Err
 								}
@@ -469,38 +506,38 @@ func Index(p *LoginProps) templ.Component {
 								Class: "justify-center items-center gap-3",
 								Href:  method.Href,
 								Attrs: attrs,
-							}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var18), templ_7745c5c3_Buffer)
+							}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var20), templ_7745c5c3_Buffer)
 							if templ_7745c5c3_Err != nil {
 								return templ_7745c5c3_Err
 							}
 						}
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, " ")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, " ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					if hasPasswordMethod {
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "<p class=\"text-xs text-200 text-center\">")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "<p class=\"text-xs text-200 text-center\">")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						var templ_7745c5c3_Var20 string
-						templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.OrSignInWith"))
+						var templ_7745c5c3_Var22 string
+						templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.OrSignInWith"))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 185, Col: 82}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 196, Col: 82}
 						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
-						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</p>")
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</p>")
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 					}
 				}
 				if len(p.ErrorMessage) > 0 {
-					templ_7745c5c3_Var21 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+					templ_7745c5c3_Var23 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 						templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 						templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 						if !templ_7745c5c3_IsBuffer {
@@ -512,18 +549,18 @@ func Index(p *LoginProps) templ.Component {
 							}()
 						}
 						ctx = templ.InitializeContext(ctx)
-						var templ_7745c5c3_Var22 string
-						templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(p.ErrorMessage)
+						var templ_7745c5c3_Var24 string
+						templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(p.ErrorMessage)
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 190, Col: 25}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 201, Col: 25}
 						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
 						return nil
 					})
-					templ_7745c5c3_Err = alert.Error().Render(templ.WithChildren(ctx, templ_7745c5c3_Var21), templ_7745c5c3_Buffer)
+					templ_7745c5c3_Err = alert.Error().Render(templ.WithChildren(ctx, templ_7745c5c3_Var23), templ_7745c5c3_Buffer)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -540,7 +577,7 @@ func Index(p *LoginProps) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, " ")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, " ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
@@ -554,11 +591,11 @@ func Index(p *LoginProps) templ.Component {
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, " ")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, " ")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Var23 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+					templ_7745c5c3_Var25 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 						templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 						templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 						if !templ_7745c5c3_IsBuffer {
@@ -570,12 +607,12 @@ func Index(p *LoginProps) templ.Component {
 							}()
 						}
 						ctx = templ.InitializeContext(ctx)
-						var templ_7745c5c3_Var24 string
-						templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.Login"))
+						var templ_7745c5c3_Var26 string
+						templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Login.Login"))
 						if templ_7745c5c3_Err != nil {
-							return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 216, Col: 35}
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/login/index.templ`, Line: 227, Col: 35}
 						}
-						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 						if templ_7745c5c3_Err != nil {
 							return templ_7745c5c3_Err
 						}
@@ -587,17 +624,17 @@ func Index(p *LoginProps) templ.Component {
 						Attrs: templ.Attributes{
 							"type": "submit",
 						},
-					}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var23), templ_7745c5c3_Buffer)
+					}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var25), templ_7745c5c3_Buffer)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</form>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</form>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</div></div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "</div></div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -627,12 +664,12 @@ func GoogleIcon() templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var25 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var25 == nil {
-			templ_7745c5c3_Var25 = templ.NopComponent
+		templ_7745c5c3_Var27 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var27 == nil {
+			templ_7745c5c3_Var27 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M23.52 12.2729C23.52 11.422 23.4436 10.6038 23.3018 9.81836H12V14.4602H18.4582C18.18 15.9602 17.3345 17.2311 16.0636 18.082V21.0929H19.9418C22.2109 19.0038 23.52 15.9274 23.52 12.2729Z\" fill=\"#4285F4\"></path> <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M12 23.9993C15.24 23.9993 17.9564 22.9248 19.9418 21.092L16.0636 18.0811C14.9891 18.8011 13.6145 19.2266 12 19.2266C8.87455 19.2266 6.22909 17.1157 5.28546 14.2793H1.27637V17.3884C3.25091 21.3102 7.30909 23.9993 12 23.9993Z\" fill=\"#34A853\"></path> <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M5.28545 14.2804C5.04545 13.5604 4.90909 12.7913 4.90909 12.0004C4.90909 11.2095 5.04545 10.4404 5.28545 9.72042V6.61133H1.27636C0.463636 8.23133 0 10.0641 0 12.0004C0 13.9368 0.463636 15.7695 1.27636 17.3895L5.28545 14.2804Z\" fill=\"#FBBC05\"></path> <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M12 4.77273C13.7618 4.77273 15.3436 5.37818 16.5873 6.56727L20.0291 3.12545C17.9509 1.18909 15.2345 0 12 0C7.30909 0 3.25091 2.68909 1.27637 6.61091L5.28546 9.72C6.22909 6.88364 8.87455 4.77273 12 4.77273Z\" fill=\"#EA4335\"></path></svg>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "<svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\"><path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M23.52 12.2729C23.52 11.422 23.4436 10.6038 23.3018 9.81836H12V14.4602H18.4582C18.18 15.9602 17.3345 17.2311 16.0636 18.082V21.0929H19.9418C22.2109 19.0038 23.52 15.9274 23.52 12.2729Z\" fill=\"#4285F4\"></path> <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M12 23.9993C15.24 23.9993 17.9564 22.9248 19.9418 21.092L16.0636 18.0811C14.9891 18.8011 13.6145 19.2266 12 19.2266C8.87455 19.2266 6.22909 17.1157 5.28546 14.2793H1.27637V17.3884C3.25091 21.3102 7.30909 23.9993 12 23.9993Z\" fill=\"#34A853\"></path> <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M5.28545 14.2804C5.04545 13.5604 4.90909 12.7913 4.90909 12.0004C4.90909 11.2095 5.04545 10.4404 5.28545 9.72042V6.61133H1.27636C0.463636 8.23133 0 10.0641 0 12.0004C0 13.9368 0.463636 15.7695 1.27636 17.3895L5.28545 14.2804Z\" fill=\"#FBBC05\"></path> <path fill-rule=\"evenodd\" clip-rule=\"evenodd\" d=\"M12 4.77273C13.7618 4.77273 15.3436 5.37818 16.5873 6.56727L20.0291 3.12545C17.9509 1.18909 15.2345 0 12 0C7.30909 0 3.25091 2.68909 1.27637 6.61091L5.28546 9.72C6.22909 6.88364 8.87455 4.77273 12 4.77273Z\" fill=\"#EA4335\"></path></svg>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/modules/core/services/auth_flow_service.go
+++ b/modules/core/services/auth_flow_service.go
@@ -33,8 +33,9 @@ type AuthenticationResult struct {
 }
 
 type FinalizeAuthenticationOptions struct {
-	NextURL     string
-	AccessCheck LoginAccessChecker
+	NextURL            string
+	SessionCookieValue string
+	AccessCheck        LoginAccessChecker
 }
 
 type FinalizeAuthenticationResult struct {
@@ -65,6 +66,20 @@ type AuthFlowService struct {
 	httpCfg         *httpconfig.Config
 	cookiesCfg      *cookies.Config
 	appCfg          *appconfig.Config
+	browserSessions *BrowserSessionService
+}
+
+func NewAuthFlowServiceWithBrowserSessions(
+	authService *AuthService,
+	sessionService *SessionService,
+	httpCfg *httpconfig.Config,
+	cookiesCfg *cookies.Config,
+	appCfg *appconfig.Config,
+	browserSessions *BrowserSessionService,
+) *AuthFlowService {
+	service := NewAuthFlowService(authService, sessionService, httpCfg, cookiesCfg, appCfg)
+	service.browserSessions = browserSessions
+	return service
 }
 
 func NewAuthFlowService(
@@ -191,14 +206,22 @@ func (s *AuthFlowService) FinalizeAuthentication(
 			redirectURL = fmt.Sprintf("/login/2fa/verify?next=%s", url.QueryEscape(validatedNextURL))
 		}
 
+		cookie, err := s.sessionCookie(ctx, opts.SessionCookieValue, pendingSession)
+		if err != nil {
+			return nil, serrors.E(op, err)
+		}
 		return &FinalizeAuthenticationResult{
-			Cookie:      s.sessionCookie(pendingSession.Token(), pendingSession.ExpiresAt()),
+			Cookie:      cookie,
 			RedirectURL: redirectURL,
 		}, nil
 	}
 
+	cookie, err := s.sessionCookie(ctx, opts.SessionCookieValue, sess)
+	if err != nil {
+		return nil, serrors.E(op, err)
+	}
 	return &FinalizeAuthenticationResult{
-		Cookie:      s.sessionCookie(sess.Token(), sess.ExpiresAt()),
+		Cookie:      cookie,
 		RedirectURL: validatedNextURL,
 	}, nil
 }
@@ -238,17 +261,20 @@ func (s *AuthFlowService) requiresTwoFactor(
 	return requires2FA || policyRequires2FA, nil
 }
 
-func (s *AuthFlowService) sessionCookie(token string, expiresAt time.Time) *http.Cookie {
+func (s *AuthFlowService) sessionCookie(ctx context.Context, currentValue string, sess session.Session) (*http.Cookie, error) {
+	if s.browserSessions != nil {
+		return s.browserSessions.Add(ctx, currentValue, sess)
+	}
 	return &http.Cookie{
 		Name:     s.cookiesCfg.SID,
-		Value:    token,
-		Expires:  expiresAt,
+		Value:    sess.Token(),
+		Expires:  sess.ExpiresAt(),
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
 		Secure:   s.appCfg.IsProduction(),
 		Domain:   s.cookiesCfg.Domain,
 		Path:     "/",
-	}
+	}, nil
 }
 
 func userIDToNamespacedUUID(tenantID uuid.UUID, userID uint) uuid.UUID {

--- a/modules/core/services/auth_flow_service_cookie_test.go
+++ b/modules/core/services/auth_flow_service_cookie_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/session"
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/appconfig"
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig/cookies"
 	"github.com/stretchr/testify/require"
@@ -39,7 +41,10 @@ func TestAuthFlowSessionCookie_DomainAndSecurity(t *testing.T) {
 				cookiesCfg: &cookies.Config{SID: "granite_sid", Domain: tt.domain},
 				appCfg:     &appconfig.Config{Environment: tt.environment},
 			}
-			cookie := service.sessionCookie("token", time.Now().Add(time.Hour))
+			cookie, err := service.sessionCookie(t.Context(), "", session.New(
+				"token", 1, uuid.New(), "", "", session.WithExpiresAt(time.Now().Add(time.Hour)),
+			))
+			require.NoError(t, err)
 
 			require.Equal(t, "granite_sid", cookie.Name)
 			require.Equal(t, tt.wantDomain, cookie.Domain)

--- a/modules/core/services/auth_service.go
+++ b/modules/core/services/auth_service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/googleoauthconfig"
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig"
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig/cookies"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -455,14 +456,15 @@ type oauthContinuation struct {
 }
 
 func (s *AuthService) GoogleAuthenticateFor(w http.ResponseWriter, nextURL, authRequestID string) (string, error) {
+	const op serrors.Op = "AuthService.GoogleAuthenticateFor"
 	cookie, err := s.generateStateOauthCookie()
 	if err != nil {
-		return "", err
+		return "", serrors.E(op, err)
 	}
 	http.SetCookie(w, cookie)
 	payload, err := json.Marshal(oauthContinuation{NextURL: nextURL, AuthRequestID: authRequestID})
 	if err != nil {
-		return "", err
+		return "", serrors.E(op, err)
 	}
 	http.SetCookie(w, &http.Cookie{
 		Name:     s.cookiesCfg.OAuthState + "-continuation",

--- a/modules/core/services/auth_service.go
+++ b/modules/core/services/auth_service.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
@@ -445,11 +446,50 @@ func (s *AuthService) generateStateOauthCookie() (*http.Cookie, error) {
 }
 
 func (s *AuthService) GoogleAuthenticate(w http.ResponseWriter) (string, error) {
+	return s.GoogleAuthenticateFor(w, "", "")
+}
+
+type oauthContinuation struct {
+	NextURL       string `json:"next_url"`
+	AuthRequestID string `json:"auth_request_id"`
+}
+
+func (s *AuthService) GoogleAuthenticateFor(w http.ResponseWriter, nextURL, authRequestID string) (string, error) {
 	cookie, err := s.generateStateOauthCookie()
 	if err != nil {
 		return "", err
 	}
 	http.SetCookie(w, cookie)
+	payload, err := json.Marshal(oauthContinuation{NextURL: nextURL, AuthRequestID: authRequestID})
+	if err != nil {
+		return "", err
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     s.cookiesCfg.OAuthState + "-continuation",
+		Value:    base64.RawURLEncoding.EncodeToString(payload),
+		Expires:  cookie.Expires,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   s.appCfg.IsProduction(),
+		Domain:   s.cookiesCfg.Domain,
+		Path:     "/",
+	})
 	u := s.oAuthConfig.AuthCodeURL(cookie.Value, oauth2.AccessTypeOffline, oauth2.ApprovalForce)
 	return u, nil
+}
+
+func (s *AuthService) OAuthContinuation(r *http.Request) (string, string) {
+	cookie, err := r.Cookie(s.cookiesCfg.OAuthState + "-continuation")
+	if err != nil {
+		return "", ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(cookie.Value)
+	if err != nil {
+		return "", ""
+	}
+	var continuation oauthContinuation
+	if err := json.Unmarshal(payload, &continuation); err != nil {
+		return "", ""
+	}
+	return continuation.NextURL, continuation.AuthRequestID
 }

--- a/modules/core/services/browser_session_service.go
+++ b/modules/core/services/browser_session_service.go
@@ -1,0 +1,411 @@
+package services
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	coreuser "github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/user"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/session"
+	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence"
+	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/appconfig"
+	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig/cookies"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
+)
+
+const (
+	browserSessionCookieVersion = 1
+	MaxBrowserSessions          = 5
+)
+
+type browserSessionEntry struct {
+	Token      string `json:"token"`
+	LastActive int64  `json:"last_active"`
+}
+
+type browserSessionState struct {
+	Version int                   `json:"version"`
+	Active  string                `json:"active"`
+	Entries []browserSessionEntry `json:"entries"`
+}
+
+type BrowserSession struct {
+	Session session.Session
+	User    coreuser.User
+	Active  bool
+}
+
+func (s BrowserSession) Reference() string {
+	return BrowserSessionReference(s.Session.Token())
+}
+
+type browserSessionsContextKey struct{}
+
+func WithBrowserSessions(ctx context.Context, sessions []BrowserSession) context.Context {
+	return context.WithValue(ctx, browserSessionsContextKey{}, sessions)
+}
+
+func UseBrowserSessions(ctx context.Context) []BrowserSession {
+	sessions, _ := ctx.Value(browserSessionsContextKey{}).([]BrowserSession)
+	return sessions
+}
+
+func BrowserSessionReference(token string) string {
+	digest := sha256.Sum256([]byte(token))
+	return base64.RawURLEncoding.EncodeToString(digest[:18])
+}
+
+type BrowserSessionService struct {
+	sessionService        *SessionService
+	userRepo              coreuser.Repository
+	cookiesCfg            *cookies.Config
+	appCfg                *appconfig.Config
+	now                   func() time.Time
+	authorizationRequests AuthorizationRequestValidator
+}
+
+type AuthorizationRequestValidator interface {
+	ValidateAuthorizationRequest(ctx context.Context, id string) error
+}
+
+func (s *BrowserSessionService) SetAuthorizationRequestValidator(validator AuthorizationRequestValidator) {
+	s.authorizationRequests = validator
+}
+
+func (s *BrowserSessionService) ValidateAuthorizationRequest(ctx context.Context, id string) error {
+	if strings.TrimSpace(id) == "" {
+		return nil
+	}
+	if s.authorizationRequests == nil {
+		return errors.New("authorization requests are unavailable")
+	}
+	return s.authorizationRequests.ValidateAuthorizationRequest(ctx, id)
+}
+
+func NewBrowserSessionService(
+	sessionService *SessionService,
+	userRepo coreuser.Repository,
+	cookiesCfg *cookies.Config,
+	appCfg *appconfig.Config,
+) *BrowserSessionService {
+	return &BrowserSessionService{
+		sessionService: sessionService,
+		userRepo:       userRepo,
+		cookiesCfg:     cookiesCfg,
+		appCfg:         appCfg,
+		now:            time.Now,
+	}
+}
+
+func (s *BrowserSessionService) Resolve(w http.ResponseWriter, r *http.Request) ([]BrowserSession, error) {
+	value := ""
+	if cookie, err := r.Cookie(s.cookiesCfg.SID); err == nil {
+		value = cookie.Value
+	} else if !errors.Is(err, http.ErrNoCookie) {
+		return nil, err
+	}
+
+	state, sessions, changed, err := s.resolveValue(r.Context(), value)
+	if err != nil {
+		return nil, err
+	}
+	if changed && w != nil {
+		http.SetCookie(w, s.cookie(state, sessions))
+	}
+	return sessions, nil
+}
+
+func (s *BrowserSessionService) Active(w http.ResponseWriter, r *http.Request) (BrowserSession, error) {
+	sessions, err := s.Resolve(w, r)
+	if err != nil {
+		return BrowserSession{}, err
+	}
+	for _, browserSession := range sessions {
+		if browserSession.Active {
+			return browserSession, nil
+		}
+	}
+	return BrowserSession{}, persistence.ErrSessionNotFound
+}
+
+func (s *BrowserSessionService) Add(ctx context.Context, cookieValue string, sess session.Session) (*http.Cookie, error) {
+	state, sessions, _, err := s.resolveValue(ctx, cookieValue)
+	if err != nil {
+		return nil, err
+	}
+
+	now := s.now().UnixNano()
+	entries := make([]browserSessionEntry, 0, len(state.Entries)+1)
+	entries = append(entries, browserSessionEntry{Token: sess.Token(), LastActive: now})
+	for _, entry := range state.Entries {
+		if entry.Token != sess.Token() {
+			entries = append(entries, entry)
+		}
+	}
+	state.Active = sess.Token()
+	state.Entries = entries
+	sessions = append([]BrowserSession{{Session: sess, Active: true}}, withoutToken(sessions, sess.Token())...)
+	for i := 1; i < len(sessions); i++ {
+		sessions[i].Active = false
+	}
+
+	if len(state.Entries) > MaxBrowserSessions {
+		evicted := state.Entries[MaxBrowserSessions:]
+		state.Entries = state.Entries[:MaxBrowserSessions]
+		sessions = sessions[:MaxBrowserSessions]
+		for _, entry := range evicted {
+			if err := s.deleteToken(ctx, entry.Token); err != nil && !errors.Is(err, persistence.ErrSessionNotFound) {
+				return nil, serrors.E("core.BrowserSessionService.Add", err)
+			}
+		}
+	}
+
+	return s.cookie(state, sessions), nil
+}
+
+func (s *BrowserSessionService) AddFromRequest(ctx context.Context, r *http.Request, sess session.Session) (*http.Cookie, error) {
+	value := ""
+	if cookie, err := r.Cookie(s.cookiesCfg.SID); err == nil {
+		value = cookie.Value
+	}
+	return s.Add(ctx, value, sess)
+}
+
+func (s *BrowserSessionService) Activate(w http.ResponseWriter, r *http.Request, reference string) (BrowserSession, error) {
+	state, sessions, changed, err := s.resolveRequest(r)
+	if err != nil {
+		return BrowserSession{}, err
+	}
+	for i, browserSession := range sessions {
+		if browserSession.Reference() != reference || !browserSession.Session.IsActive() {
+			continue
+		}
+		state.Active = browserSession.Session.Token()
+		for j := range state.Entries {
+			if state.Entries[j].Token == state.Active {
+				state.Entries[j].LastActive = s.now().UnixNano()
+			}
+		}
+		sortEntries(state.Entries)
+		for j := range sessions {
+			sessions[j].Active = j == i
+		}
+		http.SetCookie(w, s.cookie(state, sessions))
+		return browserSession, nil
+	}
+	if changed {
+		http.SetCookie(w, s.cookie(state, sessions))
+	}
+	return BrowserSession{}, persistence.ErrSessionNotFound
+}
+
+func (s *BrowserSessionService) RemoveCurrent(w http.ResponseWriter, r *http.Request) ([]BrowserSession, error) {
+	state, sessions, _, err := s.resolveRequest(r)
+	if err != nil {
+		return nil, err
+	}
+	activeToken := state.Active
+	if activeToken != "" {
+		if err := s.deleteToken(r.Context(), activeToken); err != nil && !errors.Is(err, persistence.ErrSessionNotFound) {
+			return nil, err
+		}
+	}
+	state.Entries = withoutEntry(state.Entries, activeToken)
+	sessions = withoutToken(sessions, activeToken)
+	state.Active = ""
+	if len(state.Entries) > 0 {
+		state.Active = state.Entries[0].Token
+	}
+	for i := range sessions {
+		sessions[i].Active = sessions[i].Session.Token() == state.Active
+	}
+	http.SetCookie(w, s.cookie(state, sessions))
+	return sessions, nil
+}
+
+func (s *BrowserSessionService) RemoveAll(w http.ResponseWriter, r *http.Request) error {
+	state, _, _, err := s.resolveRequest(r)
+	if err != nil {
+		return err
+	}
+	for _, entry := range state.Entries {
+		if err := s.deleteToken(r.Context(), entry.Token); err != nil && !errors.Is(err, persistence.ErrSessionNotFound) {
+			return err
+		}
+	}
+	http.SetCookie(w, s.clearCookie())
+	return nil
+}
+
+func (s *BrowserSessionService) resolveRequest(r *http.Request) (browserSessionState, []BrowserSession, bool, error) {
+	value := ""
+	if cookie, err := r.Cookie(s.cookiesCfg.SID); err == nil {
+		value = cookie.Value
+	}
+	return s.resolveValue(r.Context(), value)
+}
+
+func (s *BrowserSessionService) resolveValue(ctx context.Context, value string) (browserSessionState, []BrowserSession, bool, error) {
+	state, migrated := decodeBrowserSessionState(value, s.now())
+	changed := migrated
+	resolved := make([]BrowserSession, 0, len(state.Entries))
+	validEntries := make([]browserSessionEntry, 0, len(state.Entries))
+	for _, entry := range state.Entries {
+		sess, err := s.sessionService.GetBrowserSessionByToken(ctx, entry.Token)
+		if err != nil || sess.IsExpired() || (!sess.IsActive() && !sess.IsPending()) {
+			changed = true
+			continue
+		}
+		userCtx := composables.WithTenantID(ctx, sess.TenantID())
+		u, err := s.userRepo.GetByID(userCtx, sess.UserID())
+		if err != nil || u.IsBlocked() {
+			changed = true
+			continue
+		}
+		validEntries = append(validEntries, entry)
+		resolved = append(resolved, BrowserSession{Session: sess, User: u, Active: entry.Token == state.Active})
+	}
+	state.Entries = validEntries
+	if !containsToken(state.Entries, state.Active) {
+		state.Active = ""
+		if len(state.Entries) > 0 {
+			state.Active = state.Entries[0].Token
+		}
+		changed = true
+	}
+	for i := range resolved {
+		resolved[i].Active = resolved[i].Session.Token() == state.Active
+	}
+	return state, resolved, changed, nil
+}
+
+func (s *BrowserSessionService) deleteToken(ctx context.Context, token string) error {
+	sess, err := s.sessionService.GetBrowserSessionByToken(ctx, token)
+	if err != nil {
+		return err
+	}
+	return s.sessionService.Delete(composables.WithTenantID(ctx, sess.TenantID()), token)
+}
+
+func (s *BrowserSessionService) cookie(state browserSessionState, sessions []BrowserSession) *http.Cookie {
+	if len(state.Entries) == 0 {
+		return s.clearCookie()
+	}
+	expires := s.now()
+	for _, browserSession := range sessions {
+		if browserSession.Session.ExpiresAt().After(expires) {
+			expires = browserSession.Session.ExpiresAt()
+		}
+	}
+	encoded, _ := encodeBrowserSessionState(state)
+	return &http.Cookie{
+		Name:     s.cookiesCfg.SID,
+		Value:    encoded,
+		Expires:  expires,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   s.appCfg.IsProduction(),
+		Domain:   s.cookiesCfg.Domain,
+		Path:     "/",
+	}
+}
+
+func (s *BrowserSessionService) clearCookie() *http.Cookie {
+	return &http.Cookie{
+		Name:     s.cookiesCfg.SID,
+		Value:    "",
+		Expires:  time.Unix(0, 0),
+		MaxAge:   -1,
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   s.appCfg.IsProduction(),
+		Domain:   s.cookiesCfg.Domain,
+		Path:     "/",
+	}
+}
+
+func encodeBrowserSessionState(state browserSessionState) (string, error) {
+	state.Version = browserSessionCookieVersion
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return "", err
+	}
+	return "v1." + base64.RawURLEncoding.EncodeToString(payload), nil
+}
+
+func decodeBrowserSessionState(value string, now time.Time) (browserSessionState, bool) {
+	empty := browserSessionState{Version: browserSessionCookieVersion, Entries: []browserSessionEntry{}}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return empty, false
+	}
+	if !strings.HasPrefix(value, "v1.") {
+		empty.Active = value
+		empty.Entries = []browserSessionEntry{{Token: value, LastActive: now.UnixNano()}}
+		return empty, true
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(value, "v1."))
+	if err != nil {
+		return empty, true
+	}
+	var state browserSessionState
+	if err := json.Unmarshal(payload, &state); err != nil || state.Version != browserSessionCookieVersion {
+		return empty, true
+	}
+	seen := make(map[string]struct{}, len(state.Entries))
+	entries := make([]browserSessionEntry, 0, len(state.Entries))
+	for _, entry := range state.Entries {
+		entry.Token = strings.TrimSpace(entry.Token)
+		if entry.Token == "" {
+			continue
+		}
+		if _, ok := seen[entry.Token]; ok {
+			continue
+		}
+		seen[entry.Token] = struct{}{}
+		entries = append(entries, entry)
+	}
+	state.Entries = entries
+	sortEntries(state.Entries)
+	return state, false
+}
+
+func sortEntries(entries []browserSessionEntry) {
+	sort.SliceStable(entries, func(i, j int) bool { return entries[i].LastActive > entries[j].LastActive })
+}
+
+func containsToken(entries []browserSessionEntry, token string) bool {
+	for _, entry := range entries {
+		if entry.Token == token {
+			return true
+		}
+	}
+	return false
+}
+
+func withoutEntry(entries []browserSessionEntry, token string) []browserSessionEntry {
+	filtered := entries[:0]
+	for _, entry := range entries {
+		if entry.Token != token {
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered
+}
+
+func withoutToken(sessions []BrowserSession, token string) []BrowserSession {
+	filtered := make([]BrowserSession, 0, len(sessions))
+	for _, browserSession := range sessions {
+		if browserSession.Session.Token() != token {
+			filtered = append(filtered, browserSession)
+		}
+	}
+	return filtered
+}

--- a/modules/core/services/browser_session_service.go
+++ b/modules/core/services/browser_session_service.go
@@ -106,7 +106,7 @@ func NewBrowserSessionService(
 
 func (s *BrowserSessionService) Resolve(w http.ResponseWriter, r *http.Request) ([]BrowserSession, error) {
 	value := ""
-	if cookie, err := r.Cookie(s.cookiesCfg.SID); err == nil {
+	if cookie, err := r.Cookie(s.sidName()); err == nil {
 		value = cookie.Value
 	} else if !errors.Is(err, http.ErrNoCookie) {
 		return nil, err
@@ -172,7 +172,7 @@ func (s *BrowserSessionService) Add(ctx context.Context, cookieValue string, ses
 
 func (s *BrowserSessionService) AddFromRequest(ctx context.Context, r *http.Request, sess session.Session) (*http.Cookie, error) {
 	value := ""
-	if cookie, err := r.Cookie(s.cookiesCfg.SID); err == nil {
+	if cookie, err := r.Cookie(s.sidName()); err == nil {
 		value = cookie.Value
 	}
 	return s.Add(ctx, value, sess)
@@ -246,7 +246,7 @@ func (s *BrowserSessionService) RemoveAll(w http.ResponseWriter, r *http.Request
 
 func (s *BrowserSessionService) resolveRequest(r *http.Request) (browserSessionState, []BrowserSession, bool, error) {
 	value := ""
-	if cookie, err := r.Cookie(s.cookiesCfg.SID); err == nil {
+	if cookie, err := r.Cookie(s.sidName()); err == nil {
 		value = cookie.Value
 	}
 	return s.resolveValue(r.Context(), value)
@@ -306,7 +306,7 @@ func (s *BrowserSessionService) cookie(state browserSessionState, sessions []Bro
 	}
 	encoded, _ := encodeBrowserSessionState(state)
 	return &http.Cookie{
-		Name:     s.cookiesCfg.SID,
+		Name:     s.sidName(),
 		Value:    encoded,
 		Expires:  expires,
 		HttpOnly: true,
@@ -319,7 +319,7 @@ func (s *BrowserSessionService) cookie(state browserSessionState, sessions []Bro
 
 func (s *BrowserSessionService) clearCookie() *http.Cookie {
 	return &http.Cookie{
-		Name:     s.cookiesCfg.SID,
+		Name:     s.sidName(),
 		Value:    "",
 		Expires:  time.Unix(0, 0),
 		MaxAge:   -1,
@@ -329,6 +329,13 @@ func (s *BrowserSessionService) clearCookie() *http.Cookie {
 		Domain:   s.cookiesCfg.Domain,
 		Path:     "/",
 	}
+}
+
+func (s *BrowserSessionService) sidName() string {
+	if s.cookiesCfg != nil && s.cookiesCfg.SID != "" {
+		return s.cookiesCfg.SID
+	}
+	return "sid"
 }
 
 func encodeBrowserSessionState(state browserSessionState) (string, error) {

--- a/modules/core/services/browser_session_service.go
+++ b/modules/core/services/browser_session_service.go
@@ -244,6 +244,10 @@ func (s *BrowserSessionService) RemoveAll(w http.ResponseWriter, r *http.Request
 	return nil
 }
 
+func (s *BrowserSessionService) Clear(w http.ResponseWriter) {
+	http.SetCookie(w, s.clearCookie())
+}
+
 func (s *BrowserSessionService) resolveRequest(r *http.Request) (browserSessionState, []BrowserSession, bool, error) {
 	value := ""
 	if cookie, err := r.Cookie(s.sidName()); err == nil {
@@ -259,13 +263,27 @@ func (s *BrowserSessionService) resolveValue(ctx context.Context, value string) 
 	validEntries := make([]browserSessionEntry, 0, len(state.Entries))
 	for _, entry := range state.Entries {
 		sess, err := s.sessionService.GetBrowserSessionByToken(ctx, entry.Token)
-		if err != nil || sess.IsExpired() || (!sess.IsActive() && !sess.IsPending()) {
+		if errors.Is(err, persistence.ErrSessionNotFound) {
+			changed = true
+			continue
+		}
+		if err != nil {
+			return state, nil, changed, serrors.E("core.BrowserSessionService.resolveValue", err)
+		}
+		if sess.Audience() != "" || sess.IsExpired() || (!sess.IsActive() && !sess.IsPending()) {
 			changed = true
 			continue
 		}
 		userCtx := composables.WithTenantID(ctx, sess.TenantID())
 		u, err := s.userRepo.GetByID(userCtx, sess.UserID())
-		if err != nil || u.IsBlocked() {
+		if errors.Is(err, persistence.ErrUserNotFound) {
+			changed = true
+			continue
+		}
+		if err != nil {
+			return state, nil, changed, serrors.E("core.BrowserSessionService.resolveValue", err)
+		}
+		if u.IsBlocked() {
 			changed = true
 			continue
 		}
@@ -304,7 +322,10 @@ func (s *BrowserSessionService) cookie(state browserSessionState, sessions []Bro
 			expires = browserSession.Session.ExpiresAt()
 		}
 	}
-	encoded, _ := encodeBrowserSessionState(state)
+	encoded, err := encodeBrowserSessionState(state)
+	if err != nil {
+		return s.clearCookie()
+	}
 	return &http.Cookie{
 		Name:     s.sidName(),
 		Value:    encoded,
@@ -381,6 +402,10 @@ func decodeBrowserSessionState(value string, now time.Time) (browserSessionState
 	}
 	state.Entries = entries
 	sortEntries(state.Entries)
+	if len(state.Entries) > MaxBrowserSessions {
+		state.Entries = state.Entries[:MaxBrowserSessions]
+		return state, true
+	}
 	return state, false
 }
 

--- a/modules/core/services/browser_session_service.go
+++ b/modules/core/services/browser_session_service.go
@@ -80,13 +80,18 @@ func (s *BrowserSessionService) SetAuthorizationRequestValidator(validator Autho
 }
 
 func (s *BrowserSessionService) ValidateAuthorizationRequest(ctx context.Context, id string) error {
+	const op serrors.Op = "core.BrowserSessionService.ValidateAuthorizationRequest"
+
 	if strings.TrimSpace(id) == "" {
 		return nil
 	}
 	if s.authorizationRequests == nil {
-		return errors.New("authorization requests are unavailable")
+		return serrors.E(op, errors.New("authorization requests are unavailable"))
 	}
-	return s.authorizationRequests.ValidateAuthorizationRequest(ctx, id)
+	if err := s.authorizationRequests.ValidateAuthorizationRequest(ctx, id); err != nil {
+		return serrors.E(op, err)
+	}
+	return nil
 }
 
 func NewBrowserSessionService(
@@ -105,16 +110,18 @@ func NewBrowserSessionService(
 }
 
 func (s *BrowserSessionService) Resolve(w http.ResponseWriter, r *http.Request) ([]BrowserSession, error) {
+	const op serrors.Op = "core.BrowserSessionService.Resolve"
+
 	value := ""
 	if cookie, err := r.Cookie(s.sidName()); err == nil {
 		value = cookie.Value
 	} else if !errors.Is(err, http.ErrNoCookie) {
-		return nil, err
+		return nil, serrors.E(op, err)
 	}
 
 	state, sessions, changed, err := s.resolveValue(r.Context(), value)
 	if err != nil {
-		return nil, err
+		return nil, serrors.E(op, err)
 	}
 	if changed && w != nil {
 		http.SetCookie(w, s.cookie(state, sessions))
@@ -123,22 +130,26 @@ func (s *BrowserSessionService) Resolve(w http.ResponseWriter, r *http.Request) 
 }
 
 func (s *BrowserSessionService) Active(w http.ResponseWriter, r *http.Request) (BrowserSession, error) {
+	const op serrors.Op = "core.BrowserSessionService.Active"
+
 	sessions, err := s.Resolve(w, r)
 	if err != nil {
-		return BrowserSession{}, err
+		return BrowserSession{}, serrors.E(op, err)
 	}
 	for _, browserSession := range sessions {
 		if browserSession.Active {
 			return browserSession, nil
 		}
 	}
-	return BrowserSession{}, persistence.ErrSessionNotFound
+	return BrowserSession{}, serrors.E(op, persistence.ErrSessionNotFound)
 }
 
 func (s *BrowserSessionService) Add(ctx context.Context, cookieValue string, sess session.Session) (*http.Cookie, error) {
+	const op serrors.Op = "core.BrowserSessionService.Add"
+
 	state, sessions, _, err := s.resolveValue(ctx, cookieValue)
 	if err != nil {
-		return nil, err
+		return nil, serrors.E(op, err)
 	}
 
 	now := s.now().UnixNano()
@@ -162,7 +173,7 @@ func (s *BrowserSessionService) Add(ctx context.Context, cookieValue string, ses
 		sessions = sessions[:MaxBrowserSessions]
 		for _, entry := range evicted {
 			if err := s.deleteToken(ctx, entry.Token); err != nil && !errors.Is(err, persistence.ErrSessionNotFound) {
-				return nil, serrors.E("core.BrowserSessionService.Add", err)
+				return nil, serrors.E(op, err)
 			}
 		}
 	}
@@ -179,9 +190,11 @@ func (s *BrowserSessionService) AddFromRequest(ctx context.Context, r *http.Requ
 }
 
 func (s *BrowserSessionService) Activate(w http.ResponseWriter, r *http.Request, reference string) (BrowserSession, error) {
+	const op serrors.Op = "core.BrowserSessionService.Activate"
+
 	state, sessions, changed, err := s.resolveRequest(r)
 	if err != nil {
-		return BrowserSession{}, err
+		return BrowserSession{}, serrors.E(op, err)
 	}
 	for i, browserSession := range sessions {
 		if browserSession.Reference() != reference || !browserSession.Session.IsActive() {
@@ -203,18 +216,20 @@ func (s *BrowserSessionService) Activate(w http.ResponseWriter, r *http.Request,
 	if changed {
 		http.SetCookie(w, s.cookie(state, sessions))
 	}
-	return BrowserSession{}, persistence.ErrSessionNotFound
+	return BrowserSession{}, serrors.E(op, persistence.ErrSessionNotFound)
 }
 
 func (s *BrowserSessionService) RemoveCurrent(w http.ResponseWriter, r *http.Request) ([]BrowserSession, error) {
+	const op serrors.Op = "core.BrowserSessionService.RemoveCurrent"
+
 	state, sessions, _, err := s.resolveRequest(r)
 	if err != nil {
-		return nil, err
+		return nil, serrors.E(op, err)
 	}
 	activeToken := state.Active
 	if activeToken != "" {
 		if err := s.deleteToken(r.Context(), activeToken); err != nil && !errors.Is(err, persistence.ErrSessionNotFound) {
-			return nil, err
+			return nil, serrors.E(op, err)
 		}
 	}
 	state.Entries = withoutEntry(state.Entries, activeToken)
@@ -231,13 +246,15 @@ func (s *BrowserSessionService) RemoveCurrent(w http.ResponseWriter, r *http.Req
 }
 
 func (s *BrowserSessionService) RemoveAll(w http.ResponseWriter, r *http.Request) error {
+	const op serrors.Op = "core.BrowserSessionService.RemoveAll"
+
 	state, _, _, err := s.resolveRequest(r)
 	if err != nil {
-		return err
+		return serrors.E(op, err)
 	}
 	for _, entry := range state.Entries {
 		if err := s.deleteToken(r.Context(), entry.Token); err != nil && !errors.Is(err, persistence.ErrSessionNotFound) {
-			return err
+			return serrors.E(op, err)
 		}
 	}
 	http.SetCookie(w, s.clearCookie())

--- a/modules/core/services/browser_session_service_test.go
+++ b/modules/core/services/browser_session_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -44,4 +45,19 @@ func TestBrowserSessionReferenceDoesNotExposeToken(t *testing.T) {
 	require.NotContains(t, reference, token)
 	require.Equal(t, reference, BrowserSessionReference(token))
 	require.NotEqual(t, reference, BrowserSessionReference(token+"-other"))
+}
+
+func TestBrowserSessionCookieCapsDecodedEntries(t *testing.T) {
+	t.Parallel()
+	state := browserSessionState{Version: browserSessionCookieVersion, Active: "token-9"}
+	for i := int64(0); i < 10; i++ {
+		state.Entries = append(state.Entries, browserSessionEntry{Token: fmt.Sprintf("token-%d", i), LastActive: i})
+	}
+	encoded, err := encodeBrowserSessionState(state)
+	require.NoError(t, err)
+
+	decoded, changed := decodeBrowserSessionState(encoded, time.Now())
+	require.True(t, changed)
+	require.Len(t, decoded.Entries, MaxBrowserSessions)
+	require.Equal(t, "token-9", decoded.Entries[0].Token)
 }

--- a/modules/core/services/browser_session_service_test.go
+++ b/modules/core/services/browser_session_service_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,17 +48,36 @@ func TestBrowserSessionReferenceDoesNotExposeToken(t *testing.T) {
 	require.NotEqual(t, reference, BrowserSessionReference(token+"-other"))
 }
 
-func TestBrowserSessionCookieCapsDecodedEntries(t *testing.T) {
+func TestBrowserSessionCookieCapsDecodedEntries_Scenarios(t *testing.T) {
 	t.Parallel()
-	state := browserSessionState{Version: browserSessionCookieVersion, Active: "token-9"}
-	for i := int64(0); i < 10; i++ {
-		state.Entries = append(state.Entries, browserSessionEntry{Token: fmt.Sprintf("token-%d", i), LastActive: i})
+	tests := []struct {
+		name          string
+		entryCount    int64
+		activeToken   string
+		expectedToken string
+	}{
+		{
+			name:          "caps decoded entries and retains the most recent token",
+			entryCount:    10,
+			activeToken:   "token-9",
+			expectedToken: "token-9",
+		},
 	}
-	encoded, err := encodeBrowserSessionState(state)
-	require.NoError(t, err)
 
-	decoded, changed := decodeBrowserSessionState(encoded, time.Now())
-	require.True(t, changed)
-	require.Len(t, decoded.Entries, MaxBrowserSessions)
-	require.Equal(t, "token-9", decoded.Entries[0].Token)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := browserSessionState{Version: browserSessionCookieVersion, Active: tt.activeToken}
+			for i := int64(0); i < tt.entryCount; i++ {
+				state.Entries = append(state.Entries, browserSessionEntry{Token: fmt.Sprintf("token-%d", i), LastActive: i})
+			}
+			encoded, err := encodeBrowserSessionState(state)
+			require.NoError(t, err)
+
+			decoded, changed := decodeBrowserSessionState(encoded, time.Now())
+			assert.True(t, changed)
+			assert.Len(t, decoded.Entries, MaxBrowserSessions)
+			require.NotEmpty(t, decoded.Entries)
+			assert.Equal(t, tt.expectedToken, decoded.Entries[0].Token)
+		})
+	}
 }

--- a/modules/core/services/browser_session_service_test.go
+++ b/modules/core/services/browser_session_service_test.go
@@ -1,0 +1,47 @@
+package services
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBrowserSessionCookieLegacyMigration(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, time.September, 1, 12, 0, 0, 0, time.UTC)
+	state, migrated := decodeBrowserSessionState("legacy-opaque-token", now)
+
+	require.True(t, migrated)
+	require.Equal(t, browserSessionCookieVersion, state.Version)
+	require.Equal(t, "legacy-opaque-token", state.Active)
+	require.Equal(t, []browserSessionEntry{{Token: "legacy-opaque-token", LastActive: now.UnixNano()}}, state.Entries)
+
+	encoded, err := encodeBrowserSessionState(state)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(encoded, "v1."))
+	decoded, migrated := decodeBrowserSessionState(encoded, now.Add(time.Hour))
+	require.False(t, migrated)
+	require.Equal(t, state, decoded)
+}
+
+func TestBrowserSessionCookieRejectsMalformedVersionedValue(t *testing.T) {
+	t.Parallel()
+	state, migrated := decodeBrowserSessionState("v1.not-valid-base64", time.Now())
+
+	require.True(t, migrated)
+	require.Empty(t, state.Active)
+	require.Empty(t, state.Entries)
+}
+
+func TestBrowserSessionReferenceDoesNotExposeToken(t *testing.T) {
+	t.Parallel()
+	token := "server-side-secret-session-token"
+	reference := BrowserSessionReference(token)
+
+	require.NotEmpty(t, reference)
+	require.NotContains(t, reference, token)
+	require.Equal(t, reference, BrowserSessionReference(token))
+	require.NotEqual(t, reference, BrowserSessionReference(token+"-other"))
+}

--- a/modules/core/services/session_service.go
+++ b/modules/core/services/session_service.go
@@ -39,6 +39,10 @@ func (s *SessionService) GetByToken(ctx context.Context, id string) (session.Ses
 	return s.repo.GetByToken(ctx, id)
 }
 
+func (s *SessionService) GetBrowserSessionByToken(ctx context.Context, token string) (session.Session, error) {
+	return s.repo.GetByTokenAnyTenant(ctx, token)
+}
+
 func (s *SessionService) GetPaginated(
 	ctx context.Context, params *session.FindParams,
 ) ([]session.Session, error) {

--- a/modules/oidc/component.go
+++ b/modules/oidc/component.go
@@ -98,9 +98,10 @@ func (c *component) Build(builder *composition.Builder) error {
 			storage *oidcinfra.Storage,
 			oidcService *services.OIDCService,
 			sessionService *coreservices.SessionService,
+			browserSessions *coreservices.BrowserSessionService,
 		) []application.Controller {
 			return []application.Controller{
-				controllers.NewOIDCController(storage, cfg, oidcService, sessionService, httpCfg, cookiesCfg),
+				controllers.NewOIDCController(storage, cfg, oidcService, sessionService, browserSessions, httpCfg),
 			}
 		})
 	}

--- a/modules/oidc/presentation/controllers/account_selection_controller_test.go
+++ b/modules/oidc/presentation/controllers/account_selection_controller_test.go
@@ -31,8 +31,44 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/itf"
 )
 
-func TestOIDCAccountSelectionDerivesIdentityFromBrowserSession(t *testing.T) {
+func TestOIDCAccountSelection_Scenarios(t *testing.T) {
 	t.Parallel()
+	tests := []struct {
+		name string
+		run  func(*testing.T)
+	}{
+		{name: "derives identity from browser session", run: testOIDCAccountSelectionDerivesIdentityFromBrowserSession},
+		{name: "rejects expired authorization request", run: testOIDCAccountSelectionRejectsExpiredAuthorizationRequest},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, tt.run)
+	}
+}
+
+func newAccountSelectionRouter(
+	env *itf.TestEnvironment,
+	clientRepo client.Repository,
+	authRequestRepo authrequest.Repository,
+) *mux.Router {
+	cryptoKey := base64.StdEncoding.EncodeToString(make([]byte, 32))
+	storage := oidcstorage.NewStorage(
+		clientRepo, authRequestRepo, persistence.NewTokenRepository(), nil, env.Pool,
+		cryptoKey, "https://issuer.example.test/oidc", 0, 0,
+	)
+	controller := controllers.NewOIDCController(
+		storage,
+		&oidcconfig.Config{IssuerURL: "https://issuer.example.test/oidc", CryptoKey: cryptoKey},
+		oidcservices.NewOIDCService(clientRepo, authRequestRepo),
+		itf.GetService[coreservices.SessionService](env),
+		itf.GetService[coreservices.BrowserSessionService](env),
+		&httpconfig.Config{},
+	)
+	router := mux.NewRouter()
+	controller.Register(router)
+	return router
+}
+
+func testOIDCAccountSelectionDerivesIdentityFromBrowserSession(t *testing.T) {
 	env := itf.Setup(t, itf.WithComponents(modules.Components()...))
 	clientRepo := persistence.NewClientRepository()
 	authRequestRepo := persistence.NewAuthRequestRepository()
@@ -74,26 +110,12 @@ func TestOIDCAccountSelectionDerivesIdentityFromBrowserSession(t *testing.T) {
 	)
 	require.NoError(t, authRequestRepo.Create(env.Ctx, request))
 
-	cryptoKey := base64.StdEncoding.EncodeToString(make([]byte, 32))
-	storage := oidcstorage.NewStorage(
-		clientRepo, authRequestRepo, persistence.NewTokenRepository(), nil, env.Pool,
-		cryptoKey, "https://issuer.example.test/oidc", 0, 0,
-	)
-	controller := controllers.NewOIDCController(
-		storage,
-		&oidcconfig.Config{IssuerURL: "https://issuer.example.test/oidc", CryptoKey: cryptoKey},
-		oidcservices.NewOIDCService(clientRepo, authRequestRepo),
-		coreSessionService,
-		browserSessions,
-		&httpconfig.Config{},
-	)
-	router := mux.NewRouter()
-	controller.Register(router)
+	router := newAccountSelectionRouter(env, clientRepo, authRequestRepo)
 
 	form := url.Values{
-		"SessionRef": {coreservices.BrowserSessionReference(token)},
-		"user_id":    {"999999"},
-		"tenant_id":  {uuid.NewString()},
+		"SessionReference": {coreservices.BrowserSessionReference(token)},
+		"user_id":          {"999999"},
+		"tenant_id":        {uuid.NewString()},
 	}
 	recorder := httptest.NewRecorder()
 	requestContext := context.WithValue(env.Ctx, constants.LoggerKey, logrus.New().WithField("test", true))
@@ -117,8 +139,7 @@ func TestOIDCAccountSelectionDerivesIdentityFromBrowserSession(t *testing.T) {
 	require.Equal(t, "challenge", *completed.CodeChallenge())
 }
 
-func TestOIDCAccountSelectionRejectsExpiredAuthorizationRequest(t *testing.T) {
-	t.Parallel()
+func testOIDCAccountSelectionRejectsExpiredAuthorizationRequest(t *testing.T) {
 	env := itf.Setup(t, itf.WithComponents(modules.Components()...))
 	clientRepo := persistence.NewClientRepository()
 	authRequestRepo := persistence.NewAuthRequestRepository()
@@ -135,27 +156,13 @@ func TestOIDCAccountSelectionRejectsExpiredAuthorizationRequest(t *testing.T) {
 	)
 	require.NoError(t, authRequestRepo.Create(env.Ctx, request))
 
-	cryptoKey := base64.StdEncoding.EncodeToString(make([]byte, 32))
-	storage := oidcstorage.NewStorage(
-		clientRepo, authRequestRepo, persistence.NewTokenRepository(), nil, env.Pool,
-		cryptoKey, "https://issuer.example.test/oidc", 0, 0,
-	)
-	controller := controllers.NewOIDCController(
-		storage,
-		&oidcconfig.Config{IssuerURL: "https://issuer.example.test/oidc", CryptoKey: cryptoKey},
-		oidcservices.NewOIDCService(clientRepo, authRequestRepo),
-		itf.GetService[coreservices.SessionService](env),
-		itf.GetService[coreservices.BrowserSessionService](env),
-		&httpconfig.Config{},
-	)
-	router := mux.NewRouter()
-	controller.Register(router)
+	router := newAccountSelectionRouter(env, clientRepo, authRequestRepo)
 
 	recorder := httptest.NewRecorder()
 	httpRequest := httptest.NewRequest(
 		http.MethodPost,
 		"/oidc/authorize/select?auth_request="+request.ID().String(),
-		strings.NewReader(url.Values{"SessionRef": {"untrusted"}}.Encode()),
+		strings.NewReader(url.Values{"SessionReference": {"untrusted"}}.Encode()),
 	).WithContext(context.WithValue(env.Ctx, constants.LoggerKey, logrus.New().WithField("test", true)))
 	httpRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	router.ServeHTTP(recorder, httpRequest)

--- a/modules/oidc/presentation/controllers/account_selection_controller_test.go
+++ b/modules/oidc/presentation/controllers/account_selection_controller_test.go
@@ -91,9 +91,9 @@ func TestOIDCAccountSelectionDerivesIdentityFromBrowserSession(t *testing.T) {
 	controller.Register(router)
 
 	form := url.Values{
-		"session_ref": {coreservices.BrowserSessionReference(token)},
-		"user_id":     {"999999"},
-		"tenant_id":   {uuid.NewString()},
+		"SessionRef": {coreservices.BrowserSessionReference(token)},
+		"user_id":    {"999999"},
+		"tenant_id":  {uuid.NewString()},
 	}
 	recorder := httptest.NewRecorder()
 	requestContext := context.WithValue(env.Ctx, constants.LoggerKey, logrus.New().WithField("test", true))
@@ -155,7 +155,7 @@ func TestOIDCAccountSelectionRejectsExpiredAuthorizationRequest(t *testing.T) {
 	httpRequest := httptest.NewRequest(
 		http.MethodPost,
 		"/oidc/authorize/select?auth_request="+request.ID().String(),
-		strings.NewReader(url.Values{"session_ref": {"untrusted"}}.Encode()),
+		strings.NewReader(url.Values{"SessionRef": {"untrusted"}}.Encode()),
 	).WithContext(context.WithValue(env.Ctx, constants.LoggerKey, logrus.New().WithField("test", true)))
 	httpRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	router.ServeHTTP(recorder, httpRequest)

--- a/modules/oidc/presentation/controllers/account_selection_controller_test.go
+++ b/modules/oidc/presentation/controllers/account_selection_controller_test.go
@@ -69,6 +69,8 @@ func newAccountSelectionRouter(
 }
 
 func testOIDCAccountSelectionDerivesIdentityFromBrowserSession(t *testing.T) {
+	t.Helper()
+
 	env := itf.Setup(t, itf.WithComponents(modules.Components()...))
 	clientRepo := persistence.NewClientRepository()
 	authRequestRepo := persistence.NewAuthRequestRepository()
@@ -140,6 +142,8 @@ func testOIDCAccountSelectionDerivesIdentityFromBrowserSession(t *testing.T) {
 }
 
 func testOIDCAccountSelectionRejectsExpiredAuthorizationRequest(t *testing.T) {
+	t.Helper()
+
 	env := itf.Setup(t, itf.WithComponents(modules.Components()...))
 	clientRepo := persistence.NewClientRepository()
 	authRequestRepo := persistence.NewAuthRequestRepository()

--- a/modules/oidc/presentation/controllers/account_selection_controller_test.go
+++ b/modules/oidc/presentation/controllers/account_selection_controller_test.go
@@ -1,0 +1,164 @@
+package controllers_test
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iota-uz/iota-sdk/modules"
+	coresession "github.com/iota-uz/iota-sdk/modules/core/domain/entities/session"
+	coreservices "github.com/iota-uz/iota-sdk/modules/core/services"
+	"github.com/iota-uz/iota-sdk/modules/oidc/domain/entities/authrequest"
+	"github.com/iota-uz/iota-sdk/modules/oidc/domain/entities/client"
+	oidcstorage "github.com/iota-uz/iota-sdk/modules/oidc/infrastructure/oidc"
+	"github.com/iota-uz/iota-sdk/modules/oidc/infrastructure/persistence"
+	"github.com/iota-uz/iota-sdk/modules/oidc/presentation/controllers"
+	oidcservices "github.com/iota-uz/iota-sdk/modules/oidc/services"
+	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig"
+	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/oidcconfig"
+	"github.com/iota-uz/iota-sdk/pkg/constants"
+	"github.com/iota-uz/iota-sdk/pkg/itf"
+)
+
+func TestOIDCAccountSelectionDerivesIdentityFromBrowserSession(t *testing.T) {
+	t.Parallel()
+	env := itf.Setup(t, itf.WithComponents(modules.Components()...))
+	clientRepo := persistence.NewClientRepository()
+	authRequestRepo := persistence.NewAuthRequestRepository()
+	callbackURL := "https://client.example.test/callback"
+	_, err := clientRepo.Create(env.Ctx, client.New("picker-client", "Picker client", "web", []string{callbackURL}))
+	require.NoError(t, err)
+
+	tenantID := uuid.New()
+	_, err = env.Tx.Exec(env.Ctx, `INSERT INTO tenants (id, name) VALUES ($1, $2)`, tenantID, "Picker tenant")
+	require.NoError(t, err)
+	var userID uint
+	err = env.Tx.QueryRow(env.Ctx, `
+		INSERT INTO users (tenant_id, type, first_name, last_name, email, ui_language)
+		VALUES ($1, 'user', 'Picker', 'User', $2, 'en') RETURNING id`,
+		tenantID,
+		"picker-"+uuid.NewString()+"@example.test",
+	).Scan(&userID)
+	require.NoError(t, err)
+
+	coreSessionService := itf.GetService[coreservices.SessionService](env)
+	browserSessions := itf.GetService[coreservices.BrowserSessionService](env)
+	token := "oidc-picker-" + uuid.NewString()
+	require.NoError(t, coreSessionService.Create(env.Ctx, &coresession.CreateDTO{
+		Token: token, UserID: userID, TenantID: tenantID, IP: "127.0.0.1", UserAgent: "controller-test",
+	}))
+	sess, err := coreSessionService.GetBrowserSessionByToken(env.Ctx, token)
+	require.NoError(t, err)
+	browserCookie, err := browserSessions.Add(env.Ctx, "", sess)
+	require.NoError(t, err)
+
+	request := authrequest.New(
+		"picker-client",
+		callbackURL,
+		[]string{"openid"},
+		"code",
+		authrequest.WithState("preserved-state"),
+		authrequest.WithNonce("preserved-nonce"),
+		authrequest.WithCodeChallenge("challenge", "S256"),
+	)
+	require.NoError(t, authRequestRepo.Create(env.Ctx, request))
+
+	cryptoKey := base64.StdEncoding.EncodeToString(make([]byte, 32))
+	storage := oidcstorage.NewStorage(
+		clientRepo, authRequestRepo, persistence.NewTokenRepository(), nil, env.Pool,
+		cryptoKey, "https://issuer.example.test/oidc", 0, 0,
+	)
+	controller := controllers.NewOIDCController(
+		storage,
+		&oidcconfig.Config{IssuerURL: "https://issuer.example.test/oidc", CryptoKey: cryptoKey},
+		oidcservices.NewOIDCService(clientRepo, authRequestRepo),
+		coreSessionService,
+		browserSessions,
+		&httpconfig.Config{},
+	)
+	router := mux.NewRouter()
+	controller.Register(router)
+
+	form := url.Values{
+		"session_ref": {coreservices.BrowserSessionReference(token)},
+		"user_id":     {"999999"},
+		"tenant_id":   {uuid.NewString()},
+	}
+	recorder := httptest.NewRecorder()
+	requestContext := context.WithValue(env.Ctx, constants.LoggerKey, logrus.New().WithField("test", true))
+	httpRequest := httptest.NewRequest(
+		http.MethodPost,
+		"/oidc/authorize/select?auth_request="+request.ID().String(),
+		strings.NewReader(form.Encode()),
+	).WithContext(requestContext)
+	httpRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	httpRequest.AddCookie(browserCookie)
+	router.ServeHTTP(recorder, httpRequest)
+
+	require.Equal(t, http.StatusSeeOther, recorder.Code)
+	require.Equal(t, "/oidc/authorize/callback?id="+request.ID().String(), recorder.Header().Get("Location"))
+	completed, err := authRequestRepo.GetByID(env.Ctx, request.ID())
+	require.NoError(t, err)
+	require.Equal(t, int(userID), *completed.UserID())
+	require.Equal(t, tenantID, *completed.TenantID())
+	require.Equal(t, "preserved-state", *completed.State())
+	require.Equal(t, "preserved-nonce", *completed.Nonce())
+	require.Equal(t, "challenge", *completed.CodeChallenge())
+}
+
+func TestOIDCAccountSelectionRejectsExpiredAuthorizationRequest(t *testing.T) {
+	t.Parallel()
+	env := itf.Setup(t, itf.WithComponents(modules.Components()...))
+	clientRepo := persistence.NewClientRepository()
+	authRequestRepo := persistence.NewAuthRequestRepository()
+	_, err := clientRepo.Create(env.Ctx, client.New(
+		"expired-picker-client", "Expired picker client", "web", []string{"https://client.example.test/callback"},
+	))
+	require.NoError(t, err)
+	request := authrequest.New(
+		"expired-picker-client",
+		"https://client.example.test/callback",
+		[]string{"openid"},
+		"code",
+		authrequest.WithExpiresAt(time.Now().Add(-time.Minute)),
+	)
+	require.NoError(t, authRequestRepo.Create(env.Ctx, request))
+
+	cryptoKey := base64.StdEncoding.EncodeToString(make([]byte, 32))
+	storage := oidcstorage.NewStorage(
+		clientRepo, authRequestRepo, persistence.NewTokenRepository(), nil, env.Pool,
+		cryptoKey, "https://issuer.example.test/oidc", 0, 0,
+	)
+	controller := controllers.NewOIDCController(
+		storage,
+		&oidcconfig.Config{IssuerURL: "https://issuer.example.test/oidc", CryptoKey: cryptoKey},
+		oidcservices.NewOIDCService(clientRepo, authRequestRepo),
+		itf.GetService[coreservices.SessionService](env),
+		itf.GetService[coreservices.BrowserSessionService](env),
+		&httpconfig.Config{},
+	)
+	router := mux.NewRouter()
+	controller.Register(router)
+
+	recorder := httptest.NewRecorder()
+	httpRequest := httptest.NewRequest(
+		http.MethodPost,
+		"/oidc/authorize/select?auth_request="+request.ID().String(),
+		strings.NewReader(url.Values{"session_ref": {"untrusted"}}.Encode()),
+	).WithContext(context.WithValue(env.Ctx, constants.LoggerKey, logrus.New().WithField("test", true)))
+	httpRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	router.ServeHTTP(recorder, httpRequest)
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+	require.Contains(t, recorder.Body.String(), "start again")
+}

--- a/modules/oidc/presentation/controllers/account_selection_controller_test.go
+++ b/modules/oidc/presentation/controllers/account_selection_controller_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/iota-uz/iota-sdk/modules/oidc/infrastructure/persistence"
 	"github.com/iota-uz/iota-sdk/modules/oidc/presentation/controllers"
 	oidcservices "github.com/iota-uz/iota-sdk/modules/oidc/services"
+	"github.com/iota-uz/iota-sdk/pkg/composables"
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig"
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/oidcconfig"
 	"github.com/iota-uz/iota-sdk/pkg/constants"
@@ -54,7 +55,7 @@ func TestOIDCAccountSelectionDerivesIdentityFromBrowserSession(t *testing.T) {
 	coreSessionService := itf.GetService[coreservices.SessionService](env)
 	browserSessions := itf.GetService[coreservices.BrowserSessionService](env)
 	token := "oidc-picker-" + uuid.NewString()
-	require.NoError(t, coreSessionService.Create(env.Ctx, &coresession.CreateDTO{
+	require.NoError(t, coreSessionService.Create(composables.WithTenantID(env.Ctx, tenantID), &coresession.CreateDTO{
 		Token: token, UserID: userID, TenantID: tenantID, IP: "127.0.0.1", UserAgent: "controller-test",
 	}))
 	sess, err := coreSessionService.GetBrowserSessionByToken(env.Ctx, token)

--- a/modules/oidc/presentation/controllers/oidc_controller.go
+++ b/modules/oidc/presentation/controllers/oidc_controller.go
@@ -145,7 +145,7 @@ func (c *OIDCController) handleAccountSelection(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	browserSession, err := c.browserSessions.Activate(w, r, r.FormValue("SessionRef"))
+	browserSession, err := c.browserSessions.Activate(w, r, r.FormValue("SessionReference"))
 	if err != nil || !browserSession.Session.IsActive() {
 		shared.SetFlash(w, "error", []byte("That account session expired. Sign in again or choose another account."))
 		http.Redirect(w, r, "/login?auth_request="+url.QueryEscape(authRequestID), http.StatusSeeOther)

--- a/modules/oidc/presentation/controllers/oidc_controller.go
+++ b/modules/oidc/presentation/controllers/oidc_controller.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"net/url"
 
 	"github.com/gorilla/mux"
 	"github.com/zitadel/oidc/v3/pkg/op"
@@ -16,8 +17,8 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/application"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig"
-	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig/cookies"
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/oidcconfig"
+	"github.com/iota-uz/iota-sdk/pkg/shared"
 )
 
 // CallbackQueryDTO represents the query parameters for the OIDC callback endpoint
@@ -26,13 +27,13 @@ type CallbackQueryDTO struct {
 }
 
 type OIDCController struct {
-	storage     *oidc.Storage
-	oidcCfg     *oidcconfig.Config
-	httpCfg     *httpconfig.Config
-	cookiesCfg  *cookies.Config
-	oidcService *oidcservices.OIDCService
-	sessionSvc  *coreservices.SessionService
-	provider    op.OpenIDProvider
+	storage         *oidc.Storage
+	oidcCfg         *oidcconfig.Config
+	httpCfg         *httpconfig.Config
+	oidcService     *oidcservices.OIDCService
+	sessionSvc      *coreservices.SessionService
+	browserSessions *coreservices.BrowserSessionService
+	provider        op.OpenIDProvider
 }
 
 func NewOIDCController(
@@ -40,16 +41,19 @@ func NewOIDCController(
 	oidcCfg *oidcconfig.Config,
 	oidcService *oidcservices.OIDCService,
 	sessionService *coreservices.SessionService,
+	browserSessions *coreservices.BrowserSessionService,
 	httpCfg *httpconfig.Config,
-	cookiesCfg *cookies.Config,
 ) *OIDCController {
+	if browserSessions != nil {
+		browserSessions.SetAuthorizationRequestValidator(oidcService)
+	}
 	return &OIDCController{
-		storage:     storage,
-		oidcCfg:     oidcCfg,
-		httpCfg:     httpCfg,
-		cookiesCfg:  cookiesCfg,
-		oidcService: oidcService,
-		sessionSvc:  sessionService,
+		storage:         storage,
+		oidcCfg:         oidcCfg,
+		httpCfg:         httpCfg,
+		oidcService:     oidcService,
+		sessionSvc:      sessionService,
+		browserSessions: browserSessions,
 	}
 }
 
@@ -123,9 +127,40 @@ func (c *OIDCController) Register(r *mux.Router) {
 	// This is called after user successfully logs in via /login
 	// IMPORTANT: Must be registered before PathPrefix("/oidc/") to avoid being shadowed
 	r.HandleFunc("/oidc/authorize/callback", c.handleCallback).Methods(http.MethodGet)
+	r.HandleFunc("/oidc/authorize/select", c.handleAccountSelection).Methods(http.MethodPost)
 
 	// Register catch-all OIDC provider routes last
 	r.PathPrefix("/oidc/").Handler(http.StripPrefix("/oidc", provider))
+}
+
+func (c *OIDCController) handleAccountSelection(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "Invalid account selection", http.StatusBadRequest)
+		return
+	}
+	authRequestID := r.URL.Query().Get("auth_request")
+	authReq, err := c.oidcService.GetAuthRequest(r.Context(), authRequestID)
+	if err != nil || authReq.IsExpired() || authReq.IsAuthenticated() || authReq.IsCodeUsed() || authReq.Code() != nil {
+		http.Error(w, "This authorization request is no longer valid. Return to the application and start again.", http.StatusBadRequest)
+		return
+	}
+
+	browserSession, err := c.browserSessions.Activate(w, r, r.FormValue("session_ref"))
+	if err != nil || !browserSession.Session.IsActive() {
+		shared.SetFlash(w, "error", []byte("That account session expired. Sign in again or choose another account."))
+		http.Redirect(w, r, "/login?auth_request="+url.QueryEscape(authRequestID), http.StatusSeeOther)
+		return
+	}
+	if err := c.oidcService.CompleteAuthRequest(
+		r.Context(),
+		authRequestID,
+		int(browserSession.Session.UserID()),
+		browserSession.Session.TenantID(),
+	); err != nil {
+		http.Error(w, "This authorization request is no longer valid. Return to the application and start again.", http.StatusBadRequest)
+		return
+	}
+	http.Redirect(w, r, "/oidc/authorize/callback?id="+url.QueryEscape(authRequestID), http.StatusSeeOther)
 }
 
 // handleCallback completes the authorization flow after successful login
@@ -153,23 +188,21 @@ func (c *OIDCController) handleCallback(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "Invalid auth request", http.StatusBadRequest)
 		return
 	}
+	if authReq.IsExpired() || authReq.IsCodeUsed() || authReq.Code() != nil {
+		http.Error(w, "This authorization request is no longer valid. Return to the application and start again.", http.StatusBadRequest)
+		return
+	}
 
 	// Complete auth request from active session if not already authenticated.
 	// This ensures users finish 2FA before OIDC authorization can proceed.
 	if !authReq.IsAuthenticated() {
-		sessionCookie, err := r.Cookie(c.cookiesCfg.SID)
-		if err != nil {
-			logger.WithError(err).Error("Missing session cookie for OIDC callback")
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-
-		sess, err := c.sessionSvc.GetByToken(r.Context(), sessionCookie.Value)
+		browserSession, err := c.browserSessions.Active(w, r)
 		if err != nil {
 			logger.WithError(err).Error("Failed to load session for OIDC callback")
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
+		sess := browserSession.Session
 
 		if sess.Status() != session.StatusActive {
 			logger.Error("Session not active for OIDC callback", "status", sess.Status())

--- a/modules/oidc/presentation/controllers/oidc_controller.go
+++ b/modules/oidc/presentation/controllers/oidc_controller.go
@@ -145,7 +145,7 @@ func (c *OIDCController) handleAccountSelection(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	browserSession, err := c.browserSessions.Activate(w, r, r.FormValue("session_ref"))
+	browserSession, err := c.browserSessions.Activate(w, r, r.FormValue("SessionRef"))
 	if err != nil || !browserSession.Session.IsActive() {
 		shared.SetFlash(w, "error", []byte("That account session expired. Sign in again or choose another account."))
 		http.Redirect(w, r, "/login?auth_request="+url.QueryEscape(authRequestID), http.StatusSeeOther)

--- a/modules/oidc/presentation/controllers/oidc_controller_test.go
+++ b/modules/oidc/presentation/controllers/oidc_controller_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/iota-uz/iota-sdk/modules/oidc/presentation/controllers"
 	"github.com/iota-uz/iota-sdk/modules/oidc/services"
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig"
-	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig/cookies"
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/oidcconfig"
 	"github.com/iota-uz/iota-sdk/pkg/constants"
 	"github.com/iota-uz/iota-sdk/pkg/itf"
@@ -85,8 +84,8 @@ func TestOIDCCallbackCompletesStoredAuthorizationRequest(t *testing.T) {
 		&oidcconfig.Config{IssuerURL: "https://issuer.example.test/oidc", CryptoKey: cryptoKey},
 		services.NewOIDCService(clientRepo, authRequestRepo),
 		nil,
+		nil,
 		&httpconfig.Config{},
-		&cookies.Config{SID: "sid"},
 	)
 	router := mux.NewRouter()
 	controller.Register(router)

--- a/modules/oidc/services/oidc_service.go
+++ b/modules/oidc/services/oidc_service.go
@@ -50,6 +50,9 @@ func (s *OIDCService) CompleteAuthRequest(
 	if authReq.IsExpired() {
 		return serrors.E(op, serrors.KindValidation, "auth request has expired")
 	}
+	if authReq.IsAuthenticated() || authReq.IsCodeUsed() || authReq.Code() != nil {
+		return serrors.E(op, serrors.KindValidation, "auth request has already been consumed")
+	}
 
 	// Complete authentication
 	completedReq := authReq.CompleteAuthentication(userID, tenantID)
@@ -79,4 +82,15 @@ func (s *OIDCService) GetAuthRequest(ctx context.Context, authRequestID string) 
 	}
 
 	return authReq, nil
+}
+
+func (s *OIDCService) ValidateAuthorizationRequest(ctx context.Context, authRequestID string) error {
+	authReq, err := s.GetAuthRequest(ctx, authRequestID)
+	if err != nil {
+		return err
+	}
+	if authReq.IsExpired() || authReq.IsAuthenticated() || authReq.IsCodeUsed() || authReq.Code() != nil {
+		return serrors.E("OIDCService.ValidateAuthorizationRequest", serrors.KindValidation, "auth request is no longer valid")
+	}
+	return nil
 }

--- a/modules/oidc/services/oidc_service.go
+++ b/modules/oidc/services/oidc_service.go
@@ -85,12 +85,13 @@ func (s *OIDCService) GetAuthRequest(ctx context.Context, authRequestID string) 
 }
 
 func (s *OIDCService) ValidateAuthorizationRequest(ctx context.Context, authRequestID string) error {
+	const op serrors.Op = "OIDCService.ValidateAuthorizationRequest"
 	authReq, err := s.GetAuthRequest(ctx, authRequestID)
 	if err != nil {
-		return err
+		return serrors.E(op, err)
 	}
 	if authReq.IsExpired() || authReq.IsAuthenticated() || authReq.IsCodeUsed() || authReq.Code() != nil {
-		return serrors.E("OIDCService.ValidateAuthorizationRequest", serrors.KindValidation, "auth request is no longer valid")
+		return serrors.E(op, serrors.KindValidation, "auth request is no longer valid")
 	}
 	return nil
 }

--- a/modules/oidc/services/oidc_service_test.go
+++ b/modules/oidc/services/oidc_service_test.go
@@ -169,6 +169,8 @@ func TestOIDCService_CompleteAuthRequest_AlreadyAuthenticated(t *testing.T) {
 
 	unchanged, err := authRequestRepo.GetByID(env.Ctx, testAuthReq.ID())
 	require.NoError(t, err)
+	require.NotNil(t, unchanged.UserID())
+	require.NotNil(t, unchanged.TenantID())
 	require.Equal(t, 101, *unchanged.UserID())
 	require.Equal(t, originalTenantID, *unchanged.TenantID())
 }

--- a/modules/oidc/services/oidc_service_test.go
+++ b/modules/oidc/services/oidc_service_test.go
@@ -145,6 +145,34 @@ func TestOIDCService_CompleteAuthRequest_Expired(t *testing.T) {
 	require.Contains(t, err.Error(), "expired")
 }
 
+func TestOIDCService_CompleteAuthRequest_AlreadyAuthenticated(t *testing.T) {
+	t.Parallel()
+	env := itf.Setup(t, itf.WithComponents(modules.Components()...))
+	clientRepo := persistence.NewClientRepository()
+	authRequestRepo := persistence.NewAuthRequestRepository()
+	oidcService := services.NewOIDCService(clientRepo, authRequestRepo)
+	testClient := client.New(
+		"already-authenticated-client", "Already authenticated client", "web", []string{"http://localhost:3000/callback"},
+	)
+	_, err := clientRepo.Create(env.Ctx, testClient)
+	require.NoError(t, err)
+	originalTenantID := createOIDCTestTenantAndUser(t, env, 101)
+	testAuthReq := authrequest.New(
+		testClient.ClientID(), "http://localhost:3000/callback", []string{"openid"}, "code",
+	).CompleteAuthentication(101, originalTenantID)
+	require.NoError(t, authRequestRepo.Create(env.Ctx, testAuthReq))
+
+	otherTenantID := createOIDCTestTenantAndUser(t, env, 102)
+	err = oidcService.CompleteAuthRequest(env.Ctx, testAuthReq.ID().String(), 102, otherTenantID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "already been consumed")
+
+	unchanged, err := authRequestRepo.GetByID(env.Ctx, testAuthReq.ID())
+	require.NoError(t, err)
+	require.Equal(t, 101, *unchanged.UserID())
+	require.Equal(t, originalTenantID, *unchanged.TenantID())
+}
+
 func TestOIDCService_GetAuthRequest(t *testing.T) {
 	t.Parallel()
 

--- a/modules/testkit/domain/schemas/populate_schema.go
+++ b/modules/testkit/domain/schemas/populate_schema.go
@@ -20,10 +20,18 @@ type TenantSpec struct {
 }
 
 type DataSpec struct {
-	Users     []UserSpec     `json:"users,omitempty"`
-	Finance   *FinanceSpec   `json:"finance,omitempty"`
-	CRM       *CRMSpec       `json:"crm,omitempty"`
-	Warehouse *WarehouseSpec `json:"warehouse,omitempty"`
+	Users       []UserSpec       `json:"users,omitempty"`
+	Finance     *FinanceSpec     `json:"finance,omitempty"`
+	CRM         *CRMSpec         `json:"crm,omitempty"`
+	Warehouse   *WarehouseSpec   `json:"warehouse,omitempty"`
+	OIDCClients []OIDCClientSpec `json:"oidcClients,omitempty"`
+}
+
+type OIDCClientSpec struct {
+	ClientID     string   `json:"clientId"`
+	Name         string   `json:"name"`
+	RedirectURIs []string `json:"redirectUris"`
+	Scopes       []string `json:"scopes,omitempty"`
 }
 
 type UserSpec struct {

--- a/modules/testkit/services/populate_service.go
+++ b/modules/testkit/services/populate_service.go
@@ -152,6 +152,11 @@ func (s *PopulateService) populateData(ctx context.Context, data *schemas.DataSp
 			return fmt.Errorf("failed to create users: %w", err)
 		}
 	}
+	if len(data.OIDCClients) > 0 {
+		if err := s.createOIDCClients(ctx, data.OIDCClients); err != nil {
+			return fmt.Errorf("failed to create OIDC clients: %w", err)
+		}
+	}
 
 	// Create finance entities
 	if data.Finance != nil {
@@ -174,6 +179,39 @@ func (s *PopulateService) populateData(ctx context.Context, data *schemas.DataSp
 		}
 	}
 
+	return nil
+}
+
+func (s *PopulateService) createOIDCClients(ctx context.Context, clients []schemas.OIDCClientSpec) error {
+	tx, err := composables.UseTx(ctx)
+	if err != nil {
+		return err
+	}
+	for _, clientSpec := range clients {
+		scopes := clientSpec.Scopes
+		if len(scopes) == 0 {
+			scopes = []string{"openid", "profile", "email"}
+		}
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO oidc.clients (
+				client_id, name, application_type, redirect_uris, grant_types,
+				response_types, scopes, auth_method, require_pkce, is_active
+			) VALUES ($1, $2, 'web', $3, ARRAY['authorization_code'], ARRAY['code'], $4, 'none', true, true)
+			ON CONFLICT (client_id) DO UPDATE SET
+				name = EXCLUDED.name,
+				redirect_uris = EXCLUDED.redirect_uris,
+				scopes = EXCLUDED.scopes,
+				auth_method = 'none',
+				require_pkce = true,
+				is_active = true`,
+			clientSpec.ClientID,
+			clientSpec.Name,
+			clientSpec.RedirectURIs,
+			scopes,
+		); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/modules/testkit/services/populate_service.go
+++ b/modules/testkit/services/populate_service.go
@@ -146,6 +146,7 @@ func (s *PopulateService) setupTenant(ctx context.Context, tenantSpec *schemas.T
 }
 
 func (s *PopulateService) populateData(ctx context.Context, data *schemas.DataSpec) error {
+	const op serrors.Op = "PopulateService.populateData"
 	// Create users first as they're referenced by other entities
 	if len(data.Users) > 0 {
 		if err := s.createUsers(ctx, data.Users); err != nil {
@@ -154,7 +155,7 @@ func (s *PopulateService) populateData(ctx context.Context, data *schemas.DataSp
 	}
 	if len(data.OIDCClients) > 0 {
 		if err := s.createOIDCClients(ctx, data.OIDCClients); err != nil {
-			return fmt.Errorf("failed to create OIDC clients: %w", err)
+			return serrors.E(op, err)
 		}
 	}
 
@@ -183,9 +184,10 @@ func (s *PopulateService) populateData(ctx context.Context, data *schemas.DataSp
 }
 
 func (s *PopulateService) createOIDCClients(ctx context.Context, clients []schemas.OIDCClientSpec) error {
+	const op serrors.Op = "PopulateService.createOIDCClients"
 	tx, err := composables.UseTx(ctx)
 	if err != nil {
-		return err
+		return serrors.E(op, err)
 	}
 	for _, clientSpec := range clients {
 		scopes := clientSpec.Scopes
@@ -197,10 +199,13 @@ func (s *PopulateService) createOIDCClients(ctx context.Context, clients []schem
 				client_id, name, application_type, redirect_uris, grant_types,
 				response_types, scopes, auth_method, require_pkce, is_active
 			) VALUES ($1, $2, 'web', $3, ARRAY['authorization_code'], ARRAY['code'], $4, 'none', true, true)
-			ON CONFLICT (client_id) DO UPDATE SET
-				name = EXCLUDED.name,
-				redirect_uris = EXCLUDED.redirect_uris,
-				scopes = EXCLUDED.scopes,
+				ON CONFLICT (client_id) DO UPDATE SET
+					name = EXCLUDED.name,
+					application_type = EXCLUDED.application_type,
+					redirect_uris = EXCLUDED.redirect_uris,
+					grant_types = EXCLUDED.grant_types,
+					response_types = EXCLUDED.response_types,
+					scopes = EXCLUDED.scopes,
 				auth_method = 'none',
 				require_pkce = true,
 				is_active = true`,
@@ -209,7 +214,7 @@ func (s *PopulateService) createOIDCClients(ctx context.Context, clients []schem
 			clientSpec.RedirectURIs,
 			scopes,
 		); err != nil {
-			return err
+			return serrors.E(op, err)
 		}
 	}
 	return nil

--- a/pkg/bootstrap/installers.go
+++ b/pkg/bootstrap/installers.go
@@ -90,6 +90,10 @@ func InstallCoreControllers() Installer {
 		if err != nil {
 			return fmt.Errorf("resolve AuthService for GraphQL controller: %w", err)
 		}
+		browserSessions, err := composition.Resolve[*coreservices.BrowserSessionService](container)
+		if err != nil {
+			return fmt.Errorf("resolve BrowserSessionService for GraphQL controller: %w", err)
+		}
 		httpCfg, err := composition.Resolve[*httpconfig.Config](container)
 		if err != nil {
 			return fmt.Errorf("resolve httpconfig.Config for GraphQL controller: %w", err)
@@ -108,7 +112,7 @@ func InstallCoreControllers() Installer {
 		}
 		container.AppendControllers(
 			controllers.NewStaticFilesController(container.HashFSAssets()),
-			controllers.NewGraphQLController(rt.App, userService, uploadService, authService, httpCfg, cookiesCfg, appCfg, uploadsCfg),
+			controllers.NewGraphQLController(rt.App, userService, uploadService, authService, browserSessions, httpCfg, cookiesCfg, appCfg, uploadsCfg),
 		)
 		return nil
 	})

--- a/pkg/bootstrap/installers.go
+++ b/pkg/bootstrap/installers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig"
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/httpconfig/cookies"
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/uploadsconfig"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -71,6 +72,8 @@ func InstallStaticFilesController() Installer {
 
 func InstallCoreControllers() Installer {
 	return InstallerFunc(func(_ context.Context, rt *Runtime) error {
+		const op serrors.Op = "bootstrap.InstallCoreControllers"
+
 		container := rt.Container()
 		if container == nil {
 			return fmt.Errorf("install components before core controllers")
@@ -92,7 +95,7 @@ func InstallCoreControllers() Installer {
 		}
 		browserSessions, err := composition.Resolve[*coreservices.BrowserSessionService](container)
 		if err != nil {
-			return fmt.Errorf("resolve BrowserSessionService for GraphQL controller: %w", err)
+			return serrors.E(op, err)
 		}
 		httpCfg, err := composition.Resolve[*httpconfig.Config](container)
 		if err != nil {

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -54,7 +54,7 @@ func getToken(w http.ResponseWriter, r *http.Request, container *composition.Con
 		return "", nil, err
 	}
 	browserSessionService, resolveErr := composition.Resolve[*services.BrowserSessionService](container)
-	if resolveErr != nil {
+	if resolveErr != nil || browserSessionService == nil {
 		return token.Value, nil, nil
 	}
 	browserSessions, err := browserSessionService.Resolve(w, r)

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -41,21 +41,30 @@ func resolveSIDKey(ctx context.Context) string {
 	return cfg.SID
 }
 
-func getToken(w http.ResponseWriter, r *http.Request, container *composition.Container, sidKey string) (string, []services.BrowserSession, error) {
+func getToken(r *http.Request, sidKey string) (string, bool, error) {
 	token, err := r.Cookie(sidKey)
 	if errors.Is(err, http.ErrNoCookie) {
 		v := r.Header.Get("Authorization")
 		if v == "" {
-			return "", nil, errors.New("no token found")
+			return "", false, errors.New("no token found")
 		}
-		return v, nil, nil
+		return v, false, nil
 	}
 	if err != nil {
-		return "", nil, err
+		return "", false, err
 	}
+	return token.Value, true, nil
+}
+
+func resolveBrowserToken(
+	w http.ResponseWriter,
+	r *http.Request,
+	container *composition.Container,
+	fallback string,
+) (string, []services.BrowserSession, error) {
 	browserSessionService, _ := composition.Resolve[*services.BrowserSessionService](container)
 	if browserSessionService == nil {
-		return token.Value, nil, nil
+		return fallback, nil, nil
 	}
 	browserSessions, err := browserSessionService.Resolve(w, r)
 	if err != nil {
@@ -74,16 +83,24 @@ func Authorize() mux.MiddlewareFunc {
 		return http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
 				ctx := r.Context()
+				token, fromCookie, err := getToken(r, resolveSIDKey(ctx))
+				if err != nil {
+					next.ServeHTTP(w, r)
+					return
+				}
 				container, err := composition.UseContainer(ctx)
 				if err != nil {
 					composables.UseLogger(ctx).WithError(err).Error("Authorize: composition container not found in context")
 					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 					return
 				}
-				token, browserSessions, err := getToken(w, r, container, resolveSIDKey(ctx))
-				if err != nil {
-					next.ServeHTTP(w, r)
-					return
+				var browserSessions []services.BrowserSession
+				if fromCookie {
+					token, browserSessions, err = resolveBrowserToken(w, r, container, token)
+					if err != nil {
+						next.ServeHTTP(w, r)
+						return
+					}
 				}
 				ctx = services.WithBrowserSessions(ctx, browserSessions)
 				authService, err := composition.Resolve[*services.AuthService](container)
@@ -129,16 +146,24 @@ func AuthorizeAnySession() mux.MiddlewareFunc {
 		return http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
 				ctx := r.Context()
+				token, fromCookie, err := getToken(r, resolveSIDKey(ctx))
+				if err != nil {
+					next.ServeHTTP(w, r)
+					return
+				}
 				container, err := composition.UseContainer(ctx)
 				if err != nil {
 					composables.UseLogger(ctx).WithError(err).Error("AuthorizeAnySession: composition container not found in context")
 					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 					return
 				}
-				token, browserSessions, err := getToken(w, r, container, resolveSIDKey(ctx))
-				if err != nil {
-					next.ServeHTTP(w, r)
-					return
+				var browserSessions []services.BrowserSession
+				if fromCookie {
+					token, browserSessions, err = resolveBrowserToken(w, r, container, token)
+					if err != nil {
+						next.ServeHTTP(w, r)
+						return
+					}
 				}
 				ctx = services.WithBrowserSessions(ctx, browserSessions)
 				authService, err := composition.Resolve[*services.AuthService](container)

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -53,8 +53,8 @@ func getToken(w http.ResponseWriter, r *http.Request, container *composition.Con
 	if err != nil {
 		return "", nil, err
 	}
-	browserSessionService, err := composition.Resolve[*services.BrowserSessionService](container)
-	if err != nil {
+	browserSessionService, resolveErr := composition.Resolve[*services.BrowserSessionService](container)
+	if resolveErr != nil {
 		return token.Value, nil, nil
 	}
 	browserSessions, err := browserSessionService.Resolve(w, r)

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -53,8 +53,8 @@ func getToken(w http.ResponseWriter, r *http.Request, container *composition.Con
 	if err != nil {
 		return "", nil, err
 	}
-	browserSessionService, resolveErr := composition.Resolve[*services.BrowserSessionService](container)
-	if resolveErr != nil || browserSessionService == nil {
+	browserSessionService, _ := composition.Resolve[*services.BrowserSessionService](container)
+	if browserSessionService == nil {
 		return token.Value, nil, nil
 	}
 	browserSessions, err := browserSessionService.Resolve(w, r)

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -41,19 +41,32 @@ func resolveSIDKey(ctx context.Context) string {
 	return cfg.SID
 }
 
-func getToken(r *http.Request, sidKey string) (string, error) {
+func getToken(w http.ResponseWriter, r *http.Request, container *composition.Container, sidKey string) (string, []services.BrowserSession, error) {
 	token, err := r.Cookie(sidKey)
 	if errors.Is(err, http.ErrNoCookie) {
 		v := r.Header.Get("Authorization")
 		if v == "" {
-			return "", errors.New("no token found")
+			return "", nil, errors.New("no token found")
 		}
-		return v, nil
+		return v, nil, nil
 	}
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
-	return token.Value, nil
+	browserSessionService, err := composition.Resolve[*services.BrowserSessionService](container)
+	if err != nil {
+		return token.Value, nil, nil
+	}
+	browserSessions, err := browserSessionService.Resolve(w, r)
+	if err != nil {
+		return "", nil, err
+	}
+	for _, browserSession := range browserSessions {
+		if browserSession.Active {
+			return browserSession.Session.Token(), browserSessions, nil
+		}
+	}
+	return "", browserSessions, errors.New("no active session found")
 }
 
 func Authorize() mux.MiddlewareFunc {
@@ -61,17 +74,18 @@ func Authorize() mux.MiddlewareFunc {
 		return http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
 				ctx := r.Context()
-				token, err := getToken(r, resolveSIDKey(ctx))
-				if err != nil {
-					next.ServeHTTP(w, r)
-					return
-				}
 				container, err := composition.UseContainer(ctx)
 				if err != nil {
 					composables.UseLogger(ctx).WithError(err).Error("Authorize: composition container not found in context")
 					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 					return
 				}
+				token, browserSessions, err := getToken(w, r, container, resolveSIDKey(ctx))
+				if err != nil {
+					next.ServeHTTP(w, r)
+					return
+				}
+				ctx = services.WithBrowserSessions(ctx, browserSessions)
 				authService, err := composition.Resolve[*services.AuthService](container)
 				if err != nil {
 					composables.UseLogger(ctx).WithError(err).Error("Authorize: failed to resolve AuthService")
@@ -115,17 +129,18 @@ func AuthorizeAnySession() mux.MiddlewareFunc {
 		return http.HandlerFunc(
 			func(w http.ResponseWriter, r *http.Request) {
 				ctx := r.Context()
-				token, err := getToken(r, resolveSIDKey(ctx))
-				if err != nil {
-					next.ServeHTTP(w, r)
-					return
-				}
 				container, err := composition.UseContainer(ctx)
 				if err != nil {
 					composables.UseLogger(ctx).WithError(err).Error("AuthorizeAnySession: composition container not found in context")
 					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 					return
 				}
+				token, browserSessions, err := getToken(w, r, container, resolveSIDKey(ctx))
+				if err != nil {
+					next.ServeHTTP(w, r)
+					return
+				}
+				ctx = services.WithBrowserSessions(ctx, browserSessions)
 				authService, err := composition.Resolve[*services.AuthService](container)
 				if err != nil {
 					composables.UseLogger(ctx).WithError(err).Error("AuthorizeAnySession: failed to resolve AuthService")
@@ -195,13 +210,10 @@ func ProvideUser() mux.MiddlewareFunc {
 
 				// Check if user is blocked
 				if u.IsBlocked() {
-					// Clear session cookie
-					http.SetCookie(w, &http.Cookie{
-						Name:   resolveSIDKey(ctx),
-						Value:  "",
-						Path:   "/",
-						MaxAge: -1,
-					})
+					browserSessionService, resolveErr := composition.Resolve[*services.BrowserSessionService](container)
+					if resolveErr == nil {
+						_, _ = browserSessionService.RemoveCurrent(w, r)
+					}
 					// Redirect to login with localized error
 					errorMsg := intl.MustT(ctx, "Login.Errors.AccountBlocked")
 					escapedError := url.QueryEscape(errorMsg)


### PR DESCRIPTION
## Summary
- add one versioned, HttpOnly browser-session cookie holding up to five server-validated opaque sessions with active/LRU handling and scalar-cookie migration
- share account selection across ordinary login, custom login renderers, authenticated navigation, password/OAuth/2FA completion, and OIDC authorization
- derive OIDC identity exclusively from the selected server-side session while preserving the stored authorization request, state, nonce, and PKCE inputs
- add scoped current/all-account logout behavior and server-side eviction of a sixth session
- add controller/integration and Playwright coverage for picker rendering, switching, expiry/replay rejection, logout, limits, and the OIDC Authorization Code + PKCE round trip

Closes #872

## Validation
- local test suites intentionally not run, per task instruction
- templates regenerated and source formatting/import organization applied
- GitHub Actions CI is the validation source

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1040"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790857952&installation_model_id=2042&pr_number=1040&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1040&signature=c853ceb6aa472528efa384e76f5aaf5078d324496ba708f5302ea57d63808070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added multi-account sign-in, supporting up to five accounts for quick switching.
  - Added account selection during login and OIDC authorization flows.
  - Added “Add account,” “Log out current account,” and “Log out all accounts” actions.
  - Preserved login destinations during account switching and authentication.
  - Added localized account-management and session-error messages.

- **Bug Fixes**
  - Improved handling of expired or already-used authorization requests.
  - Improved session cleanup and blocked-account handling.
  - Improved account switching and logout reliability across authentication flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->