### PR TITLE
fix(bichat): deliver terminal events for async HITL runs

### DIFF
--- a/modules/bichat/presentation/controllers/stream_controller.go
+++ b/modules/bichat/presentation/controllers/stream_controller.go
@@ -609,7 +609,17 @@ func (c *StreamController) TailEvents(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if c.logger != nil {
-			c.logger.WithError(serrors.E(op, err)).Error("TailEvents failed")
+			c.logger.WithError(serrors.E(op, err)).
+				WithField("session_id", sessionID.String()).
+				WithField("run_id", runID.String()).
+				WithField("stage", "event_log_tail").Error("TailEvents failed")
+		}
+		if r.Context().Err() == nil {
+			writeMu.Lock()
+			defer writeMu.Unlock()
+			c.sendSSEEvent(w, flusher, "error", httpdto.StreamChunkPayload{
+				Type: "error", Error: "run event stream interrupted", Timestamp: time.Now().UnixMilli(),
+			})
 		}
 	}
 }

--- a/modules/bichat/presentation/controllers/tail_events_controller_test.go
+++ b/modules/bichat/presentation/controllers/tail_events_controller_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -187,4 +188,23 @@ func TestTailEvents_UnavailableEmitsErrorEvent(t *testing.T) {
 	body := rw.Body.String()
 	assert.Contains(t, body, "event: error", "must emit SSE error event when log unavailable")
 	assert.Contains(t, body, "unavailable", "error payload must mention unavailable")
+}
+
+// False-green guard: an HTTP 200 alone misses the silent EOF; require a
+// terminal SSE error even when the service returns an unexpected failure.
+func TestTailEvents_UnexpectedFailureEmitsTerminal(t *testing.T) {
+	t.Parallel()
+	commands := &fakeStreamCommands{tailRunEventsFunc: func(context.Context, uuid.UUID, uuid.UUID, string, func(bichatservices.RunEventDelivery)) error {
+		return errors.New("storage unavailable")
+	}}
+	controller := NewStreamController(commands, &fakeSessionQueries{}, nil)
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/stream/events?sessionId=%s&runId=%s", uuid.New(), uuid.New()), nil)
+	req = req.WithContext(composables.WithUser(req.Context(), testUser(t)))
+	rw := httptest.NewRecorder()
+	router := mux.NewRouter()
+	router.HandleFunc("/stream/events", controller.TailEvents).Methods("GET")
+	router.ServeHTTP(rw, req)
+	require.Equal(t, http.StatusOK, rw.Code)
+	require.Contains(t, rw.Body.String(), "event: error\n")
+	require.NotContains(t, rw.Body.String(), "storage unavailable", "internal errors must not leak into the stream")
 }

