### PR TITLE
fix(ci): isolate release candidate configuration

### DIFF
--- a/.changes/keep-ci-e2e-environment-isolated.json
+++ b/.changes/keep-ci-e2e-environment-isolated.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "summary": "Keep local E2E database settings from overriding CI service ports."
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -13,8 +13,9 @@ const isCI = process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true';
 function loadEnvironmentConfig() {
 	const envPath = path.join(__dirname, '.env.e2e');
 
-	// Load .env.e2e if it exists (local development)
-	if (fs.existsSync(envPath)) {
+	// Load .env.e2e only for local development. CI provides its own service
+	// ports and credentials, which must not be overwritten by local defaults.
+	if (!isCI && fs.existsSync(envPath)) {
 		dotenv.config({ path: envPath });
 	}
 

--- a/pkg/clienthost/host_test.go
+++ b/pkg/clienthost/host_test.go
@@ -45,7 +45,7 @@ func TestController_ServesCanonicalBootstrapAndDescriptor(t *testing.T) {
 	require.Contains(t, body, `data-sdk-commit="0123456789abcdef0123456789abcdef01234567"`)
 	require.Contains(t, body, `integrity="sha384-example"`)
 	require.Contains(t, body, `"protocolVersion":"1.0.0"`)
-	require.Contains(t, body, `"sdkReleaseVersion":"0.5.6"`)
+	require.Contains(t, body, `"sdkReleaseVersion":"`+sdkidentity.ReleaseVersion+`"`)
 	require.Contains(t, body, `"sdkCommit":"0123456789abcdef0123456789abcdef01234567"`)
 	require.Contains(t, body, `"theme":"dark"`)
 	require.Contains(t, body, `"csrf":"token"`)


### PR DESCRIPTION
## Summary
- keep the tracked local E2E environment from overriding CI database service settings
- assert client-host output against the generated SDK release identity instead of the previous release literal

## Verification
- `go test ./pkg/clienthost`
- `CI=true pnpm exec playwright test --list` from `e2e/`

This fixes the two deterministic failures found by the verified release candidate run for SDK PR #1072.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791825377&installation_model_id=2042&pr_number=1073&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1073&signature=003f6d3413b52cef79f9e502ba48b40acff0911a0144b4f612d0e389fa63d9c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved end-to-end test execution in CI by preventing local environment settings from overriding CI service ports and credentials.

- **Tests**
  - Updated bootstrap descriptor validation to use the current SDK release version, helping keep automated checks aligned with the shipped version.

- **Chores**
  - Recorded the changes in the upcoming patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->