### PR TITLE
fix(bichat): recover orphaned generation runs

### DIFF
--- a/modules/bichat/services/chat_service_impl.go
+++ b/modules/bichat/services/chat_service_impl.go
@@ -33,6 +33,8 @@ const streamPersistenceTimeout = 30 * time.Second
 const titleGenerationFallbackTimeout = 15 * time.Second
 const streamSnapshotThrottle = 2 * time.Second
 const remoteResumePollInterval = time.Second
+const runStateFinalizationAttempts = 3
+const runStateFinalizationRetryDelay = 25 * time.Millisecond
 
 // chatServiceImpl is the production implementation of ChatService.
 // It orchestrates chat sessions, messages, and agent execution.
@@ -320,6 +322,64 @@ func (s *chatServiceImpl) createRunState(ctx context.Context, run domain.Generat
 	return created, nil
 }
 
+func (s *chatServiceImpl) createRunStateRecoveringOrphan(
+	ctx context.Context,
+	run domain.GenerationRun,
+) (bool, error) {
+	created, err := s.createRunState(ctx, run)
+	if err == nil || !errors.Is(err, domain.ErrActiveRunExists) {
+		return created, err
+	}
+
+	persistedRun, persistedErr := s.runState.GetPersistedRunForSession(
+		ctx,
+		run.TenantID(),
+		run.SessionID(),
+	)
+	if persistedErr != nil {
+		return false, err
+	}
+	databaseRun, databaseErr := s.chatRepo.GetActiveRunBySession(ctx, run.SessionID())
+	if databaseErr != nil || databaseRun == nil {
+		return false, err
+	}
+
+	// PostgreSQL owns the durable run lifecycle. CreateRun has already inserted
+	// the new row in this transaction, so a different Redis run for the same
+	// session can only be residue from a finalization that completed in SQL but
+	// failed before clearing Redis. A genuinely concurrent run would have
+	// prevented the PostgreSQL insert through its unique active-run constraint.
+	if databaseRun.ID() != run.ID() || persistedRun.ID() == run.ID() {
+		return false, err
+	}
+
+	if clearErr := s.finalizeRunState(
+		ctx,
+		run.TenantID(),
+		run.SessionID(),
+		persistedRun.ID(),
+		string(domain.GenerationRunStatusFailed),
+		s.runState.FailRunState,
+	); clearErr != nil {
+		return false, serrors.E("chatServiceImpl.createRunStateRecoveringOrphan", clearErr)
+	}
+	s.publishTerminalStatus(
+		ctx,
+		run.TenantID(),
+		run.SessionID(),
+		persistedRun.ID(),
+		string(domain.GenerationRunStatusFailed),
+	)
+	s.log().WithFields(logrus.Fields{
+		"tenant_id":          run.TenantID().String(),
+		"session_id":         run.SessionID().String(),
+		"orphaned_run_id":    persistedRun.ID().String(),
+		"replacement_run_id": run.ID().String(),
+	}).Warn("bichat: recovered orphaned redis generation run")
+
+	return s.createRunState(ctx, run)
+}
+
 func (s *chatServiceImpl) getPersistedRun(ctx context.Context, sessionID uuid.UUID) (domain.GenerationRun, error) {
 	return s.runState.GetPersistedRun(ctx, sessionID)
 }
@@ -338,7 +398,14 @@ func (s *chatServiceImpl) completeRunState(ctx context.Context, tenantID, sessio
 	}); err != nil {
 		return err
 	}
-	err := s.runState.CompleteRunState(ctx, tenantID, sessionID, runID)
+	err := s.finalizeRunState(
+		ctx,
+		tenantID,
+		sessionID,
+		runID,
+		string(domain.GenerationRunStatusCompleted),
+		s.runState.CompleteRunState,
+	)
 	if err == nil {
 		s.publishTerminalStatus(ctx, tenantID, sessionID, runID, string(domain.GenerationRunStatusCompleted))
 	}
@@ -351,11 +418,54 @@ func (s *chatServiceImpl) cancelRunState(ctx context.Context, tenantID, sessionI
 	}); err != nil {
 		return err
 	}
-	err := s.runState.CancelRunState(ctx, tenantID, sessionID, runID)
+	err := s.finalizeRunState(
+		ctx,
+		tenantID,
+		sessionID,
+		runID,
+		string(domain.GenerationRunStatusCancelled),
+		s.runState.CancelRunState,
+	)
 	if err == nil {
 		s.publishTerminalStatus(ctx, tenantID, sessionID, runID, string(domain.GenerationRunStatusCancelled))
 	}
 	return err
+}
+
+func (s *chatServiceImpl) finalizeRunState(
+	ctx context.Context,
+	tenantID, sessionID, runID uuid.UUID,
+	terminalStatus string,
+	finalize func(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) error,
+) error {
+	var finalErr error
+	for attempt := 1; attempt <= runStateFinalizationAttempts; attempt++ {
+		finalErr = finalize(ctx, tenantID, sessionID, runID)
+		if finalErr == nil {
+			return nil
+		}
+		if attempt == runStateFinalizationAttempts || ctx.Err() != nil {
+			break
+		}
+
+		timer := time.NewTimer(time.Duration(attempt) * runStateFinalizationRetryDelay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			finalErr = errors.Join(finalErr, ctx.Err())
+			attempt = runStateFinalizationAttempts
+		case <-timer.C:
+		}
+	}
+
+	s.log().WithError(finalErr).WithFields(logrus.Fields{
+		"tenant_id":       tenantID.String(),
+		"session_id":      sessionID.String(),
+		"run_id":          runID.String(),
+		"terminal_status": terminalStatus,
+		"attempts":        runStateFinalizationAttempts,
+	}).Error("bichat: failed to finalize generation run state")
+	return finalErr
 }
 
 // publishTerminalStatus is the single choke point for emitting the last
