### PR TITLE
feat(uploads): add private storage namespace

### DIFF
--- a/modules/core/infrastructure/persistence/upload_fs_storage.go
+++ b/modules/core/infrastructure/persistence/upload_fs_storage.go
@@ -7,32 +7,37 @@ import (
 	"path/filepath"
 
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/uploadsconfig"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
 )
 
 type FSStorage struct{}
 
 func NewFSStorage(cfg *uploadsconfig.Config) (*FSStorage, error) {
+	const op serrors.Op = "persistence.NewFSStorage"
 	uploadsPath := "static"
 	if cfg != nil && cfg.Path != "" {
 		uploadsPath = cfg.Path
 	}
 	workDir, err := os.Getwd()
 	if err != nil {
-		return nil, err
+		return nil, serrors.E(op, err)
 	}
 	fullPath := uploadsPath
 	if !filepath.IsAbs(fullPath) {
 		fullPath = filepath.Join(workDir, fullPath)
 	}
-	if err := os.MkdirAll(fullPath, 0777); err != nil {
-		return nil, err
+	if err := os.MkdirAll(fullPath, 0755); err != nil {
+		return nil, serrors.E(op, err)
+	}
+	if err := os.Chmod(fullPath, 0755); err != nil {
+		return nil, serrors.E(op, err)
 	}
 	privatePath := filepath.Join(fullPath, uploadsconfig.PrivateDirectory)
 	if err := os.MkdirAll(privatePath, 0700); err != nil {
-		return nil, err
+		return nil, serrors.E(op, err)
 	}
 	if err := os.Chmod(privatePath, 0700); err != nil {
-		return nil, err
+		return nil, serrors.E(op, err)
 	}
 	return &FSStorage{}, nil
 }

--- a/modules/core/infrastructure/persistence/upload_fs_storage.go
+++ b/modules/core/infrastructure/persistence/upload_fs_storage.go
@@ -20,8 +20,18 @@ func NewFSStorage(cfg *uploadsconfig.Config) (*FSStorage, error) {
 	if err != nil {
 		return nil, err
 	}
-	fullPath := filepath.Join(workDir, uploadsPath)
+	fullPath := uploadsPath
+	if !filepath.IsAbs(fullPath) {
+		fullPath = filepath.Join(workDir, fullPath)
+	}
 	if err := os.MkdirAll(fullPath, 0777); err != nil {
+		return nil, err
+	}
+	privatePath := filepath.Join(fullPath, uploadsconfig.PrivateDirectory)
+	if err := os.MkdirAll(privatePath, 0700); err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(privatePath, 0700); err != nil {
 		return nil, err
 	}
 	return &FSStorage{}, nil

--- a/modules/core/infrastructure/persistence/upload_fs_storage_test.go
+++ b/modules/core/infrastructure/persistence/upload_fs_storage_test.go
@@ -21,6 +21,9 @@ func TestNewFSStorage_RestrictsExistingPrivateDirectory(t *testing.T) {
 	_, err := persistence.NewFSStorage(&uploadsconfig.Config{Path: root})
 	require.NoError(t, err)
 
+	rootInfo, err := os.Stat(root)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0755), rootInfo.Mode().Perm())
 	info, err := os.Stat(privatePath)
 	require.NoError(t, err)
 	require.Equal(t, os.FileMode(0700), info.Mode().Perm())

--- a/modules/core/infrastructure/persistence/upload_fs_storage_test.go
+++ b/modules/core/infrastructure/persistence/upload_fs_storage_test.go
@@ -1,0 +1,27 @@
+package persistence_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence"
+	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/uploadsconfig"
+	"github.com/stretchr/testify/require"
+)
+
+// Falsely green if the private directory starts with mode 0700.
+func TestNewFSStorage_RestrictsExistingPrivateDirectory(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	privatePath := filepath.Join(root, uploadsconfig.PrivateDirectory)
+	require.NoError(t, os.MkdirAll(privatePath, 0755))
+	require.NoError(t, os.Chmod(privatePath, 0755))
+
+	_, err := persistence.NewFSStorage(&uploadsconfig.Config{Path: root})
+	require.NoError(t, err)
+
+	info, err := os.Stat(privatePath)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0700), info.Mode().Perm())
+}

