### PR TITLE
fix(e2e): select combobox backing values

### DIFF
--- a/.changes/fix-hidden-select-e2e.json
+++ b/.changes/fix-hidden-select-e2e.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "summary": "Exercise hidden combobox backing selects reliably in user form E2E coverage."
+}

--- a/e2e/tests/users/forms-and-password.spec.ts
+++ b/e2e/tests/users/forms-and-password.spec.ts
@@ -105,8 +105,8 @@ test.describe('user form scalability and self-service password change', () => {
 			await expect(page.locator(`select[name="GroupIDs"] option[value="${fixture.groupID}"]`)).toHaveText('Twenty thousand members');
 		}
 		await page.locator('[name="LastName"]').fill('Preserved edit');
-		await page.locator('select[name="GroupIDs"]').selectOption(fixture.groupID);
-		await page.locator('select[name="RoleIDs"]').selectOption(fixture.roleID);
+		await page.locator('select[name="GroupIDs"]').selectOption(fixture.groupID, { force: true });
+		await page.locator('select[name="RoleIDs"]').selectOption(fixture.roleID, { force: true });
 		await page.locator('[name="FirstName"]').fill('');
 		await page.locator('#save-btn').click();
 		await expect(page.locator('[name="LastName"]')).toHaveValue('Preserved edit');
@@ -115,8 +115,8 @@ test.describe('user form scalability and self-service password change', () => {
 
 		await page.goto('/users/new');
 		await page.locator('[name="FirstName"]').fill('Preserved');
-		await page.locator('select[name="GroupIDs"]').selectOption(fixture.groupID);
-		await page.locator('select[name="RoleIDs"]').selectOption(fixture.roleID);
+		await page.locator('select[name="GroupIDs"]').selectOption(fixture.groupID, { force: true });
+		await page.locator('select[name="RoleIDs"]').selectOption(fixture.roleID, { force: true });
 		await page.locator('#save-btn').click();
 		await expect(page.locator('[name="FirstName"]')).toHaveValue('Preserved');
 		await expect(page.locator('select[name="GroupIDs"]')).toHaveValue(fixture.groupID);


### PR DESCRIPTION
## Summary
- use Playwright forced selection for the intentionally hidden native selects behind user-form comboboxes
- preserve the existing validation and submitted-value assertions

## Verification
- `pnpm exec tsc --noEmit` from `e2e/`
- `CI=true pnpm exec playwright test tests/users/forms-and-password.spec.ts --list`

This fixes the remaining deterministic shard 4 failure found by the verified SDK release candidate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791826327&installation_model_id=2042&pr_number=1074&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1074&signature=c6085e7512b5457b5800178e0739124ebb27a82934d13ed3af00e4f97c52fc84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved end-to-end coverage for user form selections involving hidden or obscured group and role fields.
  - User creation and editing flows now reliably select group and role options in large-group scenarios.

- **Chores**
  - Added a patch release changeset for the update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->