### PR TITLE
feat(lens): expose stable chart test selectors

### DIFF
--- a/.changes/lens-stable-test-selectors.json
+++ b/.changes/lens-stable-test-selectors.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "summary": "Expose stable test selectors and raw totals for Lens panels, legends, and tabs."
+}

--- a/web/lens/src/DashboardPanels.tsx
+++ b/web/lens/src/DashboardPanels.tsx
@@ -393,6 +393,7 @@ function TabsGroup({ group, items, depth, panels, registry, filterToday }: {
             aria-controls={panelId(index)}
             aria-selected={tab === current}
             className="lens-tabstrip-tab"
+            data-testid={`lens-tabs-${group.id}-tab-${index}`}
             id={tabId(index)}
             key={tab}
             onClick={() => select(tab)}

--- a/web/lens/src/dashboardGroups.test.tsx
+++ b/web/lens/src/dashboardGroups.test.tsx
@@ -77,6 +77,8 @@ describe('nested tabs', () => {
 
     const tablists = screen.getAllByRole('tablist')
     expect(tablists).toHaveLength(2)
+    expect(within(tablists[0]!).getAllByRole('tab')[0]).toHaveAttribute('data-testid', 'lens-tabs-outer-tab-0')
+    expect(within(tablists[1]!).getAllByRole('tab')[1]).toHaveAttribute('data-testid', 'lens-tabs-inner-tab-1')
     expect(within(tablists[0]!).getAllByRole('tab').map((tab) => tab.textContent)).toEqual(['Stock', 'Movement'])
     expect(within(tablists[1]!).getAllByRole('tab').map((tab) => tab.textContent)).toEqual(['Detail', 'Summary'])
   })

--- a/web/lens/src/panels/ChartPanel.tsx
+++ b/web/lens/src/panels/ChartPanel.tsx
@@ -1230,7 +1230,7 @@ const ChartLegend = memo(function ChartLegend({
         data-overflow-top={legendEdges.top || undefined}
       >
         {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- overflowing native scroll regions must be keyboard-focusable. */}
-        <ul aria-label={translate('chart.legendControls', 'Legend controls')} className="lens-chart-legend" ref={legendRef} role="region" tabIndex={legendEdges.top || legendEdges.bottom ? 0 : undefined}>
+        <ul aria-label={translate('chart.legendControls', 'Legend controls')} className="lens-chart-legend" data-testid={`lens-panel-${panel.id}-legend`} ref={legendRef} role="region" tabIndex={legendEdges.top || legendEdges.bottom ? 0 : undefined}>
           {visibleEntries.map((index, visibleIndex) => {
             const row = frame.rows[index]!
             const entryIndex = model.entryPositions.get(index) ?? index
@@ -1248,6 +1248,7 @@ const ChartLegend = memo(function ChartLegend({
                   <button
                     aria-pressed={!isHidden}
                     className={`lens-chart-legend-toggle${isHidden ? ' lens-chart-legend-hidden' : ''}`}
+                    data-testid={`lens-panel-${panel.id}-legend-series-${visibleIndex}`}
                     onClick={() => onToggle(key)}
                     // The charting idiom every reader arrives with, and the
                     // one the isolate glyph beside it was the only way to

--- a/web/lens/src/panels/ChartPanel.tsx
+++ b/web/lens/src/panels/ChartPanel.tsx
@@ -1248,7 +1248,7 @@ const ChartLegend = memo(function ChartLegend({
                   <button
                     aria-pressed={!isHidden}
                     className={`lens-chart-legend-toggle${isHidden ? ' lens-chart-legend-hidden' : ''}`}
-                    data-testid={`lens-panel-${panel.id}-legend-series-${visibleIndex}`}
+                    data-testid={`lens-panel-${panel.id}-legend-series-${entryIndex}`}
                     onClick={() => onToggle(key)}
                     // The charting idiom every reader arrives with, and the
                     // one the isolate glyph beside it was the only way to

--- a/web/lens/src/panels/PanelFrame.tsx
+++ b/web/lens/src/panels/PanelFrame.tsx
@@ -262,6 +262,7 @@ export function PanelFrame({
       data-calculation-ms={frame.calculation?.durationMs}
       data-panel-kind={panel.kind}
       data-panel-id={panel.id}
+      data-testid={`lens-panel-${panel.id}`}
       data-stale={frame.isStale || undefined}
     >
       <header className="lens-panel-header">
@@ -281,7 +282,12 @@ export function PanelFrame({
         <div className="lens-panel-actions">
           {headerActions}
           {showTotal && (
-            <span className="lens-panel-total" title={`${totalLabel}: ${formatTotal(total)}`}>
+            <span
+              className="lens-panel-total"
+              data-testid={`lens-panel-${panel.id}-total`}
+              data-value={total}
+              title={`${totalLabel}: ${formatTotal(total)}`}
+            >
               <span className="lens-panel-total-label">{totalLabel}:</span>
               {' '}
               {formatTotal(total)}

--- a/web/lens/src/panels/panels.test.tsx
+++ b/web/lens/src/panels/panels.test.tsx
@@ -274,6 +274,9 @@ describe('panel total badge', () => {
     const badge = view.container.querySelector('.lens-panel-total')
     // The badge names what it totals instead of showing an unlabeled number.
     expect(badge).toHaveTextContent('Total: 12345')
+    expect(badge).toHaveAttribute('data-testid', 'lens-panel-panel-bar-total')
+    expect(badge).toHaveAttribute('data-value', '12345')
+    expect(view.container.querySelector('section')).toHaveAttribute('data-testid', 'lens-panel-panel-bar')
   })
 
   it('omits the badge when panel.total is absent', () => {
@@ -845,6 +848,8 @@ describe('chart encoding and drill behavior', () => {
     })
     const view = render(<LinePanel panel={line} adapter={fakeAdapter((input) => inputs.push(input))} />)
 
+    expect(view.getByTestId('lens-panel-panel-line-legend')).toBeInTheDocument()
+    expect(view.getByTestId('lens-panel-panel-line-legend-series-0')).toHaveTextContent('Written')
     expect(legendRow(view.container, 'Written')).toHaveTextContent('220')
     // Isolating is the row's double-click — the charting idiom — rather than a
     // second button beside it.

--- a/web/lens/src/panels/panels.test.tsx
+++ b/web/lens/src/panels/panels.test.tsx
@@ -1070,11 +1070,14 @@ describe('chart encoding and drill behavior', () => {
       presentation: { legend: 'below' },
     })
     const view = render(<LinePanel panel={line} adapter={fakeAdapter()} />)
+    expect(view.getByTestId('lens-panel-panel-line-legend-series-6')).toHaveTextContent('Product 7')
     const search = screen.getByRole('searchbox', { name: 'Search legend' })
     fireEvent.change(search, { target: { value: 'Product 7' } })
     // The search narrows the list a reader reads; it must not narrow the plot,
     // which still has to draw the series the reader filtered out of view.
     expect(legendLabels(view.container)).toEqual(['Product 7'])
+    expect(view.getByTestId('lens-panel-panel-line-legend-series-6')).toHaveTextContent('Product 7')
+    expect(view.queryByTestId('lens-panel-panel-line-legend-series-0')).toBeNull()
     expect(view.container.querySelector('.lens-chart-canvas')).toBeInTheDocument()
   })
 


### PR DESCRIPTION
## Summary

- expose stable panel, total, legend, series, and tab test selectors
- expose the raw numeric panel total through `data-value`
- cover the selector contract in Lens component tests

## Validation

- `pnpm --dir web/lens exec vitest run src/panels/panels.test.tsx src/dashboardGroups.test.tsx`
- `pnpm --dir web/lens typecheck`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791739566&installation_model_id=2042&pr_number=1072&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1072&signature=e2d56362bc0e131fe6a3e7b2dcbd2d8ee8cbbd3f6918cefbe4becbb1d587b840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added stable identifiers for dashboard tabs, panel sections, totals, chart legends, and legend controls.
  * Expanded automated coverage to verify element identifiers, displayed total values, and chart series availability when filtering legends.
  * Improved consistency when locating dashboard elements during interface testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->