--- a/modules/core/presentation/controllers/upload_controller.go
+++ b/modules/core/presentation/controllers/upload_controller.go
@@ -57,7 +57,7 @@ func (c *UploadController) Register(r *mux.Router) {
 	if !filepath.IsAbs(fullPath) {
 		fullPath = filepath.Join(workDir, fullPath)
 	}
-	prefix := path.Join("/", c.cfg.Path, "/")
+	prefix := path.Join("/", c.cfg.Path) + "/"
 	privatePrefix := path.Join(prefix, uploadsconfig.PrivateDirectory)
 	neuteredFS := multifs.NewNeuteredFileSystem(http.Dir(fullPath))
 	publicFiles := http.StripPrefix(prefix, http.FileServer(neuteredFS))

--- a/modules/core/presentation/controllers/upload_controller.go
+++ b/modules/core/presentation/controllers/upload_controller.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/a-h/templ"
 	"github.com/gorilla/mux"
@@ -52,10 +53,21 @@ func (c *UploadController) Register(r *mux.Router) {
 	if err != nil {
 		panic(err)
 	}
-	fullPath := filepath.Join(workDir, c.cfg.Path)
+	fullPath := c.cfg.Path
+	if !filepath.IsAbs(fullPath) {
+		fullPath = filepath.Join(workDir, fullPath)
+	}
 	prefix := path.Join("/", c.cfg.Path, "/")
+	privatePrefix := path.Join(prefix, uploadsconfig.PrivateDirectory)
 	neuteredFS := multifs.NewNeuteredFileSystem(http.Dir(fullPath))
-	r.PathPrefix(prefix).Handler(http.StripPrefix(prefix, http.FileServer(neuteredFS)))
+	publicFiles := http.StripPrefix(prefix, http.FileServer(neuteredFS))
+	r.PathPrefix(prefix).Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == privatePrefix || strings.HasPrefix(r.URL.Path, privatePrefix+"/") {
+			http.NotFound(w, r)
+			return
+		}
+		publicFiles.ServeHTTP(w, r)
+	}))
 }
 
 func (c *UploadController) Create(w http.ResponseWriter, r *http.Request) {

--- a/modules/core/presentation/controllers/upload_controller_test.go
+++ b/modules/core/presentation/controllers/upload_controller_test.go
@@ -84,6 +84,30 @@ func TestUploadController_FileAccess_ReturnsFile(t *testing.T) {
 	require.Contains(t, response.Body(), testContent)
 }
 
+// Falsely green if the fixture is absent or the request never reaches the public file handler.
+func TestUploadController_PrivateFileAccess_Returns404(t *testing.T) {
+	uploadsPath := "test-uploads"
+	testSubDir := strings.ReplaceAll(t.Name(), "/", "-")
+	privatePath := filepath.Join(uploadsPath, uploadsconfig.PrivateDirectory, testSubDir)
+	require.NoError(t, os.MkdirAll(privatePath, 0700))
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(privatePath)) })
+
+	suite := itf.NewSuiteBuilder(t).WithComponents(core.NewComponent(&core.ModuleOptions{
+		PermissionSchema: defaults.PermissionSchema(),
+	})).Build()
+	uploadService := itf.GetService[services.UploadService](suite.Environment())
+	uploadsCfg := itf.GetService[uploadsconfig.Config](suite.Environment())
+	suite.Register(controllers.NewUploadController(uploadService, uploadsCfg))
+
+	filePath := filepath.Join(privatePath, "confidential.pdf")
+	require.NoError(t, os.WriteFile(filePath, []byte("private evidence"), 0600))
+	_, err := os.ReadFile(filePath)
+	require.NoError(t, err)
+
+	urlPath := "/" + filepath.ToSlash(filepath.Join(uploadsPath, uploadsconfig.PrivateDirectory, testSubDir, "confidential.pdf"))
+	suite.GET(urlPath).Expect(t).Status(http.StatusNotFound)
+}
+
 func TestUploadController_SubdirectoryListing_Returns404(t *testing.T) {
 	// Use consistent uploads path (singleton configuration)
 	uploadsPath := "test-uploads"

--- a/modules/core/presentation/controllers/upload_controller_test.go
+++ b/modules/core/presentation/controllers/upload_controller_test.go
@@ -88,10 +88,6 @@ func TestUploadController_FileAccess_ReturnsFile(t *testing.T) {
 func TestUploadController_PrivateFileAccess_Returns404(t *testing.T) {
 	uploadsPath := "test-uploads"
 	testSubDir := strings.ReplaceAll(t.Name(), "/", "-")
-	privatePath := filepath.Join(uploadsPath, uploadsconfig.PrivateDirectory, testSubDir)
-	require.NoError(t, os.MkdirAll(privatePath, 0700))
-	t.Cleanup(func() { require.NoError(t, os.RemoveAll(privatePath)) })
-
 	suite := itf.NewSuiteBuilder(t).WithComponents(core.NewComponent(&core.ModuleOptions{
 		PermissionSchema: defaults.PermissionSchema(),
 	})).Build()
@@ -99,13 +95,33 @@ func TestUploadController_PrivateFileAccess_Returns404(t *testing.T) {
 	uploadsCfg := itf.GetService[uploadsconfig.Config](suite.Environment())
 	suite.Register(controllers.NewUploadController(uploadService, uploadsCfg))
 
-	filePath := filepath.Join(privatePath, "confidential.pdf")
-	require.NoError(t, os.WriteFile(filePath, []byte("private evidence"), 0600))
-	_, err := os.ReadFile(filePath)
-	require.NoError(t, err)
-
-	urlPath := "/" + filepath.ToSlash(filepath.Join(uploadsPath, uploadsconfig.PrivateDirectory, testSubDir, "confidential.pdf"))
-	suite.GET(urlPath).Expect(t).Status(http.StatusNotFound)
+	cases := []struct {
+		name        string
+		fixtureRoot string
+		urlPath     string
+	}{
+		{
+			name:        "private namespace",
+			fixtureRoot: filepath.Join(uploadsPath, uploadsconfig.PrivateDirectory, testSubDir),
+			urlPath:     "/" + filepath.ToSlash(filepath.Join(uploadsPath, uploadsconfig.PrivateDirectory, testSubDir, "confidential.pdf")),
+		},
+		{
+			name:        "adjacent URL prefix",
+			fixtureRoot: filepath.Join(uploadsPath+"private", testSubDir),
+			urlPath:     "/" + filepath.ToSlash(filepath.Join(uploadsPath+"private", testSubDir, "confidential.pdf")),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, os.MkdirAll(tc.fixtureRoot, 0700))
+			t.Cleanup(func() { require.NoError(t, os.RemoveAll(tc.fixtureRoot)) })
+			filePath := filepath.Join(tc.fixtureRoot, "confidential.pdf")
+			require.NoError(t, os.WriteFile(filePath, []byte("private evidence"), 0600))
+			_, err := os.ReadFile(filePath)
+			require.NoError(t, err)
+			suite.GET(tc.urlPath).Expect(t).Status(http.StatusNotFound)
+		})
+	}
 }
 
 func TestUploadController_SubdirectoryListing_Returns404(t *testing.T) {

--- a/modules/core/services/upload_service.go
+++ b/modules/core/services/upload_service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/upload"
 	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence"
 	"github.com/iota-uz/iota-sdk/pkg/eventbus"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
 )
 
 var ErrUploadSlugConflict = errors.New("upload slug already belongs to different content")
@@ -75,8 +76,9 @@ func (s *UploadService) Create(ctx context.Context, data *upload.CreateDTO) (upl
 // Hash deduplication is intentionally limited to the deterministic slug so a
 // private upload can never resolve to content from the public namespace.
 func (s *UploadService) CreatePrivate(ctx context.Context, data *upload.CreateDTO, privatePath string) (upload.Upload, error) {
+	const op serrors.Op = "UploadService.CreatePrivate"
 	if privatePath == "" {
-		return nil, ErrPrivateUploadPathRequired
+		return nil, serrors.E(op, ErrPrivateUploadPathRequired)
 	}
 	privateData := *data
 	privateData.UploadsPath = privatePath
@@ -89,6 +91,7 @@ func pathWithin(root, candidate string) bool {
 }
 
 func (s *UploadService) create(ctx context.Context, data *upload.CreateDTO, deduplicateByHash, replaceSlug bool, requiredPath ...string) (upload.Upload, error) {
+	const op serrors.Op = "UploadService.create"
 	entity, bytes, err := data.ToEntity()
 	if err != nil {
 		return nil, err
@@ -107,11 +110,11 @@ func (s *UploadService) create(ctx context.Context, data *upload.CreateDTO, dedu
 	}
 	if up != nil {
 		if len(requiredPath) > 0 && !pathWithin(requiredPath[0], up.Path()) {
-			return nil, fmt.Errorf("%w: %s", ErrUploadSlugConflict, entity.Slug())
+			return nil, serrors.E(op, fmt.Errorf("%w: %s", ErrUploadSlugConflict, entity.Slug()))
 		}
 		if up.Hash() != entity.Hash() {
 			if !replaceSlug {
-				return nil, fmt.Errorf("%w: %s", ErrUploadSlugConflict, entity.Slug())
+				return nil, serrors.E(op, fmt.Errorf("%w: %s", ErrUploadSlugConflict, entity.Slug()))
 			}
 			existing, err := s.repo.GetByHash(ctx, entity.Hash())
 			if err != nil && !errors.Is(err, persistence.ErrUploadNotFound) {

--- a/modules/core/services/upload_service.go
+++ b/modules/core/services/upload_service.go
@@ -16,6 +16,7 @@ import (
 
 var ErrUploadSlugConflict = errors.New("upload slug already belongs to different content")
 var ErrPrivateUploadPathRequired = errors.New("private upload path is required")
+var ErrPrivateUploadPathInvalid = errors.New("private upload path escapes namespace")
 
 type UploadService struct {
 	repo      upload.Repository
@@ -95,6 +96,9 @@ func (s *UploadService) create(ctx context.Context, data *upload.CreateDTO, dedu
 	entity, bytes, err := data.ToEntity()
 	if err != nil {
 		return nil, err
+	}
+	if len(requiredPath) > 0 && !pathWithin(requiredPath[0], entity.Path()) {
+		return nil, serrors.E(op, ErrPrivateUploadPathInvalid)
 	}
 
 	up, err := s.repo.GetBySlug(ctx, entity.Slug())

--- a/modules/core/services/upload_service.go
+++ b/modules/core/services/upload_service.go
@@ -4,11 +4,14 @@ package services
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/upload"
 	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence"
 	"github.com/iota-uz/iota-sdk/pkg/eventbus"
 )
+
+var ErrUploadSlugConflict = errors.New("upload slug already belongs to different content")
 
 type UploadService struct {
 	repo      upload.Repository
@@ -62,6 +65,19 @@ func (s *UploadService) GetPaginated(ctx context.Context, params *upload.FindPar
 }
 
 func (s *UploadService) Create(ctx context.Context, data *upload.CreateDTO) (upload.Upload, error) {
+	return s.create(ctx, data, true, true)
+}
+
+// CreatePrivate stores an upload in a caller-provided non-public namespace.
+// Hash deduplication is intentionally limited to the deterministic slug so a
+// private upload can never resolve to content from the public namespace.
+func (s *UploadService) CreatePrivate(ctx context.Context, data *upload.CreateDTO, privatePath string) (upload.Upload, error) {
+	privateData := *data
+	privateData.UploadsPath = privatePath
+	return s.create(ctx, &privateData, false, false)
+}
+
+func (s *UploadService) create(ctx context.Context, data *upload.CreateDTO, deduplicateByHash, replaceSlug bool) (upload.Upload, error) {
 	entity, bytes, err := data.ToEntity()
 	if err != nil {
 		return nil, err
@@ -72,7 +88,7 @@ func (s *UploadService) Create(ctx context.Context, data *upload.CreateDTO) (upl
 		return nil, err
 	}
 
-	if up == nil {
+	if up == nil && deduplicateByHash {
 		up, err = s.repo.GetByHash(ctx, entity.Hash())
 		if err != nil && !errors.Is(err, persistence.ErrUploadNotFound) {
 			return nil, err
@@ -80,6 +96,9 @@ func (s *UploadService) Create(ctx context.Context, data *upload.CreateDTO) (upl
 	}
 	if up != nil {
 		if up.Hash() != entity.Hash() {
+			if !replaceSlug {
+				return nil, fmt.Errorf("%w: %s", ErrUploadSlugConflict, entity.Slug())
+			}
 			existing, err := s.repo.GetByHash(ctx, entity.Hash())
 			if err != nil && !errors.Is(err, persistence.ErrUploadNotFound) {
 				return nil, err

--- a/modules/core/services/upload_service.go
+++ b/modules/core/services/upload_service.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/upload"
 	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence"
@@ -78,10 +80,15 @@ func (s *UploadService) CreatePrivate(ctx context.Context, data *upload.CreateDT
 	}
 	privateData := *data
 	privateData.UploadsPath = privatePath
-	return s.create(ctx, &privateData, false, false)
+	return s.create(ctx, &privateData, false, false, privatePath)
 }
 
-func (s *UploadService) create(ctx context.Context, data *upload.CreateDTO, deduplicateByHash, replaceSlug bool) (upload.Upload, error) {
+func pathWithin(root, candidate string) bool {
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(candidate))
+	return err == nil && rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func (s *UploadService) create(ctx context.Context, data *upload.CreateDTO, deduplicateByHash, replaceSlug bool, requiredPath ...string) (upload.Upload, error) {
 	entity, bytes, err := data.ToEntity()
 	if err != nil {
 		return nil, err
@@ -99,6 +106,9 @@ func (s *UploadService) create(ctx context.Context, data *upload.CreateDTO, dedu
 		}
 	}
 	if up != nil {
+		if len(requiredPath) > 0 && !pathWithin(requiredPath[0], up.Path()) {
+			return nil, fmt.Errorf("%w: %s", ErrUploadSlugConflict, entity.Slug())
+		}
 		if up.Hash() != entity.Hash() {
 			if !replaceSlug {
 				return nil, fmt.Errorf("%w: %s", ErrUploadSlugConflict, entity.Slug())

--- a/modules/core/services/upload_service.go
+++ b/modules/core/services/upload_service.go
@@ -12,6 +12,7 @@ import (
 )
 
 var ErrUploadSlugConflict = errors.New("upload slug already belongs to different content")
+var ErrPrivateUploadPathRequired = errors.New("private upload path is required")
 
 type UploadService struct {
 	repo      upload.Repository
@@ -72,6 +73,9 @@ func (s *UploadService) Create(ctx context.Context, data *upload.CreateDTO) (upl
 // Hash deduplication is intentionally limited to the deterministic slug so a
 // private upload can never resolve to content from the public namespace.
 func (s *UploadService) CreatePrivate(ctx context.Context, data *upload.CreateDTO, privatePath string) (upload.Upload, error) {
+	if privatePath == "" {
+		return nil, ErrPrivateUploadPathRequired
+	}
 	privateData := *data
 	privateData.UploadsPath = privatePath
 	return s.create(ctx, &privateData, false, false)

--- a/modules/core/services/upload_service_private_test.go
+++ b/modules/core/services/upload_service_private_test.go
@@ -46,54 +46,67 @@ func TestUploadServiceCreatePrivate_DoesNotReusePublicHash(t *testing.T) {
 	storage.AssertExpectations(t)
 }
 
-func TestUploadServiceCreatePrivate_RejectsSlugReplacement(t *testing.T) {
-	// This test would be falsely green if the replacement path failed only
-	// because storage or repository mutation mocks were incomplete.
-	ctx := context.Background()
-	repo := new(MockUploadRepository)
-	storage := new(MockUploadStorage)
-	service := services.NewUploadService(repo, storage, eventbus.NewEventPublisher(logrus.New()))
-	privatePath := filepath.Join(t.TempDir(), ".private")
-	slug := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-	existing := upload.New("different-hash", filepath.Join(privatePath, slug+".pdf"), "old.pdf", slug, 3, mimetype.Detect([]byte("old")))
-	repo.On("GetBySlug", ctx, slug).Return(existing, nil).Once()
-
-	_, err := service.CreatePrivate(ctx, &upload.CreateDTO{
-		File: bytes.NewReader([]byte("%PDF-new")), Name: "new.pdf", Size: 8, Slug: slug,
-	}, privatePath)
-	require.ErrorIs(t, err, services.ErrUploadSlugConflict)
-	require.NotErrorIs(t, err, persistence.ErrUploadNotFound)
-	repo.AssertNotCalled(t, "GetByHash", mock.Anything, mock.Anything)
-	repo.AssertNotCalled(t, "Update", mock.Anything, mock.Anything)
-	storage.AssertNotCalled(t, "Save", mock.Anything, mock.Anything, mock.Anything)
-}
-
-func TestUploadServiceCreatePrivate_RejectsPublicSlugMatch(t *testing.T) {
-	// This test would be falsely green if matching content were accepted without
-	// checking that the existing upload belongs to the private namespace.
-	ctx := context.Background()
-	repo := new(MockUploadRepository)
-	storage := new(MockUploadStorage)
-	service := services.NewUploadService(repo, storage, eventbus.NewEventPublisher(logrus.New()))
-	content := []byte("%PDF-same")
-	privatePath := filepath.Join(t.TempDir(), ".private")
-	slug := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-	public := upload.New("635b3969c08c7cac341c01f017ab0e0a", filepath.Join(t.TempDir(), slug+".pdf"), "public.pdf", slug, len(content), mimetype.Detect(content))
-	repo.On("GetBySlug", ctx, slug).Return(public, nil).Once()
-
-	_, err := service.CreatePrivate(ctx, &upload.CreateDTO{
-		File: bytes.NewReader(content), Name: "private.pdf", Size: len(content), Slug: slug,
-	}, privatePath)
-	require.ErrorIs(t, err, services.ErrUploadSlugConflict)
-	storage.AssertNotCalled(t, "Save", mock.Anything, mock.Anything, mock.Anything)
-}
-
-func TestUploadServiceCreatePrivate_RequiresNamespace(t *testing.T) {
-	// This test would be falsely green if an empty path reached ToEntity and
-	// another dependency happened to reject the upload first.
-	service := services.NewUploadService(new(MockUploadRepository), new(MockUploadStorage), eventbus.NewEventPublisher(logrus.New()))
-	_, err := service.CreatePrivate(context.Background(), &upload.CreateDTO{
-		File: bytes.NewReader([]byte("%PDF")), Name: "private.pdf", Size: 4,
-	}, "")
-	require.ErrorIs(t, err, services.ErrPrivateUploadPathRequired)
+func TestUploadServiceCreatePrivate_RejectsInvalidRequests(t *testing.T) {
+	// These cases would be falsely green if failures came from unconfigured
+	// repository or storage mocks instead of the intended validation boundary.
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, repo *MockUploadRepository) (*upload.CreateDTO, string)
+		expected error
+	}{
+		{
+			name: "slug replacement",
+			setup: func(t *testing.T, repo *MockUploadRepository) (*upload.CreateDTO, string) {
+				t.Helper()
+				privatePath := filepath.Join(t.TempDir(), ".private")
+				slug := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+				existing := upload.New("different-hash", filepath.Join(privatePath, slug+".pdf"), "old.pdf", slug, 3, mimetype.Detect([]byte("old")))
+				repo.On("GetBySlug", mock.Anything, slug).Return(existing, nil).Once()
+				return &upload.CreateDTO{File: bytes.NewReader([]byte("%PDF-new")), Name: "new.pdf", Size: 8, Slug: slug}, privatePath
+			},
+			expected: services.ErrUploadSlugConflict,
+		},
+		{
+			name: "public slug match",
+			setup: func(t *testing.T, repo *MockUploadRepository) (*upload.CreateDTO, string) {
+				t.Helper()
+				content := []byte("%PDF-same")
+				privatePath := filepath.Join(t.TempDir(), ".private")
+				slug := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+				public := upload.New("635b3969c08c7cac341c01f017ab0e0a", filepath.Join(t.TempDir(), slug+".pdf"), "public.pdf", slug, len(content), mimetype.Detect(content))
+				repo.On("GetBySlug", mock.Anything, slug).Return(public, nil).Once()
+				return &upload.CreateDTO{File: bytes.NewReader(content), Name: "private.pdf", Size: len(content), Slug: slug}, privatePath
+			},
+			expected: services.ErrUploadSlugConflict,
+		},
+		{
+			name: "missing namespace",
+			setup: func(t *testing.T, _ *MockUploadRepository) (*upload.CreateDTO, string) {
+				t.Helper()
+				return &upload.CreateDTO{File: bytes.NewReader([]byte("%PDF")), Name: "private.pdf", Size: 4}, ""
+			},
+			expected: services.ErrPrivateUploadPathRequired,
+		},
+		{
+			name: "path traversal",
+			setup: func(t *testing.T, _ *MockUploadRepository) (*upload.CreateDTO, string) {
+				t.Helper()
+				return &upload.CreateDTO{File: bytes.NewReader([]byte("%PDF")), Name: "private.pdf", Size: 4, Slug: "../escaped"}, filepath.Join(t.TempDir(), ".private")
+			},
+			expected: services.ErrPrivateUploadPathInvalid,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := new(MockUploadRepository)
+			storage := new(MockUploadStorage)
+			service := services.NewUploadService(repo, storage, eventbus.NewEventPublisher(logrus.New()))
+			data, privatePath := tt.setup(t, repo)
+			_, err := service.CreatePrivate(context.Background(), data, privatePath)
+			require.ErrorIs(t, err, tt.expected)
+			repo.AssertNotCalled(t, "GetByHash", mock.Anything, mock.Anything)
+			repo.AssertNotCalled(t, "Update", mock.Anything, mock.Anything)
+			storage.AssertNotCalled(t, "Save", mock.Anything, mock.Anything, mock.Anything)
+		})
+	}
 }

--- a/modules/core/services/upload_service_private_test.go
+++ b/modules/core/services/upload_service_private_test.go
@@ -3,7 +3,6 @@ package services_test
 import (
 	"bytes"
 	"context"
-	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -63,7 +62,7 @@ func TestUploadServiceCreatePrivateRejectsSlugReplacement(t *testing.T) {
 		File: bytes.NewReader([]byte("%PDF-new")), Name: "new.pdf", Size: 8, Slug: slug,
 	}, privatePath)
 	require.ErrorIs(t, err, services.ErrUploadSlugConflict)
-	require.False(t, errors.Is(err, persistence.ErrUploadNotFound))
+	require.NotErrorIs(t, err, persistence.ErrUploadNotFound)
 	repo.AssertNotCalled(t, "GetByHash", mock.Anything, mock.Anything)
 	repo.AssertNotCalled(t, "Update", mock.Anything, mock.Anything)
 	storage.AssertNotCalled(t, "Save", mock.Anything, mock.Anything, mock.Anything)

--- a/modules/core/services/upload_service_private_test.go
+++ b/modules/core/services/upload_service_private_test.go
@@ -69,6 +69,26 @@ func TestUploadServiceCreatePrivateRejectsSlugReplacement(t *testing.T) {
 	storage.AssertNotCalled(t, "Save", mock.Anything, mock.Anything, mock.Anything)
 }
 
+func TestUploadServiceCreatePrivateRejectsPublicSlugMatch(t *testing.T) {
+	// This test would be falsely green if matching content were accepted without
+	// checking that the existing upload belongs to the private namespace.
+	ctx := context.Background()
+	repo := new(MockUploadRepository)
+	storage := new(MockUploadStorage)
+	service := services.NewUploadService(repo, storage, eventbus.NewEventPublisher(logrus.New()))
+	content := []byte("%PDF-same")
+	privatePath := filepath.Join(t.TempDir(), ".private")
+	slug := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	public := upload.New("635b3969c08c7cac341c01f017ab0e0a", filepath.Join(t.TempDir(), slug+".pdf"), "public.pdf", slug, len(content), mimetype.Detect(content))
+	repo.On("GetBySlug", ctx, slug).Return(public, nil).Once()
+
+	_, err := service.CreatePrivate(ctx, &upload.CreateDTO{
+		File: bytes.NewReader(content), Name: "private.pdf", Size: len(content), Slug: slug,
+	}, privatePath)
+	require.ErrorIs(t, err, services.ErrUploadSlugConflict)
+	storage.AssertNotCalled(t, "Save", mock.Anything, mock.Anything, mock.Anything)
+}
+
 func TestUploadServiceCreatePrivateRequiresNamespace(t *testing.T) {
 	// This test would be falsely green if an empty path reached ToEntity and
 	// another dependency happened to reject the upload first.

--- a/modules/core/services/upload_service_private_test.go
+++ b/modules/core/services/upload_service_private_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUploadServiceCreatePrivateDoesNotReusePublicHash(t *testing.T) {
+func TestUploadServiceCreatePrivate_DoesNotReusePublicHash(t *testing.T) {
 	// This test would be falsely green if CreatePrivate queried the global hash
 	// but the mock happened to return not found.
 	ctx := context.Background()
@@ -46,7 +46,7 @@ func TestUploadServiceCreatePrivateDoesNotReusePublicHash(t *testing.T) {
 	storage.AssertExpectations(t)
 }
 
-func TestUploadServiceCreatePrivateRejectsSlugReplacement(t *testing.T) {
+func TestUploadServiceCreatePrivate_RejectsSlugReplacement(t *testing.T) {
 	// This test would be falsely green if the replacement path failed only
 	// because storage or repository mutation mocks were incomplete.
 	ctx := context.Background()
@@ -68,7 +68,7 @@ func TestUploadServiceCreatePrivateRejectsSlugReplacement(t *testing.T) {
 	storage.AssertNotCalled(t, "Save", mock.Anything, mock.Anything, mock.Anything)
 }
 
-func TestUploadServiceCreatePrivateRejectsPublicSlugMatch(t *testing.T) {
+func TestUploadServiceCreatePrivate_RejectsPublicSlugMatch(t *testing.T) {
 	// This test would be falsely green if matching content were accepted without
 	// checking that the existing upload belongs to the private namespace.
 	ctx := context.Background()
@@ -88,7 +88,7 @@ func TestUploadServiceCreatePrivateRejectsPublicSlugMatch(t *testing.T) {
 	storage.AssertNotCalled(t, "Save", mock.Anything, mock.Anything, mock.Anything)
 }
 
-func TestUploadServiceCreatePrivateRequiresNamespace(t *testing.T) {
+func TestUploadServiceCreatePrivate_RequiresNamespace(t *testing.T) {
 	// This test would be falsely green if an empty path reached ToEntity and
 	// another dependency happened to reject the upload first.
 	service := services.NewUploadService(new(MockUploadRepository), new(MockUploadStorage), eventbus.NewEventPublisher(logrus.New()))

--- a/modules/core/services/upload_service_private_test.go
+++ b/modules/core/services/upload_service_private_test.go
@@ -68,3 +68,13 @@ func TestUploadServiceCreatePrivateRejectsSlugReplacement(t *testing.T) {
 	repo.AssertNotCalled(t, "Update", mock.Anything, mock.Anything)
 	storage.AssertNotCalled(t, "Save", mock.Anything, mock.Anything, mock.Anything)
 }
+
+func TestUploadServiceCreatePrivateRequiresNamespace(t *testing.T) {
+	// This test would be falsely green if an empty path reached ToEntity and
+	// another dependency happened to reject the upload first.
+	service := services.NewUploadService(new(MockUploadRepository), new(MockUploadStorage), eventbus.NewEventPublisher(logrus.New()))
+	_, err := service.CreatePrivate(context.Background(), &upload.CreateDTO{
+		File: bytes.NewReader([]byte("%PDF")), Name: "private.pdf", Size: 4,
+	}, "")
+	require.ErrorIs(t, err, services.ErrPrivateUploadPathRequired)
+}

--- a/modules/core/services/upload_service_private_test.go
+++ b/modules/core/services/upload_service_private_test.go
@@ -1,0 +1,70 @@
+package services_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gabriel-vasile/mimetype"
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/upload"
+	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence"
+	"github.com/iota-uz/iota-sdk/modules/core/services"
+	"github.com/iota-uz/iota-sdk/pkg/eventbus"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUploadServiceCreatePrivateDoesNotReusePublicHash(t *testing.T) {
+	// This test would be falsely green if CreatePrivate queried the global hash
+	// but the mock happened to return not found.
+	ctx := context.Background()
+	repo := new(MockUploadRepository)
+	storage := new(MockUploadStorage)
+	service := services.NewUploadService(repo, storage, eventbus.NewEventPublisher(logrus.New()))
+	content := []byte("%PDF-1.7\nprivate")
+	privatePath := filepath.Join(t.TempDir(), ".private")
+	slug := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	created := upload.NewWithID(7, uuid.New(), "hash", filepath.Join(privatePath, slug+".pdf"), "policy.pdf", slug, len(content), mimetype.Detect(content), upload.UploadTypeDocument, time.Now(), time.Now())
+
+	repo.On("GetBySlug", ctx, slug).Return(nil, persistence.ErrUploadNotFound).Once()
+	storage.On("Save", ctx, filepath.Join(privatePath, slug+".pdf"), content).Return(nil).Once()
+	repo.On("Create", ctx, mock.MatchedBy(func(entity upload.Upload) bool {
+		return entity.Path() == filepath.Join(privatePath, slug+".pdf")
+	})).Return(created, nil).Once()
+
+	result, err := service.CreatePrivate(ctx, &upload.CreateDTO{
+		File: bytes.NewReader(content), Name: "policy.pdf", Size: len(content), Slug: slug,
+	}, privatePath)
+	require.NoError(t, err)
+	require.Equal(t, created, result)
+	repo.AssertNotCalled(t, "GetByHash", mock.Anything, mock.Anything)
+	repo.AssertExpectations(t)
+	storage.AssertExpectations(t)
+}
+
+func TestUploadServiceCreatePrivateRejectsSlugReplacement(t *testing.T) {
+	// This test would be falsely green if the replacement path failed only
+	// because storage or repository mutation mocks were incomplete.
+	ctx := context.Background()
+	repo := new(MockUploadRepository)
+	storage := new(MockUploadStorage)
+	service := services.NewUploadService(repo, storage, eventbus.NewEventPublisher(logrus.New()))
+	privatePath := filepath.Join(t.TempDir(), ".private")
+	slug := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	existing := upload.New("different-hash", filepath.Join(privatePath, slug+".pdf"), "old.pdf", slug, 3, mimetype.Detect([]byte("old")))
+	repo.On("GetBySlug", ctx, slug).Return(existing, nil).Once()
+
+	_, err := service.CreatePrivate(ctx, &upload.CreateDTO{
+		File: bytes.NewReader([]byte("%PDF-new")), Name: "new.pdf", Size: 8, Slug: slug,
+	}, privatePath)
+	require.ErrorIs(t, err, services.ErrUploadSlugConflict)
+	require.False(t, errors.Is(err, persistence.ErrUploadNotFound))
+	repo.AssertNotCalled(t, "GetByHash", mock.Anything, mock.Anything)
+	repo.AssertNotCalled(t, "Update", mock.Anything, mock.Anything)
+	storage.AssertNotCalled(t, "Save", mock.Anything, mock.Anything, mock.Anything)
+}

--- a/pkg/config/stdconfig/uploadsconfig/config.go
+++ b/pkg/config/stdconfig/uploadsconfig/config.go
@@ -2,6 +2,10 @@
 // It is a stdconfig package intended to be registered via config.Register[uploadsconfig.Config].
 package uploadsconfig
 
+import "path/filepath"
+
+const PrivateDirectory = ".private"
+
 // Config holds file upload path and size constraints.
 //
 // Env prefix: "uploads" (e.g. UPLOADS_PATH → uploads.path,
@@ -14,3 +18,12 @@ type Config struct {
 
 // ConfigPrefix returns the koanf prefix for uploadsconfig ("uploads").
 func (Config) ConfigPrefix() string { return "uploads" }
+
+// PrivatePath returns the non-public namespace inside the configured storage root.
+func (c Config) PrivatePath() string {
+	root := c.Path
+	if root == "" {
+		root = "static"
+	}
+	return filepath.Join(root, PrivateDirectory)
+}


### PR DESCRIPTION
Adds a private namespace inside the configured upload root and prevents the public file handler from serving it. `UploadService.CreatePrivate` keeps hash deduplication scoped to a deterministic slug, so private uploads cannot resolve to public content and cannot replace an existing slug with different bytes.

Validation:
- `go test ./modules/core/services -run '^TestUploadServiceCreatePrivate' -count=1`
- `go test ./modules/core/infrastructure/persistence -run '^TestNewFSStorage_RestrictsExistingPrivateDirectory$' -count=1`
- `go test ./modules/core/presentation/controllers -run '^(TestUploadController_PrivateFileAccess_Returns404|TestUploadController_FileAccess_ReturnsFile)$' -count=1`
- `go vet ./...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791184632&installation_model_id=2042&pr_number=1044&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1044&signature=aa8c9de7a346eff29c3f9650031be92de3f856f789c663787f113e8a8435cf46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for storing uploads in a private directory.
  - Private uploads now detect conflicting slugs instead of replacing existing files.
  - Configured upload paths support both relative and absolute locations.

- **Bug Fixes**
  - Restricted private upload directories to owner-only access.
  - Blocked direct requests for private files, returning HTTP 404.
  - Preserved public upload behavior, including existing replacement handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->