@@ -486,7 +596,7 @@ func (s *chatServiceImpl) startAsyncRun(
 				return serrors.E(op, err)
 			}
 		}
-		_, err = s.createRunState(txCtx, run)
+		_, err = s.createRunStateRecoveringOrphan(txCtx, run)
 		if err != nil {
 			return serrors.E(op, err)
 		}
@@ -1058,7 +1168,7 @@ func (s *chatServiceImpl) SendMessageStream(ctx context.Context, req bichatservi
 		if err != nil {
 			return serrors.E(op, serrors.KindValidation, err)
 		}
-		runStateCreated, err = s.createRunState(txCtx, run)
+		runStateCreated, err = s.createRunStateRecoveringOrphan(txCtx, run)
 		if err != nil {
 			return err
 		}

--- a/modules/bichat/services/chat_service_impl.go
+++ b/modules/bichat/services/chat_service_impl.go
@@ -1611,7 +1611,7 @@ func (s *chatServiceImpl) runStreamLoop(
 			WithField("generation_ms", generationMs).
 			Error("bichat: failed to persist assistant message; answer discarded")
 		active.Broadcast(streamingsvc.TerminalChunk(err, 0))
-		runStateCtx, runStateCancel := context.WithTimeout(context.Background(), streamPersistenceTimeout)
+		runStateCtx, runStateCancel := context.WithTimeout(context.WithoutCancel(persistCtx), streamPersistenceTimeout)
 		defer runStateCancel()
 		_ = s.cancelRunState(runStateCtx, session.TenantID(), req.SessionID, runID)
 		return
@@ -1633,7 +1633,7 @@ func (s *chatServiceImpl) runStreamLoop(
 		}
 	}
 
-	runStateCtx, runStateCancel := context.WithTimeout(context.Background(), streamPersistenceTimeout)
+	runStateCtx, runStateCancel := context.WithTimeout(context.WithoutCancel(persistCtx), streamPersistenceTimeout)
 	defer runStateCancel()
 	_ = s.completeRunState(runStateCtx, session.TenantID(), req.SessionID, runID)
 	if emitDoneChunk {

--- a/modules/bichat/services/chat_service_impl.go
+++ b/modules/bichat/services/chat_service_impl.go
@@ -438,6 +438,8 @@ func (s *chatServiceImpl) finalizeRunState(
 	terminalStatus string,
 	finalize func(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) error,
 ) error {
+	const op serrors.Op = "chatServiceImpl.finalizeRunState"
+
 	var finalErr error
 	for attempt := 1; attempt <= runStateFinalizationAttempts; attempt++ {
 		finalErr = finalize(ctx, tenantID, sessionID, runID)
@@ -465,7 +467,7 @@ func (s *chatServiceImpl) finalizeRunState(
 		"terminal_status": terminalStatus,
 		"attempts":        runStateFinalizationAttempts,
 	}).Error("bichat: failed to finalize generation run state")
-	return finalErr
+	return serrors.E(op, finalErr)
 }
 
 // publishTerminalStatus is the single choke point for emitting the last
@@ -1167,6 +1169,11 @@ func (s *chatServiceImpl) SendMessageStream(ctx context.Context, req bichatservi
 		})
 		if err != nil {
 			return serrors.E(op, serrors.KindValidation, err)
+		}
+		if s.runState.Enabled() {
+			if err := s.chatRepo.CreateRun(txCtx, run); err != nil {
+				return serrors.E(op, err)
+			}
 		}
 		runStateCreated, err = s.createRunStateRecoveringOrphan(txCtx, run)
 		if err != nil {

--- a/modules/bichat/services/chat_service_impl.go
+++ b/modules/bichat/services/chat_service_impl.go
@@ -459,6 +459,9 @@ func (s *chatServiceImpl) finalizeRunState(
 		case <-timer.C:
 		}
 	}
+	if ctxErr := ctx.Err(); ctxErr != nil && !errors.Is(finalErr, ctxErr) {
+		finalErr = errors.Join(finalErr, ctxErr)
+	}
 
 	s.log().WithError(finalErr).WithFields(logrus.Fields{
 		"tenant_id":       tenantID.String(),

--- a/modules/bichat/services/chat_service_impl_test.go
+++ b/modules/bichat/services/chat_service_impl_test.go
@@ -869,199 +869,226 @@ func TestChatService_ResumeWithAnswerAsync_PersistsSubmittedStateBeforeWorkerCom
 	close(release)
 }
 
-func TestChatService_CompleteRunState_RetriesRedisFinalization(t *testing.T) {
+func TestChatService_CompleteRunState_RedisFinalization(t *testing.T) {
 	t.Parallel()
 
-	mr := miniredis.RunT(t)
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
-	t.Cleanup(func() { require.NoError(t, client.Close()) })
-	baseStore, err := newRedisGenerationRunStore(redisGenerationRunStoreConfig{Client: client})
-	require.NoError(t, err)
-	store := &failingCompleteRunStore{generationRunStore: baseStore, failures: 1}
-
-	tenantID := uuid.New()
-	sessionID := uuid.New()
-	run, err := domain.NewGenerationRun(domain.GenerationRunSpec{
-		SessionID: sessionID,
-		TenantID:  tenantID,
-		UserID:    1,
-	})
-	require.NoError(t, err)
-
-	chatRepo := newMockChatRepository()
-	require.NoError(t, chatRepo.CreateRun(t.Context(), run))
-	require.NoError(t, baseStore.CreateRun(t.Context(), run))
-
-	svc, err := NewChatService(chatRepo, nil, nil, nil, nil)
-	require.NoError(t, err)
-	svc.runState = streamingsvc.NewRunStateManager(store)
-
-	// Falsely green if the store never fails between SQL completion and Redis cleanup.
-	require.NoError(t, svc.completeRunState(t.Context(), tenantID, sessionID, run.ID()))
-	assert.Equal(t, 2, store.completeCalls)
-
-	databaseRun, err := chatRepo.GetRunByID(t.Context(), run.ID())
-	require.NoError(t, err)
-	assert.Equal(t, domain.GenerationRunStatusCompleted, databaseRun.Status())
-	_, err = baseStore.GetActiveRunBySession(t.Context(), tenantID, sessionID)
-	require.ErrorIs(t, err, domain.ErrNoActiveRun)
-}
-
-func TestChatService_CompleteRunState_LogsTerminalRedisFailure(t *testing.T) {
-	t.Parallel()
-
-	mr := miniredis.RunT(t)
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
-	t.Cleanup(func() { require.NoError(t, client.Close()) })
-	baseStore, err := newRedisGenerationRunStore(redisGenerationRunStoreConfig{Client: client})
-	require.NoError(t, err)
-	store := &failingCompleteRunStore{
-		generationRunStore: baseStore,
-		failures:           runStateFinalizationAttempts,
+	tests := []struct {
+		name                string
+		failures            int
+		cancelContext       bool
+		wantErr             bool
+		wantContextCanceled bool
+		wantCompleteCalls   int
+		wantRedisCleared    bool
+		wantFailureLog      bool
+	}{
+		{
+			name:              "retries a transient failure",
+			failures:          1,
+			wantCompleteCalls: 2,
+			wantRedisCleared:  true,
+		},
+		{
+			name:              "logs exhausted retries",
+			failures:          runStateFinalizationAttempts,
+			wantErr:           true,
+			wantCompleteCalls: runStateFinalizationAttempts,
+			wantFailureLog:    true,
+		},
+		{
+			name:                "preserves context cancellation",
+			failures:            1,
+			cancelContext:       true,
+			wantErr:             true,
+			wantContextCanceled: true,
+			wantCompleteCalls:   1,
+			wantFailureLog:      true,
+		},
 	}
 
-	tenantID := uuid.New()
-	sessionID := uuid.New()
-	run, err := domain.NewGenerationRun(domain.GenerationRunSpec{
-		SessionID: sessionID,
-		TenantID:  tenantID,
-		UserID:    1,
-	})
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	chatRepo := newMockChatRepository()
-	require.NoError(t, chatRepo.CreateRun(t.Context(), run))
-	require.NoError(t, baseStore.CreateRun(t.Context(), run))
+			mr := miniredis.RunT(t)
+			client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+			t.Cleanup(func() { require.NoError(t, client.Close()) })
+			baseStore, err := newRedisGenerationRunStore(redisGenerationRunStoreConfig{Client: client})
+			require.NoError(t, err)
+			store := &failingCompleteRunStore{generationRunStore: baseStore, failures: tt.failures}
 
-	var logs bytes.Buffer
-	logger := logrus.New()
-	logger.SetOutput(&logs)
-	logger.SetFormatter(&logrus.JSONFormatter{})
-	svc, err := NewChatService(chatRepo, nil, nil, nil, nil)
-	require.NoError(t, err)
-	svc.WithLogger(logger)
-	svc.runState = streamingsvc.NewRunStateManager(store)
+			tenantID := uuid.New()
+			sessionID := uuid.New()
+			run, err := domain.NewGenerationRun(domain.GenerationRunSpec{
+				SessionID: sessionID,
+				TenantID:  tenantID,
+				UserID:    1,
+			})
+			require.NoError(t, err)
 
-	// Falsely green if terminal Redis errors are swallowed without identifiers.
-	require.Error(t, svc.completeRunState(t.Context(), tenantID, sessionID, run.ID()))
-	assert.Equal(t, runStateFinalizationAttempts, store.completeCalls)
-	assert.Contains(t, logs.String(), "failed to finalize generation run state")
-	assert.Contains(t, logs.String(), tenantID.String())
-	assert.Contains(t, logs.String(), sessionID.String())
-	assert.Contains(t, logs.String(), run.ID().String())
-}
+			chatRepo := newMockChatRepository()
+			require.NoError(t, chatRepo.CreateRun(t.Context(), run))
+			require.NoError(t, baseStore.CreateRun(t.Context(), run))
 
-func TestChatService_ResumeWithAnswerAsync_RecoversOrphanedRedisRun(t *testing.T) {
-	t.Parallel()
+			var logs bytes.Buffer
+			logger := logrus.New()
+			logger.SetOutput(&logs)
+			logger.SetFormatter(&logrus.JSONFormatter{})
+			svc, err := NewChatService(chatRepo, nil, nil, nil, nil)
+			require.NoError(t, err)
+			svc.WithLogger(logger)
+			svc.runState = streamingsvc.NewRunStateManager(store)
 
-	mr := miniredis.RunT(t)
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
-	t.Cleanup(func() { require.NoError(t, client.Close()) })
-	store, err := newRedisGenerationRunStore(redisGenerationRunStoreConfig{Client: client})
-	require.NoError(t, err)
+			ctx := t.Context()
+			if tt.cancelContext {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
 
-	tenantID := uuid.New()
-	session := mustSession(t,
-		withSessionTenantID(tenantID),
-		withSessionUserID(1),
-		withSessionTitle("resume after orphaned redis run"),
-	)
-	orphanedRun, err := domain.NewGenerationRun(domain.GenerationRunSpec{
-		SessionID: session.ID(),
-		TenantID:  tenantID,
-		UserID:    session.UserID(),
-	})
-	require.NoError(t, err)
-	require.NoError(t, store.CreateRun(t.Context(), orphanedRun))
+			// Falsely green if Redis never fails after SQL completion or cancellation is discarded.
+			err = svc.completeRunState(ctx, tenantID, sessionID, run.ID())
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			if tt.wantContextCanceled {
+				require.ErrorIs(t, err, context.Canceled)
+			}
+			assert.Equal(t, tt.wantCompleteCalls, store.completeCalls)
 
-	chatRepo := newMockChatRepository()
-	require.NoError(t, chatRepo.CreateSession(t.Context(), session))
-	require.NoError(t, chatRepo.SaveMessage(t.Context(), types.NewMessage(
-		types.WithSessionID(session.ID()),
-		types.WithRole(types.RoleAssistant),
-		types.WithContent("Need scope"),
-		types.WithQuestionData(mustQuestionData(t, "cp-orphaned-redis-run")),
-	)))
+			databaseRun, err := chatRepo.GetRunByID(t.Context(), run.ID())
+			require.NoError(t, err)
+			assert.Equal(t, domain.GenerationRunStatusCompleted, databaseRun.Status())
+			activeRun, err := baseStore.GetActiveRunBySession(t.Context(), tenantID, sessionID)
+			if tt.wantRedisCleared {
+				require.ErrorIs(t, err, domain.ErrNoActiveRun)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, run.ID(), activeRun.ID())
+			}
 
-	agentSvc := &stubAgentService{resumeEvents: []agents.ExecutorEvent{{Type: agents.EventTypeDone}}}
-	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
-	require.NoError(t, err)
-	svc.runState = streamingsvc.NewRunStateManager(store)
-
-	// Falsely green if resume bypasses the real Redis SETNX conflict.
-	accepted, err := svc.ResumeWithAnswerAsync(t.Context(), bichatservices.ResumeRequest{
-		SessionID:    session.ID(),
-		CheckpointID: "cp-orphaned-redis-run",
-		Answers:      map[string]string{"scope": "all"},
-	})
-	require.NoError(t, err)
-	assert.NotEqual(t, orphanedRun.ID(), accepted.RunID)
-
-	recovered, err := store.GetRunByID(t.Context(), tenantID, orphanedRun.ID())
-	require.NoError(t, err)
-	assert.Equal(t, domain.GenerationRunStatusFailed, recovered.Status())
-}
-
-func TestChatService_SendMessageStream_RecoversOrphanedRedisRun(t *testing.T) {
-	t.Parallel()
-
-	mr := miniredis.RunT(t)
-	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
-	t.Cleanup(func() { require.NoError(t, client.Close()) })
-	store, err := newRedisGenerationRunStore(redisGenerationRunStoreConfig{Client: client})
-	require.NoError(t, err)
-
-	tenantID := uuid.New()
-	session := mustSession(t,
-		withSessionTenantID(tenantID),
-		withSessionUserID(1),
-		withSessionTitle("send after orphaned redis run"),
-	)
-	orphanedRun, err := domain.NewGenerationRun(domain.GenerationRunSpec{
-		SessionID: session.ID(),
-		TenantID:  tenantID,
-		UserID:    session.UserID(),
-	})
-	require.NoError(t, err)
-	require.NoError(t, store.CreateRun(t.Context(), orphanedRun))
-
-	chatRepo := &tenantCheckingRunRepository{
-		mockChatRepository: newMockChatRepository(),
-		tenantID:           tenantID,
+			if tt.wantFailureLog {
+				assert.Contains(t, logs.String(), "failed to finalize generation run state")
+				assert.Contains(t, logs.String(), tenantID.String())
+				assert.Contains(t, logs.String(), sessionID.String())
+				assert.Contains(t, logs.String(), run.ID().String())
+			} else {
+				assert.Empty(t, logs.String())
+			}
+		})
 	}
-	require.NoError(t, chatRepo.CreateSession(t.Context(), session))
-	agentSvc := &stubAgentService{processEvents: []agents.ExecutorEvent{
-		{Type: agents.EventTypeContent, Content: "recovered response"},
-		{Type: agents.EventTypeDone},
-	}}
-	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
-	require.NoError(t, err)
-	svc.runState = streamingsvc.NewRunStateManager(store)
+}
 
-	var replacementRunID uuid.UUID
-	// Falsely green if SendMessageStream bypasses PostgreSQL run creation or
-	// the real Redis SETNX conflict that guards one active run per session.
-	ctx := composables.WithTenantID(t.Context(), tenantID)
-	err = svc.SendMessageStream(ctx, bichatservices.SendMessageRequest{
-		SessionID: session.ID(),
-		Content:   "continue",
-	}, func(chunk bichatservices.StreamChunk) {
-		if chunk.Type == bichatservices.ChunkTypeStreamStarted {
-			replacementRunID = uuid.MustParse(chunk.RunID)
-		}
-	})
-	require.NoError(t, err)
-	require.NotEqual(t, uuid.Nil, replacementRunID)
-	assert.NotEqual(t, orphanedRun.ID(), replacementRunID)
+func TestChatService_CreateRunState_RecoversOrphanedRedisRun(t *testing.T) {
+	t.Parallel()
 
-	recovered, err := store.GetRunByID(t.Context(), tenantID, orphanedRun.ID())
-	require.NoError(t, err)
-	assert.Equal(t, domain.GenerationRunStatusFailed, recovered.Status())
-	replacement, err := chatRepo.GetRunByID(t.Context(), replacementRunID)
-	require.NoError(t, err)
-	assert.Equal(t, domain.GenerationRunStatusCompleted, replacement.Status())
-	_, err = store.GetActiveRunBySession(t.Context(), tenantID, session.ID())
-	require.ErrorIs(t, err, domain.ErrNoActiveRun)
+	type recoveryOperation string
+	const (
+		resumeWithAnswer recoveryOperation = "resume_with_answer"
+		sendMessage      recoveryOperation = "send_message"
+	)
+
+	tests := []struct {
+		name      string
+		operation recoveryOperation
+	}{
+		{name: "resume with answer", operation: resumeWithAnswer},
+		{name: "send message stream", operation: sendMessage},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mr := miniredis.RunT(t)
+			client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+			t.Cleanup(func() { require.NoError(t, client.Close()) })
+			store, err := newRedisGenerationRunStore(redisGenerationRunStoreConfig{Client: client})
+			require.NoError(t, err)
+
+			tenantID := uuid.New()
+			session := mustSession(t,
+				withSessionTenantID(tenantID),
+				withSessionUserID(1),
+				withSessionTitle(tt.name+" after orphaned redis run"),
+			)
+			orphanedRun, err := domain.NewGenerationRun(domain.GenerationRunSpec{
+				SessionID: session.ID(),
+				TenantID:  tenantID,
+				UserID:    session.UserID(),
+			})
+			require.NoError(t, err)
+			require.NoError(t, store.CreateRun(t.Context(), orphanedRun))
+
+			baseRepo := newMockChatRepository()
+			require.NoError(t, baseRepo.CreateSession(t.Context(), session))
+			var chatRepo domain.ChatRepository = baseRepo
+			agentSvc := &stubAgentService{}
+			switch tt.operation {
+			case resumeWithAnswer:
+				require.NoError(t, baseRepo.SaveMessage(t.Context(), types.NewMessage(
+					types.WithSessionID(session.ID()),
+					types.WithRole(types.RoleAssistant),
+					types.WithContent("Need scope"),
+					types.WithQuestionData(mustQuestionData(t, "cp-orphaned-redis-run")),
+				)))
+				agentSvc.resumeEvents = []agents.ExecutorEvent{{Type: agents.EventTypeDone}}
+			case sendMessage:
+				chatRepo = &tenantCheckingRunRepository{
+					mockChatRepository: baseRepo,
+					tenantID:           tenantID,
+				}
+				agentSvc.processEvents = []agents.ExecutorEvent{
+					{Type: agents.EventTypeContent, Content: "recovered response"},
+					{Type: agents.EventTypeDone},
+				}
+			default:
+				require.FailNow(t, "unknown recovery operation", tt.operation)
+			}
+
+			svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+			require.NoError(t, err)
+			svc.runState = streamingsvc.NewRunStateManager(store)
+
+			var replacementRunID uuid.UUID
+			// Falsely green if the operation bypasses PostgreSQL run creation or the real Redis SETNX conflict.
+			switch tt.operation {
+			case resumeWithAnswer:
+				accepted, err := svc.ResumeWithAnswerAsync(t.Context(), bichatservices.ResumeRequest{
+					SessionID:    session.ID(),
+					CheckpointID: "cp-orphaned-redis-run",
+					Answers:      map[string]string{"scope": "all"},
+				})
+				require.NoError(t, err)
+				replacementRunID = accepted.RunID
+			case sendMessage:
+				ctx := composables.WithTenantID(t.Context(), tenantID)
+				err = svc.SendMessageStream(ctx, bichatservices.SendMessageRequest{
+					SessionID: session.ID(),
+					Content:   "continue",
+				}, func(chunk bichatservices.StreamChunk) {
+					if chunk.Type == bichatservices.ChunkTypeStreamStarted {
+						replacementRunID = uuid.MustParse(chunk.RunID)
+					}
+				})
+				require.NoError(t, err)
+			}
+
+			require.NotEqual(t, uuid.Nil, replacementRunID)
+			assert.NotEqual(t, orphanedRun.ID(), replacementRunID)
+			recovered, err := store.GetRunByID(t.Context(), tenantID, orphanedRun.ID())
+			require.NoError(t, err)
+			assert.Equal(t, domain.GenerationRunStatusFailed, recovered.Status())
+			require.Eventually(t, func() bool {
+				replacement, err := baseRepo.GetRunByID(t.Context(), replacementRunID)
+				return err == nil && replacement.Status() == domain.GenerationRunStatusCompleted
+			}, 2*time.Second, 10*time.Millisecond)
+			_, err = store.GetActiveRunBySession(t.Context(), tenantID, session.ID())
+			require.ErrorIs(t, err, domain.ErrNoActiveRun)
+		})
+	}
 }
 
 type tenantCheckingRunRepository struct {

--- a/modules/bichat/services/chat_service_impl_test.go
+++ b/modules/bichat/services/chat_service_impl_test.go
@@ -1,13 +1,16 @@
 package services
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/google/uuid"
 	"github.com/iota-uz/iota-sdk/modules"
+	streamingsvc "github.com/iota-uz/iota-sdk/modules/bichat/services/streaming"
 	"github.com/iota-uz/iota-sdk/pkg/bichat/agents"
 	"github.com/iota-uz/iota-sdk/pkg/bichat/domain"
 	bichatservices "github.com/iota-uz/iota-sdk/pkg/bichat/services"
@@ -15,9 +18,28 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/composables"
 	"github.com/iota-uz/iota-sdk/pkg/constants"
 	"github.com/iota-uz/iota-sdk/pkg/itf"
+	"github.com/redis/go-redis/v9"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type failingCompleteRunStore struct {
+	generationRunStore
+	completeCalls int
+	failures      int
+}
+
+func (s *failingCompleteRunStore) CompleteRun(
+	ctx context.Context,
+	tenantID, sessionID, runID uuid.UUID,
+) error {
+	s.completeCalls++
+	if s.completeCalls <= s.failures {
+		return errors.New("temporary redis finalization failure")
+	}
+	return s.generationRunStore.CompleteRun(ctx, tenantID, sessionID, runID)
+}
 
 func mustQuestionData(t *testing.T, checkpointID string) *types.QuestionData {
 	t.Helper()
@@ -845,6 +867,139 @@ func TestChatService_ResumeWithAnswerAsync_PersistsSubmittedStateBeforeWorkerCom
 	require.ErrorIs(t, err, domain.ErrNoPendingQuestion)
 
 	close(release)
+}
+
+func TestChatService_CompleteRunState_RetriesRedisFinalization(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+	baseStore, err := newRedisGenerationRunStore(redisGenerationRunStoreConfig{Client: client})
+	require.NoError(t, err)
+	store := &failingCompleteRunStore{generationRunStore: baseStore, failures: 1}
+
+	tenantID := uuid.New()
+	sessionID := uuid.New()
+	run, err := domain.NewGenerationRun(domain.GenerationRunSpec{
+		SessionID: sessionID,
+		TenantID:  tenantID,
+		UserID:    1,
+	})
+	require.NoError(t, err)
+
+	chatRepo := newMockChatRepository()
+	require.NoError(t, chatRepo.CreateRun(t.Context(), run))
+	require.NoError(t, baseStore.CreateRun(t.Context(), run))
+
+	svc, err := NewChatService(chatRepo, nil, nil, nil, nil)
+	require.NoError(t, err)
+	svc.runState = streamingsvc.NewRunStateManager(store)
+
+	// Falsely green if the store never fails between SQL completion and Redis cleanup.
+	require.NoError(t, svc.completeRunState(t.Context(), tenantID, sessionID, run.ID()))
+	assert.Equal(t, 2, store.completeCalls)
+
+	databaseRun, err := chatRepo.GetRunByID(t.Context(), run.ID())
+	require.NoError(t, err)
+	assert.Equal(t, domain.GenerationRunStatusCompleted, databaseRun.Status())
+	_, err = baseStore.GetActiveRunBySession(t.Context(), tenantID, sessionID)
+	require.ErrorIs(t, err, domain.ErrNoActiveRun)
+}
+
+func TestChatService_CompleteRunState_LogsTerminalRedisFailure(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+	baseStore, err := newRedisGenerationRunStore(redisGenerationRunStoreConfig{Client: client})
+	require.NoError(t, err)
+	store := &failingCompleteRunStore{
+		generationRunStore: baseStore,
+		failures:           runStateFinalizationAttempts,
+	}
+
+	tenantID := uuid.New()
+	sessionID := uuid.New()
+	run, err := domain.NewGenerationRun(domain.GenerationRunSpec{
+		SessionID: sessionID,
+		TenantID:  tenantID,
+		UserID:    1,
+	})
+	require.NoError(t, err)
+
+	chatRepo := newMockChatRepository()
+	require.NoError(t, chatRepo.CreateRun(t.Context(), run))
+	require.NoError(t, baseStore.CreateRun(t.Context(), run))
+
+	var logs bytes.Buffer
+	logger := logrus.New()
+	logger.SetOutput(&logs)
+	logger.SetFormatter(&logrus.JSONFormatter{})
+	svc, err := NewChatService(chatRepo, nil, nil, nil, nil)
+	require.NoError(t, err)
+	svc.WithLogger(logger)
+	svc.runState = streamingsvc.NewRunStateManager(store)
+
+	// Falsely green if terminal Redis errors are swallowed without identifiers.
+	require.Error(t, svc.completeRunState(t.Context(), tenantID, sessionID, run.ID()))
+	assert.Equal(t, runStateFinalizationAttempts, store.completeCalls)
+	assert.Contains(t, logs.String(), "failed to finalize generation run state")
+	assert.Contains(t, logs.String(), tenantID.String())
+	assert.Contains(t, logs.String(), sessionID.String())
+	assert.Contains(t, logs.String(), run.ID().String())
+}
+
+func TestChatService_ResumeWithAnswerAsync_RecoversOrphanedRedisRun(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+	store, err := newRedisGenerationRunStore(redisGenerationRunStoreConfig{Client: client})
+	require.NoError(t, err)
+
+	tenantID := uuid.New()
+	session := mustSession(t,
+		withSessionTenantID(tenantID),
+		withSessionUserID(1),
+		withSessionTitle("resume after orphaned redis run"),
+	)
+	orphanedRun, err := domain.NewGenerationRun(domain.GenerationRunSpec{
+		SessionID: session.ID(),
+		TenantID:  tenantID,
+		UserID:    session.UserID(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.CreateRun(t.Context(), orphanedRun))
+
+	chatRepo := newMockChatRepository()
+	require.NoError(t, chatRepo.CreateSession(t.Context(), session))
+	require.NoError(t, chatRepo.SaveMessage(t.Context(), types.NewMessage(
+		types.WithSessionID(session.ID()),
+		types.WithRole(types.RoleAssistant),
+		types.WithContent("Need scope"),
+		types.WithQuestionData(mustQuestionData(t, "cp-orphaned-redis-run")),
+	)))
+
+	agentSvc := &stubAgentService{resumeEvents: []agents.ExecutorEvent{{Type: agents.EventTypeDone}}}
+	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	require.NoError(t, err)
+	svc.runState = streamingsvc.NewRunStateManager(store)
+
+	// Falsely green if resume bypasses the real Redis SETNX conflict.
+	accepted, err := svc.ResumeWithAnswerAsync(t.Context(), bichatservices.ResumeRequest{
+		SessionID:    session.ID(),
+		CheckpointID: "cp-orphaned-redis-run",
+		Answers:      map[string]string{"scope": "all"},
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, orphanedRun.ID(), accepted.RunID)
+
+	recovered, err := store.GetRunByID(t.Context(), tenantID, orphanedRun.ID())
+	require.NoError(t, err)
+	assert.Equal(t, domain.GenerationRunStatusFailed, recovered.Status())
 }
 
 func TestChatService_RejectPendingQuestionAsync_PersistsSubmittedStateBeforeWorkerCompletes(t *testing.T) {

--- a/modules/bichat/services/chat_service_impl_test.go
+++ b/modules/bichat/services/chat_service_impl_test.go
@@ -1002,6 +1002,64 @@ func TestChatService_ResumeWithAnswerAsync_RecoversOrphanedRedisRun(t *testing.T
 	assert.Equal(t, domain.GenerationRunStatusFailed, recovered.Status())
 }
 
+func TestChatService_SendMessageStream_RecoversOrphanedRedisRun(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+	store, err := newRedisGenerationRunStore(redisGenerationRunStoreConfig{Client: client})
+	require.NoError(t, err)
+
+	tenantID := uuid.New()
+	session := mustSession(t,
+		withSessionTenantID(tenantID),
+		withSessionUserID(1),
+		withSessionTitle("send after orphaned redis run"),
+	)
+	orphanedRun, err := domain.NewGenerationRun(domain.GenerationRunSpec{
+		SessionID: session.ID(),
+		TenantID:  tenantID,
+		UserID:    session.UserID(),
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.CreateRun(t.Context(), orphanedRun))
+
+	chatRepo := newMockChatRepository()
+	require.NoError(t, chatRepo.CreateSession(t.Context(), session))
+	agentSvc := &stubAgentService{processEvents: []agents.ExecutorEvent{
+		{Type: agents.EventTypeContent, Content: "recovered response"},
+		{Type: agents.EventTypeDone},
+	}}
+	svc, err := NewChatService(chatRepo, agentSvc, nil, nil, nil)
+	require.NoError(t, err)
+	svc.runState = streamingsvc.NewRunStateManager(store)
+
+	var replacementRunID uuid.UUID
+	// Falsely green if SendMessageStream bypasses PostgreSQL run creation or
+	// the real Redis SETNX conflict that guards one active run per session.
+	err = svc.SendMessageStream(t.Context(), bichatservices.SendMessageRequest{
+		SessionID: session.ID(),
+		Content:   "continue",
+	}, func(chunk bichatservices.StreamChunk) {
+		if chunk.Type == bichatservices.ChunkTypeStreamStarted {
+			replacementRunID = uuid.MustParse(chunk.RunID)
+		}
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, uuid.Nil, replacementRunID)
+	assert.NotEqual(t, orphanedRun.ID(), replacementRunID)
+
+	recovered, err := store.GetRunByID(t.Context(), tenantID, orphanedRun.ID())
+	require.NoError(t, err)
+	assert.Equal(t, domain.GenerationRunStatusFailed, recovered.Status())
+	replacement, err := chatRepo.GetRunByID(t.Context(), replacementRunID)
+	require.NoError(t, err)
+	assert.Equal(t, domain.GenerationRunStatusCompleted, replacement.Status())
+	_, err = store.GetActiveRunBySession(t.Context(), tenantID, session.ID())
+	require.ErrorIs(t, err, domain.ErrNoActiveRun)
+}
+
 func TestChatService_RejectPendingQuestionAsync_PersistsSubmittedStateBeforeWorkerCompletes(t *testing.T) {
 	t.Parallel()
 

--- a/modules/bichat/services/chat_service_impl_test.go
+++ b/modules/bichat/services/chat_service_impl_test.go
@@ -1025,7 +1025,10 @@ func TestChatService_SendMessageStream_RecoversOrphanedRedisRun(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, store.CreateRun(t.Context(), orphanedRun))
 
-	chatRepo := newMockChatRepository()
+	chatRepo := &tenantCheckingRunRepository{
+		mockChatRepository: newMockChatRepository(),
+		tenantID:           tenantID,
+	}
 	require.NoError(t, chatRepo.CreateSession(t.Context(), session))
 	agentSvc := &stubAgentService{processEvents: []agents.ExecutorEvent{
 		{Type: agents.EventTypeContent, Content: "recovered response"},
@@ -1038,7 +1041,8 @@ func TestChatService_SendMessageStream_RecoversOrphanedRedisRun(t *testing.T) {
 	var replacementRunID uuid.UUID
 	// Falsely green if SendMessageStream bypasses PostgreSQL run creation or
 	// the real Redis SETNX conflict that guards one active run per session.
-	err = svc.SendMessageStream(t.Context(), bichatservices.SendMessageRequest{
+	ctx := composables.WithTenantID(t.Context(), tenantID)
+	err = svc.SendMessageStream(ctx, bichatservices.SendMessageRequest{
 		SessionID: session.ID(),
 		Content:   "continue",
 	}, func(chunk bichatservices.StreamChunk) {
@@ -1058,6 +1062,22 @@ func TestChatService_SendMessageStream_RecoversOrphanedRedisRun(t *testing.T) {
 	assert.Equal(t, domain.GenerationRunStatusCompleted, replacement.Status())
 	_, err = store.GetActiveRunBySession(t.Context(), tenantID, session.ID())
 	require.ErrorIs(t, err, domain.ErrNoActiveRun)
+}
+
+type tenantCheckingRunRepository struct {
+	*mockChatRepository
+	tenantID uuid.UUID
+}
+
+func (r *tenantCheckingRunRepository) CompleteRun(ctx context.Context, runID uuid.UUID) error {
+	tenantID, err := composables.UseTenantID(ctx)
+	if err != nil {
+		return err
+	}
+	if tenantID != r.tenantID {
+		return errors.New("run finalization used the wrong tenant context")
+	}
+	return r.mockChatRepository.CompleteRun(ctx, runID)
 }
 
 func TestChatService_RejectPendingQuestionAsync_PersistsSubmittedStateBeforeWorkerCompletes(t *testing.T) {

--- a/modules/bichat/services/streaming/run_state.go
+++ b/modules/bichat/services/streaming/run_state.go
@@ -57,6 +57,25 @@ func (m *RunStateManager) GetPersistedRun(ctx context.Context, sessionID uuid.UU
 	return m.store.GetActiveRunBySession(ctx, tenantID, sessionID)
 }
 
+// GetPersistedRunForSession reads the active run with an explicit tenant. It is
+// used while a new database run is being created inside a transaction, where
+// the service must compare PostgreSQL's active row with Redis before deciding
+// whether an existing Redis session key is orphaned.
+func (m *RunStateManager) GetPersistedRunForSession(
+	ctx context.Context,
+	tenantID, sessionID uuid.UUID,
+) (domain.GenerationRun, error) {
+	const op serrors.Op = "runStateManager.GetPersistedRunForSession"
+	if m == nil || m.store == nil {
+		return nil, domain.ErrNoActiveRun
+	}
+	run, err := m.store.GetActiveRunBySession(ctx, tenantID, sessionID)
+	if err != nil {
+		return nil, serrors.E(op, err)
+	}
+	return run, nil
+}
+
 func (m *RunStateManager) GetPersistedRunByID(ctx context.Context, runID uuid.UUID) (domain.GenerationRun, error) {
 	const op serrors.Op = "runStateManager.GetPersistedRunByID"
 	if m == nil || m.store == nil {

--- a/modules/bichat/services/streaming/run_state.go
+++ b/modules/bichat/services/streaming/run_state.go
@@ -31,6 +31,11 @@ func NewRunStateManager(store RunStateStore) *RunStateManager {
 	return &RunStateManager{store: store}
 }
 
+// Enabled reports whether generation run state is backed by a store.
+func (m *RunStateManager) Enabled() bool {
+	return m != nil && m.store != nil
+}
+
 func (m *RunStateManager) CreateRunState(ctx context.Context, run domain.GenerationRun) (bool, error) {
 	const op serrors.Op = "runStateManager.CreateRunState"
 	if m == nil || m.store == nil {


### PR DESCRIPTION
## Summary
- retry Redis terminal-state writes before exposing a completed PostgreSQL run
- recover a stale Redis session key only when the active PostgreSQL row is the replacement run
- log unrecoverable finalization failures with tenant, session, run, status, and attempt count
- apply the recovery path to normal sends and HITL continuations

## Regression evidence
The new tests failed before the production fix with `session already has an active generation run` and a one-shot Redis finalization error.

## Tests
- `go test ./modules/bichat/... -count=1`
- `go vet ./modules/bichat/...`

Consumer issue: EAI-UZ/granite#4512

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791005822&installation_model_id=2042&pr_number=1043&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1043&signature=184e69a65425e5d296fb6972b309ca9b432f6cecd777dc70d050c38311d56dcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when completing, cancelling, or failing chat runs after temporary service interruptions.
  - Added recovery for stale or orphaned runs, allowing new asynchronous and streaming runs to start successfully.
  - Retried run finalization when transient failures occur, reducing incomplete run states.
  - Prevented abandoned run states from blocking future messages in the same session.
  - Improved consistency between persisted chat history and active run status during recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->