--- a/modules/bichat/services/async_run_events_test.go
+++ b/modules/bichat/services/async_run_events_test.go
@@ -1,0 +1,84 @@
+package services
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/modules/bichat/services/streaming"
+	"github.com/iota-uz/iota-sdk/pkg/bichat/domain"
+	api "github.com/iota-uz/iota-sdk/pkg/bichat/services"
+	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"github.com/stretchr/testify/require"
+)
+
+// False-green guard: the worker only broadcasts; seeding its journal in the
+// test would bypass the missing async-run wiring that broke HITL delivery.
+func TestAsyncRunEvents_IdleWorkerThenTerminalReplay(t *testing.T) {
+	t.Parallel()
+	for _, operation := range []api.AsyncRunOperation{api.AsyncRunOperationContinuation, api.AsyncRunOperationQuestionSubmit, api.AsyncRunOperationQuestionReject} {
+		t.Run(string(operation), func(t *testing.T) {
+			t.Parallel()
+			tailSvc, _, _, log := newTailTestService(t)
+			repo := newMockChatRepository()
+			session := mustSession(t, withSessionTenantID(uuid.New()), withSessionUserID(1))
+			require.NoError(t, repo.CreateSession(t.Context(), session))
+			svc, err := NewChatService(repo, &stubAgentService{}, nil, nil, nil)
+			require.NoError(t, err)
+			svc.eventLog = log
+			svc.runState = tailSvc.runState
+			ctx := composables.WithTenantID(t.Context(), session.TenantID())
+			release := make(chan struct{})
+			var once sync.Once
+			unblock := func() { once.Do(func() { close(release) }) }
+			defer unblock()
+			finished := make(chan struct{})
+			accepted, err := svc.startAsyncRun(ctx, session.ID(), operation, "", nil, func(_ context.Context, persistCtx context.Context, runID uuid.UUID, _ domain.Session, active *streaming.ActiveRun) {
+				defer close(finished)
+				<-release
+				active.Broadcast(api.StreamChunk{Type: api.ChunkTypeContent, Content: "resumed answer"})
+				active.Broadcast(streaming.TerminalChunk(nil, 1))
+			})
+			require.NoError(t, err)
+			replay, err := log.Replay(ctx, session.TenantID(), accepted.RunID, "")
+			require.NoError(t, err)
+			require.Len(t, replay, 1, "the journal must exist before the worker produces output")
+			require.Equal(t, "stream_started", replay[0].Type)
+			// An idle tail must survive longer than Redis's BLOCK interval.
+			tailCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+			defer cancel()
+			tail, err := log.Tail(tailCtx, session.TenantID(), accepted.RunID, replay[0].StreamID)
+			require.NoError(t, err)
+			select {
+			case <-tail:
+				t.Fatal("idle worker lost its event stream")
+			case <-time.After(120 * time.Millisecond):
+			}
+			unblock()
+			var types []string
+			for event := range tail {
+				types = append(types, event.Type)
+			}
+			require.Equal(t, []string{"content", "done"}, types)
+			<-finished
+			replay, err = log.Replay(ctx, session.TenantID(), accepted.RunID, replay[0].StreamID)
+			require.NoError(t, err)
+			require.Len(t, replay, 2, "reconnecting readers must recover the terminal event")
+		})
+	}
+}
+
+// False-green guard: no terminal event is inserted into the missing journal.
+func TestTailRunEvents_MissingJournalIsNotSuccessfulEOF(t *testing.T) {
+	t.Parallel()
+	svc, _, store, _ := newTailTestService(t)
+	tenant, session, run := uuid.New(), uuid.New(), uuid.New()
+	seedTailRun(t, store, tenant, session, run)
+	ctx, cancel := context.WithTimeout(composables.WithTenantID(t.Context(), tenant), time.Second)
+	defer cancel()
+	err := svc.TailRunEvents(ctx, session, run, "", func(api.RunEventDelivery) { t.Error("unexpected event") })
+	require.Error(t, err)
+	require.NoError(t, ctx.Err(), "must detect missing journal before the request times out")
+}

--- a/modules/bichat/services/async_run_events_test.go
+++ b/modules/bichat/services/async_run_events_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/bichat/domain"
 	api "github.com/iota-uz/iota-sdk/pkg/bichat/services"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,7 +46,7 @@ func TestAsyncRunEvents_IdleWorkerThenTerminalReplay(t *testing.T) {
 			replay, err := log.Replay(ctx, session.TenantID(), accepted.RunID, "")
 			require.NoError(t, err)
 			require.Len(t, replay, 1, "the journal must exist before the worker produces output")
-			require.Equal(t, "stream_started", replay[0].Type)
+			assert.Equal(t, "stream_started", replay[0].Type)
 			// An idle tail must survive longer than Redis's BLOCK interval.
 			tailCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 			defer cancel()
@@ -61,11 +62,11 @@ func TestAsyncRunEvents_IdleWorkerThenTerminalReplay(t *testing.T) {
 			for event := range tail {
 				types = append(types, event.Type)
 			}
-			require.Equal(t, []string{"content", "done"}, types)
+			assert.Equal(t, []string{"content", "done"}, types)
 			<-finished
 			replay, err = log.Replay(ctx, session.TenantID(), accepted.RunID, replay[0].StreamID)
 			require.NoError(t, err)
-			require.Len(t, replay, 2, "reconnecting readers must recover the terminal event")
+			assert.Len(t, replay, 2, "reconnecting readers must recover the terminal event")
 		})
 	}
 }
