### PR TITLE
fix(auth): deduplicate browser accounts

### DIFF
--- a/.changes/deduplicate-browser-accounts.json
+++ b/.changes/deduplicate-browser-accounts.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "summary": "Keep only the newest browser session for each account in the login account picker."
+}

--- a/modules/core/presentation/controllers/login_account_controller_test.go
+++ b/modules/core/presentation/controllers/login_account_controller_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/iota-uz/iota-sdk/modules/core"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/session"
+	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence"
 	"github.com/iota-uz/iota-sdk/modules/core/presentation/controllers"
 	"github.com/iota-uz/iota-sdk/modules/core/services"
 	"github.com/iota-uz/iota-sdk/pkg/config/stdconfig/googleoauthconfig"
@@ -24,13 +25,13 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/itf"
 )
 
-func TestLoginController_CustomRendererReceivesAccountPickerContext_Scenarios(t *testing.T) {
+func TestLoginController_CustomRendererDeduplicatesRepeatedAccountLogin_Scenarios(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name    string
 		nextURL string
 	}{
-		{name: "renders and activates a stored account", nextURL: "/users"},
+		{name: "renders and activates only the newest session for an account", nextURL: "/users"},
 	}
 
 	for _, tt := range tests {
@@ -42,15 +43,19 @@ func TestLoginController_CustomRendererReceivesAccountPickerContext_Scenarios(t 
 
 			sessionService := itf.GetService[services.SessionService](suite.Env())
 			browserSessions := itf.GetService[services.BrowserSessionService](suite.Env())
-			token := "login-renderer-" + uuid.NewString()
-			require.NoError(t, sessionService.Create(suite.Env().Ctx, &session.CreateDTO{
-				Token: token, UserID: suite.Env().User.ID(), TenantID: suite.Env().Tenant.ID,
-				IP: "127.0.0.1", UserAgent: "login-renderer-test",
-			}))
-			sess, err := sessionService.GetBrowserSessionByToken(suite.Env().Ctx, token)
-			require.NoError(t, err)
-			browserCookie, err := browserSessions.Add(suite.Env().Ctx, "", sess)
-			require.NoError(t, err)
+			oldToken := "login-renderer-old-" + uuid.NewString()
+			token := "login-renderer-new-" + uuid.NewString()
+			browserCookie := &http.Cookie{}
+			for _, sessionToken := range []string{oldToken, token} {
+				require.NoError(t, sessionService.Create(suite.Env().Ctx, &session.CreateDTO{
+					Token: sessionToken, UserID: suite.Env().User.ID(), TenantID: suite.Env().Tenant.ID,
+					IP: "127.0.0.1", UserAgent: "login-renderer-test",
+				}))
+				sess, err := sessionService.GetBrowserSessionByToken(suite.Env().Ctx, sessionToken)
+				require.NoError(t, err)
+				browserCookie, err = browserSessions.Add(suite.Env().Ctx, browserCookie.Value, sess)
+				require.NoError(t, err)
+			}
 
 			var captured controllers.LoginPageViewModel
 			options := &controllers.LoginControllerOptions{
@@ -80,11 +85,16 @@ func TestLoginController_CustomRendererReceivesAccountPickerContext_Scenarios(t 
 				Expect(t).
 				Status(http.StatusOK)
 
+			// Falsely green if the renderer hides duplicate cards while the browser
+			// session state still retains multiple tokens for the same account.
 			require.Len(t, captured.Accounts, 1)
 			assert.Equal(t, tt.nextURL, captured.NextURL)
 			assert.Equal(t, suite.Env().User.ID(), captured.Accounts[0].UserID)
 			assert.Equal(t, suite.Env().Tenant.ID.String(), captured.Accounts[0].TenantID)
 			assert.NotEqual(t, token, captured.Accounts[0].SessionReference)
+			assert.Equal(t, services.BrowserSessionReference(token), captured.Accounts[0].SessionReference)
+			_, err := sessionService.GetBrowserSessionByToken(suite.Env().Ctx, oldToken)
+			require.ErrorIs(t, err, persistence.ErrSessionNotFound)
 			assert.Contains(t, response.Body(), "accounts=1 next="+tt.nextURL)
 
 			suite.POST("/login/session?next="+tt.nextURL).

--- a/modules/core/presentation/controllers/logout_controller_test.go
+++ b/modules/core/presentation/controllers/logout_controller_test.go
@@ -88,11 +88,22 @@ func TestLogoutController_Scenarios(t *testing.T) {
 			name: "post removes only current account and activates remaining account",
 			run: func(t *testing.T, suite *itf.Suite, cfg cfgBundle, sessionService *services.SessionService, browserSessions *services.BrowserSessionService) {
 				t.Helper()
+				secondUserID := suite.Env().User.ID() + 10_000
+				_, err := suite.Env().Pool.Exec(suite.Env().Ctx, `
+					INSERT INTO users (id, type, first_name, last_name, email, password, tenant_id, ui_language, created_at, updated_at)
+					VALUES ($1, 'user', 'Second', 'Account', $2, '', $3, 'en', NOW(), NOW())`,
+					secondUserID, "logout-second-account@example.com", suite.Env().Tenant.ID,
+				)
+				require.NoError(t, err)
 				firstToken := "logout-first-session-token"
 				secondToken := "logout-second-session-token"
-				for _, token := range []string{firstToken, secondToken} {
+				for i, token := range []string{firstToken, secondToken} {
+					userID := suite.Env().User.ID()
+					if i == 1 {
+						userID = secondUserID
+					}
 					require.NoError(t, sessionService.Create(suite.Env().Ctx, &session.CreateDTO{
-						UserID: suite.Env().User.ID(), TenantID: suite.Env().Tenant.ID,
+						UserID: userID, TenantID: suite.Env().Tenant.ID,
 						IP: "127.0.0.1", UserAgent: "logout-test-agent", Token: token,
 					}))
 				}

--- a/modules/core/services/browser_session_service.go
+++ b/modules/core/services/browser_session_service.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	coreuser "github.com/iota-uz/iota-sdk/modules/core/domain/aggregates/user"
 	"github.com/iota-uz/iota-sdk/modules/core/domain/entities/session"
 	"github.com/iota-uz/iota-sdk/modules/core/infrastructure/persistence"
@@ -40,6 +41,11 @@ type BrowserSession struct {
 	Session session.Session
 	User    coreuser.User
 	Active  bool
+}
+
+type browserAccountKey struct {
+	TenantID uuid.UUID
+	UserID   uint
 }
 
 func (s BrowserSession) Reference() string {
@@ -155,17 +161,24 @@ func (s *BrowserSessionService) Add(ctx context.Context, cookieValue string, ses
 	now := s.now().UnixNano()
 	entries := make([]browserSessionEntry, 0, len(state.Entries)+1)
 	entries = append(entries, browserSessionEntry{Token: sess.Token(), LastActive: now})
-	for _, entry := range state.Entries {
-		if entry.Token != sess.Token() {
-			entries = append(entries, entry)
+	retainedSessions := make([]BrowserSession, 0, len(sessions)+1)
+	retainedSessions = append(retainedSessions, BrowserSession{Session: sess, Active: true})
+	for i, browserSession := range sessions {
+		if accountKey(browserSession.Session) == accountKey(sess) {
+			if browserSession.Session.Token() != sess.Token() {
+				if err := s.deleteToken(ctx, browserSession.Session.Token()); err != nil && !errors.Is(err, persistence.ErrSessionNotFound) {
+					return nil, serrors.E(op, err)
+				}
+			}
+			continue
 		}
+		entries = append(entries, state.Entries[i])
+		browserSession.Active = false
+		retainedSessions = append(retainedSessions, browserSession)
 	}
 	state.Active = sess.Token()
 	state.Entries = entries
-	sessions = append([]BrowserSession{{Session: sess, Active: true}}, withoutToken(sessions, sess.Token())...)
-	for i := 1; i < len(sessions); i++ {
-		sessions[i].Active = false
-	}
+	sessions = retainedSessions
 
 	if len(state.Entries) > MaxBrowserSessions {
 		evicted := state.Entries[MaxBrowserSessions:]
@@ -278,6 +291,7 @@ func (s *BrowserSessionService) resolveValue(ctx context.Context, value string) 
 	changed := migrated
 	resolved := make([]BrowserSession, 0, len(state.Entries))
 	validEntries := make([]browserSessionEntry, 0, len(state.Entries))
+	accountIndexes := make(map[browserAccountKey]int, len(state.Entries))
 	for _, entry := range state.Entries {
 		sess, err := s.sessionService.GetBrowserSessionByToken(ctx, entry.Token)
 		if errors.Is(err, persistence.ErrSessionNotFound) {
@@ -304,8 +318,19 @@ func (s *BrowserSessionService) resolveValue(ctx context.Context, value string) 
 			changed = true
 			continue
 		}
+		browserSession := BrowserSession{Session: sess, User: u, Active: entry.Token == state.Active}
+		key := accountKey(sess)
+		if index, ok := accountIndexes[key]; ok {
+			changed = true
+			if browserSession.Active {
+				validEntries[index] = entry
+				resolved[index] = browserSession
+			}
+			continue
+		}
+		accountIndexes[key] = len(resolved)
 		validEntries = append(validEntries, entry)
-		resolved = append(resolved, BrowserSession{Session: sess, User: u, Active: entry.Token == state.Active})
+		resolved = append(resolved, browserSession)
 	}
 	state.Entries = validEntries
 	if !containsToken(state.Entries, state.Active) {
@@ -319,6 +344,10 @@ func (s *BrowserSessionService) resolveValue(ctx context.Context, value string) 
 		resolved[i].Active = resolved[i].Session.Token() == state.Active
 	}
 	return state, resolved, changed, nil
+}
+
+func accountKey(sess session.Session) browserAccountKey {
+	return browserAccountKey{TenantID: sess.TenantID(), UserID: sess.UserID()}
 }
 
 func (s *BrowserSessionService) deleteToken(ctx context.Context, token string) error {


### PR DESCRIPTION
## Summary

- keep only the newest browser session for each tenant/user account
- compact already-duplicated browser-session cookies during resolution
- delete the replaced session when the same account signs in again
- preserve multiple genuinely distinct accounts

## Testing

- `go test ./modules/core/presentation/controllers -run 'Test(LoginController_CustomRendererDeduplicatesRepeatedAccountLogin|LogoutController_Scenarios)' -count=1`\n- `go test ./modules/core/services -count=1`\n- `go vet ./modules/core/services ./modules/core/presentation/controllers`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791450764&installation_model_id=2042&pr_number=1067&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1067&signature=a80636e55c1cbc30210c5ecb383f8e4d43d12973e2f33e5a82ec100172f9f422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The login account picker now shows only the newest browser session for each account.
  - Older browser sessions for the same account are automatically removed when a newer session is created.
  - Session handling now keeps separate accounts available correctly during login and logout flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->