### PR TITLE
fix(roles): load every role in the list

### DIFF
--- a/.changes/roles-list-pagination.json
+++ b/.changes/roles-list-pagination.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "summary": "Paginate the roles list so roles past the first page are reachable."
+}

--- a/modules/core/presentation/controllers/roles_controller.go
+++ b/modules/core/presentation/controllers/roles_controller.go
@@ -23,12 +23,15 @@ import (
 	"github.com/iota-uz/iota-sdk/pkg/middleware"
 	"github.com/iota-uz/iota-sdk/pkg/rbac"
 	"github.com/iota-uz/iota-sdk/pkg/repo"
+	"github.com/iota-uz/iota-sdk/pkg/serrors"
 	"github.com/iota-uz/iota-sdk/pkg/shared"
 	"github.com/sirupsen/logrus"
 
 	"github.com/a-h/templ"
 	"github.com/gorilla/mux"
 )
+
+const opRolesList serrors.Op = "core.controllers.RolesController.List"
 
 type RolesController struct {
 	basePath         string
@@ -137,6 +140,13 @@ func (c *RolesController) List(
 		return
 	}
 
+	total, err := roleService.Count(r.Context(), findParams)
+	if err != nil {
+		logger.Error(serrors.E(opRolesList, err))
+		http.Error(w, "Error counting roles", http.StatusInternalServerError)
+		return
+	}
+
 	roleViewModels := mapping.MapViewModels(roleEntities, mappers.RoleToViewModel)
 	actor, err := composables.UseUser(r.Context())
 	if err != nil {
@@ -151,8 +161,11 @@ func (c *RolesController) List(
 	}
 
 	props := &roles.IndexPageProps{
-		Roles:  roleViewModels,
-		Search: search,
+		Roles:   roleViewModels,
+		Page:    params.Page,
+		PerPage: params.Limit,
+		HasMore: total > int64(params.Page*params.Limit),
+		Search:  search,
 	}
 
 	if htmx.IsHxRequest(r) {

--- a/modules/core/presentation/templates/pages/roles/roles.templ
+++ b/modules/core/presentation/templates/pages/roles/roles.templ
@@ -12,21 +12,39 @@ import (
 	"github.com/iota-uz/iota-sdk/modules/core/presentation/templates/layouts"
 	"github.com/iota-uz/iota-sdk/modules/core/presentation/viewmodels"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"net/url"
+	"strconv"
 )
 
 type IndexPageProps struct {
-	Roles  []*viewmodels.Role
-	Search string
+	Roles   []*viewmodels.Role
+	Page    int
+	PerPage int
+	HasMore bool
+	Search  string
 }
 
-templ RoleRow(role *viewmodels.Role) {
-	@base.TableRow(base.TableRowProps{
-		Attrs: templ.Attributes{
-			"id":           fmt.Sprintf("role-%s", role.ID),
-			"class":        "hide-on-load",
-			"data-test-id": fmt.Sprintf("role-row-%s", role.ID),
-		},
-	}) {
+func mkInfiniteAttrs(props *IndexPageProps) templ.Attributes {
+	params := url.Values{}
+	params.Set("page", strconv.Itoa(props.Page+1))
+	params.Set("name", props.Search)
+	params.Set("limit", strconv.Itoa(props.PerPage))
+
+	return templ.Attributes{
+		"hx-get":     "/roles?" + params.Encode(),
+		"hx-trigger": "intersect once",
+		"hx-swap":    "afterend",
+		"hx-target":  "this",
+	}
+}
+
+templ RoleRow(role *viewmodels.Role, rowProps *base.TableRowProps) {
+	{{
+		rowProps.Attrs["id"] = fmt.Sprintf("role-%s", role.ID)
+		rowProps.Attrs["class"] = "hide-on-load"
+		rowProps.Attrs["data-test-id"] = fmt.Sprintf("role-row-%s", role.ID)
+	}}
+	@base.TableRow(*rowProps) {
 		@base.TableCell(base.TableCellProps{}) {
 			{ role.Name }
 		}
@@ -53,17 +71,28 @@ templ RoleRow(role *viewmodels.Role) {
 }
 
 templ RoleRows(props *IndexPageProps) {
-	<tr class="hidden">
-		<td colspan="3">
-			@loaders.Spinner(loaders.SpinnerProps{
-				ContainerClass: templ.Classes(
-					"flex justify-center items-center py-4",
-				),
-			})
-		</td>
-	</tr>
-	for _, role := range props.Roles {
-		@RoleRow(role)
+	if props.Page <= 1 {
+		<tr class="hidden">
+			<td colspan="3">
+				@loaders.Spinner(loaders.SpinnerProps{
+					ContainerClass: templ.Classes(
+						"flex justify-center items-center py-4",
+					),
+				})
+			</td>
+		</tr>
+	}
+	for ix, role := range props.Roles {
+		{{
+			isLastRow := ix == len(props.Roles)-1
+			rowProps := &base.TableRowProps{
+				Attrs: templ.Attributes{},
+			}
+			if isLastRow && props.HasMore {
+				rowProps.Attrs = mkInfiniteAttrs(props)
+			}
+		}}
+		@RoleRow(role, rowProps)
 	}
 }
 

--- a/modules/core/presentation/templates/pages/roles/roles_templ.go
+++ b/modules/core/presentation/templates/pages/roles/roles_templ.go
@@ -20,14 +20,33 @@ import (
 	"github.com/iota-uz/iota-sdk/modules/core/presentation/templates/layouts"
 	"github.com/iota-uz/iota-sdk/modules/core/presentation/viewmodels"
 	"github.com/iota-uz/iota-sdk/pkg/composables"
+	"net/url"
+	"strconv"
 )
 
 type IndexPageProps struct {
-	Roles  []*viewmodels.Role
-	Search string
+	Roles   []*viewmodels.Role
+	Page    int
+	PerPage int
+	HasMore bool
+	Search  string
 }
 
-func RoleRow(role *viewmodels.Role) templ.Component {
+func mkInfiniteAttrs(props *IndexPageProps) templ.Attributes {
+	params := url.Values{}
+	params.Set("page", strconv.Itoa(props.Page+1))
+	params.Set("name", props.Search)
+	params.Set("limit", strconv.Itoa(props.PerPage))
+
+	return templ.Attributes{
+		"hx-get":     "/roles?" + params.Encode(),
+		"hx-trigger": "intersect once",
+		"hx-swap":    "afterend",
+		"hx-target":  "this",
+	}
+}
+
+func RoleRow(role *viewmodels.Role, rowProps *base.TableRowProps) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -48,6 +67,10 @@ func RoleRow(role *viewmodels.Role) templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
+
+		rowProps.Attrs["id"] = fmt.Sprintf("role-%s", role.ID)
+		rowProps.Attrs["class"] = "hide-on-load"
+		rowProps.Attrs["data-test-id"] = fmt.Sprintf("role-row-%s", role.ID)
 		templ_7745c5c3_Var2 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
@@ -75,7 +98,7 @@ func RoleRow(role *viewmodels.Role) templ.Component {
 				var templ_7745c5c3_Var4 string
 				templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(role.Name)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/roles/roles.templ`, Line: 31, Col: 14}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/roles/roles.templ`, Line: 49, Col: 14}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 				if templ_7745c5c3_Err != nil {
@@ -110,7 +133,7 @@ func RoleRow(role *viewmodels.Role) templ.Component {
 				var templ_7745c5c3_Var6 string
 				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("format('%s')", role.UpdatedAt))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/roles/roles.templ`, Line: 35, Col: 62}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/roles/roles.templ`, Line: 53, Col: 62}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 				if templ_7745c5c3_Err != nil {
@@ -181,13 +204,7 @@ func RoleRow(role *viewmodels.Role) templ.Component {
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = base.TableRow(base.TableRowProps{
-			Attrs: templ.Attributes{
-				"id":           fmt.Sprintf("role-%s", role.ID),
-				"class":        "hide-on-load",
-				"data-test-id": fmt.Sprintf("role-row-%s", role.ID),
-			},
-		}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var2), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = base.TableRow(*rowProps).Render(templ.WithChildren(ctx, templ_7745c5c3_Var2), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -216,24 +233,34 @@ func RoleRows(props *IndexPageProps) templ.Component {
 			templ_7745c5c3_Var9 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<tr class=\"hidden\"><td colspan=\"3\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
+		if props.Page <= 1 {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<tr class=\"hidden\"><td colspan=\"3\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = loaders.Spinner(loaders.SpinnerProps{
+				ContainerClass: templ.Classes(
+					"flex justify-center items-center py-4",
+				),
+			}).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</td></tr>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
-		templ_7745c5c3_Err = loaders.Spinner(loaders.SpinnerProps{
-			ContainerClass: templ.Classes(
-				"flex justify-center items-center py-4",
-			),
-		}).Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "</td></tr>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		for _, role := range props.Roles {
-			templ_7745c5c3_Err = RoleRow(role).Render(ctx, templ_7745c5c3_Buffer)
+		for ix, role := range props.Roles {
+
+			isLastRow := ix == len(props.Roles)-1
+			rowProps := &base.TableRowProps{
+				Attrs: templ.Attributes{},
+			}
+			if isLastRow && props.HasMore {
+				rowProps.Attrs = mkInfiniteAttrs(props)
+			}
+			templ_7745c5c3_Err = RoleRow(role, rowProps).Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -328,7 +355,7 @@ func RolesContent(props *IndexPageProps) templ.Component {
 		var templ_7745c5c3_Var13 string
 		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("NavigationLinks.Roles"))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/roles/roles.templ`, Line: 91, Col: 40}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/roles/roles.templ`, Line: 120, Col: 40}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 		if templ_7745c5c3_Err != nil {
@@ -375,7 +402,7 @@ func RolesContent(props *IndexPageProps) templ.Component {
 				var templ_7745c5c3_Var15 string
 				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(pageCtx.T("Roles.List.New"))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/roles/roles.templ`, Line: 123, Col: 35}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `modules/core/presentation/templates/pages/roles/roles.templ`, Line: 152, Col: 35}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 				if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
The roles list showed only the first page of roles and had no way to reach the rest. On a tenant with 31 roles the screen stopped at 25.

## Root cause

`roles.IndexPageProps` carried no page state (`Page` / `PerPage` / `HasMore`) and `RoleRows` attached no infinite-scroll attributes to the last row. The controller passed `composables.UsePaginated(r)` into `role.FindParams` but never counted the total, so the list was capped at `composables.DefaultPageSize` (25) with nothing to request page 2.

## Fix

Mirror the pagination the sibling core lists already use (`positions`, `departments`, `groups`) — no new mechanism:

- `roles_controller.go`: call `roleService.Count` with the same `findParams` and fill `Page` / `PerPage` / `HasMore`.
- `roles.templ`: add `mkInfiniteAttrs` (`hx-get=/roles?page=N+1`, `intersect once`, `afterend`, `hx-target="this"`), give `RoleRow` a `*base.TableRowProps`, and hang the attributes on the last row while `HasMore`.

The search form is untouched: it still swaps `#roles-table-body` with `innerHTML` and still uses the same `hx-indicator`, and a search carries no `page` parameter so `UsePaginated` resets it to 1. The hidden indicator row is rendered only for page 1, so appended pages do not duplicate it mid-table.

`RoleRepository.Count` ignores `Limit`/`Offset` and honours the same search and tenant filters, so the total matches the filtered list.

## Verification

- `go build ./...`, `go vet ./modules/core/presentation/...` — clean
- `go test ./modules/core/presentation/... ./modules/core/services/...` — all pass, including `TestRolesController_List_Search` and `TestRolesController_BasicRoutes`

Refs EAI-UZ/tasks#388

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added pagination to the roles list, including page navigation and indicators when additional roles are available.
  - Added infinite scrolling to load subsequent role entries automatically.
  - Search results now replace the complete roles table and reset pagination to the first page.
  - Added a loading indicator while the initial roles table is being displayed.

- **Bug Fixes**
  - Fixed role list requests so subsequent pages display the correct role rows instead of repeating the first-page table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->