@@ -80,5 +81,5 @@ func TestTailRunEvents_MissingJournalIsNotSuccessfulEOF(t *testing.T) {
 	defer cancel()
 	err := svc.TailRunEvents(ctx, session, run, "", func(api.RunEventDelivery) { t.Error("unexpected event") })
 	require.Error(t, err)
-	require.NoError(t, ctx.Err(), "must detect missing journal before the request times out")
+	assert.NoError(t, ctx.Err(), "must detect missing journal before the request times out")
 }

--- a/modules/bichat/services/chat_service_continuation.go
+++ b/modules/bichat/services/chat_service_continuation.go
@@ -55,9 +55,6 @@ func (s *chatServiceImpl) ContinueSession(
 				active.CloseAllSubscribers()
 				s.runRegistry.Remove(active.RunID)
 				s.unregisterStreamCancel(req.SessionID)
-				if s.eventLog != nil {
-					_ = s.eventLog.DropAfterTerminal(persistCtx, session.TenantID(), runID, 5*time.Minute)
-				}
 			}()
 
 			if req.ReasoningEffort != nil {
@@ -65,18 +62,6 @@ func (s *chatServiceImpl) ContinueSession(
 			}
 			if req.Model != nil {
 				processCtx = bichatservices.WithModelOverride(processCtx, *req.Model)
-			}
-			if s.eventLog != nil {
-				active.SetMirror(func(chunk bichatservices.StreamChunk) {
-					eventType, body, err := encodeRunEventFromChunk(chunk)
-					if err != nil {
-						return
-					}
-					_, _ = s.eventLog.Append(persistCtx, session.TenantID(), runID, RunEvent{
-						Type:    eventType,
-						Payload: body,
-					})
-				})
 			}
 
 			startedAt := time.Now()

--- a/modules/bichat/services/chat_service_impl.go
+++ b/modules/bichat/services/chat_service_impl.go
@@ -889,7 +889,7 @@ func (s *chatServiceImpl) TailRunEvents(
 		}
 	}
 	if ctx.Err() != nil {
-		return nil
+		return nil //nolint:nilerr // context cancelled — clean stop, not an error
 	}
 	return serrors.E(op, bichatservices.ErrRunEventStreamInterrupted)
 }

