### PR TITLE
fix(release): align client-host identity

### DIFF
--- a/.changes/release-client-host-identity.json
+++ b/.changes/release-client-host-identity.json
@@ -1,0 +1,4 @@
+{
+  "bump": "patch",
+  "summary": "Keep the embedded client-host release identity aligned with Go and npm release candidates."
+}

--- a/.claude/tools/internal/sdk/release.go
+++ b/.claude/tools/internal/sdk/release.go
@@ -217,11 +217,21 @@ func (g GitHub) Prepare(ctx context.Context, runID string, retry bool) (*Candida
 		return nil, fmt.Errorf("expected exactly one Go release identity")
 	}
 	identity = pattern.ReplaceAll(identity, []byte(`ReleaseVersion  = "`+version+`"`))
+	clientHostIdentity, _, err := g.File(ctx, "web/client-host/src/identity.ts", source)
+	if err != nil {
+		return nil, err
+	}
+	clientHostPattern := regexp.MustCompile(`SDK_RELEASE_VERSION\s*=\s*'[^']+'`)
+	if len(clientHostPattern.FindAll(clientHostIdentity, -1)) != 1 {
+		return nil, fmt.Errorf("expected exactly one client-host release identity")
+	}
+	clientHostIdentity = clientHostPattern.ReplaceAll(clientHostIdentity, []byte(`SDK_RELEASE_VERSION = '`+version+`'`))
 	metadata, _ := json.MarshalIndent(map[string]any{"version": version, "source": source, "changes": changes}, "", "  ")
 	sha, err := g.CommitFiles(ctx, source, "chore: prepare SDK v"+version, map[string][]byte{
-		"web/sdk/package.json":        append(packageData, '\n'),
-		"pkg/sdkidentity/identity.go": identity,
-		".sdk/release.json":           append(metadata, '\n'),
+		"web/sdk/package.json":            append(packageData, '\n'),
+		"pkg/sdkidentity/identity.go":     identity,
+		"web/client-host/src/identity.ts": clientHostIdentity,
+		".sdk/release.json":               append(metadata, '\n'),
 	})
 	if err != nil {
 		return nil, err

--- a/.claude/tools/internal/sdk/release_test.go
+++ b/.claude/tools/internal/sdk/release_test.go
@@ -45,6 +45,8 @@ func TestPrepare_CreatesVersionedCandidateWithoutPublishing(t *testing.T) {
 			return encoded(content{SHA: "package", Content: base64.StdEncoding.EncodeToString([]byte(packageSource))}), nil
 		case strings.HasPrefix(endpoint, "contents/pkg/sdkidentity/identity.go"):
 			return encoded(content{Content: base64.StdEncoding.EncodeToString([]byte("package sdkidentity\nconst ReleaseVersion = \"0.5.6\"\n"))}), nil
+		case strings.HasPrefix(endpoint, "contents/web/client-host/src/identity.ts"):
+			return encoded(content{Content: base64.StdEncoding.EncodeToString([]byte("export const SDK_RELEASE_VERSION = '0.5.6'\n"))}), nil
 		case endpoint == "git/trees/"+baseline+"?recursive=1":
 			return []byte(`{"tree":[]}`), nil
 		case endpoint == "git/trees/"+source+"?recursive=1":
@@ -95,6 +97,7 @@ func TestPrepare_CreatesVersionedCandidateWithoutPublishing(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(committedFiles["web/sdk/package.json"]), &pkg))
 	require.Equal(t, "0.6.0", pkg["version"])
 	require.Contains(t, committedFiles["pkg/sdkidentity/identity.go"], `"0.6.0"`)
+	require.Contains(t, committedFiles["web/client-host/src/identity.ts"], `'0.6.0'`)
 	require.Equal(t, strings.Replace(packageSource, `"version": "0.5.6"`, `"version": "0.6.0"`, 1)+"\n", committedFiles["web/sdk/package.json"])
 	var metadata struct {
 		Version, Source string


### PR DESCRIPTION
## Summary
- update the embedded client-host release identity when preparing an SDK candidate
- extend the release-controller contract test to cover all three version identities
- declare a patch release

## Validation
- `go test ./internal/sdk/...` in `.claude/tools`
- `go vet ./internal/sdk/...` in `.claude/tools`
- `GOWORK=off go vet ./...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/iota-uz/codesmith/iota-sdk/pr/1075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791827753&installation_model_id=2042&pr_number=1075&repository=iota-uz%2Fiota-sdk&return_to=https%3A%2F%2Fgithub.com%2Fiota-uz%2Fiota-sdk%2Fpull%2F1075&signature=4f08ed3937066b3567092e29472f84b525fdfd2bd0c690dde00683e5f7bd4910"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->