### PR TITLE
fix(repo): rebase multi-digit placeholders atomically

### DIFF
--- a/.changes/fix-filter-placeholder-rebasing.json
+++ b/.changes/fix-filter-placeholder-rebasing.json
@@ -1,0 +1,1 @@
+{"bump":"patch","summary":"Rebase multi-digit repository filter placeholders without corrupting their indices."}

--- a/pkg/repo/filters.go
+++ b/pkg/repo/filters.go
@@ -3,8 +3,12 @@ package repo
 import (
 	"fmt"
 	"reflect"
+	"regexp"
+	"strconv"
 	"strings"
 )
+
+var positionalPlaceholderPattern = regexp.MustCompile(`\$[1-9][0-9]*`)
 
 type FieldFilter[T any] struct {
 	Column T
@@ -289,15 +293,7 @@ type existsFilter struct {
 }
 
 func (f *existsFilter) String(column string, argIdx int) string {
-	// Replace placeholders in subquery with actual argument indices
-	// IMPORTANT: Iterate in reverse order to avoid cascading replacements
-	subquery := f.subquery
-	for i := len(f.values) - 1; i >= 0; i-- {
-		placeholder := fmt.Sprintf("$%d", i+1)
-		actualPlaceholder := fmt.Sprintf("$%d", argIdx+i)
-		subquery = strings.ReplaceAll(subquery, placeholder, actualPlaceholder)
-	}
-	return subquery
+	return rebasePlaceholders(f.subquery, len(f.values), argIdx)
 }
 
 func (f *existsFilter) Value() []any {
@@ -311,14 +307,7 @@ type subqueryFilter struct {
 }
 
 func (f *subqueryFilter) String(column string, argIdx int) string {
-	// Replace placeholders in subquery with actual argument indices
-	// IMPORTANT: Iterate in reverse order to avoid cascading replacements
-	subquery := f.subquery
-	for i := len(f.values) - 1; i >= 0; i-- {
-		placeholder := fmt.Sprintf("$%d", i+1)
-		actualPlaceholder := fmt.Sprintf("$%d", argIdx+i)
-		subquery = strings.ReplaceAll(subquery, placeholder, actualPlaceholder)
-	}
+	subquery := rebasePlaceholders(f.subquery, len(f.values), argIdx)
 	return fmt.Sprintf("%s IN (%s)", column, subquery)
 }
 
@@ -334,20 +323,21 @@ type rawFilter struct {
 }
 
 func (f *rawFilter) String(column string, argIdx int) string {
-	// Replace placeholders in SQL with actual argument indices
-	// IMPORTANT: Iterate in reverse order to avoid cascading replacements
-	// (e.g., $1 -> $2, then $2 -> $3 would incorrectly change the first replacement)
-	sql := f.sql
-	for i := len(f.values) - 1; i >= 0; i-- {
-		placeholder := fmt.Sprintf("$%d", i+1)
-		actualPlaceholder := fmt.Sprintf("$%d", argIdx+i)
-		sql = strings.ReplaceAll(sql, placeholder, actualPlaceholder)
-	}
-	return sql
+	return rebasePlaceholders(f.sql, len(f.values), argIdx)
 }
 
 func (f *rawFilter) Value() []any {
 	return f.values
+}
+
+func rebasePlaceholders(query string, valueCount, argIdx int) string {
+	return positionalPlaceholderPattern.ReplaceAllStringFunc(query, func(placeholder string) string {
+		position, err := strconv.Atoi(placeholder[1:])
+		if err != nil || position > valueCount {
+			return placeholder
+		}
+		return fmt.Sprintf("$%d", argIdx+position-1)
+	})
 }
 
 // ==============================

--- a/pkg/repo/filters_test.go
+++ b/pkg/repo/filters_test.go
@@ -82,6 +82,37 @@ func TestNotLikeFilter(t *testing.T) {
 	assert.Equal(t, []any{"%test%"}, filter.Value())
 }
 
+func TestComplexFilterPlaceholderRebasing(t *testing.T) {
+	values := make([]any, 10)
+	tests := []struct {
+		name     string
+		filter   Filter
+		expected string
+	}{
+		{
+			name:     "raw filter",
+			filter:   RawFilter("first = $1 AND tenth = $10", values...),
+			expected: "first = $6 AND tenth = $15",
+		},
+		{
+			name:     "exists filter",
+			filter:   ExistsFilter("EXISTS (SELECT 1 WHERE first = $1 AND tenth = $10)", values...),
+			expected: "EXISTS (SELECT 1 WHERE first = $6 AND tenth = $15)",
+		},
+		{
+			name:     "subquery filter",
+			filter:   SubqueryFilter("SELECT id WHERE first = $1 AND tenth = $10", values...),
+			expected: "column IN (SELECT id WHERE first = $6 AND tenth = $15)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.filter.String("column", 6))
+		})
+	}
+}
+
 func TestOrFilter(t *testing.T) {
 	t.Run("simple OR", func(t *testing.T) {
 		filter := Or(Eq("test"), Like("%sample%"))

--- a/pkg/repo/filters_test.go
+++ b/pkg/repo/filters_test.go
@@ -82,7 +82,7 @@ func TestNotLikeFilter(t *testing.T) {
 	assert.Equal(t, []any{"%test%"}, filter.Value())
 }
 
-func TestComplexFilterPlaceholderRebasing(t *testing.T) {
+func TestRebasePlaceholders_MultiDigitPlaceholders(t *testing.T) {
 	values := make([]any, 10)
 	tests := []struct {
 		name     string


### PR DESCRIPTION
## Summary
- rebase positional SQL placeholders in one regex pass
- prevent `$1` from corrupting `$10` after offsets are applied
- cover RawFilter, ExistsFilter, and SubqueryFilter with a ten-parameter regression test
- declare a patch SDK release

## Testing
- Not run locally per consumer request; relying on PR CI.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791490572&installation_model_id=2042&pr_number=1069&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1069&signature=0b5bf7abe9234e0e01b63907c15958ddd82a78d9621e97316ba03ad5334413bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed repository filter placeholder rebasing for multi-digit indices.
  - Preserved valid placeholder positions when filters contain non-sequential or higher-numbered placeholders.
  - Prevented invalid or out-of-range placeholders from being incorrectly modified.
  - Improved consistency across raw, existence, and subquery filters when rebasing placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->