--- a/modules/bichat/services/chat_service_impl.go
+++ b/modules/bichat/services/chat_service_impl.go
@@ -605,6 +605,13 @@ func (s *chatServiceImpl) startAsyncRun(
 		if err != nil {
 			return serrors.E(op, err)
 		}
+		// Create the journal before accepting the run. HITL may produce no
+		// chunks while the model is working; an absent key ends Redis tailing.
+		if err := s.appendRunEvent(txCtx, session.TenantID(), sessionID, run.ID(), bichatservices.StreamChunk{
+			Type: bichatservices.ChunkTypeStreamStarted, RunID: run.ID().String(), Timestamp: time.Now(),
+		}); err != nil {
+			return serrors.E(op, err)
+		}
 		if prepare != nil {
 			if err := prepare(txCtx, session); err != nil {
 				return err
@@ -636,7 +643,11 @@ func (s *chatServiceImpl) startAsyncRun(
 
 	persistCtx := context.WithoutCancel(ctx)
 	persistCtx = context.WithValue(persistCtx, constants.TxKey, nil)
-	go worker(processCtx, persistCtx, run.ID(), session, active)
+	s.mirrorRunEvents(persistCtx, session.TenantID(), active)
+	go func() {
+		defer s.expireRunEvents(persistCtx, session.TenantID(), sessionID, run.ID())
+		worker(processCtx, persistCtx, run.ID(), session, active)
+	}()
 
 	return bichatservices.AsyncRunAccepted{
 		Accepted:  true,
@@ -873,8 +884,14 @@ func (s *chatServiceImpl) TailRunEvents(
 			Type:     evt.Type,
 			Payload:  append([]byte(nil), evt.Payload...),
 		})
+		if IsRunEventTerminal(evt.Type) {
+			return nil
+		}
 	}
-	return nil
+	if ctx.Err() != nil {
+		return nil
+	}
+	return serrors.E(op, bichatservices.ErrRunEventStreamInterrupted)
 }
 
 // TailActiveRuns delivers the per-tenant sidebar view: snapshot rows
@@ -1250,27 +1267,7 @@ func (s *chatServiceImpl) SendMessageStream(ctx context.Context, req bichatservi
 	// Clear TxKey so persistence always opens its own durable transaction.
 	persistCtx = context.WithValue(persistCtx, constants.TxKey, nil)
 
-	// When a Redis event log is configured, mirror every broadcast into
-	// bichat:run-events:{tenant}:{run_id} so out-of-process readers (the
-	// SSE controller on a reconnect, or another replica of the server)
-	// can tail/replay via Last-Event-ID. Mirror failures are logged
-	// implicitly by the log implementation and deliberately do not break
-	// the in-memory path — an error appending to Redis should not abort
-	// a live agent streaming to its primary client.
-	if s.eventLog != nil {
-		tenantID := session.TenantID()
-		runID := run.ID()
-		active.SetMirror(func(chunk bichatservices.StreamChunk) {
-			eventType, body, err := encodeRunEventFromChunk(chunk)
-			if err != nil {
-				return
-			}
-			_, _ = s.eventLog.Append(persistCtx, tenantID, runID, RunEvent{
-				Type:    eventType,
-				Payload: body,
-			})
-		})
-	}
+	s.mirrorRunEvents(persistCtx, session.TenantID(), active)
 
 	go s.runStreamLoop(processCtx, persistCtx, run.ID(), req, session, domainAttachments, startedAt, active)
 

--- a/modules/bichat/services/chat_service_impl.go
+++ b/modules/bichat/services/chat_service_impl.go
@@ -856,7 +856,10 @@ func (s *chatServiceImpl) TailRunEvents(
 	lastID := from
 	for _, evt := range replayed {
 		if err := ctx.Err(); err != nil {
-			return nil //nolint:nilerr // context cancelled — clean stop, not an error
+			if errors.Is(err, context.Canceled) {
+				return nil
+			}
+			return serrors.E(op, bichatservices.ErrRunEventStreamInterrupted)
 		}
 		onEvent(bichatservices.RunEventDelivery{
 			StreamID: evt.StreamID,
@@ -877,7 +880,10 @@ func (s *chatServiceImpl) TailRunEvents(
 	}
 	for evt := range tailCh {
 		if err := ctx.Err(); err != nil {
-			return nil //nolint:nilerr // context cancelled — clean stop, not an error
+			if errors.Is(err, context.Canceled) {
+				return nil
+			}
+			return serrors.E(op, bichatservices.ErrRunEventStreamInterrupted)
 		}
 		onEvent(bichatservices.RunEventDelivery{
 			StreamID: evt.StreamID,
@@ -888,8 +894,8 @@ func (s *chatServiceImpl) TailRunEvents(
 			return nil
 		}
 	}
-	if ctx.Err() != nil {
-		return nil //nolint:nilerr // context cancelled — clean stop, not an error
+	if errors.Is(ctx.Err(), context.Canceled) {
+		return nil
 	}
 	return serrors.E(op, bichatservices.ErrRunEventStreamInterrupted)
 }

--- a/modules/bichat/services/chat_service_run_events.go
+++ b/modules/bichat/services/chat_service_run_events.go
@@ -1,0 +1,54 @@
+package services
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/iota-uz/iota-sdk/modules/bichat/services/streaming"
+	api "github.com/iota-uz/iota-sdk/pkg/bichat/services"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
+	"github.com/sirupsen/logrus"
+)
+
+func (s *chatServiceImpl) appendRunEvent(ctx context.Context, tenantID, sessionID, runID uuid.UUID, chunk api.StreamChunk) error {
+	const op serrors.Op = "chatServiceImpl.appendRunEvent"
+	if s.eventLog == nil {
+		return nil
+	}
+	eventType, body, err := encodeRunEventFromChunk(chunk)
+	if err == nil {
+		_, err = s.eventLog.Append(ctx, tenantID, runID, RunEvent{Type: eventType, Payload: body})
+	}
+	if err != nil {
+		s.log().WithError(err).WithFields(logrus.Fields{
+			"tenant_id": tenantID.String(), "session_id": sessionID.String(), "run_id": runID.String(),
+			"stage": "event_log_append", "event_type": string(chunk.Type),
+		}).Error("bichat: failed to persist run event")
+		return serrors.E(op, err)
+	}
+	return nil
+}
+
+func (s *chatServiceImpl) mirrorRunEvents(ctx context.Context, tenantID uuid.UUID, active *streaming.ActiveRun) {
+	if s.eventLog == nil {
+		return
+	}
+	active.SetMirror(func(chunk api.StreamChunk) {
+		// Keep the in-memory stream alive on journal failure; appendRunEvent logs
+		// the failure, including terminal events, with the run's correlation IDs.
+		_ = s.appendRunEvent(ctx, tenantID, active.SessionID, active.RunID, chunk)
+	})
+}
+
+func (s *chatServiceImpl) expireRunEvents(ctx context.Context, tenantID, sessionID, runID uuid.UUID) {
+	if s.eventLog == nil {
+		return
+	}
+	if err := s.eventLog.DropAfterTerminal(ctx, tenantID, runID, 5*time.Minute); err != nil {
+		s.log().WithError(err).WithFields(logrus.Fields{
+			"tenant_id": tenantID.String(), "session_id": sessionID.String(), "run_id": runID.String(),
+			"stage": "event_log_expire",
+		}).Warn("bichat: failed to expire run events")
+	}
+}

--- a/modules/bichat/services/chat_service_run_events.go
+++ b/modules/bichat/services/chat_service_run_events.go
@@ -42,11 +42,12 @@ func (s *chatServiceImpl) mirrorRunEvents(ctx context.Context, tenantID uuid.UUI
 }
 
 func (s *chatServiceImpl) expireRunEvents(ctx context.Context, tenantID, sessionID, runID uuid.UUID) {
+	const op serrors.Op = "chatServiceImpl.expireRunEvents"
 	if s.eventLog == nil {
 		return
 	}
 	if err := s.eventLog.DropAfterTerminal(ctx, tenantID, runID, 5*time.Minute); err != nil {
-		s.log().WithError(err).WithFields(logrus.Fields{
+		s.log().WithError(serrors.E(op, err)).WithFields(logrus.Fields{
 			"tenant_id": tenantID.String(), "session_id": sessionID.String(), "run_id": runID.String(),
 			"stage": "event_log_expire",
 		}).Warn("bichat: failed to expire run events")

--- a/modules/bichat/services/tail_run_events_test.go
+++ b/modules/bichat/services/tail_run_events_test.go
@@ -155,3 +155,54 @@ func TestChatService_TailRunEvents_NoLogReturnsSentinel(t *testing.T) {
 	})
 	require.ErrorIs(t, err, bichatservices.ErrRunEventLogUnavailable)
 }
+
+func TestChatService_TailRunEvents_ContextEndsBeforeTerminal(t *testing.T) {
+	t.Parallel()
+	for _, phase := range []string{"replay", "live_tail"} {
+		for _, deadline := range []bool{false, true} {
+			name := phase + "/cancelled"
+			if deadline {
+				name = phase + "/deadline"
+			}
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				// False-green guard: seed a real journal but no terminal event;
+				// otherwise a missing journal or normal completion masks the deadline.
+				svc, _, store, log := newTailTestService(t)
+				tenant, session, run := uuid.New(), uuid.New(), uuid.New()
+				seedTailRun(t, store, tenant, session, run)
+				for range 2 {
+					_, err := log.Append(t.Context(), tenant, run, RunEvent{Type: "content", Payload: json.RawMessage(`{}`)})
+					require.NoError(t, err)
+				}
+				parent := composables.WithTenantID(t.Context(), tenant)
+				ctx, cancel := context.WithTimeout(parent, 200*time.Millisecond)
+				defer cancel()
+				seen := 0
+				err := svc.TailRunEvents(ctx, session, run, "", func(bichatservices.RunEventDelivery) {
+					seen++
+					if phase == "replay" && seen == 1 {
+						if !deadline {
+							cancel()
+						}
+						<-ctx.Done()
+					} else if phase == "live_tail" && seen == 2 && !deadline {
+						cancel()
+					}
+				})
+				if deadline {
+					require.ErrorIs(t, err, bichatservices.ErrRunEventStreamInterrupted)
+					require.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+				} else {
+					require.NoError(t, err)
+					require.ErrorIs(t, ctx.Err(), context.Canceled)
+				}
+				if phase == "replay" {
+					assert.Equal(t, 1, seen)
+				} else {
+					assert.Equal(t, 2, seen)
+				}
+			})
+		}
+	}
+}

--- a/pkg/bichat/services/chat_service.go
+++ b/pkg/bichat/services/chat_service.go
@@ -20,6 +20,9 @@ var ErrRunNotFoundOrFinished = errors.New("generation run not found or already f
 // stream so clients can display the condition without switching transports.
 var ErrRunEventLogUnavailable = errors.New("run event log unavailable")
 
+// ErrRunEventStreamInterrupted means the event journal ended without a terminal event.
+var ErrRunEventStreamInterrupted = errors.New("run event stream interrupted")
+
 // ErrActiveRunIndexUnavailable is returned by TailActiveRuns when the
 // active-run index (per-tenant sidebar Redis hash) is not configured. Like
 // ErrRunEventLogUnavailable, the stream controller surfaces it as an SSE


### PR DESCRIPTION
HITL answer/reject runs broadcast their result only to in-memory subscribers, while clients resume through the Redis event journal. A slow continuation therefore closes `/stream/events` without a terminal event even though its answer is successfully persisted.

This change seeds `stream_started` before accepting an async run and attaches the shared journal mirror before its worker starts. Continuations use the same wiring. Journal append/expiry failures include tenant, session, run and stage fields; unexpected tail termination returns a terminal SSE error instead of a silent EOF.

Validation:
- New async journal and SSE controller tests fail on a separate worktree at `726f31a1c` with only the tests applied, and pass with the fix.
- All BiChat service, streaming, HITL and controller package tests pass.
- `GOWORK=off go vet ./...` passes.
- Consumer browser validation passes with a delayed deterministic model and real PostgreSQL/Redis: both live HITL delivery and reload/reconnect receive stream_started, content and done. Both scenarios fail on the pre-fix production tree with only the test fixture applied.
- Consumer PR: https://github.com/EAI-UZ/granite/pull/4579 (Depends-On linkage; production pin finalized only after this SDK PR merges).
- Targeted async journal/tail tests pass under the race detector; golangci-lint passes.

No schema migrations or frontend package changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791278585&installation_model_id=2042&pr_number=1055&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1055&signature=7b4ed98399d417686118a02b77bf1cc5f532b5c195e84e1037322c95ebb1e680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved reliability of asynchronous chat event streaming, including recovery of terminal events after reconnecting.
  * Run streams now preserve an initial “started” event and detect interruptions that end without a terminal event.
  * Client-facing stream interruptions now return sanitized error events without exposing internal error details.

* **Bug Fixes**
  * Missing event journals and unexpected streaming failures are no longer treated as successful completion.
  * Context cancellations no longer generate unnecessary client-facing error events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->